### PR TITLE
Convert spaces to tabs in data model files

### DIFF
--- a/src/main/java/com/collectionloghelper/data/CollectionLogCategory.java
+++ b/src/main/java/com/collectionloghelper/data/CollectionLogCategory.java
@@ -31,11 +31,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum CollectionLogCategory
 {
-    BOSSES("Bosses"),
-    RAIDS("Raids"),
-    CLUES("Clues"),
-    MINIGAMES("Minigames"),
-    OTHER("Other");
+	BOSSES("Bosses"),
+	RAIDS("Raids"),
+	CLUES("Clues"),
+	MINIGAMES("Minigames"),
+	OTHER("Other");
 
-    private final String displayName;
+	private final String displayName;
 }

--- a/src/main/java/com/collectionloghelper/data/CollectionLogItem.java
+++ b/src/main/java/com/collectionloghelper/data/CollectionLogItem.java
@@ -29,14 +29,14 @@ import lombok.Value;
 @Value
 public class CollectionLogItem
 {
-    int itemId;
-    String name;
-    double dropRate;
-    int varbitId;
-    boolean isPet;
-    String wikiPage;
-    int pointCost;
-    int milestoneKills;
-    boolean requiresPrevious;
-    boolean independent;
+	int itemId;
+	String name;
+	double dropRate;
+	int varbitId;
+	boolean isPet;
+	String wikiPage;
+	int pointCost;
+	int milestoneKills;
+	boolean requiresPrevious;
+	boolean independent;
 }

--- a/src/main/java/com/collectionloghelper/data/CollectionLogSource.java
+++ b/src/main/java/com/collectionloghelper/data/CollectionLogSource.java
@@ -31,99 +31,99 @@ import net.runelite.api.coords.WorldPoint;
 @Value
 public class CollectionLogSource
 {
-    String name;
-    CollectionLogCategory category;
-    int worldX;
-    int worldY;
-    int worldPlane;
-    int killTimeSeconds;
-    int ironKillTimeSeconds;
-    String locationDescription;
-    List<Waypoint> waypoints;
-    RewardType rewardType;
-    double pointsPerHour;
-    boolean mutuallyExclusive;
-    List<String> mutuallyExclusiveSources;
-    int rollsPerKill;
-    boolean aggregated;
-    int afkLevel;
-    String travelTip;
-    int npcId;
-    String interactAction;
-    List<String> dialogOptions;
-    List<GuidanceStep> guidanceSteps;
-    SourceRequirements requirements;
-    int cumulativeTrackItemId;
-    List<Integer> cumulativeTrackObjectIds;
-    int cumulativeTrackThreshold;
-    List<CollectionLogItem> items;
+	String name;
+	CollectionLogCategory category;
+	int worldX;
+	int worldY;
+	int worldPlane;
+	int killTimeSeconds;
+	int ironKillTimeSeconds;
+	String locationDescription;
+	List<Waypoint> waypoints;
+	RewardType rewardType;
+	double pointsPerHour;
+	boolean mutuallyExclusive;
+	List<String> mutuallyExclusiveSources;
+	int rollsPerKill;
+	boolean aggregated;
+	int afkLevel;
+	String travelTip;
+	int npcId;
+	String interactAction;
+	List<String> dialogOptions;
+	List<GuidanceStep> guidanceSteps;
+	SourceRequirements requirements;
+	int cumulativeTrackItemId;
+	List<Integer> cumulativeTrackObjectIds;
+	int cumulativeTrackThreshold;
+	List<CollectionLogItem> items;
 
-    public RewardType getRewardType()
-    {
-        return rewardType != null ? rewardType : RewardType.DROP;
-    }
+	public RewardType getRewardType()
+	{
+		return rewardType != null ? rewardType : RewardType.DROP;
+	}
 
-    public int getRollsPerKill()
-    {
-        return rollsPerKill > 0 ? rollsPerKill : 1;
-    }
+	public int getRollsPerKill()
+	{
+		return rollsPerKill > 0 ? rollsPerKill : 1;
+	}
 
-    public WorldPoint getWorldPoint()
-    {
-        if (waypoints != null && !waypoints.isEmpty())
-        {
-            return waypoints.get(0).getWorldPoint();
-        }
-        return new WorldPoint(worldX, worldY, worldPlane);
-    }
+	public WorldPoint getWorldPoint()
+	{
+		if (waypoints != null && !waypoints.isEmpty())
+		{
+			return waypoints.get(0).getWorldPoint();
+		}
+		return new WorldPoint(worldX, worldY, worldPlane);
+	}
 
-    /**
-     * Returns the best accessible waypoint for this source based on the player's
-     * quest/skill progression. Falls back to the first waypoint or default coords.
-     */
-    public WorldPoint getWorldPoint(RequirementsChecker checker)
-    {
-        if (waypoints != null && !waypoints.isEmpty())
-        {
-            for (Waypoint wp : waypoints)
-            {
-                if (wp.getRequirements() == null || checker.meetsRequirements(wp.getRequirements()))
-                {
-                    return wp.getWorldPoint();
-                }
-            }
-            // All waypoints locked — use last as fallback
-            return waypoints.get(waypoints.size() - 1).getWorldPoint();
-        }
-        return new WorldPoint(worldX, worldY, worldPlane);
-    }
+	/**
+	 * Returns the best accessible waypoint for this source based on the player's
+	 * quest/skill progression. Falls back to the first waypoint or default coords.
+	 */
+	public WorldPoint getWorldPoint(RequirementsChecker checker)
+	{
+		if (waypoints != null && !waypoints.isEmpty())
+		{
+			for (Waypoint wp : waypoints)
+			{
+				if (wp.getRequirements() == null || checker.meetsRequirements(wp.getRequirements()))
+				{
+					return wp.getWorldPoint();
+				}
+			}
+			// All waypoints locked — use last as fallback
+			return waypoints.get(waypoints.size() - 1).getWorldPoint();
+		}
+		return new WorldPoint(worldX, worldY, worldPlane);
+	}
 
-    /**
-     * Returns the display location for the best accessible waypoint.
-     */
-    public String getDisplayLocation(RequirementsChecker checker)
-    {
-        if (waypoints != null && !waypoints.isEmpty())
-        {
-            for (Waypoint wp : waypoints)
-            {
-                if (wp.getRequirements() == null || checker.meetsRequirements(wp.getRequirements()))
-                {
-                    return wp.getName() != null ? wp.getName() : getDisplayLocation();
-                }
-            }
-            Waypoint last = waypoints.get(waypoints.size() - 1);
-            return last.getName() != null ? last.getName() : getDisplayLocation();
-        }
-        return getDisplayLocation();
-    }
+	/**
+	 * Returns the display location for the best accessible waypoint.
+	 */
+	public String getDisplayLocation(RequirementsChecker checker)
+	{
+		if (waypoints != null && !waypoints.isEmpty())
+		{
+			for (Waypoint wp : waypoints)
+			{
+				if (wp.getRequirements() == null || checker.meetsRequirements(wp.getRequirements()))
+				{
+					return wp.getName() != null ? wp.getName() : getDisplayLocation();
+				}
+			}
+			Waypoint last = waypoints.get(waypoints.size() - 1);
+			return last.getName() != null ? last.getName() : getDisplayLocation();
+		}
+		return getDisplayLocation();
+	}
 
-    public String getDisplayLocation()
-    {
-        if (locationDescription != null && !locationDescription.isEmpty())
-        {
-            return locationDescription;
-        }
-        return name;
-    }
+	public String getDisplayLocation()
+	{
+		if (locationDescription != null && !locationDescription.isEmpty())
+		{
+			return locationDescription;
+		}
+		return name;
+	}
 }

--- a/src/main/java/com/collectionloghelper/data/DropRateDatabase.java
+++ b/src/main/java/com/collectionloghelper/data/DropRateDatabase.java
@@ -44,121 +44,121 @@ import lombok.extern.slf4j.Slf4j;
 @Singleton
 public class DropRateDatabase
 {
-    private List<CollectionLogSource> sources = Collections.emptyList();
-    private Map<Integer, CollectionLogItem> itemsById = Collections.emptyMap();
-    private Map<String, CollectionLogItem> itemsByName = Collections.emptyMap();
-    private Map<Integer, CollectionLogSource> sourcesByNpcId = Collections.emptyMap();
-    private Map<CollectionLogCategory, List<CollectionLogSource>> sourcesByCategory = Collections.emptyMap();
-    private Map<String, CollectionLogSource> sourcesByNameLower = Collections.emptyMap();
+	private List<CollectionLogSource> sources = Collections.emptyList();
+	private Map<Integer, CollectionLogItem> itemsById = Collections.emptyMap();
+	private Map<String, CollectionLogItem> itemsByName = Collections.emptyMap();
+	private Map<Integer, CollectionLogSource> sourcesByNpcId = Collections.emptyMap();
+	private Map<CollectionLogCategory, List<CollectionLogSource>> sourcesByCategory = Collections.emptyMap();
+	private Map<String, CollectionLogSource> sourcesByNameLower = Collections.emptyMap();
 
-    @Inject
-    private Gson gson;
+	@Inject
+	private Gson gson;
 
-    public void load()
-    {
-        try (InputStream is = getClass().getResourceAsStream("/com/collectionloghelper/drop_rates.json"))
-        {
-            if (is == null)
-            {
-                log.warn("drop_rates.json not found in resources");
-                return;
-            }
+	public void load()
+	{
+		try (InputStream is = getClass().getResourceAsStream("/com/collectionloghelper/drop_rates.json"))
+		{
+			if (is == null)
+			{
+				log.warn("drop_rates.json not found in resources");
+				return;
+			}
 
-            Type listType = new TypeToken<List<CollectionLogSource>>(){}.getType();
-            sources = gson.fromJson(new InputStreamReader(is), listType);
+			Type listType = new TypeToken<List<CollectionLogSource>>(){}.getType();
+			sources = gson.fromJson(new InputStreamReader(is), listType);
 
-            itemsById = sources.stream()
-                .flatMap(s -> s.getItems().stream())
-                .collect(Collectors.toMap(
-                    CollectionLogItem::getItemId,
-                    item -> item,
-                    (a, b) -> a
-                ));
+			itemsById = sources.stream()
+				.flatMap(s -> s.getItems().stream())
+				.collect(Collectors.toMap(
+					CollectionLogItem::getItemId,
+					item -> item,
+					(a, b) -> a
+				));
 
-            Map<String, CollectionLogItem> nameMap = new HashMap<>();
-            for (CollectionLogItem item : itemsById.values())
-            {
-                nameMap.putIfAbsent(item.getName().toLowerCase(), item);
-            }
-            itemsByName = nameMap;
+			Map<String, CollectionLogItem> nameMap = new HashMap<>();
+			for (CollectionLogItem item : itemsById.values())
+			{
+				nameMap.putIfAbsent(item.getName().toLowerCase(), item);
+			}
+			itemsByName = nameMap;
 
-            Map<Integer, CollectionLogSource> npcMap = new HashMap<>();
-            Map<CollectionLogCategory, List<CollectionLogSource>> catMap = new EnumMap<>(CollectionLogCategory.class);
-            Map<String, CollectionLogSource> nameMap2 = new HashMap<>();
-            for (CollectionLogSource source : sources)
-            {
-                if (source.getNpcId() > 0)
-                {
-                    npcMap.put(source.getNpcId(), source);
-                }
-                catMap.computeIfAbsent(source.getCategory(), k -> new ArrayList<>()).add(source);
-                nameMap2.put(source.getName().toLowerCase(), source);
-            }
-            sourcesByNpcId = npcMap;
-            sourcesByCategory = catMap;
-            sourcesByNameLower = nameMap2;
+			Map<Integer, CollectionLogSource> npcMap = new HashMap<>();
+			Map<CollectionLogCategory, List<CollectionLogSource>> catMap = new EnumMap<>(CollectionLogCategory.class);
+			Map<String, CollectionLogSource> nameMap2 = new HashMap<>();
+			for (CollectionLogSource source : sources)
+			{
+				if (source.getNpcId() > 0)
+				{
+					npcMap.put(source.getNpcId(), source);
+				}
+				catMap.computeIfAbsent(source.getCategory(), k -> new ArrayList<>()).add(source);
+				nameMap2.put(source.getName().toLowerCase(), source);
+			}
+			sourcesByNpcId = npcMap;
+			sourcesByCategory = catMap;
+			sourcesByNameLower = nameMap2;
 
-            validateData();
-            log.debug("Loaded {} sources with {} items", sources.size(), itemsById.size());
-        }
-        catch (Exception e)
-        {
-            log.error("Failed to load drop rate database", e);
-        }
-    }
+			validateData();
+			log.debug("Loaded {} sources with {} items", sources.size(), itemsById.size());
+		}
+		catch (Exception e)
+		{
+			log.error("Failed to load drop rate database", e);
+		}
+	}
 
-    public List<CollectionLogSource> getAllSources()
-    {
-        return Collections.unmodifiableList(sources);
-    }
+	public List<CollectionLogSource> getAllSources()
+	{
+		return Collections.unmodifiableList(sources);
+	}
 
-    public List<CollectionLogSource> getSourcesByCategory(CollectionLogCategory category)
-    {
-        return sourcesByCategory.getOrDefault(category, Collections.emptyList());
-    }
+	public List<CollectionLogSource> getSourcesByCategory(CollectionLogCategory category)
+	{
+		return sourcesByCategory.getOrDefault(category, Collections.emptyList());
+	}
 
-    public CollectionLogSource getSourceByName(String name)
-    {
-        return sourcesByNameLower.get(name.toLowerCase());
-    }
+	public CollectionLogSource getSourceByName(String name)
+	{
+		return sourcesByNameLower.get(name.toLowerCase());
+	}
 
-    public CollectionLogItem getItemById(int itemId)
-    {
-        return itemsById.get(itemId);
-    }
+	public CollectionLogItem getItemById(int itemId)
+	{
+		return itemsById.get(itemId);
+	}
 
-    public CollectionLogItem getItemByName(String name)
-    {
-        return itemsByName.get(name.toLowerCase());
-    }
+	public CollectionLogItem getItemByName(String name)
+	{
+		return itemsByName.get(name.toLowerCase());
+	}
 
-    public CollectionLogSource getSourceByNpcId(int npcId)
-    {
-        return sourcesByNpcId.get(npcId);
-    }
+	public CollectionLogSource getSourceByNpcId(int npcId)
+	{
+		return sourcesByNpcId.get(npcId);
+	}
 
-    private void validateData()
-    {
-        for (CollectionLogSource source : sources)
-        {
-            for (CollectionLogItem item : source.getItems())
-            {
-                if (item.getDropRate() < 0)
-                {
-                    log.warn("Invalid negative dropRate {} for item '{}' in source '{}'",
-                        item.getDropRate(), item.getName(), source.getName());
-                }
-                else if (item.getDropRate() == 0)
-                {
-                    log.warn("Zero dropRate for item '{}' in source '{}' — will use fallback scoring",
-                        item.getName(), source.getName());
-                }
-                else if (item.getDropRate() > 1.0)
-                {
-                    log.warn("dropRate {} > 1.0 for non-guaranteed item '{}' in source '{}'",
-                        item.getDropRate(), item.getName(), source.getName());
-                }
-            }
-        }
-    }
+	private void validateData()
+	{
+		for (CollectionLogSource source : sources)
+		{
+			for (CollectionLogItem item : source.getItems())
+			{
+				if (item.getDropRate() < 0)
+				{
+					log.warn("Invalid negative dropRate {} for item '{}' in source '{}'",
+						item.getDropRate(), item.getName(), source.getName());
+				}
+				else if (item.getDropRate() == 0)
+				{
+					log.warn("Zero dropRate for item '{}' in source '{}' — will use fallback scoring",
+						item.getName(), source.getName());
+				}
+				else if (item.getDropRate() > 1.0)
+				{
+					log.warn("dropRate {} > 1.0 for non-guaranteed item '{}' in source '{}'",
+						item.getDropRate(), item.getName(), source.getName());
+				}
+			}
+		}
+	}
 }

--- a/src/main/java/com/collectionloghelper/data/Waypoint.java
+++ b/src/main/java/com/collectionloghelper/data/Waypoint.java
@@ -30,14 +30,14 @@ import net.runelite.api.coords.WorldPoint;
 @Value
 public class Waypoint
 {
-    String name;
-    int worldX;
-    int worldY;
-    int worldPlane;
-    SourceRequirements requirements;
+	String name;
+	int worldX;
+	int worldY;
+	int worldPlane;
+	SourceRequirements requirements;
 
-    public WorldPoint getWorldPoint()
-    {
-        return new WorldPoint(worldX, worldY, worldPlane);
-    }
+	public WorldPoint getWorldPoint()
+	{
+		return new WorldPoint(worldX, worldY, worldPlane);
+	}
 }


### PR DESCRIPTION
## Summary
- Convert 4-space indentation to tabs in 5 data model files for Plugin Hub checkstyle compliance
- Whitespace-only change, zero functional impact
- Files: CollectionLogCategory, CollectionLogItem, CollectionLogSource, DropRateDatabase, Waypoint

## Test plan
- [x] `./gradlew test` passes
- [x] 231 insertions, 231 deletions (whitespace-only)