### PR TITLE
Fix Sol Heredit kill time to include full Colosseum run

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -6796,7 +6796,7 @@
     "worldX": 1794,
     "worldY": 3107,
     "worldPlane": 0,
-    "killTimeSeconds": 514,
+    "killTimeSeconds": 1440,
     "requirements": {
       "quests": [
         "CHILDREN_OF_THE_SUN"


### PR DESCRIPTION
## Summary
- Sol Heredit was timed at 514s (just the boss fight)
- Players must complete 12 Colosseum waves (~24 min) to reach the boss
- Updated to 1440s (2.5/hr) matching TempleOSRS EHB
- This was ranking Sol Heredit too high relative to its actual time investment

## Test plan
- [x] All existing unit tests pass
- [ ] Verify Sol Heredit drops in rankings to reflect true time cost
- [ ] Compare with Log Adviser positioning