### PR TITLE
Fix Cyclopes kill step missing npcId and interactAction

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -18114,7 +18114,9 @@
         "worldY": 3543,
         "worldPlane": 2,
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 2137
+        "completionNpcId": 2137,
+        "npcId": 2137,
+        "interactAction": "Attack"
       }
     ]
   },


### PR DESCRIPTION
## Summary
- Cyclopes ACTOR_DEATH step had `completionNpcId=2137` but was missing step-level `npcId` (needed for NPC highlighting overlay) and `interactAction` (needed for overlay action text)
- Found by `validate_drop_rates` — the only ACTOR_DEATH step without these fields

Also enhanced the `npc_lookup` MCP tool to handle Switch infobox templates (multi-form bosses like KQ, Zulrah, Hydra now return all NPC IDs).

## Test plan
- [x] `./gradlew test` passes
- [ ] Verify Cyclopes NPC highlight renders in Warriors' Guild