### PR TITLE
Remove Metamorphic dust and Twisted ancestral kit from normal CoX

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -4701,24 +4701,6 @@
         "isPet": false,
         "wikiPage": "Onyx",
         "independent": true
-      },
-      {
-        "itemId": 22386,
-        "name": "Metamorphic dust",
-        "dropRate": 0.0025,
-        "varbitId": 0,
-        "isPet": false,
-        "wikiPage": "Metamorphic_dust",
-        "independent": true
-      },
-      {
-        "itemId": 24670,
-        "name": "Twisted ancestral colour kit",
-        "dropRate": 0.01333,
-        "varbitId": 0,
-        "isPet": false,
-        "wikiPage": "Twisted_ancestral_colour_kit",
-        "independent": true
       }
     ],
     "locationDescription": "Mount Quidamortem, Great Kourend",


### PR DESCRIPTION
## Summary
- Metamorphic dust and Twisted ancestral colour kit are CM-exclusive drops per wiki
- Removed from normal Chambers of Xeric source
- Both items remain in Chambers of Xeric (Challenge Mode) with correct rates
- Fixes #258

## Test plan
- [x] All unit tests pass