### PR TITLE
fix: correct Skotizo Dark totem drop rate (#319)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -4547,10 +4547,9 @@
       {
         "itemId": 19685,
         "name": "Dark totem",
-        "dropRate": 1.0,
+        "dropRate": 0.0078125,
         "isPet": false,
-        "wikiPage": "Dark_totem",
-        "milestoneKills": 1
+        "wikiPage": "Dark_totem"
       },
       {
         "itemId": 6571,


### PR DESCRIPTION
## Summary

Fixes Skotizo Dark totem entry in `drop_rates.json` — was modeled as an always-drop (`dropRate: 1.0` + `milestoneKills: 1`) but the wiki drop table shows it at 1/128. Updated to `0.0078125` and removed the milestone flag.

## Wiki evidence

[oldschool.runescape.wiki/w/Skotizo](https://oldschool.runescape.wiki/w/Skotizo):

> Dark totem ... rarity 1/128
>
> There is a 4/128 to roll the dark totem sub-table, then a 1/4 chance to receive a complete dark totem and a 3/4 chance to receive a totem piece that the player has the least of.

Collection-log membership verified via `/w/Collection_log` and `/w/Dark_totem` — Dark totem IS a Skotizo clog slot (alongside Skotos, Jar of darkness, Dark claw, Uncut onyx, Ancient shard). The issue author's hypothesis that "Dark totem is not a clog item" was based on it being obtained via the combine mechanic; wiki confirms the complete totem itself is the clog slot.

## Not addressed in this PR

- **Barracuda Trials `pointsPerHour: 3`** — wiki has no points-per-hour rate to verify against. Left as-is; re-audit when wiki data improves.
- **Skotizo Ancient shard `dropRate: 1.0`** — actually guaranteed 1–5 (avg 1.41). Not in #319 scope; worth a follow-up issue.

## Test plan

- [ ] `./gradlew build` passes on JDK 17.
- [ ] `./gradlew test` — drop-rate integrity tests still pass.
- [ ] Plugin loads without warnings in RuneLite client.
- [ ] Skotizo Dark totem shows realistic expected-kills in the efficiency UI.

Addresses #319 (Skotizo item only; Barracuda + other audit items remain open or out of scope).

Do not merge until code-reviewer subagent approves.
