### PR TITLE
Fix dialog highlights persisting between guidance steps

### DIFF
--- a/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
@@ -1004,6 +1004,7 @@ public class CollectionLogHelperPlugin extends Plugin
 	{
 		guidanceOverlay.clearTarget();
 		guidanceMinimapOverlay.clearTarget();
+		dialogHighlightOverlay.clear();
 		objectHighlightOverlay.clearTarget();
 		itemHighlightOverlay.clearTarget();
 		activeMapPoint = null;


### PR DESCRIPTION
## Summary
- Added missing `dialogHighlightOverlay.clear()` call to `clearGuidanceOverlays()`, preventing dialog option highlights from a previous step bleeding into subsequent guidance steps

## Test plan
- [x] Unit tests pass (`./gradlew test`)
- [ ] In-game: activate a multi-step source with dialog options, verify highlights clear between steps

Fixes #182