### PR TITLE
Fix overlay performance and null safety issues

### DIFF
--- a/src/main/java/com/collectionloghelper/overlay/GroundItemHighlightOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/GroundItemHighlightOverlay.java
@@ -200,12 +200,13 @@ public class GroundItemHighlightOverlay extends Overlay
 		arrowPolygon.addPoint(x + halfW, topY);
 		arrowPolygon.addPoint(x - halfW, topY);
 
+		// Colored fill first, then black outline on top
+		graphics.setColor(color);
+		graphics.fillPolygon(arrowPolygon);
+
 		graphics.setColor(Color.BLACK);
 		graphics.setStroke(STROKE_2);
 		graphics.drawPolygon(arrowPolygon);
-
-		graphics.setColor(color);
-		graphics.fillPolygon(arrowPolygon);
 	}
 
 	private void renderOutlinedText(Graphics2D graphics, Point point, String text, Color color)

--- a/src/main/java/com/collectionloghelper/overlay/GuidanceMinimapOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/GuidanceMinimapOverlay.java
@@ -82,7 +82,13 @@ public class GuidanceMinimapOverlay extends Overlay
 
 		Color overlayColor = config.overlayColor();
 
-		LocalPoint localPoint = LocalPoint.fromWorld(client.getTopLevelWorldView(), targetPoint);
+		net.runelite.api.WorldView wv = client.getTopLevelWorldView();
+		if (wv == null)
+		{
+			return null;
+		}
+
+		LocalPoint localPoint = LocalPoint.fromWorld(wv, targetPoint);
 
 		// If target is visible on the minimap, no arrow needed
 		if (localPoint != null)

--- a/src/main/java/com/collectionloghelper/overlay/GuidanceOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/GuidanceOverlay.java
@@ -41,6 +41,7 @@ import javax.inject.Singleton;
 import net.runelite.api.Client;
 import net.runelite.api.NPC;
 import net.runelite.api.Perspective;
+import net.runelite.api.Player;
 import net.runelite.api.Point;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
@@ -152,12 +153,14 @@ public class GuidanceOverlay extends OverlayPanel
 		}
 
 		// Skip world rendering if player is on a different plane than the target
-		boolean samePlane = client.getLocalPlayer() != null
-			&& client.getLocalPlayer().getWorldLocation().getPlane() == point.getPlane();
+		Player localPlayer = client.getLocalPlayer();
+		boolean samePlane = localPlayer != null
+			&& localPlayer.getWorldLocation().getPlane() == point.getPlane();
 
 		// Tile highlight rendering
-		LocalPoint localPoint = samePlane
-			? LocalPoint.fromWorld(client.getTopLevelWorldView(), point) : null;
+		net.runelite.api.WorldView wv = client.getTopLevelWorldView();
+		LocalPoint localPoint = samePlane && wv != null
+			? LocalPoint.fromWorld(wv, point) : null;
 		if (localPoint == null)
 		{
 			// Target tile is not on screen — show compact direction panel
@@ -197,43 +200,12 @@ public class GuidanceOverlay extends OverlayPanel
 			return null;
 		}
 
-		// NPC highlighting — if we have a target NPC ID, try to find and highlight it
+		// NPC highlighting — use event-driven tracked NPC (set via onNpcSpawned/onNpcDespawned)
 		boolean npcHighlighted = false;
 		if (npcId > 0)
 		{
 			NPC npc = this.trackedNpc;
-			// Use tracked NPC if available and still matches; fall back to full scan
-			if (npc == null || npc.getId() != npcId)
-			{
-				npc = null;
-				net.runelite.api.WorldView wv = client.getTopLevelWorldView();
-				LocalPoint playerLocal = client.getLocalPlayer() != null
-					? client.getLocalPlayer().getLocalLocation() : null;
-				if (wv != null)
-				{
-					for (NPC candidate : wv.npcs())
-					{
-						if (candidate != null && candidate.getId() == npcId)
-						{
-							// Skip NPCs too far from the player to be visible
-							if (playerLocal != null)
-							{
-								LocalPoint candidateLocal = candidate.getLocalLocation();
-								if (candidateLocal != null
-									&& playerLocal.distanceTo(candidateLocal) > MAX_RENDER_DISTANCE)
-								{
-									continue;
-								}
-							}
-							npc = candidate;
-							this.trackedNpc = candidate;
-							rebuildNpcLabel(this.interactAction, candidate);
-							break;
-						}
-					}
-				}
-			}
-			if (npc != null)
+			if (npc != null && npc.getId() == npcId)
 			{
 				renderNpcHighlight(graphics, npc, overlayColor, action, locDesc);
 				npcHighlighted = true;
@@ -361,14 +333,13 @@ public class GuidanceOverlay extends OverlayPanel
 		arrowPolygon.addPoint(x + halfW, topY);
 		arrowPolygon.addPoint(x - halfW, topY);
 
-		// Black outline
+		// Colored fill first, then black outline on top
+		graphics.setColor(color);
+		graphics.fillPolygon(arrowPolygon);
+
 		graphics.setColor(Color.BLACK);
 		graphics.setStroke(STROKE_2);
 		graphics.drawPolygon(arrowPolygon);
-
-		// Colored fill
-		graphics.setColor(color);
-		graphics.fillPolygon(arrowPolygon);
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- **Remove NPC scan fallback in render()** — `GuidanceOverlay.render()` was iterating `wv.npcs()` every frame when the tracked NPC was stale. Now relies entirely on event-driven `NpcSpawned`/`NpcDespawned` tracking + one-time `scanForTrackedNpc()` on step change. (fixes #276)
- **Null-check `getTopLevelWorldView()`** — `GuidanceMinimapOverlay.render()` passed the result directly to `LocalPoint.fromWorld()` without guarding against null during login transitions. (fixes #277)
- **Snapshot `getLocalPlayer()`** — `GuidanceOverlay.render()` called `getLocalPlayer()` twice without snapshotting, creating a TOCTOU race. Also adds null check for `getTopLevelWorldView()`. (fixes #278)
- **Fix arrow draw order** — Direction arrows in `GuidanceOverlay` and `GroundItemHighlightOverlay` drew outline before fill. Now fills first, then outlines on top for consistent rendering. (fixes #279)

## Test plan
- [ ] Verify NPC highlighting still works when approaching a guided NPC (arrow + hull/outline)
- [ ] Verify NPC highlight appears after scene load (NpcSpawned event picks it up)
- [ ] Verify minimap arrow renders without errors during world hops
- [ ] Verify direction arrows on ground items and NPCs look correct (fill + outline)