### PR TITLE
Fix potential NPE in GuidanceOverlay tile text rendering

### DIFF
--- a/src/main/java/com/collectionloghelper/overlay/GuidanceOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/GuidanceOverlay.java
@@ -251,9 +251,11 @@ public class GuidanceOverlay extends OverlayPanel
 
 			if (name != null)
 			{
-				OverlayUtil.renderTextLocation(graphics,
-					Perspective.getCanvasTextLocation(client, graphics, localPoint, name, 150),
-					name, overlayColor);
+				Point tileTextPoint = Perspective.getCanvasTextLocation(client, graphics, localPoint, name, 150);
+				if (tileTextPoint != null)
+				{
+					OverlayUtil.renderTextLocation(graphics, tileTextPoint, name, overlayColor);
+				}
 			}
 		}
 


### PR DESCRIPTION
## Summary
- Add null check on `Perspective.getCanvasTextLocation()` return value before passing to `OverlayUtil.renderTextLocation()` in the tile highlight path
- Prevents client crash (NPE) when the tile is off-screen or at extreme camera angles
- Matches the existing null-check pattern already used at lines 334-338 in the same file

## Test plan
- [x] `./gradlew test` passes
- [ ] Verify tile text renders normally when guidance overlay is active
- [ ] Verify no crash when panning camera away from highlighted tile