### PR TITLE
Replace sync button with dynamic sync status (#100, #105)

### DIFF
--- a/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
@@ -149,7 +149,7 @@ public class CollectionLogHelperPlugin extends Plugin
 		panel = new CollectionLogHelperPanel(
 			config, database, collectionState, calculator, itemManager,
 			requirementsChecker,
-			this::activateGuidance, this::deactivateGuidance, this::syncCollectionLog,
+			this::activateGuidance, this::deactivateGuidance,
 			() -> cachedPlayerLocation);
 		panel.setMode(config.defaultMode());
 
@@ -225,6 +225,7 @@ public class CollectionLogHelperPlugin extends Plugin
 				lastObtainedCount = collectionState.getTotalObtained();
 				if (panel != null)
 				{
+					panel.updateSyncStatus(CollectionLogHelperPanel.SyncState.NOT_SYNCED, 0);
 					panel.rebuild();
 				}
 			});
@@ -403,11 +404,13 @@ public class CollectionLogHelperPlugin extends Plugin
 				scriptScanActive = false;
 				hasCompletedFullSync = true;
 				guidanceOverlay.setShowSyncReminder(false);
+				int capturedCount = scriptScanItemCount;
 				log.info("Auto-sync complete: {} obtained items captured via script scan",
-					scriptScanItemCount);
+					capturedCount);
 				scriptScanItemCount = 0;
 				if (panel != null)
 				{
+					panel.updateSyncStatus(CollectionLogHelperPanel.SyncState.SYNCED, capturedCount);
 					panel.rebuild();
 				}
 			}
@@ -422,7 +425,7 @@ public class CollectionLogHelperPlugin extends Plugin
 				syncReminderSent = true;
 				guidanceOverlay.setShowSyncReminder(true);
 				client.addChatMessage(ChatMessageType.GAMEMESSAGE, "",
-					"<col=00c8c8>[Collection Log Helper]</col> Open your Collection Log to sync your obtained items.",
+					"<col=00c8c8>[Collection Log Helper]</col> Open your in-game Collection Log (click the quest tab icon) to sync progress.",
 					null);
 			}
 		}
@@ -500,6 +503,11 @@ public class CollectionLogHelperPlugin extends Plugin
 		scriptScanActive = false;
 		scanSettleCountdown = SCAN_SETTLE_TICKS;
 
+		if (panel != null)
+		{
+			panel.updateSyncStatus(CollectionLogHelperPanel.SyncState.SYNCING, 0);
+		}
+
 		log.info("Triggering collection log search-mode scan");
 
 		// Click the Search toggle to enter search mode (fires script 4100 for each obtained item)
@@ -512,34 +520,6 @@ public class CollectionLogHelperPlugin extends Plugin
 		// Click Back to exit search mode so the UI returns to normal
 		client.menuAction(-1, InterfaceID.Collection.SEARCH_TOGGLE,
 			MenuAction.CC_OP, 1, -1, "Back", null);
-	}
-
-	/**
-	 * Sync action triggered by the panel's Sync button.
-	 * If the collection log is open, triggers a full search-mode scan.
-	 * Otherwise, captures recent items from varps.
-	 */
-	private void syncCollectionLog()
-	{
-		clientThread.invokeLater(() ->
-		{
-			collectionState.captureRecentItems();
-
-			Widget frame = client.getWidget(InterfaceID.Collection.FRAME);
-			if (frame != null && !frame.isHidden())
-			{
-				triggerSearchModeScan();
-				log.info("Sync: triggered search-mode scan");
-			}
-			else
-			{
-				log.info("Sync: captured recent items from varps (open in-game Collection Log for full sync)");
-				if (panel != null)
-				{
-					panel.rebuild();
-				}
-			}
-		});
 	}
 
 	public void activateGuidance(CollectionLogSource source)

--- a/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
@@ -14,6 +14,7 @@ import java.awt.CardLayout;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
+import java.awt.Font;
 import java.awt.Insets;
 import java.awt.event.ItemEvent;
 import java.util.ArrayList;
@@ -45,6 +46,9 @@ public class CollectionLogHelperPanel extends PluginPanel
 {
 	private static final Color GUIDE_ME_COLOR = new Color(30, 120, 30);
 	private static final Color STOP_GUIDANCE_COLOR = new Color(140, 30, 30);
+	private static final Color SYNC_NOT_SYNCED_COLOR = new Color(230, 180, 50);
+	private static final Color SYNC_SYNCING_COLOR = new Color(0, 200, 200);
+	private static final Color SYNC_SYNCED_COLOR = new Color(50, 200, 50);
 
 	public enum Mode
 	{
@@ -68,6 +72,13 @@ public class CollectionLogHelperPanel extends PluginPanel
 		}
 	}
 
+	public enum SyncState
+	{
+		NOT_SYNCED,
+		SYNCING,
+		SYNCED
+	}
+
 	private final CollectionLogHelperConfig config;
 	private final DropRateDatabase database;
 	private final PlayerCollectionState collectionState;
@@ -76,8 +87,9 @@ public class CollectionLogHelperPanel extends PluginPanel
 	private final RequirementsChecker requirementsChecker;
 	private final Consumer<CollectionLogSource> guidanceActivator;
 	private final Runnable guidanceDeactivator;
-	private final Runnable syncAction;
 	private final Supplier<WorldPoint> playerLocationSupplier;
+
+	private final JLabel syncStatusLabel;
 
 	private final JComboBox<Mode> modeSelector;
 	private final JComboBox<CollectionLogCategory> categorySelector;
@@ -104,7 +116,7 @@ public class CollectionLogHelperPanel extends PluginPanel
 		EfficiencyCalculator calculator, ItemManager itemManager,
 		RequirementsChecker requirementsChecker,
 		Consumer<CollectionLogSource> guidanceActivator, Runnable guidanceDeactivator,
-		Runnable syncAction, Supplier<WorldPoint> playerLocationSupplier)
+		Supplier<WorldPoint> playerLocationSupplier)
 	{
 		this.config = config;
 		this.database = database;
@@ -114,7 +126,6 @@ public class CollectionLogHelperPanel extends PluginPanel
 		this.requirementsChecker = requirementsChecker;
 		this.guidanceActivator = guidanceActivator;
 		this.guidanceDeactivator = guidanceDeactivator;
-		this.syncAction = syncAction;
 		this.playerLocationSupplier = playerLocationSupplier;
 
 		setBorder(BorderFactory.createEmptyBorder(6, 6, 6, 6));
@@ -134,14 +145,14 @@ public class CollectionLogHelperPanel extends PluginPanel
 		completionLabel.setBorder(BorderFactory.createEmptyBorder(0, 0, 4, 0));
 		controlsPanel.add(completionLabel);
 
-		// Sync button
-		JButton syncButton = new JButton("Sync Collection Log");
-		syncButton.setFont(FontManager.getRunescapeSmallFont());
-		syncButton.setAlignmentX(CENTER_ALIGNMENT);
-		syncButton.setMaximumSize(new Dimension(Integer.MAX_VALUE, 24));
-		syncButton.setToolTipText("Syncs automatically when you open the Collection Log in-game");
-		syncButton.addActionListener(e -> syncAction.run());
-		controlsPanel.add(syncButton);
+		// Sync status label
+		syncStatusLabel = new JLabel("Open Collection Log to sync", SwingConstants.CENTER);
+		syncStatusLabel.setFont(FontManager.getRunescapeSmallFont().deriveFont(Font.ITALIC));
+		syncStatusLabel.setForeground(SYNC_NOT_SYNCED_COLOR);
+		syncStatusLabel.setAlignmentX(CENTER_ALIGNMENT);
+		syncStatusLabel.setMaximumSize(new Dimension(Integer.MAX_VALUE, 20));
+		syncStatusLabel.setToolTipText("Syncs automatically when you open the Collection Log in-game");
+		controlsPanel.add(syncStatusLabel);
 		controlsPanel.add(Box.createVerticalStrut(4));
 
 		// Mode selector
@@ -278,6 +289,32 @@ public class CollectionLogHelperPanel extends PluginPanel
 		int total = collectionState.getTotalPossible();
 		double pct = collectionState.getCompletionPercentage();
 		completionLabel.setText(String.format("Collection Log: %d/%d (%.1f%%)", obtained, total, pct));
+	}
+
+	public void updateSyncStatus(SyncState state, int itemCount)
+	{
+		SwingUtilities.invokeLater(() ->
+		{
+			Font smallFont = FontManager.getRunescapeSmallFont();
+			switch (state)
+			{
+				case NOT_SYNCED:
+					syncStatusLabel.setText("Open Collection Log to sync");
+					syncStatusLabel.setFont(smallFont.deriveFont(Font.ITALIC));
+					syncStatusLabel.setForeground(SYNC_NOT_SYNCED_COLOR);
+					break;
+				case SYNCING:
+					syncStatusLabel.setText("Syncing...");
+					syncStatusLabel.setFont(smallFont.deriveFont(Font.ITALIC));
+					syncStatusLabel.setForeground(SYNC_SYNCING_COLOR);
+					break;
+				case SYNCED:
+					syncStatusLabel.setText("Synced (" + itemCount + " items)");
+					syncStatusLabel.setFont(smallFont.deriveFont(Font.PLAIN));
+					syncStatusLabel.setForeground(SYNC_SYNCED_COLOR);
+					break;
+			}
+		});
 	}
 
 	public void rebuild()


### PR DESCRIPTION
## Summary
- Replace the misleading "Sync Collection Log" button with a dynamic status label that shows current sync state: pre-sync notice, syncing indicator, and synced count
- Plugin calls `panel.updateSyncStatus()` at each state transition (login, scan start, scan complete) so the label always reflects reality
- Improve the chat sync-reminder message to be more actionable ("click the quest tab icon")
- Remove the now-unused `syncCollectionLog()` method and `syncAction` constructor parameter

Closes #100, closes #105

## Test plan
- [ ] Log in — label shows "Open Collection Log to sync" in yellow italic
- [ ] Open the in-game Collection Log — label switches to "Syncing..." in cyan
- [ ] Wait for scan to settle — label shows "Synced (X items)" in green with correct count
- [ ] Log out and back in — label resets to "Open Collection Log to sync"
- [ ] Verify chat reminder says "Open your in-game Collection Log (click the quest tab icon) to sync progress."
- [ ] Verify no regression in guidance, proximity, or other panel modes