### PR TITLE
Fix Doom of Mokhaiotl rates to use cumulative delve-to-10 model

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -18820,7 +18820,7 @@
       {
         "itemId": 31088,
         "name": "Avernic treads",
-        "dropRate": 0.001852,
+        "dropRate": 0.009920,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Avernic_treads"
@@ -18828,7 +18828,7 @@
       {
         "itemId": 31115,
         "name": "Eye of ayak (uncharged)",
-        "dropRate": 0.001852,
+        "dropRate": 0.010415,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Eye_of_ayak_(uncharged)"
@@ -18836,7 +18836,7 @@
       {
         "itemId": 31109,
         "name": "Mokhaiotl cloth",
-        "dropRate": 0.001852,
+        "dropRate": 0.010811,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Mokhaiotl_cloth"
@@ -18844,7 +18844,7 @@
       {
         "itemId": 31099,
         "name": "Mokhaiotl waystone",
-        "dropRate": 0.067308,
+        "dropRate": 0.501823,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Mokhaiotl_waystone"
@@ -18861,7 +18861,7 @@
       {
         "itemId": 31130,
         "name": "Dom",
-        "dropRate": 0.004,
+        "dropRate": 0.012277,
         "varbitId": 0,
         "isPet": true,
         "wikiPage": "Dom",


### PR DESCRIPTION
## Summary
- Delving to depth 10 means fighting 10 times (depths 1-10) with independent rolls each
- Plugin was using single depth-9 rates instead of cumulative probability across all depths
- Items unlock at different depths, giving each a unique cumulative rate
- Avernic treads 1/540→1/100.8, Eye 1/540→1/96.0, Cloth 1/540→1/92.5, Waystone 1/14.9→1/2.0, Dom 1/250→1/81.5
- Now matches Log Hunters Log Adviser within rounding

## Test plan
- [x] All existing unit tests pass
- [ ] Verify Doom of Mokhaiotl ranking improves significantly
- [ ] Compare against Log Adviser positioning