### PR TITLE
Fix Aquanite coords: Fremennik -> Ynysdail Cavern

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -9739,8 +9739,8 @@
   {
     "name": "Aquanite",
     "category": "OTHER",
-    "worldX": 2712,
-    "worldY": 9882,
+    "worldX": 2275,
+    "worldY": 9880,
     "worldPlane": 0,
     "killTimeSeconds": 24,
     "afkLevel": 2,
@@ -9762,23 +9762,23 @@
         "wikiPage": "Aquanite_tendon"
       }
     ],
-    "locationDescription": "Waterfall Dungeon, east of Baxtorian Falls",
+    "locationDescription": "Ynysdail Cavern, beneath Ynysdail (73 Sailing)",
     "travelTip": "Sail to Ynysdail (73 Sailing)",
     "npcId": 15497,
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to Waterfall Dungeon, east of Baxtorian Falls.",
-        "worldX": 2712,
-        "worldY": 9882,
+        "description": "Travel to Ynysdail Cavern entrance, west of Baxtorian Falls (73 Sailing required).",
+        "worldX": 2218,
+        "worldY": 3477,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 15
       },
       {
         "description": "Kill Aquanite.",
-        "worldX": 2712,
-        "worldY": 9882,
+        "worldX": 2275,
+        "worldY": 9880,
         "worldPlane": 0,
         "npcId": 15497,
         "interactAction": "Attack",


### PR DESCRIPTION
## Summary
- Aquanite coordinates were **437 tiles off** — pointing to the Fremennik Slayer Dungeon area instead of Ynysdail Cavern
- Aquanites were moved to Ynysdail Cavern (requires 73 Sailing) with the Sailing update
- Source coords: (2712, 9882) → (2275, 9880)
- Travel step now points to cavern entrance (2218, 3477) with correct description
- Verified via OSRS Wiki `Ynysdail_Cavern` page coordinates

## Test plan
- [x] `./gradlew test` passes
- [ ] Verify guidance directs to correct cavern entrance in-game