### PR TITLE
Fix 45 guidance step description quality issues

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -8007,7 +8007,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Travel to Revenant Caves, Wilderness and kill revenants.",
+        "description": "Kill revenants in the caves for unique drops. Bring risk \u2014 it's multi-combat Wilderness.",
         "worldX": 3073,
         "worldY": 3654,
         "worldPlane": 0,
@@ -10533,7 +10533,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Travel to Mount Karuulm, near Konar and open the Brimstone Chest.",
+        "description": "Open the Brimstone chest with brimstone keys earned from Konar slayer tasks.",
         "worldX": 1309,
         "worldY": 3785,
         "worldPlane": 0,
@@ -10587,7 +10587,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Travel to Wilderness, Pirates' Hideout and open the Larran's Big Chest.",
+        "description": "Open Larran's big chest with Larran's keys dropped by Wilderness slayer creatures.",
         "worldX": 3018,
         "worldY": 3955,
         "worldPlane": 0,
@@ -10650,7 +10650,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Travel to Slayer Tower, Morytania (varies) and kill superior slayer monsters on task.",
+        "description": "Kill superior slayer monsters that spawn while on task (1/200 chance with unlock).",
         "worldX": 3429,
         "worldY": 3534,
         "worldPlane": 0,
@@ -10692,7 +10692,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Travel to East of Chaos Temple, level 14 Wilderness and open the Zombie Pirate Locker.",
+        "description": "Kill zombie pirates and use locker keys on the pirate lockers for loot.",
         "worldX": 3373,
         "worldY": 3625,
         "worldPlane": 0,
@@ -11211,7 +11211,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Travel to Brimhaven Agility Arena, east of Brimhaven and train at Brimhaven Agility Arena.",
+        "description": "Complete laps in the Brimhaven Agility Arena to earn agility tickets for rewards.",
         "worldX": 2809,
         "worldY": 3194,
         "worldPlane": 0,
@@ -11645,7 +11645,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Travel to Mage Training Arena, north-east of Al Kharid and train at Mage Training Arena.",
+        "description": "Earn pizazz points from the four training rooms to buy rewards from the shop.",
         "worldX": 3363,
         "worldY": 3316,
         "worldPlane": 0,
@@ -11933,7 +11933,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Travel to Mahogany Homes, contracts available in Falador, Varrock, Hosidius, and Ardougne and train at Mahogany Homes.",
+        "description": "Complete Mahogany Homes contracts from Amy to earn carpenter's points for rewards.",
         "worldX": 2954,
         "worldY": 3369,
         "worldPlane": 0,
@@ -12046,7 +12046,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Travel to Mastering Mixology, Aldarin in Varlamore and train at Mastering Mixology.",
+        "description": "Mix potions at the Mixology station to earn Mox, Aga, and Lye for rewards.",
         "worldX": 1389,
         "worldY": 2955,
         "worldPlane": 0,
@@ -12168,7 +12168,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Travel to Volcanic Mine, north-east Fossil Island volcano and train at Volcanic Mine.",
+        "description": "Mine ore in the Volcanic Mine for mining XP and numulite rewards.",
         "worldX": 3815,
         "worldY": 3807,
         "worldPlane": 0,
@@ -12270,7 +12270,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Travel to Tithe Farm, Hosidius and train at Tithe Farm.",
+        "description": "Plant and harvest Golovanova fruit to earn Tithe Farm points for rewards.",
         "worldX": 1791,
         "worldY": 3504,
         "worldPlane": 0,
@@ -12394,7 +12394,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Travel to Fishing Trawler, Port Khazard and train at Fishing Trawler.",
+        "description": "Board Murphy's trawler and play Fishing Trawler rounds for unique fish rewards.",
         "worldX": 2661,
         "worldY": 3164,
         "worldPlane": 0,
@@ -12469,7 +12469,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Travel to Temple Trekking, between Burgh de Rott and Paterdomus and play Temple Trekking.",
+        "description": "Escort NPCs between Burgh de Rott and Paterdomus for trek reward tokens.",
         "worldX": 3479,
         "worldY": 3241,
         "worldPlane": 0,
@@ -12544,7 +12544,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Travel to Rogues' Den beneath the Burthorpe pub and train at Rogues' Den.",
+        "description": "Complete the Rogues' Den maze to earn pieces of the rogue equipment set.",
         "worldX": 2907,
         "worldY": 3537,
         "worldPlane": 0,
@@ -13496,7 +13496,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Travel to Ferox Enclave, north of Varrock in the Wilderness and play Last Man Standing.",
+        "description": "Play Last Man Standing matches for points to spend at Justine's reward shop.",
         "worldX": 3151,
         "worldY": 3634,
         "worldPlane": 0,
@@ -13561,7 +13561,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Travel to Auburn Valley, north-west Varlamore and play Vale Totems.",
+        "description": "Participate in Vale Totems events in Auburn Valley for unique rewards.",
         "worldX": 1452,
         "worldY": 3128,
         "worldPlane": 0,
@@ -14410,7 +14410,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Travel to Sailing trial locations across the seas and play Barracuda Trials.",
+        "description": "Complete Barracuda Trial challenges at various Sailing locations for rewards.",
         "worldX": 1823,
         "worldY": 3691,
         "worldPlane": 0,
@@ -14529,7 +14529,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Travel to Lake Molch on Molch Island and train at Aerial Fishing.",
+        "description": "Catch fish using cormorants at Lake Molch for Molch pearls and unique fish.",
         "worldX": 1379,
         "worldY": 3634,
         "worldPlane": 0,
@@ -14654,7 +14654,7 @@
     "travelTip": "Port Sarim docks",
     "guidanceSteps": [
       {
-        "description": "Travel to Port Sarim docks, obtained via various Sailing activities.",
+        "description": "Travel to a Sailing port.",
         "worldX": 1824,
         "worldY": 3691,
         "worldPlane": 0,
@@ -14662,7 +14662,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Travel to Port Sarim docks, obtained via various Sailing activities and discover boat paints during Sailing.",
+        "description": "Obtain boat paints from various Sailing activities and rewards.",
         "worldX": 1824,
         "worldY": 3691,
         "worldPlane": 0,
@@ -14786,7 +14786,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Travel to Champions' Guild south of Varrock and complete champion challenges.",
+        "description": "Collect champion scrolls from monsters, then defeat champions in the guild arena.",
         "worldX": 3191,
         "worldY": 3361,
         "worldPlane": 0,
@@ -15290,7 +15290,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Travel to Seers' Village oak south of bank (W444 meta), NOT Woodcutting Guild and train at Forestry.",
+        "description": "Participate in Forestry events while woodcutting for unique log rewards.",
         "worldX": 2725,
         "worldY": 3490,
         "worldPlane": 0,
@@ -15412,7 +15412,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Travel to House on the Hill, Fossil Island and collect Fossil Island notes.",
+        "description": "Search the House on the Hill displays and complete activities for fossil notes.",
         "worldX": 3774,
         "worldY": 3819,
         "worldPlane": 0,
@@ -15593,7 +15593,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Travel to Hunter Guild in Avium Savannah, Varlamore and train Hunter.",
+        "description": "Complete Hunter Guild activities in Avium Savannah for guild rewards.",
         "worldX": 1579,
         "worldY": 3069,
         "worldPlane": 0,
@@ -15726,7 +15726,7 @@
     "travelTip": "Port Sarim docks -> sail",
     "guidanceSteps": [
       {
-        "description": "Travel to Various islands discovered through Sailing.",
+        "description": "Travel to discoverable Sailing islands.",
         "worldX": 1824,
         "worldY": 3691,
         "worldPlane": 0,
@@ -15734,7 +15734,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Travel to Various islands discovered through Sailing and discover lost schematics during Sailing.",
+        "description": "Find lost schematics while exploring islands during Sailing voyages.",
         "worldX": 1824,
         "worldY": 3691,
         "worldPlane": 0,
@@ -15835,7 +15835,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Travel to Ape Atoll Agility Course and earn monkey backpacks.",
+        "description": "Complete laps of the Ape Atoll Agility Course to earn monkey backpack variants.",
         "worldX": 2764,
         "worldY": 2703,
         "worldPlane": 0,
@@ -16333,7 +16333,7 @@
     "travelTip": "Port Sarim docks -> sail",
     "guidanceSteps": [
       {
-        "description": "Travel to Various Sailing activities and island exploration.",
+        "description": "Travel to a Sailing port.",
         "worldX": 1824,
         "worldY": 3691,
         "worldPlane": 0,
@@ -16341,7 +16341,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Complete various Sailing activities.",
+        "description": "Obtain miscellaneous Sailing items through voyages and island exploration.",
         "worldX": 1824,
         "worldY": 3691,
         "worldPlane": 0,
@@ -17246,7 +17246,7 @@
     "travelTip": "Varies by activity",
     "guidanceSteps": [
       {
-        "description": "Travel to Various locations throughout Gielinor.",
+        "description": "Travel to various locations throughout Gielinor.",
         "worldX": 3222,
         "worldY": 3218,
         "worldPlane": 0,
@@ -17254,7 +17254,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Complete miscellaneous activities throughout Gielinor.",
+        "description": "Obtain miscellaneous collection log items from various activities.",
         "worldX": 3222,
         "worldY": 3218,
         "worldPlane": 0,
@@ -17635,7 +17635,7 @@
         "completionDistance": 15
       },
       {
-        "description": "Travel to Ruins of Camdozaal beneath Ice Mountain and train skills in Camdozaal.",
+        "description": "Mine, smith, and fish in the Ruins of Camdozaal for unique Camdozaal items.",
         "worldX": 2957,
         "worldY": 5774,
         "worldPlane": 0,
@@ -17765,7 +17765,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Travel to Colossal Wyrm Agility Course in Avium Savannah, Varlamore and train at Colossal Wyrm Agility.",
+        "description": "Run the Colossal Wyrm Agility Course for marks of grace and termite rewards.",
         "worldX": 1652,
         "worldY": 2931,
         "worldPlane": 0,
@@ -17873,7 +17873,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Travel to Rooftop Agility Courses, starting at Varrock and train at Rooftop Agility.",
+        "description": "Complete rooftop agility courses for marks of grace (Graceful set, recolours).",
         "worldX": 3214,
         "worldY": 3414,
         "worldPlane": 0,
@@ -18441,7 +18441,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Travel to Shayzien Combat Ring, Great Kourend and earn Shayzien armour.",
+        "description": "Kill soldiers in the Shayzien Combat Ring to earn tier 5 Shayzien armour.",
         "worldX": 1516,
         "worldY": 3617,
         "worldPlane": 0,
@@ -18531,7 +18531,7 @@
         "completionDistance": 15
       },
       {
-        "description": "Travel to Motherlode Mine beneath Falador and train at Motherlode Mine.",
+        "description": "Mine pay-dirt in the Motherlode Mine and clean it for golden nugget rewards.",
         "worldX": 3726,
         "worldY": 5680,
         "worldPlane": 0,
@@ -18575,7 +18575,7 @@
     "travelTip": "POH telescope -> nearest teleport",
     "guidanceSteps": [
       {
-        "description": "Travel to Crashed shooting stars found throughout Gielinor.",
+        "description": "Travel to a crashed shooting star.",
         "worldX": 3214,
         "worldY": 3414,
         "worldPlane": 0,
@@ -18583,7 +18583,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Travel to Crashed shooting stars found throughout Gielinor and mine crashed shooting stars.",
+        "description": "Mine crashed shooting stars found throughout Gielinor for star dust.",
         "worldX": 3214,
         "worldY": 3414,
         "worldPlane": 0,
@@ -25511,7 +25511,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Travel to Draynor Village seed market and steal from seed stalls.",
+        "description": "Steal from seed stalls in Draynor Village for the Master Farmer outfit pieces.",
         "worldX": 3080,
         "worldY": 3252,
         "worldPlane": 0,
@@ -26274,7 +26274,7 @@
     "travelTip": "Port Sarim docks -> sort salvage",
     "guidanceSteps": [
       {
-        "description": "Travel to Sorting salvage obtained from Sailing voyages.",
+        "description": "Travel to a Sailing port to sort your salvage.",
         "worldX": 1824,
         "worldY": 3691,
         "worldPlane": 0,
@@ -26282,7 +26282,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Sort through small salvage obtained from Sailing voyages.",
+        "description": "Sort small salvage from your Sailing voyages at any port.",
         "worldX": 1824,
         "worldY": 3691,
         "worldPlane": 0,
@@ -26332,7 +26332,7 @@
     "travelTip": "Port Sarim docks -> sort salvage",
     "guidanceSteps": [
       {
-        "description": "Travel to Sorting salvage obtained from Sailing voyages.",
+        "description": "Travel to a Sailing port to sort your salvage.",
         "worldX": 1824,
         "worldY": 3691,
         "worldPlane": 0,
@@ -26340,7 +26340,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Sort through fishy salvage obtained from Sailing voyages.",
+        "description": "Sort fishy salvage from your Sailing voyages at any port.",
         "worldX": 1824,
         "worldY": 3691,
         "worldPlane": 0,
@@ -26390,7 +26390,7 @@
     "travelTip": "Port Sarim docks -> sort salvage",
     "guidanceSteps": [
       {
-        "description": "Travel to Sorting salvage obtained from Sailing voyages.",
+        "description": "Travel to a Sailing port to sort your salvage.",
         "worldX": 1824,
         "worldY": 3691,
         "worldPlane": 0,
@@ -26398,7 +26398,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Sort through barracuda salvage obtained from Sailing voyages.",
+        "description": "Sort barracuda salvage from your Sailing voyages at any port.",
         "worldX": 1824,
         "worldY": 3691,
         "worldPlane": 0,
@@ -26440,7 +26440,7 @@
     "travelTip": "Port Sarim docks -> sort salvage",
     "guidanceSteps": [
       {
-        "description": "Travel to Sorting salvage obtained from Sailing voyages.",
+        "description": "Travel to a Sailing port to sort your salvage.",
         "worldX": 1824,
         "worldY": 3691,
         "worldPlane": 0,
@@ -26448,7 +26448,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Sort through large salvage obtained from Sailing voyages.",
+        "description": "Sort large salvage from your Sailing voyages at any port.",
         "worldX": 1824,
         "worldY": 3691,
         "worldPlane": 0,
@@ -26498,7 +26498,7 @@
     "travelTip": "Port Sarim docks -> sort salvage",
     "guidanceSteps": [
       {
-        "description": "Travel to Sorting salvage obtained from Sailing voyages.",
+        "description": "Travel to a Sailing port to sort your salvage.",
         "worldX": 1824,
         "worldY": 3691,
         "worldPlane": 0,
@@ -26506,7 +26506,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Sort through plundered salvage obtained from Sailing voyages.",
+        "description": "Sort plundered salvage from your Sailing voyages at any port.",
         "worldX": 1824,
         "worldY": 3691,
         "worldPlane": 0,
@@ -26564,7 +26564,7 @@
     "travelTip": "Port Sarim docks -> sort salvage",
     "guidanceSteps": [
       {
-        "description": "Travel to Sorting salvage obtained from Sailing voyages.",
+        "description": "Travel to a Sailing port to sort your salvage.",
         "worldX": 1824,
         "worldY": 3691,
         "worldPlane": 0,
@@ -26572,7 +26572,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Sort through martial salvage obtained from Sailing voyages.",
+        "description": "Sort martial salvage from your Sailing voyages at any port.",
         "worldX": 1824,
         "worldY": 3691,
         "worldPlane": 0,
@@ -26614,7 +26614,7 @@
     "travelTip": "Port Sarim docks -> sort salvage",
     "guidanceSteps": [
       {
-        "description": "Travel to Sorting salvage obtained from Sailing voyages.",
+        "description": "Travel to a Sailing port to sort your salvage.",
         "worldX": 1824,
         "worldY": 3691,
         "worldPlane": 0,
@@ -26622,7 +26622,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Sort through fremennik salvage obtained from Sailing voyages.",
+        "description": "Sort Fremennik salvage from your Sailing voyages at any port.",
         "worldX": 1824,
         "worldY": 3691,
         "worldPlane": 0,
@@ -26704,7 +26704,7 @@
     "travelTip": "Port Sarim docks -> sort salvage",
     "guidanceSteps": [
       {
-        "description": "Travel to Sorting salvage obtained from Sailing voyages.",
+        "description": "Travel to a Sailing port to sort your salvage.",
         "worldX": 1824,
         "worldY": 3691,
         "worldPlane": 0,
@@ -26712,7 +26712,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Sort through opulent salvage obtained from Sailing voyages.",
+        "description": "Sort opulent salvage from your Sailing voyages at any port.",
         "worldX": 1824,
         "worldY": 3691,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary
- Fixes all 45 description quality issues detected by `validate_drop_rates guidance` checker
- **13 auto-generated step 0 descriptions** — salvage sources said "Travel to Sorting salvage obtained from Sailing voyages" (nonsensical), now say "Travel to a Sailing port to sort your salvage"
- **32 duplicate step 1 descriptions** — step 1 was just step 0 with "and train at..." appended. Each source now has a unique step 1 describing the actual activity (e.g., "Earn pizazz points from the four training rooms" for MTA)
- Validator now shows **2 remaining issues** (false positives — descriptions are valid but contain locationDescription substring)

Stacked on #267

## Test plan
- [x] `./gradlew test` passes
- [x] `validate_drop_rates guidance` drops from 45 → 2 issues (false positives)
- [ ] Verify step descriptions display correctly in the guidance panel UI