### PR TITLE
Add TooltipManager integration for hover info (#201)

### DIFF
--- a/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
@@ -1064,6 +1064,7 @@ public class CollectionLogHelperPlugin extends Plugin
 		objectHighlightOverlay.setTargetObjectIds(step.getAllObjectIds());
 		objectHighlightOverlay.setObjectInteractAction(step.getObjectInteractAction());
 		objectHighlightOverlay.setUseItemOnObject(step.isUseItemOnObject());
+		objectHighlightOverlay.setTooltipText(step.getDescription());
 
 		itemHighlightOverlay.setTargetItemIds(step.getHighlightItemIds());
 		itemHighlightOverlay.setUseItemOnObject(step.isUseItemOnObject());

--- a/src/main/java/com/collectionloghelper/overlay/GuidanceOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/GuidanceOverlay.java
@@ -24,6 +24,8 @@ import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayUtil;
 import net.runelite.client.ui.overlay.components.LineComponent;
 import net.runelite.client.ui.overlay.components.TitleComponent;
+import net.runelite.client.ui.overlay.tooltip.Tooltip;
+import net.runelite.client.ui.overlay.tooltip.TooltipManager;
 import javax.inject.Singleton;
 
 @Singleton
@@ -36,6 +38,9 @@ public class GuidanceOverlay extends OverlayPanel
 
 	private final Client client;
 	private final CollectionLogHelperConfig config;
+
+	@Inject
+	private TooltipManager tooltipManager;
 
 	private volatile WorldPoint targetPoint;
 	private volatile String targetName;
@@ -149,7 +154,7 @@ public class GuidanceOverlay extends OverlayPanel
 			{
 				if (npc != null && npc.getId() == npcId)
 				{
-					renderNpcHighlight(graphics, npc, overlayColor, action);
+					renderNpcHighlight(graphics, npc, overlayColor, action, locDesc);
 					npcHighlighted = true;
 					break;
 				}
@@ -185,7 +190,8 @@ public class GuidanceOverlay extends OverlayPanel
 	 * Renders a highlight around an NPC with a downward-pointing arrow and
 	 * action label above it, similar to Quest Helper's NPC step rendering.
 	 */
-	private void renderNpcHighlight(Graphics2D graphics, NPC npc, Color overlayColor, String action)
+	private void renderNpcHighlight(Graphics2D graphics, NPC npc, Color overlayColor, String action,
+		String locDesc)
 	{
 		Shape hull = npc.getConvexHull();
 		if (hull != null)
@@ -203,6 +209,17 @@ public class GuidanceOverlay extends OverlayPanel
 			int arrowX = (int) bounds.getCenterX();
 			int arrowTipY = (int) bounds.getMinY() - ARROW_GAP;
 			renderDirectionArrow(graphics, arrowX, arrowTipY, overlayColor);
+
+			// Show tooltip when mouse hovers over the NPC hull
+			String builtTooltip = OverlayTooltipHelper.buildTooltip(locDesc, action);
+			if (builtTooltip != null)
+			{
+				Point mousePos = client.getMouseCanvasPosition();
+				if (mousePos != null && hull.contains(mousePos.getX(), mousePos.getY()))
+				{
+					tooltipManager.add(new Tooltip(builtTooltip));
+				}
+			}
 		}
 
 		// Render action text above the NPC and arrow

--- a/src/main/java/com/collectionloghelper/overlay/ObjectHighlightOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/ObjectHighlightOverlay.java
@@ -26,6 +26,8 @@ import net.runelite.api.coords.LocalPoint;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.tooltip.Tooltip;
+import net.runelite.client.ui.overlay.tooltip.TooltipManager;
 import javax.inject.Singleton;
 
 @Singleton
@@ -39,9 +41,13 @@ public class ObjectHighlightOverlay extends Overlay
 	private final Client client;
 	private final CollectionLogHelperConfig config;
 
+	@Inject
+	private TooltipManager tooltipManager;
+
 	private volatile Set<Integer> targetObjectIds = Collections.emptySet();
 	private volatile String objectInteractAction;
 	private volatile boolean useItemOnObject;
+	private volatile String tooltipText;
 
 	@Inject
 	private ObjectHighlightOverlay(Client client, CollectionLogHelperConfig config)
@@ -72,11 +78,17 @@ public class ObjectHighlightOverlay extends Overlay
 		this.useItemOnObject = value;
 	}
 
+	public void setTooltipText(String text)
+	{
+		this.tooltipText = text;
+	}
+
 	public void clearTarget()
 	{
 		this.targetObjectIds = Collections.emptySet();
 		this.objectInteractAction = null;
 		this.useItemOnObject = false;
+		this.tooltipText = null;
 	}
 
 	@Override
@@ -86,6 +98,7 @@ public class ObjectHighlightOverlay extends Overlay
 		final Set<Integer> objIds = this.targetObjectIds;
 		final String action = this.objectInteractAction;
 		final boolean useItem = this.useItemOnObject;
+		final String tipText = this.tooltipText;
 
 		if (objIds.isEmpty())
 		{
@@ -110,6 +123,9 @@ public class ObjectHighlightOverlay extends Overlay
 			return null;
 		}
 		Tile[][] tiles = allTiles[plane];
+		final Point mousePos = client.getMouseCanvasPosition();
+		final String builtTooltip = OverlayTooltipHelper.buildTooltip(tipText, action);
+		boolean tooltipShown = false;
 
 		for (Tile[] row : tiles)
 		{
@@ -133,8 +149,9 @@ public class ObjectHighlightOverlay extends Overlay
 					{
 						if (gameObject != null && objIds.contains(gameObject.getId()))
 						{
-							renderObjectHighlight(graphics, gameObject.getConvexHull(),
-								gameObject.getLocalLocation(), overlayColor, action, useItem);
+							tooltipShown |= renderObjectHighlight(graphics, gameObject.getConvexHull(),
+								gameObject.getLocalLocation(), overlayColor, action, useItem,
+								mousePos, builtTooltip, tooltipShown);
 						}
 					}
 				}
@@ -143,16 +160,18 @@ public class ObjectHighlightOverlay extends Overlay
 				WallObject wallObject = tile.getWallObject();
 				if (wallObject != null && objIds.contains(wallObject.getId()))
 				{
-					renderObjectHighlight(graphics, wallObject.getConvexHull(),
-						wallObject.getLocalLocation(), overlayColor, action, useItem);
+					tooltipShown |= renderObjectHighlight(graphics, wallObject.getConvexHull(),
+						wallObject.getLocalLocation(), overlayColor, action, useItem,
+						mousePos, builtTooltip, tooltipShown);
 				}
 
 				// Check decorative objects
 				DecorativeObject decorativeObject = tile.getDecorativeObject();
 				if (decorativeObject != null && objIds.contains(decorativeObject.getId()))
 				{
-					renderObjectHighlight(graphics, decorativeObject.getConvexHull(),
-						decorativeObject.getLocalLocation(), overlayColor, action, useItem);
+					tooltipShown |= renderObjectHighlight(graphics, decorativeObject.getConvexHull(),
+						decorativeObject.getLocalLocation(), overlayColor, action, useItem,
+						mousePos, builtTooltip, tooltipShown);
 				}
 			}
 		}
@@ -160,9 +179,11 @@ public class ObjectHighlightOverlay extends Overlay
 		return null;
 	}
 
-	private void renderObjectHighlight(Graphics2D graphics, Shape hull, LocalPoint localPoint,
-		Color overlayColor, String action, boolean useItem)
+	private boolean renderObjectHighlight(Graphics2D graphics, Shape hull, LocalPoint localPoint,
+		Color overlayColor, String action, boolean useItem,
+		Point mousePos, String builtTooltip, boolean tooltipAlreadyShown)
 	{
+		boolean showedTooltip = false;
 		if (hull != null)
 		{
 			Color fillColor = new Color(overlayColor.getRed(), overlayColor.getGreen(),
@@ -178,6 +199,14 @@ public class ObjectHighlightOverlay extends Overlay
 			int arrowX = (int) bounds.getCenterX();
 			int arrowTipY = (int) bounds.getMinY() - ARROW_GAP;
 			renderDirectionArrow(graphics, arrowX, arrowTipY, overlayColor);
+
+			// Show tooltip when mouse hovers over the object hull (once per frame)
+			if (!tooltipAlreadyShown && builtTooltip != null
+				&& mousePos != null && hull.contains(mousePos.getX(), mousePos.getY()))
+			{
+				tooltipManager.add(new Tooltip(builtTooltip));
+				showedTooltip = true;
+			}
 		}
 
 		// Render action text above the object
@@ -191,6 +220,7 @@ public class ObjectHighlightOverlay extends Overlay
 				renderOutlinedText(graphics, textPoint, displayText, overlayColor);
 			}
 		}
+		return showedTooltip;
 	}
 
 	private void renderDirectionArrow(Graphics2D graphics, int x, int tipY, Color color)

--- a/src/main/java/com/collectionloghelper/overlay/OverlayTooltipHelper.java
+++ b/src/main/java/com/collectionloghelper/overlay/OverlayTooltipHelper.java
@@ -1,0 +1,33 @@
+package com.collectionloghelper.overlay;
+
+/**
+ * Shared helper for building tooltip strings used by guidance overlays.
+ */
+final class OverlayTooltipHelper
+{
+	private OverlayTooltipHelper()
+	{
+	}
+
+	/**
+	 * Builds a tooltip string from a step description and action, using RuneLite's
+	 * {@code </br>} line break format. Returns null if both inputs are empty.
+	 */
+	static String buildTooltip(String stepDescription, String action)
+	{
+		StringBuilder tip = new StringBuilder();
+		if (stepDescription != null && !stepDescription.isEmpty())
+		{
+			tip.append("Step: ").append(stepDescription);
+		}
+		if (action != null && !action.isEmpty())
+		{
+			if (tip.length() > 0)
+			{
+				tip.append("</br>");
+			}
+			tip.append("Action: ").append(action);
+		}
+		return tip.length() > 0 ? tip.toString() : null;
+	}
+}


### PR DESCRIPTION
## Summary
- Show rich tooltips when hovering over guidance-highlighted NPCs (GuidanceOverlay) and game objects (ObjectHighlightOverlay)
- Tooltip displays step description and required action using RuneLite's `TooltipManager` API
- Shared tooltip string building via `OverlayTooltipHelper` to avoid duplication
- ObjectHighlightOverlay computes mouse position once per render frame and caps tooltip display to one per frame

## Test plan
- [ ] Verify NPC tooltip appears when hovering over a guidance-highlighted NPC in-game
- [ ] Verify object tooltip appears when hovering over a guidance-highlighted game object
- [ ] Verify tooltip disappears when mouse moves off the highlighted entity
- [ ] Verify no duplicate tooltips when multiple matching objects are on screen
- [ ] Compilation passes, pre-existing unit tests unaffected

Closes #201