### PR TITLE
Cache NPC scan result in guidance overlay render fallback

### DIFF
--- a/src/main/java/com/collectionloghelper/overlay/GuidanceOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/GuidanceOverlay.java
@@ -225,6 +225,8 @@ public class GuidanceOverlay extends OverlayPanel
 								}
 							}
 							npc = candidate;
+							this.trackedNpc = candidate;
+							rebuildNpcLabel(this.interactAction, candidate);
 							break;
 						}
 					}


### PR DESCRIPTION
## Summary
- Write found NPC back to `this.trackedNpc` after the fallback scan in `render()` finds a match
- Previously, the scan assigned to a local variable but never cached the result, causing O(n) NPC iteration every frame until the NPC despawned/respawned
- Also calls `rebuildNpcLabel()` so the overlay label updates immediately

## Test plan
- [x] `./gradlew test` passes
- [ ] Verify NPC highlighting works when navigating to a source with an NPC target
- [ ] Verify NPC highlight persists across frames without lag