### PR TITLE
Fix Hallowed Sepulchre shop items and minigame rate tuning

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -10422,11 +10422,11 @@
       {
         "itemId": 24731,
         "name": "Hallowed ring",
-        "dropRate": 0.059,
+        "dropRate": 1.0,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Hallowed_ring",
-        "independent": true
+        "pointCost": 250
       },
       {
         "itemId": 24719,
@@ -10435,62 +10435,61 @@
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Hallowed_token",
-        "pointCost": 10,
-        "independent": true
+        "pointCost": 10
       },
       {
         "itemId": 24721,
         "name": "Hallowed grapple",
-        "dropRate": 0.143,
+        "dropRate": 1.0,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Hallowed_grapple",
-        "independent": true
+        "pointCost": 100
       },
       {
         "itemId": 24723,
         "name": "Hallowed focus",
-        "dropRate": 0.143,
+        "dropRate": 1.0,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Hallowed_focus",
-        "independent": true
+        "pointCost": 100
       },
       {
         "itemId": 24725,
         "name": "Hallowed symbol",
-        "dropRate": 0.143,
+        "dropRate": 1.0,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Hallowed_symbol",
-        "independent": true
+        "pointCost": 100
       },
       {
         "itemId": 24727,
         "name": "Hallowed hammer",
-        "dropRate": 0.143,
+        "dropRate": 1.0,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Hallowed_hammer",
-        "independent": true
+        "pointCost": 100
       },
       {
         "itemId": 24733,
         "name": "Dark acorn",
-        "dropRate": 0.005,
+        "dropRate": 1.0,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Dark_acorn",
-        "independent": true
+        "pointCost": 3000
       },
       {
         "itemId": 24729,
         "name": "Dark dye",
-        "dropRate": 0.0005,
+        "dropRate": 1.0,
         "varbitId": 0,
         "isPet": false,
-        "wikiPage": "Giant_squirrel",
-        "independent": true
+        "wikiPage": "Dark_dye",
+        "pointCost": 300
       }
     ],
     "locationDescription": "Hallowed Sepulchre entrance in Darkmeyer",
@@ -14645,7 +14644,7 @@
       {
         "itemId": 28626,
         "name": "Fox whistle",
-        "dropRate": 0.0333,
+        "dropRate": 0.003704,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Fox_whistle",
@@ -14654,7 +14653,7 @@
       {
         "itemId": 28663,
         "name": "Golden pheasant egg",
-        "dropRate": 0.0333,
+        "dropRate": 0.003704,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Golden_pheasant_egg",
@@ -14663,7 +14662,7 @@
       {
         "itemId": 28655,
         "name": "Petal garland",
-        "dropRate": 0.0333,
+        "dropRate": 0.003704,
         "varbitId": 0,
         "isPet": false,
         "wikiPage": "Petal_garland"
@@ -17461,7 +17460,7 @@
       }
     ],
     "rewardType": "SHOP",
-    "pointsPerHour": 25
+    "pointsPerHour": 22
   },
   {
     "name": "TzHaar",
@@ -18109,7 +18108,7 @@
       }
     ],
     "rewardType": "SHOP",
-    "pointsPerHour": 10
+    "pointsPerHour": 8
   },
   {
     "name": "Shooting Stars",


### PR DESCRIPTION
## Summary
- **Hallowed Sepulchre**: 7 shop items converted from fake dropRate to pointCost (ring 250, tools 100, dark dye 300, dark acorn 3000). Fixed Dark dye wikiPage bug.
- **Forestry**: Fox whistle/pheasant egg/petal garland corrected from 1/30 to 1/270 (1/9 event type weighting)
- **Rooftop Agility**: marks/hr 25 -> 22
- **Motherlode Mine**: nuggets/hr 10 -> 8

## Test plan
- [x] All unit tests pass
- [ ] Verify Hallowed Sepulchre shop items score by mark cost, not random chance
- [ ] Verify Forestry rare event items are appropriately rare