### PR TITLE
Add right-click Collection Log Guide menu entry on NPCs

### DIFF
--- a/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
@@ -59,9 +59,10 @@ import net.runelite.api.events.ItemSpawned;
 import net.runelite.api.events.ItemDespawned;
 import net.runelite.api.events.NpcSpawned;
 import net.runelite.api.events.NpcDespawned;
+import net.runelite.api.events.MenuEntryAdded;
+import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.client.events.NpcLootReceived;
 import net.runelite.client.game.ItemStack;
-import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.events.ScriptPreFired;
 import net.runelite.api.events.StatChanged;
 import net.runelite.api.events.VarbitChanged;
@@ -110,6 +111,8 @@ public class CollectionLogHelperPlugin extends Plugin
 
 	/** Ticks to wait after the last script 4100 fires before finalizing the scan. */
 	private static final int SCAN_SETTLE_TICKS = 3;
+
+	private static final String MENU_OPTION_GUIDE = "Collection Log Guide";
 
 	@Inject
 	private Client client;
@@ -1277,9 +1280,68 @@ public class CollectionLogHelperPlugin extends Plugin
 	}
 
 	@Subscribe
+	public void onMenuEntryAdded(MenuEntryAdded event)
+	{
+		if (!config.showOverlays())
+		{
+			return;
+		}
+
+		int type = event.getType();
+		if (type < MenuAction.NPC_FIRST_OPTION.getId() || type > MenuAction.NPC_FIFTH_OPTION.getId())
+		{
+			return;
+		}
+
+		NPC npc = event.getMenuEntry().getNpc();
+		if (npc == null)
+		{
+			return;
+		}
+
+		int npcId = npc.getId();
+		CollectionLogSource source = database.getSourceByNpcId(npcId);
+		if (source == null)
+		{
+			return;
+		}
+
+		// Skip if guidance is already active for this source
+		if (guidanceSequencer.isActive() && source.equals(guidanceSequencer.getActiveSource()))
+		{
+			return;
+		}
+
+		// Check if source has any missing items
+		boolean hasMissing = source.getItems().stream()
+			.anyMatch(item -> !collectionState.isItemObtained(item.getItemId()));
+		if (!hasMissing)
+		{
+			return;
+		}
+
+		client.getMenu().createMenuEntry(-1)
+			.setOption(MENU_OPTION_GUIDE)
+			.setTarget(event.getTarget())
+			.setType(MenuAction.RUNELITE)
+			.setIdentifier(npcId);
+	}
+
+	@Subscribe
 	public void onMenuOptionClicked(MenuOptionClicked event)
 	{
 		MenuAction action = event.getMenuAction();
+
+		// Handle "Collection Log Guide" right-click menu action
+		if (action == MenuAction.RUNELITE && MENU_OPTION_GUIDE.equals(event.getMenuOption()))
+		{
+			CollectionLogSource source = database.getSourceByNpcId(event.getId());
+			if (source != null)
+			{
+				activateGuidance(source);
+			}
+			return;
+		}
 
 		// Authoring mode: log all interactions regardless of guidance state
 		if (config.guidanceAuthoring())

--- a/src/main/java/com/collectionloghelper/data/DropRateDatabase.java
+++ b/src/main/java/com/collectionloghelper/data/DropRateDatabase.java
@@ -6,6 +6,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.reflect.Type;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -19,6 +20,7 @@ public class DropRateDatabase
 {
     private List<CollectionLogSource> sources = Collections.emptyList();
     private Map<Integer, CollectionLogItem> itemsById = Collections.emptyMap();
+    private Map<Integer, CollectionLogSource> sourcesByNpcId = Collections.emptyMap();
 
     @Inject
     private Gson gson;
@@ -43,6 +45,16 @@ public class DropRateDatabase
                     item -> item,
                     (a, b) -> a
                 ));
+
+            Map<Integer, CollectionLogSource> npcMap = new HashMap<>();
+            for (CollectionLogSource source : sources)
+            {
+                if (source.getNpcId() > 0)
+                {
+                    npcMap.put(source.getNpcId(), source);
+                }
+            }
+            sourcesByNpcId = npcMap;
 
             validateData();
             log.debug("Loaded {} sources with {} items", sources.size(), itemsById.size());
@@ -76,6 +88,11 @@ public class DropRateDatabase
     public CollectionLogItem getItemById(int itemId)
     {
         return itemsById.get(itemId);
+    }
+
+    public CollectionLogSource getSourceByNpcId(int npcId)
+    {
+        return sourcesByNpcId.get(npcId);
     }
 
     private void validateData()


### PR DESCRIPTION
## Summary
- Adds a "Collection Log Guide" right-click menu option on NPCs that match collection log sources with missing items
- Clicking the menu entry activates step-by-step guidance for that source
- Builds an NPC ID lookup map in `DropRateDatabase` for O(1) source resolution

Closes #200

## Test plan
- [ ] Right-click an NPC that has a collection log source with missing items — "Collection Log Guide" option should appear
- [ ] Click the option — guidance should activate for that source
- [ ] Right-click an NPC with no missing items — option should not appear
- [ ] Right-click a non-collection-log NPC — option should not appear
- [ ] Activate guidance for a source, then right-click that same NPC — option should not appear (already active)
- [ ] Verify menu entry does not appear when overlays are disabled in config