### PR TITLE
Fix Xeric's capes: remove from normal CoX, convert to milestones in CM

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -4720,55 +4720,6 @@
         "wikiPage": "Twisted_ancestral_colour_kit",
         "independent": true
       },
-      {
-        "itemId": 22388,
-        "name": "Xeric's guard",
-        "dropRate": 0.01,
-        "varbitId": 0,
-        "isPet": false,
-        "wikiPage": "Xeric%27s_guard",
-        "independent": true
-      },
-      {
-        "itemId": 22390,
-        "name": "Xeric's warrior",
-        "dropRate": 0.002,
-        "varbitId": 0,
-        "isPet": false,
-        "wikiPage": "Xeric%27s_warrior",
-        "independent": true,
-        "requiresPrevious": true
-      },
-      {
-        "itemId": 22392,
-        "name": "Xeric's sentinel",
-        "dropRate": 0.001,
-        "varbitId": 0,
-        "isPet": false,
-        "wikiPage": "Xeric%27s_sentinel",
-        "independent": true,
-        "requiresPrevious": true
-      },
-      {
-        "itemId": 22394,
-        "name": "Xeric's general",
-        "dropRate": 0.000667,
-        "varbitId": 0,
-        "isPet": false,
-        "wikiPage": "Xeric%27s_general",
-        "independent": true,
-        "requiresPrevious": true
-      },
-      {
-        "itemId": 22396,
-        "name": "Xeric's champion",
-        "dropRate": 0.0005,
-        "varbitId": 0,
-        "isPet": false,
-        "wikiPage": "Xeric%27s_champion",
-        "requiresPrevious": true,
-        "independent": true
-      }
     ],
     "locationDescription": "Mount Quidamortem, Great Kourend",
     "travelTip": "Xeric's talisman -> Chambers",
@@ -4975,51 +4926,51 @@
       {
         "itemId": 22388,
         "name": "Xeric's guard",
-        "dropRate": 0.02067,
+        "dropRate": 1.0,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Xeric%27s_guard",
-        "independent": true
+        "milestoneKills": 100
       },
       {
         "itemId": 22390,
         "name": "Xeric's warrior",
-        "dropRate": 0.004133,
+        "dropRate": 1.0,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Xeric%27s_warrior",
-        "independent": true,
+        "milestoneKills": 500,
         "requiresPrevious": true
       },
       {
         "itemId": 22392,
         "name": "Xeric's sentinel",
-        "dropRate": 0.002067,
+        "dropRate": 1.0,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Xeric%27s_sentinel",
-        "independent": true,
+        "milestoneKills": 1000,
         "requiresPrevious": true
       },
       {
         "itemId": 22394,
         "name": "Xeric's general",
-        "dropRate": 0.001379,
+        "dropRate": 1.0,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Xeric%27s_general",
-        "independent": true,
+        "milestoneKills": 1500,
         "requiresPrevious": true
       },
       {
         "itemId": 22396,
         "name": "Xeric's champion",
-        "dropRate": 0.001033,
+        "dropRate": 1.0,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Xeric%27s_champion",
-        "requiresPrevious": true,
-        "independent": true
+        "milestoneKills": 2000,
+        "requiresPrevious": true
       }
     ],
     "locationDescription": "Mount Quidamortem, Great Kourend",


### PR DESCRIPTION
## Summary
- Xeric's capes are CM completion count milestones (100/500/1000/1500/2000), NOT random drops
- Removed all 5 capes from normal CoX source (they cannot drop there)
- Converted CM entries from random dropRate to `milestoneKills` with `dropRate=1.0`
- Previously these were scored as if they were rare random drops, significantly skewing CoX CM efficiency scores

## Test plan
- [x] All existing unit tests pass
- [ ] Verify CoX normal no longer lists Xeric capes
- [ ] Verify CoX CM scores capes as milestone items