### PR TITLE
Fix clue scroll drop rates with wiki-accurate values (#102)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -3521,7 +3521,7 @@
       {
         "itemId": 23285,
         "name": "Mole slippers",
-        "dropRate": 0.002778,
+        "dropRate": 0.005548,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Mole_slippers"
@@ -3529,7 +3529,7 @@
       {
         "itemId": 23288,
         "name": "Frog slippers",
-        "dropRate": 0.002778,
+        "dropRate": 0.005548,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Frog_slippers"
@@ -3537,7 +3537,7 @@
       {
         "itemId": 23291,
         "name": "Bear feet",
-        "dropRate": 0.002778,
+        "dropRate": 0.005548,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bear_feet"
@@ -3545,7 +3545,7 @@
       {
         "itemId": 23294,
         "name": "Demon feet",
-        "dropRate": 0.002778,
+        "dropRate": 0.005548,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Demon_feet"
@@ -3553,7 +3553,7 @@
       {
         "itemId": 23297,
         "name": "Jester cape",
-        "dropRate": 0.002778,
+        "dropRate": 0.005548,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Jester_cape"
@@ -3561,7 +3561,7 @@
       {
         "itemId": 23300,
         "name": "Shoulder parrot",
-        "dropRate": 0.002778,
+        "dropRate": 0.005548,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Shoulder_parrot"
@@ -3569,7 +3569,7 @@
       {
         "itemId": 23303,
         "name": "Monk's robe top (t)",
-        "dropRate": 0.002778,
+        "dropRate": 0.005548,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Monk%27s_robe_top_(t)"
@@ -3577,7 +3577,7 @@
       {
         "itemId": 23306,
         "name": "Monk's robe (t)",
-        "dropRate": 0.002778,
+        "dropRate": 0.005548,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Monk%27s_robe_(t)"
@@ -3585,7 +3585,7 @@
       {
         "itemId": 23309,
         "name": "Amulet of defence (t)",
-        "dropRate": 0.002778,
+        "dropRate": 0.005548,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Amulet_of_defence_(t)"
@@ -3593,7 +3593,7 @@
       {
         "itemId": 23312,
         "name": "Sandwich lady hat",
-        "dropRate": 0.002778,
+        "dropRate": 0.005548,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Sandwich_lady_hat"
@@ -3601,7 +3601,7 @@
       {
         "itemId": 23315,
         "name": "Sandwich lady top",
-        "dropRate": 0.002778,
+        "dropRate": 0.005548,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Sandwich_lady_top"
@@ -3609,7 +3609,7 @@
       {
         "itemId": 23318,
         "name": "Sandwich lady bottom",
-        "dropRate": 0.002778,
+        "dropRate": 0.005548,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Sandwich_lady_bottom"
@@ -3617,7 +3617,7 @@
       {
         "itemId": 23321,
         "name": "Rune scimitar ornament kit (guthix)",
-        "dropRate": 0.002778,
+        "dropRate": 0.005548,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Rune_scimitar_ornament_kit_(guthix)"
@@ -3625,7 +3625,7 @@
       {
         "itemId": 23324,
         "name": "Rune scimitar ornament kit (saradomin)",
-        "dropRate": 0.002778,
+        "dropRate": 0.005548,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Rune_scimitar_ornament_kit_(saradomin)"
@@ -3633,7 +3633,7 @@
       {
         "itemId": 23327,
         "name": "Rune scimitar ornament kit (zamorak)",
-        "dropRate": 0.002778,
+        "dropRate": 0.005548,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Rune_scimitar_ornament_kit_(zamorak)"
@@ -9278,7 +9278,7 @@
       {
         "itemId": 12221,
         "name": "Bronze full helm (t)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bronze_full_helm_(t)"
@@ -9286,7 +9286,7 @@
       {
         "itemId": 12215,
         "name": "Bronze platebody (t)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bronze_platebody_(t)"
@@ -9294,7 +9294,7 @@
       {
         "itemId": 12217,
         "name": "Bronze platelegs (t)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bronze_platelegs_(t)"
@@ -9302,7 +9302,7 @@
       {
         "itemId": 12219,
         "name": "Bronze plateskirt (t)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bronze_plateskirt_(t)"
@@ -9310,7 +9310,7 @@
       {
         "itemId": 12223,
         "name": "Bronze kiteshield (t)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bronze_kiteshield_(t)"
@@ -9318,7 +9318,7 @@
       {
         "itemId": 12231,
         "name": "Iron full helm (t)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Iron_full_helm_(t)"
@@ -9326,7 +9326,7 @@
       {
         "itemId": 12225,
         "name": "Iron platebody (t)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Iron_platebody_(t)"
@@ -9334,7 +9334,7 @@
       {
         "itemId": 12227,
         "name": "Iron platelegs (t)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Iron_platelegs_(t)"
@@ -9342,7 +9342,7 @@
       {
         "itemId": 12229,
         "name": "Iron plateskirt (t)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Iron_plateskirt_(t)"
@@ -9350,7 +9350,7 @@
       {
         "itemId": 12233,
         "name": "Iron kiteshield (t)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Iron_kiteshield_(t)"
@@ -9358,7 +9358,7 @@
       {
         "itemId": 20193,
         "name": "Steel full helm (t)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Steel_full_helm_(t)"
@@ -9366,7 +9366,7 @@
       {
         "itemId": 20184,
         "name": "Steel platebody (t)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Steel_platebody_(t)"
@@ -9374,7 +9374,7 @@
       {
         "itemId": 20187,
         "name": "Steel platelegs (t)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Steel_platelegs_(t)"
@@ -9382,7 +9382,7 @@
       {
         "itemId": 20190,
         "name": "Steel plateskirt (t)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Steel_plateskirt_(t)"
@@ -9390,7 +9390,7 @@
       {
         "itemId": 20196,
         "name": "Steel kiteshield (t)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Steel_kiteshield_(t)"
@@ -9398,7 +9398,7 @@
       {
         "itemId": 2587,
         "name": "Black full helm (t)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_full_helm_(t)"
@@ -9406,7 +9406,7 @@
       {
         "itemId": 2583,
         "name": "Black platebody (t)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_platebody_(t)"
@@ -9414,7 +9414,7 @@
       {
         "itemId": 2585,
         "name": "Black platelegs (t)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_platelegs_(t)"
@@ -9422,7 +9422,7 @@
       {
         "itemId": 3472,
         "name": "Black plateskirt (t)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_plateskirt_(t)"
@@ -9430,7 +9430,7 @@
       {
         "itemId": 2589,
         "name": "Black kiteshield (t)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_kiteshield_(t)"
@@ -9438,7 +9438,7 @@
       {
         "itemId": 7364,
         "name": "Studded body (t)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Studded_body_(t)"
@@ -9446,7 +9446,7 @@
       {
         "itemId": 7368,
         "name": "Studded chaps (t)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Studded_chaps_(t)"
@@ -9454,7 +9454,7 @@
       {
         "itemId": 12211,
         "name": "Bronze full helm (g)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bronze_full_helm_(g)"
@@ -9462,7 +9462,7 @@
       {
         "itemId": 12205,
         "name": "Bronze platebody (g)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bronze_platebody_(g)"
@@ -9470,7 +9470,7 @@
       {
         "itemId": 12207,
         "name": "Bronze platelegs (g)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bronze_platelegs_(g)"
@@ -9478,7 +9478,7 @@
       {
         "itemId": 12209,
         "name": "Bronze plateskirt (g)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bronze_plateskirt_(g)"
@@ -9486,7 +9486,7 @@
       {
         "itemId": 12213,
         "name": "Bronze kiteshield (g)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bronze_kiteshield_(g)"
@@ -9494,7 +9494,7 @@
       {
         "itemId": 12241,
         "name": "Iron full helm (g)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Iron_full_helm_(g)"
@@ -9502,7 +9502,7 @@
       {
         "itemId": 12235,
         "name": "Iron platebody (g)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Iron_platebody_(g)"
@@ -9510,7 +9510,7 @@
       {
         "itemId": 12237,
         "name": "Iron platelegs (g)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Iron_platelegs_(g)"
@@ -9518,7 +9518,7 @@
       {
         "itemId": 12239,
         "name": "Iron plateskirt (g)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Iron_plateskirt_(g)"
@@ -9526,7 +9526,7 @@
       {
         "itemId": 12243,
         "name": "Iron kiteshield (g)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Iron_kiteshield_(g)"
@@ -9534,7 +9534,7 @@
       {
         "itemId": 20178,
         "name": "Steel full helm (g)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Steel_full_helm_(g)"
@@ -9542,7 +9542,7 @@
       {
         "itemId": 20169,
         "name": "Steel platebody (g)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Steel_platebody_(g)"
@@ -9550,7 +9550,7 @@
       {
         "itemId": 20172,
         "name": "Steel platelegs (g)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Steel_platelegs_(g)"
@@ -9558,7 +9558,7 @@
       {
         "itemId": 20175,
         "name": "Steel plateskirt (g)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Steel_plateskirt_(g)"
@@ -9566,7 +9566,7 @@
       {
         "itemId": 20181,
         "name": "Steel kiteshield (g)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Steel_kiteshield_(g)"
@@ -9574,7 +9574,7 @@
       {
         "itemId": 2595,
         "name": "Black full helm (g)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_full_helm_(g)"
@@ -9582,7 +9582,7 @@
       {
         "itemId": 2591,
         "name": "Black platebody (g)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_platebody_(g)"
@@ -9590,7 +9590,7 @@
       {
         "itemId": 2593,
         "name": "Black platelegs (g)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_platelegs_(g)"
@@ -9598,7 +9598,7 @@
       {
         "itemId": 3473,
         "name": "Black plateskirt (g)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_plateskirt_(g)"
@@ -9606,7 +9606,7 @@
       {
         "itemId": 2597,
         "name": "Black kiteshield (g)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_kiteshield_(g)"
@@ -9614,7 +9614,7 @@
       {
         "itemId": 7362,
         "name": "Studded body (g)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Studded_body_(g)"
@@ -9622,7 +9622,7 @@
       {
         "itemId": 7366,
         "name": "Studded chaps (g)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Studded_chaps_(g)"
@@ -9630,7 +9630,7 @@
       {
         "itemId": 23381,
         "name": "Leather body (g)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Leather_body_(g)"
@@ -9638,7 +9638,7 @@
       {
         "itemId": 23384,
         "name": "Leather chaps (g)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Leather_chaps_(g)"
@@ -9646,7 +9646,7 @@
       {
         "itemId": 7332,
         "name": "Black shield (h1)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_shield_(h1)"
@@ -9654,7 +9654,7 @@
       {
         "itemId": 7338,
         "name": "Black shield (h2)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_shield_(h2)"
@@ -9662,7 +9662,7 @@
       {
         "itemId": 7344,
         "name": "Black shield (h3)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_shield_(h3)"
@@ -9670,7 +9670,7 @@
       {
         "itemId": 7350,
         "name": "Black shield (h4)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_shield_(h4)"
@@ -9678,7 +9678,7 @@
       {
         "itemId": 7356,
         "name": "Black shield (h5)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_shield_(h5)"
@@ -9686,7 +9686,7 @@
       {
         "itemId": 10306,
         "name": "Black helm (h1)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_helm_(h1)"
@@ -9694,7 +9694,7 @@
       {
         "itemId": 10308,
         "name": "Black helm (h2)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_helm_(h2)"
@@ -9702,7 +9702,7 @@
       {
         "itemId": 10310,
         "name": "Black helm (h3)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_helm_(h3)"
@@ -9710,7 +9710,7 @@
       {
         "itemId": 10312,
         "name": "Black helm (h4)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_helm_(h4)"
@@ -9718,7 +9718,7 @@
       {
         "itemId": 10314,
         "name": "Black helm (h5)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_helm_(h5)"
@@ -9726,7 +9726,7 @@
       {
         "itemId": 23366,
         "name": "Black platebody (h1)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_platebody_(h1)"
@@ -9734,7 +9734,7 @@
       {
         "itemId": 23369,
         "name": "Black platebody (h2)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_platebody_(h2)"
@@ -9742,7 +9742,7 @@
       {
         "itemId": 23372,
         "name": "Black platebody (h3)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_platebody_(h3)"
@@ -9750,7 +9750,7 @@
       {
         "itemId": 23375,
         "name": "Black platebody (h4)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_platebody_(h4)"
@@ -9758,7 +9758,7 @@
       {
         "itemId": 23378,
         "name": "Black platebody (h5)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_platebody_(h5)"
@@ -9766,7 +9766,7 @@
       {
         "itemId": 7394,
         "name": "Blue wizard hat (g)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Blue_wizard_hat_(g)"
@@ -9774,7 +9774,7 @@
       {
         "itemId": 7390,
         "name": "Blue wizard robe (g)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Blue_wizard_robe_(g)"
@@ -9782,7 +9782,7 @@
       {
         "itemId": 7386,
         "name": "Blue skirt (g)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Blue_skirt_(g)"
@@ -9790,7 +9790,7 @@
       {
         "itemId": 7396,
         "name": "Blue wizard hat (t)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Blue_wizard_hat_(t)"
@@ -9798,7 +9798,7 @@
       {
         "itemId": 7392,
         "name": "Blue wizard robe (t)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Blue_wizard_robe_(t)"
@@ -9806,7 +9806,7 @@
       {
         "itemId": 7388,
         "name": "Blue skirt (t)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Blue_skirt_(t)"
@@ -9814,7 +9814,7 @@
       {
         "itemId": 12453,
         "name": "Black wizard hat (g)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_wizard_hat_(g)"
@@ -9822,7 +9822,7 @@
       {
         "itemId": 12449,
         "name": "Black wizard robe (g)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_wizard_robe_(g)"
@@ -9830,7 +9830,7 @@
       {
         "itemId": 12445,
         "name": "Black skirt (g)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_skirt_(g)"
@@ -9838,7 +9838,7 @@
       {
         "itemId": 12455,
         "name": "Black wizard hat (t)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_wizard_hat_(t)"
@@ -9846,7 +9846,7 @@
       {
         "itemId": 12451,
         "name": "Black wizard robe (t)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_wizard_robe_(t)"
@@ -9854,7 +9854,7 @@
       {
         "itemId": 12447,
         "name": "Black skirt (t)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_skirt_(t)"
@@ -9862,7 +9862,7 @@
       {
         "itemId": 10404,
         "name": "Red elegant shirt",
-        "dropRate": 0.007692,
+        "dropRate": 0.001068,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Red_elegant_shirt"
@@ -9870,7 +9870,7 @@
       {
         "itemId": 10424,
         "name": "Red elegant blouse",
-        "dropRate": 0.007692,
+        "dropRate": 0.001068,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Red_elegant_blouse"
@@ -9878,7 +9878,7 @@
       {
         "itemId": 10406,
         "name": "Red elegant legs",
-        "dropRate": 0.007692,
+        "dropRate": 0.001068,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Red_elegant_legs"
@@ -9886,7 +9886,7 @@
       {
         "itemId": 10426,
         "name": "Red elegant skirt",
-        "dropRate": 0.007692,
+        "dropRate": 0.001068,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Red_elegant_skirt"
@@ -9894,7 +9894,7 @@
       {
         "itemId": 10412,
         "name": "Green elegant shirt",
-        "dropRate": 0.007692,
+        "dropRate": 0.001068,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Green_elegant_shirt"
@@ -9902,7 +9902,7 @@
       {
         "itemId": 10432,
         "name": "Green elegant blouse",
-        "dropRate": 0.007692,
+        "dropRate": 0.001068,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Green_elegant_blouse"
@@ -9910,7 +9910,7 @@
       {
         "itemId": 10414,
         "name": "Green elegant legs",
-        "dropRate": 0.007692,
+        "dropRate": 0.001068,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Green_elegant_legs"
@@ -9918,7 +9918,7 @@
       {
         "itemId": 10434,
         "name": "Green elegant skirt",
-        "dropRate": 0.007692,
+        "dropRate": 0.001068,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Green_elegant_skirt"
@@ -9926,7 +9926,7 @@
       {
         "itemId": 10408,
         "name": "Blue elegant shirt",
-        "dropRate": 0.007692,
+        "dropRate": 0.001068,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Blue_elegant_shirt"
@@ -9934,7 +9934,7 @@
       {
         "itemId": 10428,
         "name": "Blue elegant blouse",
-        "dropRate": 0.007692,
+        "dropRate": 0.001068,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Blue_elegant_blouse"
@@ -9942,7 +9942,7 @@
       {
         "itemId": 10410,
         "name": "Blue elegant legs",
-        "dropRate": 0.007692,
+        "dropRate": 0.001068,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Blue_elegant_legs"
@@ -9950,7 +9950,7 @@
       {
         "itemId": 10430,
         "name": "Blue elegant skirt",
-        "dropRate": 0.007692,
+        "dropRate": 0.001068,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Blue_elegant_skirt"
@@ -9958,7 +9958,7 @@
       {
         "itemId": 10458,
         "name": "Saradomin robe top",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Saradomin_robe_top"
@@ -9966,7 +9966,7 @@
       {
         "itemId": 10464,
         "name": "Saradomin robe legs",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Saradomin_robe_legs"
@@ -9974,7 +9974,7 @@
       {
         "itemId": 10462,
         "name": "Guthix robe top",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Guthix_robe_top"
@@ -9982,7 +9982,7 @@
       {
         "itemId": 10466,
         "name": "Guthix robe legs",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Guthix_robe_legs"
@@ -9990,7 +9990,7 @@
       {
         "itemId": 10460,
         "name": "Zamorak robe top",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Zamorak_robe_top"
@@ -9998,7 +9998,7 @@
       {
         "itemId": 10468,
         "name": "Zamorak robe legs",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Zamorak_robe_legs"
@@ -10006,7 +10006,7 @@
       {
         "itemId": 12193,
         "name": "Ancient robe top",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ancient_robe_top"
@@ -10014,7 +10014,7 @@
       {
         "itemId": 12195,
         "name": "Ancient robe legs",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ancient_robe_legs"
@@ -10022,7 +10022,7 @@
       {
         "itemId": 12253,
         "name": "Armadyl robe top",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Armadyl_robe_top"
@@ -10030,7 +10030,7 @@
       {
         "itemId": 12255,
         "name": "Armadyl robe legs",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Armadyl_robe_legs"
@@ -10038,7 +10038,7 @@
       {
         "itemId": 12265,
         "name": "Bandos robe top",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bandos_robe_top"
@@ -10046,7 +10046,7 @@
       {
         "itemId": 12267,
         "name": "Bandos robe legs",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bandos_robe_legs"
@@ -10054,7 +10054,7 @@
       {
         "itemId": 10280,
         "name": "Willow comp bow",
-        "dropRate": 0.007692,
+        "dropRate": 0.00831,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Willow_comp_bow"
@@ -10062,7 +10062,7 @@
       {
         "itemId": 10366,
         "name": "Amulet of magic (t)",
-        "dropRate": 0.007692,
+        "dropRate": 0.00831,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Amulet_of_magic_(t)"
@@ -10070,7 +10070,7 @@
       {
         "itemId": 20211,
         "name": "Team cape zero",
-        "dropRate": 0.007692,
+        "dropRate": 0.000534,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Team_cape_zero"
@@ -10078,7 +10078,7 @@
       {
         "itemId": 20217,
         "name": "Team cape i",
-        "dropRate": 0.007692,
+        "dropRate": 0.000534,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Team_cape_i"
@@ -10086,7 +10086,7 @@
       {
         "itemId": 20214,
         "name": "Team cape x",
-        "dropRate": 0.007692,
+        "dropRate": 0.000534,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Team_cape_x"
@@ -10094,7 +10094,7 @@
       {
         "itemId": 23351,
         "name": "Cape of skulls",
-        "dropRate": 0.007692,
+        "dropRate": 0.000534,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Cape_of_skulls"
@@ -10102,7 +10102,7 @@
       {
         "itemId": 20205,
         "name": "Golden chef's hat",
-        "dropRate": 0.007692,
+        "dropRate": 0.001068,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Golden_chef%27s_hat"
@@ -10110,7 +10110,7 @@
       {
         "itemId": 20208,
         "name": "Golden apron",
-        "dropRate": 0.007692,
+        "dropRate": 0.001068,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Golden_apron"
@@ -10118,7 +10118,7 @@
       {
         "itemId": 20166,
         "name": "Wooden shield (g)",
-        "dropRate": 0.007692,
+        "dropRate": 0.000534,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Wooden_shield_(g)"
@@ -10126,7 +10126,7 @@
       {
         "itemId": 20199,
         "name": "Monk's robe top (g)",
-        "dropRate": 0.007692,
+        "dropRate": 0.000214,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Monk%27s_robe_top_(g)"
@@ -10134,7 +10134,7 @@
       {
         "itemId": 20202,
         "name": "Monk's robe (g)",
-        "dropRate": 0.007692,
+        "dropRate": 0.000214,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Monk%27s_robe_(g)"
@@ -10142,7 +10142,7 @@
       {
         "itemId": 10316,
         "name": "Bob's red shirt",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bob%27s_red_shirt"
@@ -10150,7 +10150,7 @@
       {
         "itemId": 10320,
         "name": "Bob's green shirt",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bob%27s_green_shirt"
@@ -10158,7 +10158,7 @@
       {
         "itemId": 10318,
         "name": "Bob's blue shirt",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bob%27s_blue_shirt"
@@ -10166,7 +10166,7 @@
       {
         "itemId": 10322,
         "name": "Bob's black shirt",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bob%27s_black_shirt"
@@ -10174,7 +10174,7 @@
       {
         "itemId": 10324,
         "name": "Bob's purple shirt",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bob%27s_purple_shirt"
@@ -10182,7 +10182,7 @@
       {
         "itemId": 2631,
         "name": "Highwayman mask",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Highwayman_mask"
@@ -10190,7 +10190,7 @@
       {
         "itemId": 2633,
         "name": "Blue beret",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Blue_beret"
@@ -10198,7 +10198,7 @@
       {
         "itemId": 2635,
         "name": "Black beret",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_beret"
@@ -10206,7 +10206,7 @@
       {
         "itemId": 12247,
         "name": "Red beret",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Red_beret"
@@ -10214,7 +10214,7 @@
       {
         "itemId": 2637,
         "name": "White beret",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "White_beret"
@@ -10222,7 +10222,7 @@
       {
         "itemId": 10392,
         "name": "A powdered wig",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "A_powdered_wig"
@@ -10230,7 +10230,7 @@
       {
         "itemId": 12245,
         "name": "Beanie",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Beanie"
@@ -10238,7 +10238,7 @@
       {
         "itemId": 12249,
         "name": "Imp mask",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Imp_mask"
@@ -10246,7 +10246,7 @@
       {
         "itemId": 12251,
         "name": "Goblin mask",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Goblin_mask"
@@ -10254,7 +10254,7 @@
       {
         "itemId": 10398,
         "name": "Sleeping cap",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Sleeping_cap"
@@ -10262,7 +10262,7 @@
       {
         "itemId": 10394,
         "name": "Flared trousers",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Flared_trousers"
@@ -10270,7 +10270,7 @@
       {
         "itemId": 10396,
         "name": "Pantaloons",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Pantaloons"
@@ -10278,7 +10278,7 @@
       {
         "itemId": 12375,
         "name": "Black cane",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_cane"
@@ -10286,7 +10286,7 @@
       {
         "itemId": 23363,
         "name": "Staff of bob the cat",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Staff_of_bob_the_cat"
@@ -10294,7 +10294,7 @@
       {
         "itemId": 23354,
         "name": "Amulet of power (t)",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Amulet_of_power_(t)"
@@ -10302,7 +10302,7 @@
       {
         "itemId": 23360,
         "name": "Ham joint",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ham_joint"
@@ -10310,7 +10310,7 @@
       {
         "itemId": 23357,
         "name": "Rain bow",
-        "dropRate": 0.007692,
+        "dropRate": 0.002135,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Rain_bow"
@@ -10337,7 +10337,7 @@
       {
         "itemId": 2577,
         "name": "Ranger boots",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ranger_boots"
@@ -10345,7 +10345,7 @@
       {
         "itemId": 2579,
         "name": "Wizard boots",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Wizard_boots"
@@ -10353,7 +10353,7 @@
       {
         "itemId": 12598,
         "name": "Holy sandals",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Holy_sandals"
@@ -10361,7 +10361,7 @@
       {
         "itemId": 23389,
         "name": "Spiked manacles",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Spiked_manacles"
@@ -10369,7 +10369,7 @@
       {
         "itemId": 23413,
         "name": "Climbing boots (g)",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Climbing_boots_(g)"
@@ -10377,7 +10377,7 @@
       {
         "itemId": 2605,
         "name": "Adamant full helm (t)",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Adamant_full_helm_(t)"
@@ -10385,7 +10385,7 @@
       {
         "itemId": 2599,
         "name": "Adamant platebody (t)",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Adamant_platebody_(t)"
@@ -10393,7 +10393,7 @@
       {
         "itemId": 2601,
         "name": "Adamant platelegs (t)",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Adamant_platelegs_(t)"
@@ -10401,7 +10401,7 @@
       {
         "itemId": 3474,
         "name": "Adamant plateskirt (t)",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Adamant_plateskirt_(t)"
@@ -10409,7 +10409,7 @@
       {
         "itemId": 2603,
         "name": "Adamant kiteshield (t)",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Adamant_kiteshield_(t)"
@@ -10417,7 +10417,7 @@
       {
         "itemId": 2613,
         "name": "Adamant full helm (g)",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Adamant_full_helm_(g)"
@@ -10425,7 +10425,7 @@
       {
         "itemId": 2607,
         "name": "Adamant platebody (g)",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Adamant_platebody_(g)"
@@ -10433,7 +10433,7 @@
       {
         "itemId": 2609,
         "name": "Adamant platelegs (g)",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Adamant_platelegs_(g)"
@@ -10441,7 +10441,7 @@
       {
         "itemId": 3475,
         "name": "Adamant plateskirt (g)",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Adamant_plateskirt_(g)"
@@ -10449,7 +10449,7 @@
       {
         "itemId": 2611,
         "name": "Adamant kiteshield (g)",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Adamant_kiteshield_(g)"
@@ -10457,7 +10457,7 @@
       {
         "itemId": 7334,
         "name": "Adamant shield (h1)",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Adamant_shield_(h1)"
@@ -10465,7 +10465,7 @@
       {
         "itemId": 7340,
         "name": "Adamant shield (h2)",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Adamant_shield_(h2)"
@@ -10473,7 +10473,7 @@
       {
         "itemId": 7346,
         "name": "Adamant shield (h3)",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Adamant_shield_(h3)"
@@ -10481,7 +10481,7 @@
       {
         "itemId": 7352,
         "name": "Adamant shield (h4)",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Adamant_shield_(h4)"
@@ -10489,7 +10489,7 @@
       {
         "itemId": 7358,
         "name": "Adamant shield (h5)",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Adamant_shield_(h5)"
@@ -10497,7 +10497,7 @@
       {
         "itemId": 10296,
         "name": "Adamant helm (h1)",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Adamant_helm_(h1)"
@@ -10505,7 +10505,7 @@
       {
         "itemId": 10298,
         "name": "Adamant helm (h2)",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Adamant_helm_(h2)"
@@ -10513,7 +10513,7 @@
       {
         "itemId": 10300,
         "name": "Adamant helm (h3)",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Adamant_helm_(h3)"
@@ -10521,7 +10521,7 @@
       {
         "itemId": 10302,
         "name": "Adamant helm (h4)",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Adamant_helm_(h4)"
@@ -10529,7 +10529,7 @@
       {
         "itemId": 10304,
         "name": "Adamant helm (h5)",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Adamant_helm_(h5)"
@@ -10537,7 +10537,7 @@
       {
         "itemId": 23392,
         "name": "Adamant platebody (h1)",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Adamant_platebody_(h1)"
@@ -10545,7 +10545,7 @@
       {
         "itemId": 23395,
         "name": "Adamant platebody (h2)",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Adamant_platebody_(h2)"
@@ -10553,7 +10553,7 @@
       {
         "itemId": 23398,
         "name": "Adamant platebody (h3)",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Adamant_platebody_(h3)"
@@ -10561,7 +10561,7 @@
       {
         "itemId": 23401,
         "name": "Adamant platebody (h4)",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Adamant_platebody_(h4)"
@@ -10569,7 +10569,7 @@
       {
         "itemId": 23404,
         "name": "Adamant platebody (h5)",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Adamant_platebody_(h5)"
@@ -10577,7 +10577,7 @@
       {
         "itemId": 12293,
         "name": "Mithril full helm (t)",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Mithril_full_helm_(t)"
@@ -10585,7 +10585,7 @@
       {
         "itemId": 12287,
         "name": "Mithril platebody (t)",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Mithril_platebody_(t)"
@@ -10593,7 +10593,7 @@
       {
         "itemId": 12289,
         "name": "Mithril platelegs (t)",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Mithril_platelegs_(t)"
@@ -10601,7 +10601,7 @@
       {
         "itemId": 12295,
         "name": "Mithril plateskirt (t)",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Mithril_plateskirt_(t)"
@@ -10609,7 +10609,7 @@
       {
         "itemId": 12291,
         "name": "Mithril kiteshield (t)",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Mithril_kiteshield_(t)"
@@ -10617,7 +10617,7 @@
       {
         "itemId": 12283,
         "name": "Mithril full helm (g)",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Mithril_full_helm_(g)"
@@ -10625,7 +10625,7 @@
       {
         "itemId": 12277,
         "name": "Mithril platebody (g)",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Mithril_platebody_(g)"
@@ -10633,7 +10633,7 @@
       {
         "itemId": 12279,
         "name": "Mithril platelegs (g)",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Mithril_platelegs_(g)"
@@ -10641,7 +10641,7 @@
       {
         "itemId": 12285,
         "name": "Mithril plateskirt (g)",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Mithril_plateskirt_(g)"
@@ -10649,7 +10649,7 @@
       {
         "itemId": 12281,
         "name": "Mithril kiteshield (g)",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Mithril_kiteshield_(g)"
@@ -10657,7 +10657,7 @@
       {
         "itemId": 7370,
         "name": "Green d'hide body (g)",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Green_d%27hide_body_(g)"
@@ -10665,7 +10665,7 @@
       {
         "itemId": 7372,
         "name": "Green d'hide body (t)",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Green_d%27hide_body_(t)"
@@ -10673,7 +10673,7 @@
       {
         "itemId": 7378,
         "name": "Green d'hide chaps (g)",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Green_d%27hide_chaps_(g)"
@@ -10681,7 +10681,7 @@
       {
         "itemId": 7380,
         "name": "Green d'hide chaps (t)",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Green_d%27hide_chaps_(t)"
@@ -10689,7 +10689,7 @@
       {
         "itemId": 10452,
         "name": "Saradomin mitre",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Saradomin_mitre"
@@ -10697,7 +10697,7 @@
       {
         "itemId": 10446,
         "name": "Saradomin cloak",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Saradomin_cloak"
@@ -10705,7 +10705,7 @@
       {
         "itemId": 10454,
         "name": "Guthix mitre",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Guthix_mitre"
@@ -10713,7 +10713,7 @@
       {
         "itemId": 10448,
         "name": "Guthix cloak",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Guthix_cloak"
@@ -10721,7 +10721,7 @@
       {
         "itemId": 10456,
         "name": "Zamorak mitre",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Zamorak_mitre"
@@ -10729,7 +10729,7 @@
       {
         "itemId": 10450,
         "name": "Zamorak cloak",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Zamorak_cloak"
@@ -10737,7 +10737,7 @@
       {
         "itemId": 12203,
         "name": "Ancient mitre",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ancient_mitre"
@@ -10745,7 +10745,7 @@
       {
         "itemId": 12197,
         "name": "Ancient cloak",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ancient_cloak"
@@ -10753,7 +10753,7 @@
       {
         "itemId": 12201,
         "name": "Ancient stole",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ancient_stole"
@@ -10761,7 +10761,7 @@
       {
         "itemId": 12199,
         "name": "Ancient crozier",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ancient_crozier"
@@ -10769,7 +10769,7 @@
       {
         "itemId": 12259,
         "name": "Armadyl mitre",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Armadyl_mitre"
@@ -10777,7 +10777,7 @@
       {
         "itemId": 12261,
         "name": "Armadyl cloak",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Armadyl_cloak"
@@ -10785,7 +10785,7 @@
       {
         "itemId": 12257,
         "name": "Armadyl stole",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Armadyl_stole"
@@ -10793,7 +10793,7 @@
       {
         "itemId": 12263,
         "name": "Armadyl crozier",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Armadyl_crozier"
@@ -10801,7 +10801,7 @@
       {
         "itemId": 12271,
         "name": "Bandos mitre",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bandos_mitre"
@@ -10809,7 +10809,7 @@
       {
         "itemId": 12273,
         "name": "Bandos cloak",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bandos_cloak"
@@ -10817,7 +10817,7 @@
       {
         "itemId": 12269,
         "name": "Bandos stole",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bandos_stole"
@@ -10825,7 +10825,7 @@
       {
         "itemId": 12275,
         "name": "Bandos crozier",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bandos_crozier"
@@ -10833,7 +10833,7 @@
       {
         "itemId": 7319,
         "name": "Red boater",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Red_boater"
@@ -10841,7 +10841,7 @@
       {
         "itemId": 7323,
         "name": "Green boater",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Green_boater"
@@ -10849,7 +10849,7 @@
       {
         "itemId": 7321,
         "name": "Orange boater",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Orange_boater"
@@ -10857,7 +10857,7 @@
       {
         "itemId": 7327,
         "name": "Black boater",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_boater"
@@ -10865,7 +10865,7 @@
       {
         "itemId": 7325,
         "name": "Blue boater",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Blue_boater"
@@ -10873,7 +10873,7 @@
       {
         "itemId": 12309,
         "name": "Pink boater",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Pink_boater"
@@ -10881,7 +10881,7 @@
       {
         "itemId": 12311,
         "name": "Purple boater",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Purple_boater"
@@ -10889,7 +10889,7 @@
       {
         "itemId": 12313,
         "name": "White boater",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "White_boater"
@@ -10897,7 +10897,7 @@
       {
         "itemId": 2645,
         "name": "Red headband",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Red_headband"
@@ -10905,7 +10905,7 @@
       {
         "itemId": 2647,
         "name": "Black headband",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_headband"
@@ -10913,7 +10913,7 @@
       {
         "itemId": 2649,
         "name": "Brown headband",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Brown_headband"
@@ -10921,7 +10921,7 @@
       {
         "itemId": 12299,
         "name": "White headband",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "White_headband"
@@ -10929,7 +10929,7 @@
       {
         "itemId": 12301,
         "name": "Blue headband",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Blue_headband"
@@ -10937,7 +10937,7 @@
       {
         "itemId": 12303,
         "name": "Gold headband",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gold_headband"
@@ -10945,7 +10945,7 @@
       {
         "itemId": 12305,
         "name": "Pink headband",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Pink_headband"
@@ -10953,7 +10953,7 @@
       {
         "itemId": 12307,
         "name": "Green headband",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Green_headband"
@@ -10961,7 +10961,7 @@
       {
         "itemId": 12319,
         "name": "Crier hat",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Crier_hat"
@@ -10969,7 +10969,7 @@
       {
         "itemId": 20240,
         "name": "Crier coat",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Crier_coat"
@@ -10977,7 +10977,7 @@
       {
         "itemId": 20243,
         "name": "Crier bell",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Crier_bell"
@@ -10985,7 +10985,7 @@
       {
         "itemId": 12377,
         "name": "Adamant cane",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Adamant_cane"
@@ -10993,7 +10993,7 @@
       {
         "itemId": 20251,
         "name": "Arceuus banner",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Arceuus_banner"
@@ -11001,7 +11001,7 @@
       {
         "itemId": 20260,
         "name": "Piscarilius banner",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Piscarilius_banner"
@@ -11009,7 +11009,7 @@
       {
         "itemId": 20254,
         "name": "Hosidius banner",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Hosidius_banner"
@@ -11017,7 +11017,7 @@
       {
         "itemId": 20263,
         "name": "Shayzien banner",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Shayzien_banner"
@@ -11025,7 +11025,7 @@
       {
         "itemId": 20257,
         "name": "Lovakengj banner",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Lovakengj_banner"
@@ -11033,7 +11033,7 @@
       {
         "itemId": 20272,
         "name": "Cabbage round shield",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Cabbage_round_shield"
@@ -11041,7 +11041,7 @@
       {
         "itemId": 20266,
         "name": "Black unicorn mask",
-        "dropRate": 0.008772,
+        "dropRate": 0.001764,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_unicorn_mask"
@@ -11049,7 +11049,7 @@
       {
         "itemId": 20269,
         "name": "White unicorn mask",
-        "dropRate": 0.008772,
+        "dropRate": 0.001764,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "White_unicorn_mask"
@@ -11057,7 +11057,7 @@
       {
         "itemId": 12361,
         "name": "Cat mask",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Cat_mask"
@@ -11065,7 +11065,7 @@
       {
         "itemId": 12428,
         "name": "Penguin mask",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Penguin_mask"
@@ -11073,7 +11073,7 @@
       {
         "itemId": 12359,
         "name": "Leprechaun hat",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Leprechaun_hat"
@@ -11081,7 +11081,7 @@
       {
         "itemId": 20246,
         "name": "Black leprechaun hat",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_leprechaun_hat"
@@ -11089,7 +11089,7 @@
       {
         "itemId": 23407,
         "name": "Wolf mask",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Wolf_mask"
@@ -11097,7 +11097,7 @@
       {
         "itemId": 23410,
         "name": "Wolf cloak",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Wolf_cloak"
@@ -11105,7 +11105,7 @@
       {
         "itemId": 10416,
         "name": "Purple elegant shirt",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Purple_elegant_shirt"
@@ -11113,7 +11113,7 @@
       {
         "itemId": 10436,
         "name": "Purple elegant blouse",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Purple_elegant_blouse"
@@ -11121,7 +11121,7 @@
       {
         "itemId": 10418,
         "name": "Purple elegant legs",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Purple_elegant_legs"
@@ -11129,7 +11129,7 @@
       {
         "itemId": 10438,
         "name": "Purple elegant skirt",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Purple_elegant_skirt"
@@ -11137,7 +11137,7 @@
       {
         "itemId": 10400,
         "name": "Black elegant shirt",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_elegant_shirt"
@@ -11145,7 +11145,7 @@
       {
         "itemId": 10402,
         "name": "Black elegant legs",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_elegant_legs"
@@ -11153,7 +11153,7 @@
       {
         "itemId": 10420,
         "name": "White elegant blouse",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "White_elegant_blouse"
@@ -11161,7 +11161,7 @@
       {
         "itemId": 10422,
         "name": "White elegant skirt",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "White_elegant_skirt"
@@ -11169,7 +11169,7 @@
       {
         "itemId": 12315,
         "name": "Pink elegant shirt",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Pink_elegant_shirt"
@@ -11177,7 +11177,7 @@
       {
         "itemId": 12339,
         "name": "Pink elegant blouse",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Pink_elegant_blouse"
@@ -11185,7 +11185,7 @@
       {
         "itemId": 12317,
         "name": "Pink elegant legs",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Pink_elegant_legs"
@@ -11193,7 +11193,7 @@
       {
         "itemId": 12341,
         "name": "Pink elegant skirt",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Pink_elegant_skirt"
@@ -11201,7 +11201,7 @@
       {
         "itemId": 12347,
         "name": "Gold elegant shirt",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gold_elegant_shirt"
@@ -11209,7 +11209,7 @@
       {
         "itemId": 12343,
         "name": "Gold elegant blouse",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gold_elegant_blouse"
@@ -11217,7 +11217,7 @@
       {
         "itemId": 12349,
         "name": "Gold elegant legs",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gold_elegant_legs"
@@ -11225,7 +11225,7 @@
       {
         "itemId": 12345,
         "name": "Gold elegant skirt",
-        "dropRate": 0.008772,
+        "dropRate": 0.003526,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gold_elegant_skirt"
@@ -11233,7 +11233,7 @@
       {
         "itemId": 10282,
         "name": "Yew comp bow",
-        "dropRate": 0.008772,
+        "dropRate": 0.011679,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Yew_comp_bow"
@@ -11241,7 +11241,7 @@
       {
         "itemId": 10364,
         "name": "Strength amulet (t)",
-        "dropRate": 0.008772,
+        "dropRate": 0.011679,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Strength_amulet_(t)"
@@ -11268,7 +11268,7 @@
       {
         "itemId": 2657,
         "name": "Zamorak full helm",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Zamorak_full_helm"
@@ -11276,7 +11276,7 @@
       {
         "itemId": 2653,
         "name": "Zamorak platebody",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Zamorak_platebody"
@@ -11284,7 +11284,7 @@
       {
         "itemId": 2655,
         "name": "Zamorak platelegs",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Zamorak_platelegs"
@@ -11292,7 +11292,7 @@
       {
         "itemId": 3478,
         "name": "Zamorak plateskirt",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Zamorak_plateskirt"
@@ -11300,7 +11300,7 @@
       {
         "itemId": 2659,
         "name": "Zamorak kiteshield",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Zamorak_kiteshield"
@@ -11308,7 +11308,7 @@
       {
         "itemId": 2673,
         "name": "Guthix full helm",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Guthix_full_helm"
@@ -11316,7 +11316,7 @@
       {
         "itemId": 2669,
         "name": "Guthix platebody",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Guthix_platebody"
@@ -11324,7 +11324,7 @@
       {
         "itemId": 2671,
         "name": "Guthix platelegs",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Guthix_platelegs"
@@ -11332,7 +11332,7 @@
       {
         "itemId": 3480,
         "name": "Guthix plateskirt",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Guthix_plateskirt"
@@ -11340,7 +11340,7 @@
       {
         "itemId": 2675,
         "name": "Guthix kiteshield",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Guthix_kiteshield"
@@ -11348,7 +11348,7 @@
       {
         "itemId": 2665,
         "name": "Saradomin full helm",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Saradomin_full_helm"
@@ -11356,7 +11356,7 @@
       {
         "itemId": 2661,
         "name": "Saradomin platebody",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Saradomin_platebody"
@@ -11364,7 +11364,7 @@
       {
         "itemId": 2663,
         "name": "Saradomin platelegs",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Saradomin_platelegs"
@@ -11372,7 +11372,7 @@
       {
         "itemId": 3479,
         "name": "Saradomin plateskirt",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Saradomin_plateskirt"
@@ -11380,7 +11380,7 @@
       {
         "itemId": 2667,
         "name": "Saradomin kiteshield",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Saradomin_kiteshield"
@@ -11388,7 +11388,7 @@
       {
         "itemId": 12466,
         "name": "Ancient full helm",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ancient_full_helm"
@@ -11396,7 +11396,7 @@
       {
         "itemId": 12460,
         "name": "Ancient platebody",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ancient_platebody"
@@ -11404,7 +11404,7 @@
       {
         "itemId": 12462,
         "name": "Ancient platelegs",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ancient_platelegs"
@@ -11412,7 +11412,7 @@
       {
         "itemId": 12464,
         "name": "Ancient plateskirt",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ancient_plateskirt"
@@ -11420,7 +11420,7 @@
       {
         "itemId": 12468,
         "name": "Ancient kiteshield",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ancient_kiteshield"
@@ -11428,7 +11428,7 @@
       {
         "itemId": 12476,
         "name": "Armadyl full helm",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Armadyl_full_helm"
@@ -11436,7 +11436,7 @@
       {
         "itemId": 12470,
         "name": "Armadyl platebody",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Armadyl_platebody"
@@ -11444,7 +11444,7 @@
       {
         "itemId": 12472,
         "name": "Armadyl platelegs",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Armadyl_platelegs"
@@ -11452,7 +11452,7 @@
       {
         "itemId": 12474,
         "name": "Armadyl plateskirt",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Armadyl_plateskirt"
@@ -11460,7 +11460,7 @@
       {
         "itemId": 12478,
         "name": "Armadyl kiteshield",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Armadyl_kiteshield"
@@ -11468,7 +11468,7 @@
       {
         "itemId": 12486,
         "name": "Bandos full helm",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bandos_full_helm"
@@ -11476,7 +11476,7 @@
       {
         "itemId": 12480,
         "name": "Bandos platebody",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bandos_platebody"
@@ -11484,7 +11484,7 @@
       {
         "itemId": 12482,
         "name": "Bandos platelegs",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bandos_platelegs"
@@ -11492,7 +11492,7 @@
       {
         "itemId": 12484,
         "name": "Bandos plateskirt",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bandos_plateskirt"
@@ -11500,7 +11500,7 @@
       {
         "itemId": 12488,
         "name": "Bandos kiteshield",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bandos_kiteshield"
@@ -11508,7 +11508,7 @@
       {
         "itemId": 10286,
         "name": "Rune helm (h1)",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Rune_helm_(h1)"
@@ -11516,7 +11516,7 @@
       {
         "itemId": 10288,
         "name": "Rune helm (h2)",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Rune_helm_(h2)"
@@ -11524,7 +11524,7 @@
       {
         "itemId": 10290,
         "name": "Rune helm (h3)",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Rune_helm_(h3)"
@@ -11532,7 +11532,7 @@
       {
         "itemId": 10292,
         "name": "Rune helm (h4)",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Rune_helm_(h4)"
@@ -11540,7 +11540,7 @@
       {
         "itemId": 10294,
         "name": "Rune helm (h5)",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Rune_helm_(h5)"
@@ -11548,7 +11548,7 @@
       {
         "itemId": 7336,
         "name": "Rune shield (h1)",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Rune_shield_(h1)"
@@ -11556,7 +11556,7 @@
       {
         "itemId": 7342,
         "name": "Rune shield (h2)",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Rune_shield_(h2)"
@@ -11564,7 +11564,7 @@
       {
         "itemId": 7348,
         "name": "Rune shield (h3)",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Rune_shield_(h3)"
@@ -11572,7 +11572,7 @@
       {
         "itemId": 7354,
         "name": "Rune shield (h4)",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Rune_shield_(h4)"
@@ -11580,7 +11580,7 @@
       {
         "itemId": 7360,
         "name": "Rune shield (h5)",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Rune_shield_(h5)"
@@ -11588,7 +11588,7 @@
       {
         "itemId": 23209,
         "name": "Rune platebody (h1)",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Rune_platebody_(h1)"
@@ -11596,7 +11596,7 @@
       {
         "itemId": 23212,
         "name": "Rune platebody (h2)",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Rune_platebody_(h2)"
@@ -11604,7 +11604,7 @@
       {
         "itemId": 23215,
         "name": "Rune platebody (h3)",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Rune_platebody_(h3)"
@@ -11612,7 +11612,7 @@
       {
         "itemId": 23218,
         "name": "Rune platebody (h4)",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Rune_platebody_(h4)"
@@ -11620,7 +11620,7 @@
       {
         "itemId": 23221,
         "name": "Rune platebody (h5)",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Rune_platebody_(h5)"
@@ -11628,7 +11628,7 @@
       {
         "itemId": 2627,
         "name": "Rune full helm (t)",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Rune_full_helm_(t)"
@@ -11636,7 +11636,7 @@
       {
         "itemId": 2623,
         "name": "Rune platebody (t)",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Rune_platebody_(t)"
@@ -11644,7 +11644,7 @@
       {
         "itemId": 2625,
         "name": "Rune platelegs (t)",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Rune_platelegs_(t)"
@@ -11652,7 +11652,7 @@
       {
         "itemId": 3477,
         "name": "Rune plateskirt (t)",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Rune_plateskirt_(t)"
@@ -11660,7 +11660,7 @@
       {
         "itemId": 2629,
         "name": "Rune kiteshield (t)",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Rune_kiteshield_(t)"
@@ -11668,7 +11668,7 @@
       {
         "itemId": 2619,
         "name": "Rune full helm (g)",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Rune_full_helm_(g)"
@@ -11676,7 +11676,7 @@
       {
         "itemId": 2615,
         "name": "Rune platebody (g)",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Rune_platebody_(g)"
@@ -11684,7 +11684,7 @@
       {
         "itemId": 2617,
         "name": "Rune platelegs (g)",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Rune_platelegs_(g)"
@@ -11692,7 +11692,7 @@
       {
         "itemId": 3476,
         "name": "Rune plateskirt (g)",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Rune_plateskirt_(g)"
@@ -11700,7 +11700,7 @@
       {
         "itemId": 2621,
         "name": "Rune kiteshield (g)",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Rune_kiteshield_(g)"
@@ -11708,7 +11708,7 @@
       {
         "itemId": 10390,
         "name": "Saradomin coif",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Saradomin_coif"
@@ -11716,7 +11716,7 @@
       {
         "itemId": 10386,
         "name": "Saradomin d'hide body",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Saradomin_d%27hide_body"
@@ -11724,7 +11724,7 @@
       {
         "itemId": 10388,
         "name": "Saradomin chaps",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Saradomin_chaps"
@@ -11732,7 +11732,7 @@
       {
         "itemId": 10384,
         "name": "Saradomin bracers",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Saradomin_bracers"
@@ -11740,7 +11740,7 @@
       {
         "itemId": 19933,
         "name": "Saradomin d'hide boots",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Saradomin_d%27hide_boots"
@@ -11748,7 +11748,7 @@
       {
         "itemId": 23191,
         "name": "Saradomin d'hide shield",
-        "dropRate": 0.007463,
+        "dropRate": 0.000513,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Saradomin_d%27hide_shield"
@@ -11756,7 +11756,7 @@
       {
         "itemId": 10382,
         "name": "Guthix coif",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Guthix_coif"
@@ -11764,7 +11764,7 @@
       {
         "itemId": 10378,
         "name": "Guthix d'hide body",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Guthix_d%27hide_body"
@@ -11772,7 +11772,7 @@
       {
         "itemId": 10380,
         "name": "Guthix chaps",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Guthix_chaps"
@@ -11780,7 +11780,7 @@
       {
         "itemId": 10376,
         "name": "Guthix bracers",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Guthix_bracers"
@@ -11788,7 +11788,7 @@
       {
         "itemId": 19927,
         "name": "Guthix d'hide boots",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Guthix_d%27hide_boots"
@@ -11796,7 +11796,7 @@
       {
         "itemId": 23188,
         "name": "Guthix d'hide shield",
-        "dropRate": 0.007463,
+        "dropRate": 0.000513,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Guthix_d%27hide_shield"
@@ -11804,7 +11804,7 @@
       {
         "itemId": 10374,
         "name": "Zamorak coif",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Zamorak_coif"
@@ -11812,7 +11812,7 @@
       {
         "itemId": 10370,
         "name": "Zamorak d'hide body",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Zamorak_d%27hide_body"
@@ -11820,7 +11820,7 @@
       {
         "itemId": 10372,
         "name": "Zamorak chaps",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Zamorak_chaps"
@@ -11828,7 +11828,7 @@
       {
         "itemId": 10368,
         "name": "Zamorak bracers",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Zamorak_bracers"
@@ -11836,7 +11836,7 @@
       {
         "itemId": 19936,
         "name": "Zamorak d'hide boots",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Zamorak_d%27hide_boots"
@@ -11844,7 +11844,7 @@
       {
         "itemId": 23194,
         "name": "Zamorak d'hide shield",
-        "dropRate": 0.007463,
+        "dropRate": 0.000513,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Zamorak_d%27hide_shield"
@@ -11852,7 +11852,7 @@
       {
         "itemId": 12504,
         "name": "Bandos coif",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bandos_coif"
@@ -11860,7 +11860,7 @@
       {
         "itemId": 12500,
         "name": "Bandos d'hide body",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bandos_d%27hide_body"
@@ -11868,7 +11868,7 @@
       {
         "itemId": 12502,
         "name": "Bandos chaps",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bandos_chaps"
@@ -11876,7 +11876,7 @@
       {
         "itemId": 12498,
         "name": "Bandos bracers",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bandos_bracers"
@@ -11884,7 +11884,7 @@
       {
         "itemId": 19924,
         "name": "Bandos d'hide boots",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bandos_d%27hide_boots"
@@ -11892,7 +11892,7 @@
       {
         "itemId": 23203,
         "name": "Bandos d'hide shield",
-        "dropRate": 0.007463,
+        "dropRate": 0.000513,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bandos_d%27hide_shield"
@@ -11900,7 +11900,7 @@
       {
         "itemId": 12512,
         "name": "Armadyl coif",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Armadyl_coif"
@@ -11908,7 +11908,7 @@
       {
         "itemId": 12508,
         "name": "Armadyl d'hide body",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Armadyl_d%27hide_body"
@@ -11916,7 +11916,7 @@
       {
         "itemId": 12510,
         "name": "Armadyl chaps",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Armadyl_chaps"
@@ -11924,7 +11924,7 @@
       {
         "itemId": 12506,
         "name": "Armadyl bracers",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Armadyl_bracers"
@@ -11932,7 +11932,7 @@
       {
         "itemId": 19930,
         "name": "Armadyl d'hide boots",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Armadyl_d%27hide_boots"
@@ -11940,7 +11940,7 @@
       {
         "itemId": 23200,
         "name": "Armadyl d'hide shield",
-        "dropRate": 0.007463,
+        "dropRate": 0.000513,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Armadyl_d%27hide_shield"
@@ -11948,7 +11948,7 @@
       {
         "itemId": 12496,
         "name": "Ancient coif",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ancient_coif"
@@ -11956,7 +11956,7 @@
       {
         "itemId": 12492,
         "name": "Ancient d'hide body",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ancient_d%27hide_body"
@@ -11964,7 +11964,7 @@
       {
         "itemId": 12494,
         "name": "Ancient chaps",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ancient_chaps"
@@ -11972,7 +11972,7 @@
       {
         "itemId": 12490,
         "name": "Ancient bracers",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ancient_bracers"
@@ -11980,7 +11980,7 @@
       {
         "itemId": 19921,
         "name": "Ancient d'hide boots",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ancient_d%27hide_boots"
@@ -11988,7 +11988,7 @@
       {
         "itemId": 23197,
         "name": "Ancient d'hide shield",
-        "dropRate": 0.007463,
+        "dropRate": 0.000513,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ancient_d%27hide_shield"
@@ -11996,7 +11996,7 @@
       {
         "itemId": 12327,
         "name": "Red d'hide body (g)",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Red_d%27hide_body_(g)"
@@ -12004,7 +12004,7 @@
       {
         "itemId": 12331,
         "name": "Red d'hide body (t)",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Red_d%27hide_body_(t)"
@@ -12012,7 +12012,7 @@
       {
         "itemId": 12329,
         "name": "Red d'hide chaps (g)",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Red_d%27hide_chaps_(g)"
@@ -12020,7 +12020,7 @@
       {
         "itemId": 12333,
         "name": "Red d'hide chaps (t)",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Red_d%27hide_chaps_(t)"
@@ -12028,7 +12028,7 @@
       {
         "itemId": 7374,
         "name": "Blue d'hide body (g)",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Blue_d%27hide_body_(g)"
@@ -12036,7 +12036,7 @@
       {
         "itemId": 7376,
         "name": "Blue d'hide body (t)",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Blue_d%27hide_body_(t)"
@@ -12044,7 +12044,7 @@
       {
         "itemId": 7382,
         "name": "Blue d'hide chaps (g)",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Blue_d%27hide_chaps_(g)"
@@ -12052,7 +12052,7 @@
       {
         "itemId": 7384,
         "name": "Blue d'hide chaps (t)",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Blue_d%27hide_chaps_(t)"
@@ -12060,7 +12060,7 @@
       {
         "itemId": 10470,
         "name": "Saradomin stole",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Saradomin_stole"
@@ -12068,7 +12068,7 @@
       {
         "itemId": 10440,
         "name": "Saradomin crozier",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Saradomin_crozier"
@@ -12076,7 +12076,7 @@
       {
         "itemId": 10472,
         "name": "Guthix stole",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Guthix_stole"
@@ -12084,7 +12084,7 @@
       {
         "itemId": 10442,
         "name": "Guthix crozier",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Guthix_crozier"
@@ -12092,7 +12092,7 @@
       {
         "itemId": 10474,
         "name": "Zamorak stole",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Zamorak_stole"
@@ -12100,7 +12100,7 @@
       {
         "itemId": 10444,
         "name": "Zamorak crozier",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Zamorak_crozier"
@@ -12108,7 +12108,7 @@
       {
         "itemId": 2581,
         "name": "Robin hood hat",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Robin_hood_hat"
@@ -12116,7 +12116,7 @@
       {
         "itemId": 7400,
         "name": "Enchanted hat",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Enchanted_hat"
@@ -12124,7 +12124,7 @@
       {
         "itemId": 7399,
         "name": "Enchanted top",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Enchanted_top"
@@ -12132,7 +12132,7 @@
       {
         "itemId": 7398,
         "name": "Enchanted robe",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Enchanted_robe"
@@ -12140,7 +12140,7 @@
       {
         "itemId": 2651,
         "name": "Pirate's hat",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Pirate%27s_hat"
@@ -12148,7 +12148,7 @@
       {
         "itemId": 12323,
         "name": "Red cavalier",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Red_cavalier"
@@ -12156,7 +12156,7 @@
       {
         "itemId": 12321,
         "name": "White cavalier",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "White_cavalier"
@@ -12164,7 +12164,7 @@
       {
         "itemId": 12325,
         "name": "Navy cavalier",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Navy_cavalier"
@@ -12172,7 +12172,7 @@
       {
         "itemId": 2639,
         "name": "Tan cavalier",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Tan_cavalier"
@@ -12180,7 +12180,7 @@
       {
         "itemId": 2641,
         "name": "Dark cavalier",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Dark_cavalier"
@@ -12188,7 +12188,7 @@
       {
         "itemId": 2643,
         "name": "Black cavalier",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_cavalier"
@@ -12196,7 +12196,7 @@
       {
         "itemId": 12516,
         "name": "Pith helmet",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Pith_helmet"
@@ -12204,7 +12204,7 @@
       {
         "itemId": 12514,
         "name": "Explorer backpack",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Explorer_backpack"
@@ -12212,7 +12212,7 @@
       {
         "itemId": 12518,
         "name": "Green dragon mask",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Green_dragon_mask"
@@ -12220,7 +12220,7 @@
       {
         "itemId": 12520,
         "name": "Blue dragon mask",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Blue_dragon_mask"
@@ -12228,7 +12228,7 @@
       {
         "itemId": 12522,
         "name": "Red dragon mask",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Red_dragon_mask"
@@ -12236,7 +12236,7 @@
       {
         "itemId": 12524,
         "name": "Black dragon mask",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_dragon_mask"
@@ -12244,7 +12244,7 @@
       {
         "itemId": 19915,
         "name": "Cyclops head",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Cyclops_head"
@@ -12252,7 +12252,7 @@
       {
         "itemId": 19918,
         "name": "Nunchaku",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Nunchaku"
@@ -12260,7 +12260,7 @@
       {
         "itemId": 12379,
         "name": "Rune cane",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Rune_cane"
@@ -12268,7 +12268,7 @@
       {
         "itemId": 23206,
         "name": "Dual sai",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Dual_sai"
@@ -12276,7 +12276,7 @@
       {
         "itemId": 10284,
         "name": "Magic comp bow",
-        "dropRate": 0.007463,
+        "dropRate": 0.018328,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Magic_comp_bow"
@@ -12284,7 +12284,7 @@
       {
         "itemId": 22231,
         "name": "Dragon boots ornament kit",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Dragon_boots_ornament_kit"
@@ -12292,7 +12292,7 @@
       {
         "itemId": 23227,
         "name": "Rune defender ornament kit",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Rune_defender_ornament_kit"
@@ -12300,7 +12300,7 @@
       {
         "itemId": 23237,
         "name": "Berserker necklace ornament kit",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Berserker_necklace_ornament_kit"
@@ -12308,7 +12308,7 @@
       {
         "itemId": 23232,
         "name": "Tzhaar-ket-om ornament kit",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Tzhaar-ket-om_ornament_kit"
@@ -12316,7 +12316,7 @@
       {
         "itemId": 23224,
         "name": "Thieving bag",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Thieving_bag"
@@ -12324,7 +12324,7 @@
       {
         "itemId": 19912,
         "name": "Zombie head",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Zombie_head_(Treasure_Trails)"
@@ -12332,7 +12332,7 @@
       {
         "itemId": 10362,
         "name": "Amulet of glory (t)",
-        "dropRate": 0.007463,
+        "dropRate": 0.003073,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Amulet_of_glory_(t)"
@@ -12351,7 +12351,7 @@
       {
         "itemId": 12538,
         "name": "Dragon full helm ornament kit",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Dragon_full_helm_ornament_kit"
@@ -12359,7 +12359,7 @@
       {
         "itemId": 12534,
         "name": "Dragon chainbody ornament kit",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Dragon_chainbody_ornament_kit"
@@ -12367,7 +12367,7 @@
       {
         "itemId": 12536,
         "name": "Dragon legs/skirt ornament kit",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Dragon_legs/skirt_ornament_kit"
@@ -12375,7 +12375,7 @@
       {
         "itemId": 12532,
         "name": "Dragon sq shield ornament kit",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Dragon_sq_shield_ornament_kit"
@@ -12383,7 +12383,7 @@
       {
         "itemId": 20002,
         "name": "Dragon scimitar ornament kit",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Dragon_scimitar_ornament_kit"
@@ -12391,7 +12391,7 @@
       {
         "itemId": 12526,
         "name": "Fury ornament kit",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Fury_ornament_kit"
@@ -12399,7 +12399,7 @@
       {
         "itemId": 12530,
         "name": "Light infinity colour kit",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Light_infinity_colour_kit"
@@ -12407,7 +12407,7 @@
       {
         "itemId": 12528,
         "name": "Dark infinity colour kit",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Dark_infinity_colour_kit"
@@ -12415,7 +12415,7 @@
       {
         "itemId": 12397,
         "name": "Royal crown",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Royal_crown"
@@ -12423,7 +12423,7 @@
       {
         "itemId": 12393,
         "name": "Royal gown top",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Royal_gown_top"
@@ -12431,7 +12431,7 @@
       {
         "itemId": 12395,
         "name": "Royal gown bottom",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Royal_gown_bottom"
@@ -12439,7 +12439,7 @@
       {
         "itemId": 12439,
         "name": "Royal sceptre",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Royal_sceptre"
@@ -12447,7 +12447,7 @@
       {
         "itemId": 12351,
         "name": "Musketeer hat",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Musketeer_hat"
@@ -12455,7 +12455,7 @@
       {
         "itemId": 12441,
         "name": "Musketeer tabard",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Musketeer_tabard"
@@ -12463,7 +12463,7 @@
       {
         "itemId": 12443,
         "name": "Musketeer pants",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Musketeer_pants"
@@ -12471,7 +12471,7 @@
       {
         "itemId": 12381,
         "name": "Black d'hide body (g)",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_d%27hide_body_(g)"
@@ -12479,7 +12479,7 @@
       {
         "itemId": 12385,
         "name": "Black d'hide body (t)",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_d%27hide_body_(t)"
@@ -12487,7 +12487,7 @@
       {
         "itemId": 12383,
         "name": "Black d'hide chaps (g)",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_d%27hide_chaps_(g)"
@@ -12495,7 +12495,7 @@
       {
         "itemId": 12387,
         "name": "Black d'hide chaps (t)",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_d%27hide_chaps_(t)"
@@ -12503,7 +12503,7 @@
       {
         "itemId": 12596,
         "name": "Rangers' tunic",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Rangers%27_tunic"
@@ -12511,7 +12511,7 @@
       {
         "itemId": 19994,
         "name": "Ranger gloves",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ranger_gloves"
@@ -12519,7 +12519,7 @@
       {
         "itemId": 23249,
         "name": "Rangers' tights",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Rangers%27_tights"
@@ -12527,7 +12527,7 @@
       {
         "itemId": 19997,
         "name": "Holy wraps",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Holy_wraps"
@@ -12535,7 +12535,7 @@
       {
         "itemId": 12363,
         "name": "Bronze dragon mask",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bronze_dragon_mask"
@@ -12543,7 +12543,7 @@
       {
         "itemId": 12365,
         "name": "Iron dragon mask",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Iron_dragon_mask"
@@ -12551,7 +12551,7 @@
       {
         "itemId": 12367,
         "name": "Steel dragon mask",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Steel_dragon_mask"
@@ -12559,7 +12559,7 @@
       {
         "itemId": 12369,
         "name": "Mithril dragon mask",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Mithril_dragon_mask"
@@ -12567,7 +12567,7 @@
       {
         "itemId": 23270,
         "name": "Adamant dragon mask",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Adamant_dragon_mask"
@@ -12575,7 +12575,7 @@
       {
         "itemId": 23273,
         "name": "Rune dragon mask",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Rune_dragon_mask"
@@ -12583,7 +12583,7 @@
       {
         "itemId": 19943,
         "name": "Arceuus scarf",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Arceuus_scarf"
@@ -12591,7 +12591,7 @@
       {
         "itemId": 19946,
         "name": "Hosidius scarf",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Hosidius_scarf"
@@ -12599,7 +12599,7 @@
       {
         "itemId": 19949,
         "name": "Lovakengj scarf",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Lovakengj_scarf"
@@ -12607,7 +12607,7 @@
       {
         "itemId": 19952,
         "name": "Piscarilius scarf",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Piscarilius_scarf"
@@ -12615,7 +12615,7 @@
       {
         "itemId": 19955,
         "name": "Shayzien scarf",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Shayzien_scarf"
@@ -12623,7 +12623,7 @@
       {
         "itemId": 12357,
         "name": "Katana",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Katana"
@@ -12631,7 +12631,7 @@
       {
         "itemId": 12373,
         "name": "Dragon cane",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Dragon_cane"
@@ -12639,7 +12639,7 @@
       {
         "itemId": 19991,
         "name": "Bucket helm",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bucket_helm"
@@ -12647,7 +12647,7 @@
       {
         "itemId": 19988,
         "name": "Blacksmith's helm",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Blacksmith%27s_helm"
@@ -12655,7 +12655,7 @@
       {
         "itemId": 12540,
         "name": "Deerstalker",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Deerstalker"
@@ -12663,7 +12663,7 @@
       {
         "itemId": 12430,
         "name": "Afro",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Afro"
@@ -12671,7 +12671,7 @@
       {
         "itemId": 12355,
         "name": "Big pirate hat",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Big_pirate_hat"
@@ -12679,7 +12679,7 @@
       {
         "itemId": 12432,
         "name": "Top hat",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Top_hat"
@@ -12687,7 +12687,7 @@
       {
         "itemId": 12353,
         "name": "Monocle",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Monocle"
@@ -12695,7 +12695,7 @@
       {
         "itemId": 12335,
         "name": "Briefcase",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Briefcase"
@@ -12703,7 +12703,7 @@
       {
         "itemId": 12337,
         "name": "Sagacious spectacles",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Sagacious_spectacles"
@@ -12711,7 +12711,7 @@
       {
         "itemId": 19970,
         "name": "Dark bow tie",
-        "dropRate": 0.017241,
+        "dropRate": 0.000392,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Dark_bow_tie"
@@ -12719,7 +12719,7 @@
       {
         "itemId": 19958,
         "name": "Dark tuxedo jacket",
-        "dropRate": 0.017241,
+        "dropRate": 0.000392,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Dark_tuxedo_jacket"
@@ -12727,7 +12727,7 @@
       {
         "itemId": 19961,
         "name": "Dark tuxedo cuffs",
-        "dropRate": 0.017241,
+        "dropRate": 0.000392,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Dark_tuxedo_cuffs"
@@ -12735,7 +12735,7 @@
       {
         "itemId": 19964,
         "name": "Dark trousers",
-        "dropRate": 0.017241,
+        "dropRate": 0.000392,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Dark_trousers"
@@ -12743,7 +12743,7 @@
       {
         "itemId": 19967,
         "name": "Dark tuxedo shoes",
-        "dropRate": 0.017241,
+        "dropRate": 0.000392,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Dark_tuxedo_shoes"
@@ -12751,7 +12751,7 @@
       {
         "itemId": 19985,
         "name": "Light bow tie",
-        "dropRate": 0.017241,
+        "dropRate": 0.000392,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Light_bow_tie"
@@ -12759,7 +12759,7 @@
       {
         "itemId": 19973,
         "name": "Light tuxedo jacket",
-        "dropRate": 0.017241,
+        "dropRate": 0.000392,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Light_tuxedo_jacket"
@@ -12767,7 +12767,7 @@
       {
         "itemId": 19976,
         "name": "Light tuxedo cuffs",
-        "dropRate": 0.017241,
+        "dropRate": 0.000392,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Light_tuxedo_cuffs"
@@ -12775,7 +12775,7 @@
       {
         "itemId": 19979,
         "name": "Light trousers",
-        "dropRate": 0.017241,
+        "dropRate": 0.000392,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Light_trousers"
@@ -12783,7 +12783,7 @@
       {
         "itemId": 19982,
         "name": "Light tuxedo shoes",
-        "dropRate": 0.017241,
+        "dropRate": 0.000392,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Light_tuxedo_shoes"
@@ -12791,7 +12791,7 @@
       {
         "itemId": 23255,
         "name": "Uri's hat",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Uri%27s_hat"
@@ -12799,7 +12799,7 @@
       {
         "itemId": 23252,
         "name": "Giant boot",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Giant_boot"
@@ -12807,7 +12807,7 @@
       {
         "itemId": 23246,
         "name": "Fremennik kilt",
-        "dropRate": 0.017241,
+        "dropRate": 0.003915,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Fremennik_kilt"
@@ -12834,7 +12834,7 @@
       {
         "itemId": 20065,
         "name": "Occult ornament kit",
-        "dropRate": 0.021277,
+        "dropRate": 0.00703,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Occult_ornament_kit"
@@ -12842,7 +12842,7 @@
       {
         "itemId": 20062,
         "name": "Torture ornament kit",
-        "dropRate": 0.021277,
+        "dropRate": 0.00703,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Torture_ornament_kit"
@@ -12850,7 +12850,7 @@
       {
         "itemId": 22246,
         "name": "Anguish ornament kit",
-        "dropRate": 0.021277,
+        "dropRate": 0.00703,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Anguish_ornament_kit"
@@ -12858,7 +12858,7 @@
       {
         "itemId": 23348,
         "name": "Tormented ornament kit",
-        "dropRate": 0.021277,
+        "dropRate": 0.00703,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Tormented_ornament_kit"
@@ -12866,7 +12866,7 @@
       {
         "itemId": 20143,
         "name": "Dragon defender ornament kit",
-        "dropRate": 0.021277,
+        "dropRate": 0.00703,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Dragon_defender_ornament_kit"
@@ -12874,7 +12874,7 @@
       {
         "itemId": 22239,
         "name": "Dragon kiteshield ornament kit",
-        "dropRate": 0.021277,
+        "dropRate": 0.000235,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Dragon_kiteshield_ornament_kit"
@@ -12882,7 +12882,7 @@
       {
         "itemId": 22236,
         "name": "Dragon platebody ornament kit",
-        "dropRate": 0.021277,
+        "dropRate": 0.00047,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Dragon_platebody_ornament_kit"
@@ -12890,7 +12890,7 @@
       {
         "itemId": 20068,
         "name": "Armadyl godsword ornament kit",
-        "dropRate": 0.021277,
+        "dropRate": 0.001761,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Armadyl_godsword_ornament_kit"
@@ -12898,7 +12898,7 @@
       {
         "itemId": 20071,
         "name": "Bandos godsword ornament kit",
-        "dropRate": 0.021277,
+        "dropRate": 0.001761,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bandos_godsword_ornament_kit"
@@ -12906,7 +12906,7 @@
       {
         "itemId": 20074,
         "name": "Saradomin godsword ornament kit",
-        "dropRate": 0.021277,
+        "dropRate": 0.001761,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Saradomin_godsword_ornament_kit"
@@ -12914,7 +12914,7 @@
       {
         "itemId": 20077,
         "name": "Zamorak godsword ornament kit",
-        "dropRate": 0.021277,
+        "dropRate": 0.001761,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Zamorak_godsword_ornament_kit"
@@ -12922,7 +12922,7 @@
       {
         "itemId": 20128,
         "name": "Hood of darkness",
-        "dropRate": 0.021277,
+        "dropRate": 0.00703,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Hood_of_darkness"
@@ -12930,7 +12930,7 @@
       {
         "itemId": 20131,
         "name": "Robe top of darkness",
-        "dropRate": 0.021277,
+        "dropRate": 0.00703,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Robe_top_of_darkness"
@@ -12938,7 +12938,7 @@
       {
         "itemId": 20134,
         "name": "Gloves of darkness",
-        "dropRate": 0.021277,
+        "dropRate": 0.00703,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gloves_of_darkness"
@@ -12946,7 +12946,7 @@
       {
         "itemId": 20137,
         "name": "Robe bottom of darkness",
-        "dropRate": 0.021277,
+        "dropRate": 0.00703,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Robe_bottom_of_darkness"
@@ -12954,7 +12954,7 @@
       {
         "itemId": 20140,
         "name": "Boots of darkness",
-        "dropRate": 0.021277,
+        "dropRate": 0.00703,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Boots_of_darkness"
@@ -12962,7 +12962,7 @@
       {
         "itemId": 20035,
         "name": "Samurai kasa",
-        "dropRate": 0.021277,
+        "dropRate": 0.00703,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Samurai_kasa"
@@ -12970,7 +12970,7 @@
       {
         "itemId": 20038,
         "name": "Samurai shirt",
-        "dropRate": 0.021277,
+        "dropRate": 0.00703,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Samurai_shirt"
@@ -12978,7 +12978,7 @@
       {
         "itemId": 20041,
         "name": "Samurai gloves",
-        "dropRate": 0.021277,
+        "dropRate": 0.00703,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Samurai_gloves"
@@ -12986,7 +12986,7 @@
       {
         "itemId": 20044,
         "name": "Samurai greaves",
-        "dropRate": 0.021277,
+        "dropRate": 0.00703,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Samurai_greaves"
@@ -12994,7 +12994,7 @@
       {
         "itemId": 20047,
         "name": "Samurai boots",
-        "dropRate": 0.021277,
+        "dropRate": 0.00703,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Samurai_boots"
@@ -13002,7 +13002,7 @@
       {
         "itemId": 20113,
         "name": "Arceuus hood",
-        "dropRate": 0.021277,
+        "dropRate": 0.00703,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Arceuus_hood"
@@ -13010,7 +13010,7 @@
       {
         "itemId": 20116,
         "name": "Hosidius hood",
-        "dropRate": 0.021277,
+        "dropRate": 0.00703,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Hosidius_hood"
@@ -13018,7 +13018,7 @@
       {
         "itemId": 20119,
         "name": "Lovakengj hood",
-        "dropRate": 0.021277,
+        "dropRate": 0.00703,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Lovakengj_hood"
@@ -13026,7 +13026,7 @@
       {
         "itemId": 20122,
         "name": "Piscarilius hood",
-        "dropRate": 0.021277,
+        "dropRate": 0.00703,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Piscarilius_hood"
@@ -13034,7 +13034,7 @@
       {
         "itemId": 20125,
         "name": "Shayzien hood",
-        "dropRate": 0.021277,
+        "dropRate": 0.00703,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Shayzien_hood"
@@ -13042,7 +13042,7 @@
       {
         "itemId": 20029,
         "name": "Old demon mask",
-        "dropRate": 0.021277,
+        "dropRate": 0.00703,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Old_demon_mask"
@@ -13050,7 +13050,7 @@
       {
         "itemId": 20020,
         "name": "Lesser demon mask",
-        "dropRate": 0.021277,
+        "dropRate": 0.00703,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Lesser_demon_mask"
@@ -13058,7 +13058,7 @@
       {
         "itemId": 20023,
         "name": "Greater demon mask",
-        "dropRate": 0.021277,
+        "dropRate": 0.00703,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Greater_demon_mask"
@@ -13066,7 +13066,7 @@
       {
         "itemId": 20026,
         "name": "Black demon mask",
-        "dropRate": 0.021277,
+        "dropRate": 0.00703,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Black_demon_mask"
@@ -13074,7 +13074,7 @@
       {
         "itemId": 20032,
         "name": "Jungle demon mask",
-        "dropRate": 0.021277,
+        "dropRate": 0.00703,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Jungle_demon_mask"
@@ -13082,7 +13082,7 @@
       {
         "itemId": 19724,
         "name": "Left eye patch",
-        "dropRate": 0.021277,
+        "dropRate": 0.00703,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Left_eye_patch"
@@ -13090,7 +13090,7 @@
       {
         "itemId": 20110,
         "name": "Bowl wig",
-        "dropRate": 0.021277,
+        "dropRate": 0.00703,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bowl_wig"
@@ -13098,7 +13098,7 @@
       {
         "itemId": 20056,
         "name": "Ale of the gods",
-        "dropRate": 0.021277,
+        "dropRate": 0.00703,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ale_of_the_gods"
@@ -13106,7 +13106,7 @@
       {
         "itemId": 20050,
         "name": "Obsidian cape (r)",
-        "dropRate": 0.021277,
+        "dropRate": 0.00703,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Obsidian_cape_(r)"
@@ -13114,7 +13114,7 @@
       {
         "itemId": 20008,
         "name": "Fancy tiara",
-        "dropRate": 0.021277,
+        "dropRate": 0.00703,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Fancy_tiara"
@@ -13122,7 +13122,7 @@
       {
         "itemId": 20053,
         "name": "Half moon spectacles",
-        "dropRate": 0.021277,
+        "dropRate": 0.00703,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Half_moon_spectacles"
@@ -13130,7 +13130,7 @@
       {
         "itemId": 20095,
         "name": "Ankou mask",
-        "dropRate": 0.021277,
+        "dropRate": 0.00047,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ankou_mask"
@@ -13138,7 +13138,7 @@
       {
         "itemId": 20098,
         "name": "Ankou top",
-        "dropRate": 0.021277,
+        "dropRate": 0.00047,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ankou_top"
@@ -13146,7 +13146,7 @@
       {
         "itemId": 20101,
         "name": "Ankou gloves",
-        "dropRate": 0.021277,
+        "dropRate": 0.00047,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ankou_gloves"
@@ -13154,7 +13154,7 @@
       {
         "itemId": 20104,
         "name": "Ankou's leggings",
-        "dropRate": 0.021277,
+        "dropRate": 0.00047,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ankou%27s_leggings"
@@ -13162,7 +13162,7 @@
       {
         "itemId": 20107,
         "name": "Ankou socks",
-        "dropRate": 0.021277,
+        "dropRate": 0.00047,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ankou_socks"
@@ -13170,7 +13170,7 @@
       {
         "itemId": 20080,
         "name": "Mummy's head",
-        "dropRate": 0.021277,
+        "dropRate": 0.00047,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Mummy%27s_head"
@@ -13178,7 +13178,7 @@
       {
         "itemId": 20083,
         "name": "Mummy's body",
-        "dropRate": 0.021277,
+        "dropRate": 0.00047,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Mummy%27s_body"
@@ -13186,7 +13186,7 @@
       {
         "itemId": 20086,
         "name": "Mummy's hands",
-        "dropRate": 0.021277,
+        "dropRate": 0.00047,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Mummy%27s_hands"
@@ -13194,7 +13194,7 @@
       {
         "itemId": 20089,
         "name": "Mummy's legs",
-        "dropRate": 0.021277,
+        "dropRate": 0.00047,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Mummy%27s_legs"
@@ -13202,7 +13202,7 @@
       {
         "itemId": 20092,
         "name": "Mummy's feet",
-        "dropRate": 0.021277,
+        "dropRate": 0.00047,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Mummy%27s_feet"
@@ -13237,7 +13237,7 @@
       {
         "itemId": 10350,
         "name": "3rd age full helmet",
-        "dropRate": 0.041667,
+        "dropRate": 2.4e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_full_helmet"
@@ -13245,7 +13245,7 @@
       {
         "itemId": 10348,
         "name": "3rd age platebody",
-        "dropRate": 0.041667,
+        "dropRate": 2.4e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_platebody"
@@ -13253,7 +13253,7 @@
       {
         "itemId": 10346,
         "name": "3rd age platelegs",
-        "dropRate": 0.041667,
+        "dropRate": 2.4e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_platelegs"
@@ -13261,7 +13261,7 @@
       {
         "itemId": 23242,
         "name": "3rd age plateskirt",
-        "dropRate": 0.041667,
+        "dropRate": 2.4e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_plateskirt"
@@ -13269,7 +13269,7 @@
       {
         "itemId": 10352,
         "name": "3rd age kiteshield",
-        "dropRate": 0.041667,
+        "dropRate": 2.4e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_kiteshield"
@@ -13277,7 +13277,7 @@
       {
         "itemId": 10334,
         "name": "3rd age range coif",
-        "dropRate": 0.041667,
+        "dropRate": 2.4e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_range_coif"
@@ -13285,7 +13285,7 @@
       {
         "itemId": 10330,
         "name": "3rd age range top",
-        "dropRate": 0.041667,
+        "dropRate": 2.4e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_range_top"
@@ -13293,7 +13293,7 @@
       {
         "itemId": 10332,
         "name": "3rd age range legs",
-        "dropRate": 0.041667,
+        "dropRate": 2.4e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_range_legs"
@@ -13301,7 +13301,7 @@
       {
         "itemId": 10336,
         "name": "3rd age vambraces",
-        "dropRate": 0.041667,
+        "dropRate": 2.4e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_vambraces"
@@ -13309,7 +13309,7 @@
       {
         "itemId": 10342,
         "name": "3rd age mage hat",
-        "dropRate": 0.041667,
+        "dropRate": 2.4e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_mage_hat"
@@ -13317,7 +13317,7 @@
       {
         "itemId": 10338,
         "name": "3rd age robe top",
-        "dropRate": 0.041667,
+        "dropRate": 2.4e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_robe_top"
@@ -13325,7 +13325,7 @@
       {
         "itemId": 10340,
         "name": "3rd age robe",
-        "dropRate": 0.041667,
+        "dropRate": 2.4e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_robe"
@@ -13333,7 +13333,7 @@
       {
         "itemId": 10344,
         "name": "3rd age amulet",
-        "dropRate": 0.041667,
+        "dropRate": 2.4e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_amulet"
@@ -13341,7 +13341,7 @@
       {
         "itemId": 3486,
         "name": "Gilded full helm",
-        "dropRate": 0.041667,
+        "dropRate": 0.00014,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_full_helm"
@@ -13349,7 +13349,7 @@
       {
         "itemId": 3481,
         "name": "Gilded platebody",
-        "dropRate": 0.041667,
+        "dropRate": 0.00014,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_platebody"
@@ -13357,7 +13357,7 @@
       {
         "itemId": 3483,
         "name": "Gilded platelegs",
-        "dropRate": 0.041667,
+        "dropRate": 0.00014,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_platelegs"
@@ -13365,7 +13365,7 @@
       {
         "itemId": 3485,
         "name": "Gilded plateskirt",
-        "dropRate": 0.041667,
+        "dropRate": 0.00014,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_plateskirt"
@@ -13373,7 +13373,7 @@
       {
         "itemId": 3488,
         "name": "Gilded kiteshield",
-        "dropRate": 0.041667,
+        "dropRate": 0.00014,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_kiteshield"
@@ -13381,7 +13381,7 @@
       {
         "itemId": 20146,
         "name": "Gilded med helm",
-        "dropRate": 0.041667,
+        "dropRate": 0.00014,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_med_helm"
@@ -13389,7 +13389,7 @@
       {
         "itemId": 20149,
         "name": "Gilded chainbody",
-        "dropRate": 0.041667,
+        "dropRate": 0.00014,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_chainbody"
@@ -13397,7 +13397,7 @@
       {
         "itemId": 20152,
         "name": "Gilded sq shield",
-        "dropRate": 0.041667,
+        "dropRate": 0.00014,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_sq_shield"
@@ -13405,7 +13405,7 @@
       {
         "itemId": 20155,
         "name": "Gilded 2h sword",
-        "dropRate": 0.041667,
+        "dropRate": 0.00014,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_2h_sword"
@@ -13413,7 +13413,7 @@
       {
         "itemId": 20158,
         "name": "Gilded spear",
-        "dropRate": 0.041667,
+        "dropRate": 0.00014,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_spear"
@@ -13421,7 +13421,7 @@
       {
         "itemId": 20161,
         "name": "Gilded hasta",
-        "dropRate": 0.041667,
+        "dropRate": 0.00014,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_hasta"
@@ -13440,7 +13440,7 @@
       {
         "itemId": 10350,
         "name": "3rd age full helmet",
-        "dropRate": 0.025641,
+        "dropRate": 2e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_full_helmet"
@@ -13448,7 +13448,7 @@
       {
         "itemId": 10348,
         "name": "3rd age platebody",
-        "dropRate": 0.025641,
+        "dropRate": 2e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_platebody"
@@ -13456,7 +13456,7 @@
       {
         "itemId": 10346,
         "name": "3rd age platelegs",
-        "dropRate": 0.025641,
+        "dropRate": 2e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_platelegs"
@@ -13464,7 +13464,7 @@
       {
         "itemId": 23242,
         "name": "3rd age plateskirt",
-        "dropRate": 0.025641,
+        "dropRate": 2e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_plateskirt"
@@ -13472,7 +13472,7 @@
       {
         "itemId": 10352,
         "name": "3rd age kiteshield",
-        "dropRate": 0.025641,
+        "dropRate": 2e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_kiteshield"
@@ -13480,7 +13480,7 @@
       {
         "itemId": 10334,
         "name": "3rd age range coif",
-        "dropRate": 0.025641,
+        "dropRate": 2e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_range_coif"
@@ -13488,7 +13488,7 @@
       {
         "itemId": 10330,
         "name": "3rd age range top",
-        "dropRate": 0.025641,
+        "dropRate": 2e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_range_top"
@@ -13496,7 +13496,7 @@
       {
         "itemId": 10332,
         "name": "3rd age range legs",
-        "dropRate": 0.025641,
+        "dropRate": 2e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_range_legs"
@@ -13504,7 +13504,7 @@
       {
         "itemId": 10336,
         "name": "3rd age vambraces",
-        "dropRate": 0.025641,
+        "dropRate": 2e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_vambraces"
@@ -13512,7 +13512,7 @@
       {
         "itemId": 10342,
         "name": "3rd age mage hat",
-        "dropRate": 0.025641,
+        "dropRate": 2e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_mage_hat"
@@ -13520,7 +13520,7 @@
       {
         "itemId": 10338,
         "name": "3rd age robe top",
-        "dropRate": 0.025641,
+        "dropRate": 2e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_robe_top"
@@ -13528,7 +13528,7 @@
       {
         "itemId": 10340,
         "name": "3rd age robe",
-        "dropRate": 0.025641,
+        "dropRate": 2e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_robe"
@@ -13536,7 +13536,7 @@
       {
         "itemId": 10344,
         "name": "3rd age amulet",
-        "dropRate": 0.025641,
+        "dropRate": 2e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_amulet"
@@ -13544,7 +13544,7 @@
       {
         "itemId": 12426,
         "name": "3rd age longsword",
-        "dropRate": 0.025641,
+        "dropRate": 2e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_longsword"
@@ -13552,7 +13552,7 @@
       {
         "itemId": 12422,
         "name": "3rd age wand",
-        "dropRate": 0.025641,
+        "dropRate": 2e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_wand"
@@ -13560,7 +13560,7 @@
       {
         "itemId": 12437,
         "name": "3rd age cloak",
-        "dropRate": 0.025641,
+        "dropRate": 2e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_cloak"
@@ -13568,7 +13568,7 @@
       {
         "itemId": 12424,
         "name": "3rd age bow",
-        "dropRate": 0.025641,
+        "dropRate": 2e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_bow"
@@ -13576,7 +13576,7 @@
       {
         "itemId": 3486,
         "name": "Gilded full helm",
-        "dropRate": 0.025641,
+        "dropRate": 0.000155,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_full_helm"
@@ -13584,7 +13584,7 @@
       {
         "itemId": 3481,
         "name": "Gilded platebody",
-        "dropRate": 0.025641,
+        "dropRate": 0.000155,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_platebody"
@@ -13592,7 +13592,7 @@
       {
         "itemId": 3483,
         "name": "Gilded platelegs",
-        "dropRate": 0.025641,
+        "dropRate": 0.000155,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_platelegs"
@@ -13600,7 +13600,7 @@
       {
         "itemId": 3485,
         "name": "Gilded plateskirt",
-        "dropRate": 0.025641,
+        "dropRate": 0.000155,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_plateskirt"
@@ -13608,7 +13608,7 @@
       {
         "itemId": 3488,
         "name": "Gilded kiteshield",
-        "dropRate": 0.025641,
+        "dropRate": 0.000155,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_kiteshield"
@@ -13616,7 +13616,7 @@
       {
         "itemId": 20146,
         "name": "Gilded med helm",
-        "dropRate": 0.025641,
+        "dropRate": 0.000155,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_med_helm"
@@ -13624,7 +13624,7 @@
       {
         "itemId": 20149,
         "name": "Gilded chainbody",
-        "dropRate": 0.025641,
+        "dropRate": 0.000155,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_chainbody"
@@ -13632,7 +13632,7 @@
       {
         "itemId": 20152,
         "name": "Gilded sq shield",
-        "dropRate": 0.025641,
+        "dropRate": 0.000155,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_sq_shield"
@@ -13640,7 +13640,7 @@
       {
         "itemId": 20155,
         "name": "Gilded 2h sword",
-        "dropRate": 0.025641,
+        "dropRate": 0.000155,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_2h_sword"
@@ -13648,7 +13648,7 @@
       {
         "itemId": 20158,
         "name": "Gilded spear",
-        "dropRate": 0.025641,
+        "dropRate": 0.000155,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_spear"
@@ -13656,7 +13656,7 @@
       {
         "itemId": 20161,
         "name": "Gilded hasta",
-        "dropRate": 0.025641,
+        "dropRate": 0.000155,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_hasta"
@@ -13664,7 +13664,7 @@
       {
         "itemId": 12389,
         "name": "Gilded scimitar",
-        "dropRate": 0.025641,
+        "dropRate": 0.000341,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_scimitar"
@@ -13672,7 +13672,7 @@
       {
         "itemId": 12391,
         "name": "Gilded boots",
-        "dropRate": 0.025641,
+        "dropRate": 0.000341,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_boots"
@@ -13680,7 +13680,7 @@
       {
         "itemId": 23258,
         "name": "Gilded coif",
-        "dropRate": 0.025641,
+        "dropRate": 0.000341,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_coif"
@@ -13688,7 +13688,7 @@
       {
         "itemId": 23261,
         "name": "Gilded d'hide vambraces",
-        "dropRate": 0.025641,
+        "dropRate": 0.000341,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_d%27hide_vambraces"
@@ -13696,7 +13696,7 @@
       {
         "itemId": 23264,
         "name": "Gilded d'hide body",
-        "dropRate": 0.025641,
+        "dropRate": 0.000341,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_d%27hide_body"
@@ -13704,7 +13704,7 @@
       {
         "itemId": 23267,
         "name": "Gilded d'hide chaps",
-        "dropRate": 0.025641,
+        "dropRate": 0.000341,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_d%27hide_chaps"
@@ -13712,7 +13712,7 @@
       {
         "itemId": 23276,
         "name": "Gilded pickaxe",
-        "dropRate": 0.025641,
+        "dropRate": 0.000341,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_pickaxe"
@@ -13720,7 +13720,7 @@
       {
         "itemId": 23279,
         "name": "Gilded axe",
-        "dropRate": 0.025641,
+        "dropRate": 0.000341,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_axe"
@@ -13728,7 +13728,7 @@
       {
         "itemId": 23282,
         "name": "Gilded spade",
-        "dropRate": 0.025641,
+        "dropRate": 0.000341,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_spade"
@@ -13736,7 +13736,7 @@
       {
         "itemId": 20005,
         "name": "Ring of nature",
-        "dropRate": 0.025641,
+        "dropRate": 0.000341,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ring_of_nature"
@@ -13744,7 +13744,7 @@
       {
         "itemId": 12371,
         "name": "Lava dragon mask",
-        "dropRate": 0.025641,
+        "dropRate": 0.000341,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Lava_dragon_mask"
@@ -13763,7 +13763,7 @@
       {
         "itemId": 10350,
         "name": "3rd age full helmet",
-        "dropRate": 0.021739,
+        "dropRate": 1.9e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_full_helmet"
@@ -13771,7 +13771,7 @@
       {
         "itemId": 10348,
         "name": "3rd age platebody",
-        "dropRate": 0.021739,
+        "dropRate": 1.9e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_platebody"
@@ -13779,7 +13779,7 @@
       {
         "itemId": 10346,
         "name": "3rd age platelegs",
-        "dropRate": 0.021739,
+        "dropRate": 1.9e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_platelegs"
@@ -13787,7 +13787,7 @@
       {
         "itemId": 23242,
         "name": "3rd age plateskirt",
-        "dropRate": 0.021739,
+        "dropRate": 1.9e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_plateskirt"
@@ -13795,7 +13795,7 @@
       {
         "itemId": 10352,
         "name": "3rd age kiteshield",
-        "dropRate": 0.021739,
+        "dropRate": 1.9e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_kiteshield"
@@ -13803,7 +13803,7 @@
       {
         "itemId": 10334,
         "name": "3rd age range coif",
-        "dropRate": 0.021739,
+        "dropRate": 1.9e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_range_coif"
@@ -13811,7 +13811,7 @@
       {
         "itemId": 10330,
         "name": "3rd age range top",
-        "dropRate": 0.021739,
+        "dropRate": 1.9e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_range_top"
@@ -13819,7 +13819,7 @@
       {
         "itemId": 10332,
         "name": "3rd age range legs",
-        "dropRate": 0.021739,
+        "dropRate": 1.9e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_range_legs"
@@ -13827,7 +13827,7 @@
       {
         "itemId": 10336,
         "name": "3rd age vambraces",
-        "dropRate": 0.021739,
+        "dropRate": 1.9e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_vambraces"
@@ -13835,7 +13835,7 @@
       {
         "itemId": 10342,
         "name": "3rd age mage hat",
-        "dropRate": 0.021739,
+        "dropRate": 1.9e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_mage_hat"
@@ -13843,7 +13843,7 @@
       {
         "itemId": 10338,
         "name": "3rd age robe top",
-        "dropRate": 0.021739,
+        "dropRate": 1.9e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_robe_top"
@@ -13851,7 +13851,7 @@
       {
         "itemId": 10340,
         "name": "3rd age robe",
-        "dropRate": 0.021739,
+        "dropRate": 1.9e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_robe"
@@ -13859,7 +13859,7 @@
       {
         "itemId": 10344,
         "name": "3rd age amulet",
-        "dropRate": 0.021739,
+        "dropRate": 1.9e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_amulet"
@@ -13867,7 +13867,7 @@
       {
         "itemId": 12426,
         "name": "3rd age longsword",
-        "dropRate": 0.021739,
+        "dropRate": 1.9e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_longsword"
@@ -13875,7 +13875,7 @@
       {
         "itemId": 12422,
         "name": "3rd age wand",
-        "dropRate": 0.021739,
+        "dropRate": 1.9e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_wand"
@@ -13883,7 +13883,7 @@
       {
         "itemId": 12437,
         "name": "3rd age cloak",
-        "dropRate": 0.021739,
+        "dropRate": 1.9e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_cloak"
@@ -13891,7 +13891,7 @@
       {
         "itemId": 12424,
         "name": "3rd age bow",
-        "dropRate": 0.021739,
+        "dropRate": 1.9e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_bow"
@@ -13899,7 +13899,7 @@
       {
         "itemId": 23336,
         "name": "3rd age druidic robe top",
-        "dropRate": 0.021739,
+        "dropRate": 1.9e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_druidic_robe_top"
@@ -13907,7 +13907,7 @@
       {
         "itemId": 23339,
         "name": "3rd age druidic robe bottoms",
-        "dropRate": 0.021739,
+        "dropRate": 1.9e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_druidic_robe_bottoms"
@@ -13915,7 +13915,7 @@
       {
         "itemId": 23345,
         "name": "3rd age druidic cloak",
-        "dropRate": 0.021739,
+        "dropRate": 1.9e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_druidic_cloak"
@@ -13923,7 +13923,7 @@
       {
         "itemId": 23342,
         "name": "3rd age druidic staff",
-        "dropRate": 0.021739,
+        "dropRate": 1.9e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_druidic_staff"
@@ -13931,7 +13931,7 @@
       {
         "itemId": 20014,
         "name": "3rd age pickaxe",
-        "dropRate": 0.021739,
+        "dropRate": 1.9e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_pickaxe"
@@ -13939,7 +13939,7 @@
       {
         "itemId": 20011,
         "name": "3rd age axe",
-        "dropRate": 0.021739,
+        "dropRate": 1.9e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "3rd_age_axe"
@@ -13947,7 +13947,7 @@
       {
         "itemId": 23185,
         "name": "Ring of 3rd age",
-        "dropRate": 0.021739,
+        "dropRate": 1.9e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ring_of_3rd_age"
@@ -13955,7 +13955,7 @@
       {
         "itemId": 3486,
         "name": "Gilded full helm",
-        "dropRate": 0.021739,
+        "dropRate": 4e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_full_helm"
@@ -13963,7 +13963,7 @@
       {
         "itemId": 3481,
         "name": "Gilded platebody",
-        "dropRate": 0.021739,
+        "dropRate": 4e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_platebody"
@@ -13971,7 +13971,7 @@
       {
         "itemId": 3483,
         "name": "Gilded platelegs",
-        "dropRate": 0.021739,
+        "dropRate": 4e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_platelegs"
@@ -13979,7 +13979,7 @@
       {
         "itemId": 3485,
         "name": "Gilded plateskirt",
-        "dropRate": 0.021739,
+        "dropRate": 4e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_plateskirt"
@@ -13987,7 +13987,7 @@
       {
         "itemId": 3488,
         "name": "Gilded kiteshield",
-        "dropRate": 0.021739,
+        "dropRate": 4e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_kiteshield"
@@ -13995,7 +13995,7 @@
       {
         "itemId": 20146,
         "name": "Gilded med helm",
-        "dropRate": 0.021739,
+        "dropRate": 4e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_med_helm"
@@ -14003,7 +14003,7 @@
       {
         "itemId": 20149,
         "name": "Gilded chainbody",
-        "dropRate": 0.021739,
+        "dropRate": 4e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_chainbody"
@@ -14011,7 +14011,7 @@
       {
         "itemId": 20152,
         "name": "Gilded sq shield",
-        "dropRate": 0.021739,
+        "dropRate": 4e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_sq_shield"
@@ -14019,7 +14019,7 @@
       {
         "itemId": 20155,
         "name": "Gilded 2h sword",
-        "dropRate": 0.021739,
+        "dropRate": 4e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_2h_sword"
@@ -14027,7 +14027,7 @@
       {
         "itemId": 20158,
         "name": "Gilded spear",
-        "dropRate": 0.021739,
+        "dropRate": 4e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_spear"
@@ -14035,7 +14035,7 @@
       {
         "itemId": 20161,
         "name": "Gilded hasta",
-        "dropRate": 0.021739,
+        "dropRate": 4e-05,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_hasta"
@@ -14043,7 +14043,7 @@
       {
         "itemId": 12389,
         "name": "Gilded scimitar",
-        "dropRate": 0.021739,
+        "dropRate": 0.000441,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_scimitar"
@@ -14051,7 +14051,7 @@
       {
         "itemId": 12391,
         "name": "Gilded boots",
-        "dropRate": 0.021739,
+        "dropRate": 0.000441,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_boots"
@@ -14059,7 +14059,7 @@
       {
         "itemId": 23258,
         "name": "Gilded coif",
-        "dropRate": 0.021739,
+        "dropRate": 0.000441,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_coif"
@@ -14067,7 +14067,7 @@
       {
         "itemId": 23261,
         "name": "Gilded d'hide vambraces",
-        "dropRate": 0.021739,
+        "dropRate": 0.000441,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_d%27hide_vambraces"
@@ -14075,7 +14075,7 @@
       {
         "itemId": 23264,
         "name": "Gilded d'hide body",
-        "dropRate": 0.021739,
+        "dropRate": 0.000441,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_d%27hide_body"
@@ -14083,7 +14083,7 @@
       {
         "itemId": 23267,
         "name": "Gilded d'hide chaps",
-        "dropRate": 0.021739,
+        "dropRate": 0.000441,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_d%27hide_chaps"
@@ -14091,7 +14091,7 @@
       {
         "itemId": 23276,
         "name": "Gilded pickaxe",
-        "dropRate": 0.021739,
+        "dropRate": 0.000441,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_pickaxe"
@@ -14099,7 +14099,7 @@
       {
         "itemId": 23279,
         "name": "Gilded axe",
-        "dropRate": 0.021739,
+        "dropRate": 0.000441,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_axe"
@@ -14107,7 +14107,7 @@
       {
         "itemId": 23282,
         "name": "Gilded spade",
-        "dropRate": 0.021739,
+        "dropRate": 0.000441,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Gilded_spade"
@@ -14115,7 +14115,7 @@
       {
         "itemId": 20059,
         "name": "Bucket helm (g)",
-        "dropRate": 0.021739,
+        "dropRate": 0.000441,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bucket_helm_(g)"
@@ -14123,7 +14123,7 @@
       {
         "itemId": 20017,
         "name": "Ring of coins",
-        "dropRate": 0.021739,
+        "dropRate": 0.000441,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ring_of_coins"
@@ -14150,7 +14150,7 @@
       {
         "itemId": 3827,
         "name": "Saradomin page 1",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Saradomin_page_1"
@@ -14158,7 +14158,7 @@
       {
         "itemId": 3828,
         "name": "Saradomin page 2",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Saradomin_page_2"
@@ -14166,7 +14166,7 @@
       {
         "itemId": 3829,
         "name": "Saradomin page 3",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Saradomin_page_3"
@@ -14174,7 +14174,7 @@
       {
         "itemId": 3830,
         "name": "Saradomin page 4",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Saradomin_page_4"
@@ -14182,7 +14182,7 @@
       {
         "itemId": 3831,
         "name": "Zamorak page 1",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Zamorak_page_1"
@@ -14190,7 +14190,7 @@
       {
         "itemId": 3832,
         "name": "Zamorak page 2",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Zamorak_page_2"
@@ -14198,7 +14198,7 @@
       {
         "itemId": 3833,
         "name": "Zamorak page 3",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Zamorak_page_3"
@@ -14206,7 +14206,7 @@
       {
         "itemId": 3834,
         "name": "Zamorak page 4",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Zamorak_page_4"
@@ -14214,7 +14214,7 @@
       {
         "itemId": 3835,
         "name": "Guthix page 1",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Guthix_page_1"
@@ -14222,7 +14222,7 @@
       {
         "itemId": 3836,
         "name": "Guthix page 2",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Guthix_page_2"
@@ -14230,7 +14230,7 @@
       {
         "itemId": 3837,
         "name": "Guthix page 3",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Guthix_page_3"
@@ -14238,7 +14238,7 @@
       {
         "itemId": 3838,
         "name": "Guthix page 4",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Guthix_page_4"
@@ -14246,7 +14246,7 @@
       {
         "itemId": 12613,
         "name": "Bandos page 1",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bandos_page_1"
@@ -14254,7 +14254,7 @@
       {
         "itemId": 12614,
         "name": "Bandos page 2",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bandos_page_2"
@@ -14262,7 +14262,7 @@
       {
         "itemId": 12615,
         "name": "Bandos page 3",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bandos_page_3"
@@ -14270,7 +14270,7 @@
       {
         "itemId": 12616,
         "name": "Bandos page 4",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bandos_page_4"
@@ -14278,7 +14278,7 @@
       {
         "itemId": 12617,
         "name": "Armadyl page 1",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Armadyl_page_1"
@@ -14286,7 +14286,7 @@
       {
         "itemId": 12618,
         "name": "Armadyl page 2",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Armadyl_page_2"
@@ -14294,7 +14294,7 @@
       {
         "itemId": 12619,
         "name": "Armadyl page 3",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Armadyl_page_3"
@@ -14302,7 +14302,7 @@
       {
         "itemId": 12620,
         "name": "Armadyl page 4",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Armadyl_page_4"
@@ -14310,7 +14310,7 @@
       {
         "itemId": 12621,
         "name": "Ancient page 1",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ancient_page_1"
@@ -14318,7 +14318,7 @@
       {
         "itemId": 12622,
         "name": "Ancient page 2",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ancient_page_2"
@@ -14326,7 +14326,7 @@
       {
         "itemId": 12623,
         "name": "Ancient page 3",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ancient_page_3"
@@ -14334,7 +14334,7 @@
       {
         "itemId": 12624,
         "name": "Ancient page 4",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ancient_page_4"
@@ -14342,7 +14342,7 @@
       {
         "itemId": 20220,
         "name": "Holy blessing",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Holy_blessing"
@@ -14350,7 +14350,7 @@
       {
         "itemId": 20223,
         "name": "Unholy blessing",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Unholy_blessing"
@@ -14358,7 +14358,7 @@
       {
         "itemId": 20226,
         "name": "Peaceful blessing",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Peaceful_blessing"
@@ -14366,7 +14366,7 @@
       {
         "itemId": 20232,
         "name": "War blessing",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "War_blessing"
@@ -14374,7 +14374,7 @@
       {
         "itemId": 20229,
         "name": "Honourable blessing",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Honourable_blessing"
@@ -14382,7 +14382,7 @@
       {
         "itemId": 20235,
         "name": "Ancient blessing",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ancient_blessing"
@@ -14390,7 +14390,7 @@
       {
         "itemId": 7329,
         "name": "Red firelighter",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Red_firelighter"
@@ -14398,7 +14398,7 @@
       {
         "itemId": 7330,
         "name": "Green firelighter",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Green_firelighter"
@@ -14406,7 +14406,7 @@
       {
         "itemId": 7331,
         "name": "Blue firelighter",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Blue_firelighter"
@@ -14414,7 +14414,7 @@
       {
         "itemId": 10326,
         "name": "Purple firelighter",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Purple_firelighter"
@@ -14422,7 +14422,7 @@
       {
         "itemId": 10327,
         "name": "White firelighter",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "White_firelighter"
@@ -14430,7 +14430,7 @@
       {
         "itemId": 12402,
         "name": "Nardah teleport",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Nardah_teleport"
@@ -14438,7 +14438,7 @@
       {
         "itemId": 12403,
         "name": "Digsite teleport",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Digsite_teleport"
@@ -14446,7 +14446,7 @@
       {
         "itemId": 12404,
         "name": "Feldip hills teleport",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Feldip_hills_teleport"
@@ -14454,7 +14454,7 @@
       {
         "itemId": 12405,
         "name": "Lunar isle teleport",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Lunar_isle_teleport"
@@ -14462,7 +14462,7 @@
       {
         "itemId": 12406,
         "name": "Mort'ton teleport",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Mort%27ton_teleport"
@@ -14470,7 +14470,7 @@
       {
         "itemId": 12407,
         "name": "Pest control teleport",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Pest_control_teleport"
@@ -14478,7 +14478,7 @@
       {
         "itemId": 12408,
         "name": "Piscatoris teleport",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Piscatoris_teleport"
@@ -14486,7 +14486,7 @@
       {
         "itemId": 12409,
         "name": "Tai bwo wannai teleport",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Tai_bwo_wannai_teleport"
@@ -14494,7 +14494,7 @@
       {
         "itemId": 12411,
         "name": "Mos le'harmless teleport",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Mos_le%27harmless_teleport"
@@ -14502,7 +14502,7 @@
       {
         "itemId": 12642,
         "name": "Lumberyard teleport",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Lumberyard_teleport"
@@ -14510,7 +14510,7 @@
       {
         "itemId": 12410,
         "name": "Iorwerth camp teleport",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Iorwerth_camp_teleport"
@@ -14518,7 +14518,7 @@
       {
         "itemId": 23387,
         "name": "Watson teleport",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Watson_teleport"
@@ -14526,7 +14526,7 @@
       {
         "itemId": 10476,
         "name": "Purple sweets",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Purple_sweets"
@@ -14534,7 +14534,7 @@
       {
         "itemId": 21387,
         "name": "Master scroll book (empty)",
-        "dropRate": 0.020408,
+        "dropRate": 0.003759,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Master_scroll_book_(empty)"


### PR DESCRIPTION
## Summary
- Replaced uniform placeholder drop rates for **all 10 clue scroll reward sources** with accurate per-item rates from the OSRS Wiki reward casket pages
- Rates are computed as per-casket probabilities: `1 - (1 - P_per_roll)^avg_rolls`
- Items within each source are now differentiated by rarity tier (standard, rare, mega-rare, etc.) rather than sharing a single uniform rate

## Sources updated
| Source | Items | Old rate | New rates (per casket) |
|--------|-------|----------|----------------------|
| Beginner Treasure Trails | 15 | 0.002778 | 0.005548 |
| Easy Treasure Trails | 131 | 0.007692 | 0.000214 - 0.00831 (5 tiers) |
| Medium Treasure Trails | 115 | 0.008772 | 0.001764 - 0.011679 (3 tiers) |
| Hard Treasure Trails | 134 | 0.007463 | 0.000513 - 0.018328 (3 tiers) |
| Elite Treasure Trails | 59 | 0.017241 | 0.000392 - 0.003915 (2 tiers) |
| Master Treasure Trails | 49 | 0.021277 | 0.000235 - 0.00703 (4 tiers) |
| Hard Rare Table | 24 | 0.041667 | 0.000024 - 0.00014 (2 tiers) |
| Elite Rare Table | 39 | 0.025641 | 0.00002 - 0.000341 (3 tiers) |
| Master Rare Table | 47 | 0.021739 | 0.000019 - 0.000441 (3 tiers) |
| Shared Rewards | 49 | 0.020408 | 0.003759 |

## Preserved
- Bloodhound pet: 0.001 (1/1,000) - unchanged
- Guaranteed drops (Large spade, Heavy casket, Scroll sack, Clueless scroll): 1.0 - unchanged

## Test plan
- [x] JSON validates successfully
- [x] `gradlew compileJava` passes
- [x] Bloodhound rate verified at 0.001
- [x] Guaranteed items verified at 1.0
- [ ] Manual testing: verify efficiency scores change appropriately in-game

Closes #102