### PR TITLE
Update docs for 225 sources, Log Adviser audit, and new conventions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -314,11 +314,28 @@ Clue items drop from **caskets**, not from kills. The `dropRate` should reflect 
 
 ### Raids (Point-Based Scaling)
 
-Raid drop rates scale with contribution points. All raids should be tagged `mutuallyExclusive: true`.
+Raid drop rates scale with contribution points. All raids should be tagged `mutuallyExclusive: true`. Rates are stored as **per-raid solo rates** — team size scaling is applied dynamically via the RaidTeamSize config.
 
-- **Chambers of Xeric**: Rates scaled to a ~30,000 point raid
-- **Theatre of Blood**: Weighted rates per 4-man completion
-- **Tombs of Amascut**: Rates per 300 invocation-level completion
+- **Chambers of Xeric**: Per-raid solo rates at ~20,000 points. CM uses a 2.067x multiplier on normal rates
+- **Theatre of Blood**: Per-completion solo rates. ToB Hard Mode is a separate source with better base rates and 3 HM-exclusive items
+- **Tombs of Amascut**: Per-raid solo rates at each invocation level (150/300/500 as separate sources). At RL 500, unique weightings shift per the June 2025 rebalance
+
+### Milestone Items (KC Thresholds)
+
+Some items are guaranteed at specific kill count milestones rather than being random drops. Use `"dropRate": 1.0` with `"milestoneKills": N` where N is the KC threshold:
+
+- **Xeric's capes** (CoX CM): 100/500/1000/1500/2000 CM completions
+- **Icthlarin's shrouds** (ToA): 100/500/1000/1500/2000 completions
+- **Sinhaza shrouds** (ToB): 100/500/1000/1500/2000 completions
+
+Use `requiresPrevious: true` on tiers 2+ since they unlock sequentially.
+
+### Cumulative Rates (Multi-Phase Bosses)
+
+Some bosses involve multiple phases or attempts per "completion," each with independent loot rolls. Store the **cumulative per-completion probability**, not the per-phase rate:
+
+- **Doom of Mokhaiotl**: Delving to depth 10 gives 10 independent rolls (depths 1-10) with improving rates. Use the cumulative `1 - Π(1 - p_depth)` across all depths
+- **Sol Heredit**: 12 Colosseum waves with independent rolls from wave 4+. Use the cumulative per-completion rate
 
 ### "All Pets" View
 

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -30,7 +30,7 @@
 - **Community:** Log Hunters Discord
 - **Invite:** https://discord.gg/loghunters
 - **Resource:** Log Adviser spreadsheet (v1.3.4 by Main Mukkor)
-- Referenced for: TempleOSRS EHB kill time alignment, independent drop table modeling, sequential drop dependencies (requiresPrevious), main vs ironman completion rates, identification of missing skilling pet sources, raid variant data, full item-by-item drop rate audit, SHOP/MIXED pointsPerHour corrections, and Miscellaneous source extraction
+- Referenced for: TempleOSRS EHB kill time alignment, independent drop table modeling, sequential drop dependencies (requiresPrevious), main vs ironman completion rates, identification of missing skilling pet sources, raid variant data, SHOP/MIXED pointsPerHour corrections, Miscellaneous source extraction, and comprehensive item-by-item accuracy audit (ToA per-raid rate corrections, Sol Heredit per-completion rates, Revenant skulled demon rates, Hallowed Sepulchre SHOP conversion, TzHaar mixed-type rate dilution, Doom of Mokhaiotl cumulative delve model, Forestry event-type weighting, Wintertodt pyromancer per-roll rates)
 
 ### C Engineer: Completed
 - **Author:** m0bilebtw
@@ -42,11 +42,16 @@
 ### TempleOSRS
 - **Website:** https://templeosrs.com
 - **API Docs:** https://templeosrs.com/api_doc.php
-- Referenced for: canonical collection log item ID verification (all 2,101 item IDs validated across 224 sources), EHB kill time alignment, collection log category verification
+- Referenced for: canonical collection log item ID verification (all 2,111 item entries validated across 225 sources), EHB kill time alignment, collection log category verification
 
 ### OSRS Wiki
 - **Website:** https://oldschool.runescape.wiki
-- Referenced for: drop rate verification (all 224 sources audited), quest requirements, NPC IDs, world coordinates, game mechanics research, raid loot mechanics (CoX points, ToB team scaling, ToA raid level formula), slayer task weights (4 masters verified), DT2 Awakened boss rates, wilderness boss variant rates
+- Referenced for: drop rate verification (all 225 sources audited), quest requirements, NPC IDs, world coordinates, game mechanics research, raid loot mechanics (CoX points, ToB team scaling, ToA raid level formula), slayer task weights (4 masters verified), DT2 Awakened boss rates, wilderness boss variant rates
+
+### Wise Old Man (WOM)
+- **Website:** https://wiseoldman.net
+- **Repository:** https://github.com/wise-old-man/wise-old-man
+- Referenced for: ironman EHB rates used to validate iron-specific kill times
 
 ### Bitterkoekje DPS Calculator
 - **Repository:** https://github.com/weirdgloop/osrs-dps-calc

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A RuneLite plugin that guides players through efficient collection log completion with intelligent efficiency scoring, on-screen guidance overlays, and multiple viewing modes.
 
-**Coverage:** 2,101 items across 224 sources — all item IDs verified against TempleOSRS, drop rates audited against OSRS Wiki and the [Log Hunters](https://discord.gg/loghunters) community spreadsheet.
+**Coverage:** 2,111 items across 225 sources — all item IDs verified against TempleOSRS, drop rates audited against OSRS Wiki and the [Log Hunters](https://discord.gg/loghunters) community spreadsheet.
 
 ## Features
 
@@ -16,7 +16,7 @@ Ranks collection log sources by how efficiently you can obtain missing items. Th
 - **Raid team size scaling** — Adjustable Solo/Duo/Trio/Full team size affects drop rates and kill times for raids
 - **Slayer task overhead** — Task-only sources inflate effective kill time by 1/P(creature|master) when not on task
 - **Main/Ironman toggle** — Separate completion rates for accounts with significantly different methods (Corp, GWD, wilderness bosses, etc.)
-- **Mutually exclusive variants** — Raid difficulty variants (CoX/CoX CM, ToA 150/300/500), DT2 Awakened bosses, and shared-loot boss groups are cross-referenced with "(also: ...)" notes
+- **Mutually exclusive variants** — Raid difficulty variants (CoX/CoX CM, ToB/ToB HM, ToA 150/300/500), DT2 Awakened bosses, and shared-loot boss groups are cross-referenced with "(also: ...)" notes
 
 ### Account-Aware Requirements
 
@@ -64,9 +64,9 @@ Click "Guide Me" on any item to activate navigation aids:
 
 ### Step-by-Step Guidance
 
-All 224 sources have multi-step guidance sequences with auto-completing steps:
+All 225 sources have multi-step guidance sequences with auto-completing steps:
 
-- **Auto-arrival detection** — 222 sources detect when you arrive at the target location (ARRIVE_AT_TILE)
+- **Auto-arrival detection** — 223 sources detect when you arrive at the target location (ARRIVE_AT_TILE)
 - **Auto-kill detection** — 112 sources detect when you kill the target (ACTOR_DEATH)
 - **Multi-floor navigation** — 9 sources guide you through stair climbing with PLAYER_ON_PLANE detection
 - **Zone-based detection** — ARRIVE_AT_ZONE for large areas (rectangular zone matching)
@@ -107,7 +107,7 @@ Automatically detects new collection log entries via chat messages and varbit ch
 
 ## Data
 
-All drop data lives in [`src/main/resources/com/collectionloghelper/drop_rates.json`](src/main/resources/com/collectionloghelper/drop_rates.json). 224 sources with 2,101 items covering all bosses, raids, slayer creatures, clue scrolls, minigames, shops, and skilling activities. Each source includes world coordinates, kill times (main + iron), drop table mechanics, quest/skill requirements, NPC IDs, multi-step guidance, and items with OSRS item IDs, decimal drop rates, and wiki links. Kill times are aligned with TempleOSRS EHB rates.
+All drop data lives in [`src/main/resources/com/collectionloghelper/drop_rates.json`](src/main/resources/com/collectionloghelper/drop_rates.json). 225 sources with 2,111 items covering all bosses, raids, slayer creatures, clue scrolls, minigames, shops, and skilling activities. Each source includes world coordinates, kill times (main + iron), drop table mechanics, quest/skill requirements, NPC IDs, multi-step guidance, and items with OSRS item IDs, decimal drop rates, and wiki links. Kill times are aligned with TempleOSRS EHB rates. Drop rates have been wiki-verified and cross-audited against the Log Hunters Log Adviser spreadsheet.
 
 Slayer task weights for all 4 masters (Duradel, Nieve, Konar, Turael) are in [`slayer_task_weights.json`](src/main/resources/com/collectionloghelper/slayer_task_weights.json) — 148 tasks verified against OSRS Wiki.
 


### PR DESCRIPTION
## Summary
- README: 224→225 sources, 2101→2111 items, added ToB HM to variant list
- CONTRIBUTING: Fixed Raids section (per-raid solo rates, not team-baked). Added Milestone Items and Cumulative Rates documentation
- CREDITS: Expanded Log Adviser audit details, added WOM credit for iron EHB data