### PR TITLE
Add cumulative hopper counter for Trouble Brewing guidance

### DIFF
--- a/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
@@ -1191,7 +1191,14 @@ public class CollectionLogHelperPlugin extends Plugin
 			int current = guidanceSequencer.getCurrentIndex() + 1;
 			int total = guidanceSequencer.getTotalSteps();
 			activeInfoBox.setStepText(current + "/" + total);
-			activeInfoBox.setTooltipText(step.getDescription());
+			String tooltip = step.getDescription();
+			if (guidanceSequencer.getCumulativeTrackThreshold() > 0)
+			{
+				tooltip += "\n" + guidanceSequencer.getCumulativeActionCount()
+					+ "/" + guidanceSequencer.getCumulativeTrackThreshold()
+					+ " actions tracked";
+			}
+			activeInfoBox.setTooltipText(tooltip);
 			if (current == total)
 			{
 				activeInfoBox.setTextColor(java.awt.Color.GREEN);
@@ -1325,6 +1332,23 @@ public class CollectionLogHelperPlugin extends Plugin
 		if (!guidanceSequencer.isActive())
 		{
 			return;
+		}
+
+		// Track cumulative use-item-on-object actions for guidance (e.g., Trouble Brewing hopper)
+		if (action == MenuAction.WIDGET_TARGET_ON_GAME_OBJECT)
+		{
+			CollectionLogSource source = guidanceSequencer.getActiveSource();
+			if (source != null && source.getCumulativeTrackItemId() > 0
+					&& source.getCumulativeTrackObjectIds() != null)
+			{
+				int objectId = event.getId();
+				int itemId = event.getParam0();
+				if (itemId == source.getCumulativeTrackItemId()
+						&& source.getCumulativeTrackObjectIds().contains(objectId))
+				{
+					guidanceSequencer.onTrackedAction();
+				}
+			}
 		}
 
 		// Detect NPC interactions for NPC_TALKED_TO completion condition.

--- a/src/main/java/com/collectionloghelper/data/CollectionLogSource.java
+++ b/src/main/java/com/collectionloghelper/data/CollectionLogSource.java
@@ -27,6 +27,9 @@ public class CollectionLogSource
     List<String> dialogOptions;
     List<GuidanceStep> guidanceSteps;
     SourceRequirements requirements;
+    int cumulativeTrackItemId;
+    List<Integer> cumulativeTrackObjectIds;
+    int cumulativeTrackThreshold;
     List<CollectionLogItem> items;
 
     public RewardType getRewardType()

--- a/src/main/java/com/collectionloghelper/guidance/GuidanceSequencer.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceSequencer.java
@@ -35,6 +35,7 @@ public class GuidanceSequencer
 	private volatile int currentIndex;
 	private volatile boolean active;
 	private volatile int loopIterationsCompleted;
+	private volatile int cumulativeActionCount;
 
 	private Consumer<GuidanceStep> onStepChanged;
 	private Runnable onSequenceComplete;
@@ -66,6 +67,7 @@ public class GuidanceSequencer
 		this.steps = source.getGuidanceSteps();
 		this.currentIndex = 0;
 		this.loopIterationsCompleted = 0;
+		this.cumulativeActionCount = 0;
 		this.onStepChanged = stepChanged;
 		this.onSequenceComplete = sequenceComplete;
 		this.active = true;
@@ -157,6 +159,56 @@ public class GuidanceSequencer
 	public int getLoopIterationsCompleted()
 	{
 		return loopIterationsCompleted;
+	}
+
+	public int getCumulativeActionCount()
+	{
+		return cumulativeActionCount;
+	}
+
+	/**
+	 * Returns the cumulative track threshold from the active source, or 0 if none.
+	 */
+	public int getCumulativeTrackThreshold()
+	{
+		return activeSource != null ? activeSource.getCumulativeTrackThreshold() : 0;
+	}
+
+	/**
+	 * Called when the player performs a tracked use-item-on-object action
+	 * (e.g., emptying a bucket of water into the Trouble Brewing hopper).
+	 * Increments the cumulative counter and force-completes any active loop
+	 * when the threshold is reached.
+	 */
+	public void onTrackedAction()
+	{
+		if (!active || activeSource == null)
+		{
+			return;
+		}
+		int threshold = activeSource.getCumulativeTrackThreshold();
+		if (threshold <= 0)
+		{
+			return;
+		}
+		cumulativeActionCount++;
+		log.debug("Cumulative action {}/{}", cumulativeActionCount, threshold);
+		if (cumulativeActionCount >= threshold)
+		{
+			log.info("Cumulative threshold reached ({}/{}), completing loop", cumulativeActionCount, threshold);
+			// Force-complete any active loop and advance past it
+			for (int i = currentIndex; i < steps.size(); i++)
+			{
+				GuidanceStep s = steps.get(i);
+				if (s.getLoopCount() > 0)
+				{
+					loopIterationsCompleted = s.getLoopCount();
+					currentIndex = i;
+					advanceStep();
+					return;
+				}
+			}
+		}
 	}
 
 	/**

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -9908,6 +9908,9 @@
     "worldPlane": 0,
     "killTimeSeconds": 1200,
     "afkLevel": 3,
+    "cumulativeTrackItemId": 1929,
+    "cumulativeTrackObjectIds": [15847, 15873],
+    "cumulativeTrackThreshold": 100,
     "requirements": {
       "quests": [
         "CABIN_FEVER"

--- a/src/test/java/com/collectionloghelper/efficiency/EfficiencyCalculatorTest.java
+++ b/src/test/java/com/collectionloghelper/efficiency/EfficiencyCalculatorTest.java
@@ -72,7 +72,7 @@ public class EfficiencyCalculatorTest
 	{
 		return new CollectionLogSource(name, category, 3000, 3000, 0,
 			killTimeSeconds, name, Collections.emptyList(),
-			RewardType.DROP, 0, false, 1, false, 0, null, 0, null, null, null, null, items);
+			RewardType.DROP, 0, false, 1, false, 0, null, 0, null, null, null, null, 0, null, 0, items);
 	}
 
 	private CollectionLogSource makeShopSource(String name, int killTimeSeconds,
@@ -80,7 +80,7 @@ public class EfficiencyCalculatorTest
 	{
 		return new CollectionLogSource(name, CollectionLogCategory.OTHER, 3000, 3000, 0,
 			killTimeSeconds, name, Collections.emptyList(),
-			RewardType.SHOP, pointsPerHour, false, 1, false, 0, null, 0, null, null, null, null, items);
+			RewardType.SHOP, pointsPerHour, false, 1, false, 0, null, 0, null, null, null, null, 0, null, 0, items);
 	}
 
 	private CollectionLogSource makeMilestoneSource(String name, int killTimeSeconds,
@@ -88,7 +88,7 @@ public class EfficiencyCalculatorTest
 	{
 		return new CollectionLogSource(name, CollectionLogCategory.OTHER, 3000, 3000, 0,
 			killTimeSeconds, name, Collections.emptyList(),
-			RewardType.MILESTONE, 0, false, 1, false, 0, null, 0, null, null, null, null, items);
+			RewardType.MILESTONE, 0, false, 1, false, 0, null, 0, null, null, null, null, 0, null, 0, items);
 	}
 
 	private CollectionLogSource makeMixedSource(String name, int killTimeSeconds,
@@ -96,7 +96,7 @@ public class EfficiencyCalculatorTest
 	{
 		return new CollectionLogSource(name, CollectionLogCategory.OTHER, 3000, 3000, 0,
 			killTimeSeconds, name, Collections.emptyList(),
-			RewardType.MIXED, pointsPerHour, false, 1, false, 0, null, 0, null, null, null, null, items);
+			RewardType.MIXED, pointsPerHour, false, 1, false, 0, null, 0, null, null, null, null, 0, null, 0, items);
 	}
 
 	private CollectionLogSource makeAggregatedSource(String name, int killTimeSeconds,
@@ -104,7 +104,7 @@ public class EfficiencyCalculatorTest
 	{
 		return new CollectionLogSource(name, CollectionLogCategory.OTHER, 3000, 3000, 0,
 			killTimeSeconds, name, Collections.emptyList(),
-			RewardType.DROP, 0, false, 1, true, 0, null, 0, null, null, null, null, items);
+			RewardType.DROP, 0, false, 1, true, 0, null, 0, null, null, null, null, 0, null, 0, items);
 	}
 
 	private CollectionLogItem makeItem(int id, String name, double dropRate)
@@ -333,7 +333,7 @@ public class EfficiencyCalculatorTest
 		List<CollectionLogItem> items = Collections.singletonList(makeItem(1, "Drop", 1.0 / 512));
 		CollectionLogSource source = new CollectionLogSource("Test", CollectionLogCategory.BOSSES,
 			3000, 3000, 0, 120, "Test", Collections.emptyList(),
-			RewardType.DROP, 0, false, 2, false, 0, null, 0, null, null, null, null, items);
+			RewardType.DROP, 0, false, 2, false, 0, null, 0, null, null, null, null, 0, null, 0, items);
 		when(collectionState.isItemObtained(anyInt())).thenReturn(false);
 
 		ScoredItem result = calculator.scoreSource(source, false);
@@ -486,7 +486,7 @@ public class EfficiencyCalculatorTest
 		CollectionLogSource source = new CollectionLogSource("Easy Treasure Trails",
 			CollectionLogCategory.CLUES, 3000, 3000, 0, 600,
 			"Easy Treasure Trails", Collections.emptyList(),
-			RewardType.DROP, 0, false, 1, false, 0, null, 0, null, null, null, null,
+			RewardType.DROP, 0, false, 1, false, 0, null, 0, null, null, null, null, 0, null, 0,
 			Collections.singletonList(makeItem(1, "Drop", 0.01)));
 		when(clueEstimator.estimateCompletionSeconds("Easy Treasure Trails")).thenReturn(900);
 
@@ -500,7 +500,7 @@ public class EfficiencyCalculatorTest
 		CollectionLogSource source = new CollectionLogSource("Easy Treasure Trails",
 			CollectionLogCategory.CLUES, 3000, 3000, 0, 600,
 			"Easy Treasure Trails", Collections.emptyList(),
-			RewardType.DROP, 0, false, 1, false, 0, null, 0, null, null, null, null,
+			RewardType.DROP, 0, false, 1, false, 0, null, 0, null, null, null, null, 0, null, 0,
 			Collections.singletonList(makeItem(1, "Drop", 0.01)));
 		when(clueEstimator.estimateCompletionSeconds("Easy Treasure Trails")).thenReturn(0);
 
@@ -592,7 +592,7 @@ public class EfficiencyCalculatorTest
 		// Source with afkLevel 0 should be excluded when filter is AFK+ (minLevel=2)
 		CollectionLogSource source = new CollectionLogSource("Test Boss", CollectionLogCategory.BOSSES,
 			3000, 3000, 0, 60, "Test Boss", Collections.emptyList(),
-			RewardType.DROP, 0, false, 1, false, 0, null, 0, null, null, null, null,
+			RewardType.DROP, 0, false, 1, false, 0, null, 0, null, null, null, null, 0, null, 0,
 			Collections.singletonList(makeItem(1, "Drop", 0.01)));
 		lenient().when(collectionState.isItemObtained(1)).thenReturn(false);
 		when(database.getAllSources()).thenReturn(Collections.singletonList(source));
@@ -608,7 +608,7 @@ public class EfficiencyCalculatorTest
 		// Source with afkLevel 2 should be included when filter is AFK+ (minLevel=2)
 		CollectionLogSource source = new CollectionLogSource("AFK Source", CollectionLogCategory.BOSSES,
 			3000, 3000, 0, 60, "AFK Source", Collections.emptyList(),
-			RewardType.DROP, 0, false, 1, false, 2, null, 0, null, null, null, null,
+			RewardType.DROP, 0, false, 1, false, 2, null, 0, null, null, null, null, 0, null, 0,
 			Collections.singletonList(makeItem(1, "Drop", 0.01)));
 		when(collectionState.isItemObtained(1)).thenReturn(false);
 		when(database.getAllSources()).thenReturn(Collections.singletonList(source));
@@ -624,7 +624,7 @@ public class EfficiencyCalculatorTest
 		// When filter is OFF, all sources show regardless of afkLevel
 		CollectionLogSource source = new CollectionLogSource("Test Boss", CollectionLogCategory.BOSSES,
 			3000, 3000, 0, 60, "Test Boss", Collections.emptyList(),
-			RewardType.DROP, 0, false, 1, false, 0, null, 0, null, null, null, null,
+			RewardType.DROP, 0, false, 1, false, 0, null, 0, null, null, null, null, 0, null, 0,
 			Collections.singletonList(makeItem(1, "Drop", 0.01)));
 		when(collectionState.isItemObtained(1)).thenReturn(false);
 		when(database.getAllSources()).thenReturn(Collections.singletonList(source));
@@ -643,7 +643,7 @@ public class EfficiencyCalculatorTest
 		// effective kill time should be 20/0.05 = 400s
 		CollectionLogSource source = new CollectionLogSource("Abyssal Demon", CollectionLogCategory.OTHER,
 			3000, 3000, 0, 20, "Abyssal Demon", Collections.emptyList(),
-			RewardType.DROP, 0, false, 1, false, 0, null, 0, null, null, null, null,
+			RewardType.DROP, 0, false, 1, false, 0, null, 0, null, null, null, null, 0, null, 0,
 			Collections.singletonList(makeItem(1, "Whip", 0.001953)));
 		when(slayerMasterDatabase.getMasterNames()).thenReturn(Collections.singletonList("Duradel"));
 		when(slayerMasterDatabase.getTaskProbability("Duradel", "abyssal demons")).thenReturn(0.05);
@@ -658,7 +658,7 @@ public class EfficiencyCalculatorTest
 		// If currently on abyssal demon task, no overhead applied
 		CollectionLogSource source = new CollectionLogSource("Abyssal Demon", CollectionLogCategory.OTHER,
 			3000, 3000, 0, 20, "Abyssal Demon", Collections.emptyList(),
-			RewardType.DROP, 0, false, 1, false, 0, null, 0, null, null, null, null,
+			RewardType.DROP, 0, false, 1, false, 0, null, 0, null, null, null, null, 0, null, 0,
 			Collections.singletonList(makeItem(1, "Whip", 0.001953)));
 		when(slayerTaskState.isTaskActive()).thenReturn(true);
 		when(slayerTaskState.getCreatureName()).thenReturn("Abyssal demons");
@@ -673,7 +673,7 @@ public class EfficiencyCalculatorTest
 		// "Abyssal Sire" is NOT task-only (it's a boss), so no overhead
 		CollectionLogSource source = new CollectionLogSource("Abyssal Sire", CollectionLogCategory.BOSSES,
 			3000, 3000, 0, 180, "Abyssal Sire", Collections.emptyList(),
-			RewardType.DROP, 0, false, 1, false, 0, null, 0, null, null, null, null,
+			RewardType.DROP, 0, false, 1, false, 0, null, 0, null, null, null, null, 0, null, 0,
 			Collections.singletonList(makeItem(1, "Unsired", 0.0078)));
 
 		int effectiveTime = calculator.getEffectiveKillTime(source);
@@ -686,7 +686,7 @@ public class EfficiencyCalculatorTest
 		// Two masters: Duradel P=0.06, Nieve P=0.04 — should use Duradel (higher P = lower overhead)
 		CollectionLogSource source = new CollectionLogSource("Abyssal Demon", CollectionLogCategory.OTHER,
 			3000, 3000, 0, 12, "Abyssal Demon", Collections.emptyList(),
-			RewardType.DROP, 0, false, 1, false, 0, null, 0, null, null, null, null,
+			RewardType.DROP, 0, false, 1, false, 0, null, 0, null, null, null, null, 0, null, 0,
 			Collections.singletonList(makeItem(1, "Whip", 0.001953)));
 		when(slayerMasterDatabase.getMasterNames()).thenReturn(Arrays.asList("Duradel", "Nieve"));
 		when(slayerMasterDatabase.getTaskProbability("Duradel", "abyssal demons")).thenReturn(0.06);


### PR DESCRIPTION
## Summary
- Adds cumulative action tracking to guidance system: tracks use-item-on-object actions against a configurable item ID + object ID list with a threshold
- Configures Trouble Brewing with bucket of water (1929) on hopper objects (15847, 15873) with threshold 100, auto-completing the loop when reached
- Shows action progress (e.g., "42/100 actions tracked") in the InfoBox tooltip during active tracking

Closes #185

## Test plan
- [ ] Start Trouble Brewing guidance and verify the 4-iteration loop plays normally without the counter interfering
- [ ] Use bucket of water on hopper and verify counter increments in InfoBox tooltip
- [ ] Reach 100 uses and verify the loop auto-completes, advancing to the AFK step
- [ ] Verify other sources without cumulative tracking are unaffected