### PR TITLE
fix: snapshot getLocalPlayer() to prevent NPE/TOCTOU in 4 sites (#321)

### DIFF
--- a/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
@@ -72,6 +72,7 @@ import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.MenuAction;
 import net.runelite.api.NPC;
+import net.runelite.api.Player;
 import net.runelite.api.WorldEntity;
 import net.runelite.api.WorldView;
 import net.runelite.api.coords.LocalPoint;
@@ -1298,12 +1299,7 @@ public class CollectionLogHelperPlugin extends Plugin
 
 				// Skip hint arrow inside Sailing instances — surface world
 				// coords render at wrong positions in instanced WorldViews
-				boolean inInstance = client.getLocalPlayer() != null
-					&& client.getLocalPlayer().getWorldView() != client.getTopLevelWorldView();
-				if (config.showHintArrow()
-					&& !inInstance
-					&& client.getLocalPlayer() != null
-					&& client.getLocalPlayer().getWorldLocation().getPlane() == worldPoint.getPlane())
+				if (shouldSetHintArrowTo(worldPoint))
 				{
 					client.setHintArrow(worldPoint);
 				}
@@ -1442,12 +1438,7 @@ public class CollectionLogHelperPlugin extends Plugin
 		{
 			client.clearHintArrow();
 
-			boolean inInstance = client.getLocalPlayer() != null
-				&& client.getLocalPlayer().getWorldView() != client.getTopLevelWorldView();
-			if (config.showHintArrow()
-				&& !inInstance
-				&& client.getLocalPlayer() != null
-				&& client.getLocalPlayer().getWorldLocation().getPlane() == worldPoint.getPlane())
+			if (shouldSetHintArrowTo(worldPoint))
 			{
 				client.setHintArrow(worldPoint);
 			}
@@ -1804,10 +1795,15 @@ public class CollectionLogHelperPlugin extends Plugin
 	 */
 	private WorldPoint resolvePlayerWorldLocation()
 	{
-		WorldPoint fallback = client.getLocalPlayer().getWorldLocation();
+		Player lp = client.getLocalPlayer();
+		if (lp == null)
+		{
+			return null;
+		}
+		WorldPoint fallback = lp.getWorldLocation();
 		try
 		{
-			WorldView playerView = client.getLocalPlayer().getWorldView();
+			WorldView playerView = lp.getWorldView();
 			if (playerView == null || playerView.isTopLevel())
 			{
 				return fallback;
@@ -1820,7 +1816,7 @@ public class CollectionLogHelperPlugin extends Plugin
 			{
 				if (entity.getWorldView() == playerView)
 				{
-					LocalPoint playerLocal = client.getLocalPlayer().getLocalLocation();
+					LocalPoint playerLocal = lp.getLocalLocation();
 					LocalPoint mainLocal = entity.transformToMainWorld(playerLocal);
 					if (mainLocal != null)
 					{
@@ -1837,6 +1833,32 @@ public class CollectionLogHelperPlugin extends Plugin
 			log.debug("WorldEntity transform failed, using fallback location", e);
 		}
 		return fallback;
+	}
+
+	/**
+	 * Decides whether a hint arrow should be placed at {@code worldPoint}.
+	 * Snapshots {@code getLocalPlayer()} once to avoid the TOCTOU race where
+	 * the player transitions to null mid-check. Skips hint arrows inside
+	 * non-top-level WorldViews (e.g. sailing boats) because surface-world
+	 * coords render at wrong positions in instanced views.
+	 */
+	private boolean shouldSetHintArrowTo(WorldPoint worldPoint)
+	{
+		if (!config.showHintArrow() || worldPoint == null)
+		{
+			return false;
+		}
+		Player lp = client.getLocalPlayer();
+		if (lp == null)
+		{
+			return false;
+		}
+		if (lp.getWorldView() != client.getTopLevelWorldView())
+		{
+			return false;
+		}
+		WorldPoint playerLoc = lp.getWorldLocation();
+		return playerLoc != null && playerLoc.getPlane() == worldPoint.getPlane();
 	}
 
 	// ---- Guidance Authoring Event Logger ----

--- a/src/main/java/com/collectionloghelper/overlay/GuidanceMinimapOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/GuidanceMinimapOverlay.java
@@ -102,18 +102,19 @@ public class GuidanceMinimapOverlay extends Overlay
 
 		// Target is far away — draw direction arrow on minimap edge
 		// Uses camera yaw rotation so the arrow always points correctly
-		if (client.getLocalPlayer() == null)
+		Player lp = client.getLocalPlayer();
+		if (lp == null)
 		{
 			return null;
 		}
 
-		WorldPoint playerLocation = client.getLocalPlayer().getWorldLocation();
+		WorldPoint playerLocation = lp.getWorldLocation();
 		if (playerLocation == null)
 		{
 			return null;
 		}
 
-		Point playerMinimapLoc = client.getLocalPlayer().getMinimapLocation();
+		Point playerMinimapLoc = lp.getMinimapLocation();
 		if (playerMinimapLoc == null)
 		{
 			return null;

--- a/src/main/java/com/collectionloghelper/overlay/WorldMapRouteOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/WorldMapRouteOverlay.java
@@ -36,6 +36,7 @@ import java.awt.geom.Line2D;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import net.runelite.api.Client;
+import net.runelite.api.Player;
 import net.runelite.api.Point;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.gameval.InterfaceID;
@@ -92,12 +93,13 @@ public class WorldMapRouteOverlay extends Overlay
 			return null;
 		}
 
-		if (client.getLocalPlayer() == null)
+		Player lp = client.getLocalPlayer();
+		if (lp == null)
 		{
 			return null;
 		}
 
-		WorldPoint playerLocation = client.getLocalPlayer().getWorldLocation();
+		WorldPoint playerLocation = lp.getWorldLocation();
 		if (playerLocation == null)
 		{
 			return null;


### PR DESCRIPTION
## Summary

Extends the null-safety pattern from #278 (GuidanceOverlay) to four additional sites surfaced by the 2026-04-15 audit. Fixes #321.

- `resolvePlayerWorldLocation()` in `CollectionLogHelperPlugin` — three `getLocalPlayer()` calls, zero null checks. Now snapshots once, returns null on pre-login access. Callers already treat the result as nullable (`cachedPlayerLocation` is volatile and explicitly nulled at startUp/shutDown).
- Hint-arrow clientThread callbacks — duplicated 8-line block at two call sites (lines 1301 and 1445) replaced with a shared `shouldSetHintArrowTo(WorldPoint)` helper that snapshots `Player` once. Also fixes the DRY violation.
- `GuidanceMinimapOverlay.render()` — three `getLocalPlayer()` reads collapsed into one snapshot. Not covered by #277 (which only fixed the `getTopLevelWorldView()` case on this file).
- `WorldMapRouteOverlay.render()` — two reads collapsed into one snapshot.

## Why

Per `memory/feedback_overlay_null_safety.md`, every overlay render path and plugin-thread callback must snapshot RuneLite API calls before null-checking. Without the snapshot, an NPE (if the player becomes null mid-method) crashes the entire RuneLite client, not just this plugin.

## Test plan

- [ ] `./gradlew build` passes on JDK 17.
- [ ] `./gradlew test` — existing `EfficiencyCalculatorTest` + `GuidanceSequencerTest` suites still pass (behavior-preserving refactor, no new logic tests required).
- [ ] Manual: start plugin from a clean client; pick a guidance target; confirm hint arrow and minimap arrow appear in normal areas.
- [ ] Manual: repeat inside a Sailing instance; confirm hint arrow is correctly suppressed (non-top-level `WorldView` branch).
- [ ] Manual: start the plugin while on the login screen → no NPE in logs from `resolvePlayerWorldLocation`.

## Scope

Null-safety refactor only — no behavior change, no new features. Other audit findings filed as separate issues (#322 raid conventions, #323 shop mechanics, #324 shadowJar, #325 hub hygiene) and will land in their own PRs.

Do not merge until code-reviewer subagent approves.