### PR TITLE
Fix Revenant drop rates to skulled demon rates per wiki

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -7566,7 +7566,7 @@
       {
         "itemId": 21817,
         "name": "Bracelet of ethereum",
-        "dropRate": 0.071,
+        "dropRate": 0.0857,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Bracelet_of_ethereum"
@@ -7574,15 +7574,16 @@
       {
         "itemId": 21820,
         "name": "Revenant ether",
-        "dropRate": 0.167,
+        "dropRate": 1.0,
         "varbitId": 0,
         "isPet": false,
-        "wikiPage": "Revenant_ether"
+        "wikiPage": "Revenant_ether",
+        "milestoneKills": 1
       },
       {
         "itemId": 21802,
         "name": "Revenant cave teleport",
-        "dropRate": 0.025,
+        "dropRate": 0.02857,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Revenant_cave_teleport"
@@ -7590,7 +7591,7 @@
       {
         "itemId": 21807,
         "name": "Ancient emblem",
-        "dropRate": 0.000187,
+        "dropRate": 0.000186,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ancient_emblem"
@@ -7598,7 +7599,7 @@
       {
         "itemId": 21810,
         "name": "Ancient totem",
-        "dropRate": 0.00075,
+        "dropRate": 0.000745,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ancient_totem"
@@ -7606,7 +7607,7 @@
       {
         "itemId": 21813,
         "name": "Ancient statuette",
-        "dropRate": 0.00025,
+        "dropRate": 0.000373,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ancient_statuette"
@@ -7614,7 +7615,7 @@
       {
         "itemId": 21804,
         "name": "Ancient crystal",
-        "dropRate": 0.0005,
+        "dropRate": 0.000559,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ancient_crystal"
@@ -7622,7 +7623,7 @@
       {
         "itemId": 22299,
         "name": "Ancient medallion",
-        "dropRate": 0.000375,
+        "dropRate": 0.000186,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ancient_medallion"
@@ -7630,7 +7631,7 @@
       {
         "itemId": 22302,
         "name": "Ancient effigy",
-        "dropRate": 0.000125,
+        "dropRate": 0.000186,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ancient_effigy"
@@ -7638,7 +7639,7 @@
       {
         "itemId": 22305,
         "name": "Ancient relic",
-        "dropRate": 5e-05,
+        "dropRate": 0.000186,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Ancient_relic"
@@ -7646,7 +7647,7 @@
       {
         "itemId": 22547,
         "name": "Craw's bow (u)",
-        "dropRate": 9.4e-06,
+        "dropRate": 0.0000559,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Craw%27s_bow_(u)"
@@ -7654,7 +7655,7 @@
       {
         "itemId": 22552,
         "name": "Thammaron's sceptre (u)",
-        "dropRate": 9.4e-06,
+        "dropRate": 0.0000559,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Thammaron%27s_sceptre_(u)"
@@ -7662,7 +7663,7 @@
       {
         "itemId": 22542,
         "name": "Viggora's chainmace (u)",
-        "dropRate": 9.4e-06,
+        "dropRate": 0.0000559,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Viggora%27s_chainmace_(u)"
@@ -7670,7 +7671,7 @@
       {
         "itemId": 22557,
         "name": "Amulet of avarice",
-        "dropRate": 1.88e-05,
+        "dropRate": 0.000112,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Amulet_of_avarice"


### PR DESCRIPTION
## Summary
- All 14 revenant drop rates corrected to Revenant demon, skulled, off-task rates (wiki-verified)
- Previous rates were from an unknown low-level rev, unskulled — weapons were ~6x too rare
- Ether now correctly marked as guaranteed (was 1/6)
- Matches Log Adviser spreadsheet for all weapons and artefacts

## Test plan
- [x] All unit tests pass
- [ ] Verify Revenants ranking improves to reflect skulled demon rates