### PR TITLE
Fix Fossil Island Notes milestones + Revenants iron kill time

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -7726,6 +7726,7 @@
     "worldY": 3654,
     "worldPlane": 0,
     "killTimeSeconds": 14,
+    "ironKillTimeSeconds": 20,
     "afkLevel": 0,
     "items": [
       {
@@ -15232,82 +15233,82 @@
       {
         "itemId": 21664,
         "name": "Scribbled note",
-        "dropRate": 0.333333,
+        "dropRate": 1.0,
         "isPet": false,
         "wikiPage": "Scribbled_note",
-        "independent": true
+        "milestoneKills": 1
       },
       {
         "itemId": 21666,
         "name": "Partial note",
-        "dropRate": 0.333333,
+        "dropRate": 1.0,
         "isPet": false,
         "wikiPage": "Partial_note",
-        "independent": true
+        "milestoneKills": 1
       },
       {
         "itemId": 21668,
         "name": "Ancient note",
-        "dropRate": 0.333333,
+        "dropRate": 1.0,
         "isPet": false,
         "wikiPage": "Ancient_note",
-        "independent": true
+        "milestoneKills": 1
       },
       {
         "itemId": 21670,
         "name": "Ancient writings",
-        "dropRate": 0.333333,
+        "dropRate": 1.0,
         "isPet": false,
         "wikiPage": "Ancient_writings",
-        "independent": true
+        "milestoneKills": 1
       },
       {
         "itemId": 21672,
         "name": "Experimental note",
-        "dropRate": 0.333333,
+        "dropRate": 1.0,
         "isPet": false,
         "wikiPage": "Experimental_note",
-        "independent": true
+        "milestoneKills": 1
       },
       {
         "itemId": 21674,
         "name": "Paragraph of text",
-        "dropRate": 0.333333,
+        "dropRate": 1.0,
         "isPet": false,
         "wikiPage": "Paragraph_of_text",
-        "independent": true
+        "milestoneKills": 1
       },
       {
         "itemId": 21676,
         "name": "Musty smelling note",
-        "dropRate": 0.333333,
+        "dropRate": 1.0,
         "isPet": false,
         "wikiPage": "Musty_smelling_note",
-        "independent": true
+        "milestoneKills": 1
       },
       {
         "itemId": 21678,
         "name": "Hastily scrawled note",
-        "dropRate": 0.333333,
+        "dropRate": 1.0,
         "isPet": false,
         "wikiPage": "Hastily_scrawled_note",
-        "independent": true
+        "milestoneKills": 1
       },
       {
         "itemId": 21680,
         "name": "Old writing",
-        "dropRate": 0.333333,
+        "dropRate": 1.0,
         "isPet": false,
         "wikiPage": "Old_writing",
-        "independent": true
+        "milestoneKills": 1
       },
       {
         "itemId": 21682,
         "name": "Short note",
-        "dropRate": 0.333333,
+        "dropRate": 1.0,
         "isPet": false,
         "wikiPage": "Short_note",
-        "independent": true
+        "milestoneKills": 1
       }
     ],
     "locationDescription": "House on the Hill, Fossil Island",


### PR DESCRIPTION
## Summary

- **Fossil Island Notes (#317):** Reclassified all 10 one-time-find notes from `dropRate: 0.333333` + `independent: true` → `dropRate: 1.0` + `milestoneKills: 1`. They're scattered around Fossil Island as one-time finds, not repeatable drops. The prior modeling caused the efficiency calculator to treat them as 900 kph probabilistic drops; now the panel correctly shows "Milestone: 1 kill" per note.
- **Revenants (#316):** Added `ironKillTimeSeconds: 20` reflecting the April 25 2026 PvP QoL update that lets iron accounts receive revenant loot even when another player attacks first. The +6s over main time accounts for wilderness overhead and prayer management.

## Test plan

- [x] `gradlew test --rerun-tasks` — 336/336 tests pass, 0 failures, 0 errors
- [x] `validate_drop_rates` — no new issues (14 pre-existing remain unchanged)
- [x] Direct file inspection — 10× `milestoneKills: 1` present, 0× prior `independent: true`/`0.333333`
- [x] `compare_source` spot-checks confirmed no drift on affected sources

## Related issues

Closes #316, Closes #317.

Two related issues (#315 LMS, #318 Giants' Foundry/Hallowed Sepulchre) were investigated and closed as false alarms — the data is already correctly modeled; the initial audit was misled by `search_drop_rates` hiding `pointCost`/`milestoneKills` fields in its output.