### PR TITLE
Display scores as human-readable time estimates (#104)

### DIFF
--- a/src/main/java/com/collectionloghelper/ui/ItemRowPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/ItemRowPanel.java
@@ -157,19 +157,23 @@ class ItemRowPanel extends JPanel
 		}
 		else if (hours < 1)
 		{
-			return "~" + Math.round(hours * 60) + " min";
+			long min = Math.max(1, Math.round(hours * 60));
+			return "~" + min + " min";
 		}
 		else if (hours < 24)
 		{
-			return "~" + Math.round(hours) + " hrs";
+			long hrs = Math.round(hours);
+			return "~" + hrs + (hrs == 1 ? " hr" : " hrs");
 		}
 		else if (hours < 720)
 		{
-			return "~" + Math.round(hours / 24) + " days";
+			long days = Math.round(hours / 24);
+			return "~" + days + (days == 1 ? " day" : " days");
 		}
 		else
 		{
-			return "~" + Math.round(hours / 720) + " months";
+			long months = Math.round(hours / 720);
+			return "~" + months + (months == 1 ? " month" : " months");
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Replace raw float score display (e.g. "126000.0") with human-readable estimated time to next drop (e.g. "~5 hrs", "~3 days", "~2 months")
- Add tooltip to score label explaining what the value represents
- Uses the inverse of the existing score formula: `hours = 100.0 / score`

## Format tiers
| Condition | Example output |
|-----------|---------------|
| < 1 minute | `< 1 min` |
| < 1 hour | `~30 min` |
| < 1 day | `~5 hrs` |
| < 30 days | `~12 days` |
| >= 30 days | `~3 months` |

Closes #104