### PR TITLE
fix: add raidRateConvention to 9 raid sources (#322)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -2541,6 +2541,7 @@
   },
   {
     "name": "The Nightmare",
+    "raidRateConvention": "SOLO",
     "category": "BOSSES",
     "worldX": 3728,
     "worldY": 3302,
@@ -2706,6 +2707,7 @@
   },
   {
     "name": "Phosani's Nightmare",
+    "raidRateConvention": "SOLO",
     "category": "BOSSES",
     "worldX": 3728,
     "worldY": 3302,
@@ -4668,6 +4670,7 @@
   },
   {
     "name": "Chambers of Xeric",
+    "raidRateConvention": "SOLO",
     "category": "RAIDS",
     "worldX": 1233,
     "worldY": 3573,
@@ -4840,6 +4843,7 @@
   },
   {
     "name": "Chambers of Xeric (Challenge Mode)",
+    "raidRateConvention": "SOLO",
     "category": "RAIDS",
     "worldX": 1233,
     "worldY": 3573,
@@ -5072,6 +5076,7 @@
   },
   {
     "name": "Theatre of Blood",
+    "raidRateConvention": "SOLO",
     "category": "RAIDS",
     "worldX": 3650,
     "worldY": 3218,
@@ -5259,6 +5264,7 @@
   },
   {
     "name": "Theatre of Blood (Hard Mode)",
+    "raidRateConvention": "SOLO",
     "category": "RAIDS",
     "worldX": 3650,
     "worldY": 3218,
@@ -5448,6 +5454,7 @@
   },
   {
     "name": "Tombs of Amascut",
+    "raidRateConvention": "PER_COMPLETION_SCALED",
     "category": "RAIDS",
     "worldX": 3234,
     "worldY": 2784,
@@ -5717,6 +5724,7 @@
   },
   {
     "name": "Tombs of Amascut (300 Invocation)",
+    "raidRateConvention": "PER_COMPLETION_SCALED",
     "category": "RAIDS",
     "worldX": 3234,
     "worldY": 2784,
@@ -5986,6 +5994,7 @@
   },
   {
     "name": "Tombs of Amascut (500 Invocation)",
+    "raidRateConvention": "PER_COMPLETION_SCALED",
     "category": "RAIDS",
     "worldX": 3234,
     "worldY": 2784,


### PR DESCRIPTION
## Summary

Documentation-only schema addition: explicit `raidRateConvention` on all 9 raid sources in `drop_rates.json`. Closes #322.

Values:
- `"SOLO"` — CoX, CoX CM, ToB, ToB HM, Nightmare, Phosani's
- `"PER_COMPLETION_SCALED"` — ToA, ToA 300, ToA 500

No Java-side changes. Field is consumed by future `validate_drop_rates` tooling (MCP side) to enforce presence on raid sources and catch the drift class documented in #229, #230, #231, #256, #258.

## Verification

Each raid's stored rate was cross-checked against the wiki's solo baseline:

| Source | Sample rate in file | Solo wiki baseline |
|---|---|---|
| CoX | Tbow 0.001 | 1/1000 |
| CoX CM | Tbow 0.002067 | 1/484 (~2.07× base) |
| ToB | Scythe 0.005784 | 1/172.9 |
| ToB HM | Scythe 0.007215 | 1/138.6 |
| Nightmare | Inquisitor helm 0.002381; staff 0.003333 | 1/420; 1/300 |
| Phosani's | solo-only content | — |
| ToA ×3 | per-completion point-scaled rolls | — |

All stored rates match the `"SOLO"` convention cleanly; no drift surfaced.

## Encoding note

`drop_rates.json` has 13 latent CP-1252 `0x97` em-dash bytes. Edits applied via byte-level `bytes.replace` with exact-match assertions; post-edit `0x97` count unchanged (13). Diff is exactly +9 lines, each immediately after a `"name"` field.

## Test plan

- [ ] `./gradlew build` still green (field is additive; Gson lenient for unknown fields).
- [ ] `./gradlew test` — `DropRateDatabaseTest` still passes.
- [ ] Spot-check non-raid sources show no diff.
- [ ] Follow-up PR: wire `validate_drop_rates` to require the field on raid sources.

Do not merge until code-reviewer subagent approves.
