### PR TITLE
Tune Tempoross and Wintertodt effective rates

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -6466,7 +6466,7 @@
     "worldX": 3135,
     "worldY": 2840,
     "worldPlane": 0,
-    "killTimeSeconds": 600,
+    "killTimeSeconds": 450,
     "afkLevel": 1,
     "items": [
       {
@@ -6714,7 +6714,7 @@
         "completionNpcId": 7374
       }
     ],
-    "rollsPerKill": 10,
+    "rollsPerKill": 8,
     "ironKillTimeSeconds": 655
   },
   {


### PR DESCRIPTION
## Summary
- **Tempoross**: killTimeSeconds 600→450 (with rollsPerKill=10, gives 80 searches/hr matching Log Adviser)
- **Wintertodt**: rollsPerKill 10→8 (at 5.5 games/hr, gives 44 rolls/hr vs Log Adviser's 42/hr)
- Both changes align with efficient high-level play rates from Log Hunters community data

## Test plan
- [x] All existing unit tests pass
- [ ] Verify Tempoross and Wintertodt rankings shift modestly
- [ ] Compare time estimates with Log Adviser