### PR TITLE
refactor: extract OverlayRegistry and SceneObjectRouter from plugin class

### DIFF
--- a/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
@@ -45,6 +45,7 @@ import com.collectionloghelper.efficiency.ScoredItem;
 import com.collectionloghelper.efficiency.SlayerStrategyCalculator;
 import com.collectionloghelper.guidance.GuidanceSequencer;
 import com.collectionloghelper.lifecycle.OverlayRegistry;
+import com.collectionloghelper.lifecycle.SceneObjectRouter;
 import com.collectionloghelper.overlay.CollectionLogWorldMapPoint;
 import com.collectionloghelper.overlay.DialogHighlightOverlay;
 import com.collectionloghelper.overlay.GroundItemHighlightOverlay;
@@ -81,15 +82,9 @@ import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ActorDeath;
 import net.runelite.api.events.AnimationChanged;
 import net.runelite.api.events.ChatMessage;
-import net.runelite.api.events.DecorativeObjectDespawned;
-import net.runelite.api.events.DecorativeObjectSpawned;
 import net.runelite.api.events.GameObjectDespawned;
 import net.runelite.api.events.GameObjectSpawned;
 import net.runelite.api.events.GameStateChanged;
-import net.runelite.api.events.GroundObjectDespawned;
-import net.runelite.api.events.GroundObjectSpawned;
-import net.runelite.api.events.WallObjectDespawned;
-import net.runelite.api.events.WallObjectSpawned;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.HitsplatApplied;
 import net.runelite.api.events.InteractingChanged;
@@ -259,6 +254,9 @@ public class CollectionLogHelperPlugin extends Plugin
 	@Inject
 	private OverlayRegistry overlayRegistry;
 
+	@Inject
+	private SceneObjectRouter sceneObjectRouter;
+
 
 	private CollectionLogHelperPanel panel;
 	private NavigationButton navButton;
@@ -352,6 +350,7 @@ public class CollectionLogHelperPlugin extends Plugin
 			clientToolbar.addNavigation(navButton);
 		});
 		overlayRegistry.registerAll();
+		eventBus.register(sceneObjectRouter);
 
 		// If already logged in (e.g., plugin enabled mid-session), load state
 		if (client.getGameState() == GameState.LOGGED_IN)
@@ -392,6 +391,7 @@ public class CollectionLogHelperPlugin extends Plugin
 		}
 		clientToolbar.removeNavigation(navButton);
 		overlayRegistry.unregisterAll();
+		eventBus.unregister(sceneObjectRouter);
 		deactivateGuidance();
 		lastObtainedCount = -1;
 		sourcesWithMissingItems.clear();
@@ -2001,42 +2001,6 @@ public class CollectionLogHelperPlugin extends Plugin
 		WorldPoint wp = event.getTile().getWorldLocation();
 		authoringLog("OBJECT_DESPAWN id=%d at=[%d,%d,%d]",
 			event.getGameObject().getId(), wp.getX(), wp.getY(), wp.getPlane());
-	}
-
-	@Subscribe
-	public void onWallObjectSpawned(WallObjectSpawned event)
-	{
-		objectHighlightOverlay.onObjectSpawned(event.getWallObject());
-	}
-
-	@Subscribe
-	public void onWallObjectDespawned(WallObjectDespawned event)
-	{
-		objectHighlightOverlay.onObjectDespawned(event.getWallObject());
-	}
-
-	@Subscribe
-	public void onDecorativeObjectSpawned(DecorativeObjectSpawned event)
-	{
-		objectHighlightOverlay.onObjectSpawned(event.getDecorativeObject());
-	}
-
-	@Subscribe
-	public void onDecorativeObjectDespawned(DecorativeObjectDespawned event)
-	{
-		objectHighlightOverlay.onObjectDespawned(event.getDecorativeObject());
-	}
-
-	@Subscribe
-	public void onGroundObjectSpawned(GroundObjectSpawned event)
-	{
-		objectHighlightOverlay.onObjectSpawned(event.getGroundObject());
-	}
-
-	@Subscribe
-	public void onGroundObjectDespawned(GroundObjectDespawned event)
-	{
-		objectHighlightOverlay.onObjectDespawned(event.getGroundObject());
 	}
 
 	@Subscribe

--- a/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
@@ -44,6 +44,7 @@ import com.collectionloghelper.efficiency.EfficiencyCalculator;
 import com.collectionloghelper.efficiency.ScoredItem;
 import com.collectionloghelper.efficiency.SlayerStrategyCalculator;
 import com.collectionloghelper.guidance.GuidanceSequencer;
+import com.collectionloghelper.lifecycle.OverlayRegistry;
 import com.collectionloghelper.overlay.CollectionLogWorldMapPoint;
 import com.collectionloghelper.overlay.DialogHighlightOverlay;
 import com.collectionloghelper.overlay.GroundItemHighlightOverlay;
@@ -255,6 +256,9 @@ public class CollectionLogHelperPlugin extends Plugin
 	@Inject
 	private GuidanceSequencer guidanceSequencer;
 
+	@Inject
+	private OverlayRegistry overlayRegistry;
+
 
 	private CollectionLogHelperPanel panel;
 	private NavigationButton navButton;
@@ -347,14 +351,7 @@ public class CollectionLogHelperPlugin extends Plugin
 				.build();
 			clientToolbar.addNavigation(navButton);
 		});
-		overlayManager.add(guidanceOverlay);
-		overlayManager.add(guidanceMinimapOverlay);
-		overlayManager.add(dialogHighlightOverlay);
-		overlayManager.add(objectHighlightOverlay);
-		overlayManager.add(itemHighlightOverlay);
-		overlayManager.add(worldMapRouteOverlay);
-		overlayManager.add(groundItemHighlightOverlay);
-		overlayManager.add(widgetHighlightOverlay);
+		overlayRegistry.registerAll();
 
 		// If already logged in (e.g., plugin enabled mid-session), load state
 		if (client.getGameState() == GameState.LOGGED_IN)
@@ -394,14 +391,7 @@ public class CollectionLogHelperPlugin extends Plugin
 			panel.shutDown();
 		}
 		clientToolbar.removeNavigation(navButton);
-		overlayManager.remove(guidanceOverlay);
-		overlayManager.remove(guidanceMinimapOverlay);
-		overlayManager.remove(dialogHighlightOverlay);
-		overlayManager.remove(objectHighlightOverlay);
-		overlayManager.remove(itemHighlightOverlay);
-		overlayManager.remove(worldMapRouteOverlay);
-		overlayManager.remove(groundItemHighlightOverlay);
-		overlayManager.remove(widgetHighlightOverlay);
+		overlayRegistry.unregisterAll();
 		deactivateGuidance();
 		lastObtainedCount = -1;
 		sourcesWithMissingItems.clear();

--- a/src/main/java/com/collectionloghelper/lifecycle/OverlayRegistry.java
+++ b/src/main/java/com/collectionloghelper/lifecycle/OverlayRegistry.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.lifecycle;
+
+import com.collectionloghelper.overlay.DialogHighlightOverlay;
+import com.collectionloghelper.overlay.GroundItemHighlightOverlay;
+import com.collectionloghelper.overlay.GuidanceMinimapOverlay;
+import com.collectionloghelper.overlay.GuidanceOverlay;
+import com.collectionloghelper.overlay.ItemHighlightOverlay;
+import com.collectionloghelper.overlay.ObjectHighlightOverlay;
+import com.collectionloghelper.overlay.WidgetHighlightOverlay;
+import com.collectionloghelper.overlay.WorldMapRouteOverlay;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import net.runelite.client.ui.overlay.OverlayManager;
+
+/**
+ * Owns the lifecycle of all plugin overlays. Registration order is
+ * preserved exactly as it was in the plugin's startUp/shutDown to avoid
+ * any subtle z-order or listener-registration ordering changes.
+ */
+@Singleton
+public class OverlayRegistry
+{
+	private final OverlayManager overlayManager;
+	private final GuidanceOverlay guidanceOverlay;
+	private final GuidanceMinimapOverlay guidanceMinimapOverlay;
+	private final DialogHighlightOverlay dialogHighlightOverlay;
+	private final ObjectHighlightOverlay objectHighlightOverlay;
+	private final ItemHighlightOverlay itemHighlightOverlay;
+	private final WorldMapRouteOverlay worldMapRouteOverlay;
+	private final GroundItemHighlightOverlay groundItemHighlightOverlay;
+	private final WidgetHighlightOverlay widgetHighlightOverlay;
+
+	@Inject
+	public OverlayRegistry(
+		OverlayManager overlayManager,
+		GuidanceOverlay guidanceOverlay,
+		GuidanceMinimapOverlay guidanceMinimapOverlay,
+		DialogHighlightOverlay dialogHighlightOverlay,
+		ObjectHighlightOverlay objectHighlightOverlay,
+		ItemHighlightOverlay itemHighlightOverlay,
+		WorldMapRouteOverlay worldMapRouteOverlay,
+		GroundItemHighlightOverlay groundItemHighlightOverlay,
+		WidgetHighlightOverlay widgetHighlightOverlay)
+	{
+		this.overlayManager = overlayManager;
+		this.guidanceOverlay = guidanceOverlay;
+		this.guidanceMinimapOverlay = guidanceMinimapOverlay;
+		this.dialogHighlightOverlay = dialogHighlightOverlay;
+		this.objectHighlightOverlay = objectHighlightOverlay;
+		this.itemHighlightOverlay = itemHighlightOverlay;
+		this.worldMapRouteOverlay = worldMapRouteOverlay;
+		this.groundItemHighlightOverlay = groundItemHighlightOverlay;
+		this.widgetHighlightOverlay = widgetHighlightOverlay;
+	}
+
+	/** Adds all plugin overlays to the OverlayManager. Call from Plugin.startUp(). */
+	public void registerAll()
+	{
+		overlayManager.add(guidanceOverlay);
+		overlayManager.add(guidanceMinimapOverlay);
+		overlayManager.add(dialogHighlightOverlay);
+		overlayManager.add(objectHighlightOverlay);
+		overlayManager.add(itemHighlightOverlay);
+		overlayManager.add(worldMapRouteOverlay);
+		overlayManager.add(groundItemHighlightOverlay);
+		overlayManager.add(widgetHighlightOverlay);
+	}
+
+	/** Removes all plugin overlays from the OverlayManager. Call from Plugin.shutDown(). */
+	public void unregisterAll()
+	{
+		overlayManager.remove(guidanceOverlay);
+		overlayManager.remove(guidanceMinimapOverlay);
+		overlayManager.remove(dialogHighlightOverlay);
+		overlayManager.remove(objectHighlightOverlay);
+		overlayManager.remove(itemHighlightOverlay);
+		overlayManager.remove(worldMapRouteOverlay);
+		overlayManager.remove(groundItemHighlightOverlay);
+		overlayManager.remove(widgetHighlightOverlay);
+	}
+}

--- a/src/main/java/com/collectionloghelper/lifecycle/SceneObjectRouter.java
+++ b/src/main/java/com/collectionloghelper/lifecycle/SceneObjectRouter.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.lifecycle;
+
+import com.collectionloghelper.overlay.ObjectHighlightOverlay;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import net.runelite.api.events.DecorativeObjectDespawned;
+import net.runelite.api.events.DecorativeObjectSpawned;
+import net.runelite.api.events.GroundObjectDespawned;
+import net.runelite.api.events.GroundObjectSpawned;
+import net.runelite.api.events.WallObjectDespawned;
+import net.runelite.api.events.WallObjectSpawned;
+import net.runelite.client.eventbus.Subscribe;
+
+/**
+ * Routes scene-object spawn/despawn events for wall, decorative, and ground
+ * objects straight to the ObjectHighlightOverlay. These handlers were pure
+ * pass-throughs in the plugin and share no state with other plugin logic,
+ * so extracting them is behavior-preserving.
+ *
+ * GameObjectSpawned/Despawned are intentionally NOT routed here because
+ * those handlers are interleaved with authoring-log side-effects that live
+ * in the plugin.
+ *
+ * Must be registered on the EventBus via eventBus.register(this) in
+ * Plugin.startUp() and unregistered in Plugin.shutDown() to match the
+ * plugin's own @Subscribe lifecycle.
+ */
+@Singleton
+public class SceneObjectRouter
+{
+	private final ObjectHighlightOverlay objectHighlightOverlay;
+
+	@Inject
+	public SceneObjectRouter(ObjectHighlightOverlay objectHighlightOverlay)
+	{
+		this.objectHighlightOverlay = objectHighlightOverlay;
+	}
+
+	@Subscribe
+	public void onWallObjectSpawned(WallObjectSpawned event)
+	{
+		objectHighlightOverlay.onObjectSpawned(event.getWallObject());
+	}
+
+	@Subscribe
+	public void onWallObjectDespawned(WallObjectDespawned event)
+	{
+		objectHighlightOverlay.onObjectDespawned(event.getWallObject());
+	}
+
+	@Subscribe
+	public void onDecorativeObjectSpawned(DecorativeObjectSpawned event)
+	{
+		objectHighlightOverlay.onObjectSpawned(event.getDecorativeObject());
+	}
+
+	@Subscribe
+	public void onDecorativeObjectDespawned(DecorativeObjectDespawned event)
+	{
+		objectHighlightOverlay.onObjectDespawned(event.getDecorativeObject());
+	}
+
+	@Subscribe
+	public void onGroundObjectSpawned(GroundObjectSpawned event)
+	{
+		objectHighlightOverlay.onObjectSpawned(event.getGroundObject());
+	}
+
+	@Subscribe
+	public void onGroundObjectDespawned(GroundObjectDespawned event)
+	{
+		objectHighlightOverlay.onObjectDespawned(event.getGroundObject());
+	}
+}


### PR DESCRIPTION
## Summary
First pass at splitting the 2,192-line \`CollectionLogHelperPlugin\` god-object. Two safe, orthogonal services extracted into a new \`com.collectionloghelper.lifecycle\` package:

- **\`OverlayRegistry\`** (105 LOC) — owns overlay lifecycle. Plugin \`startUp\`/\`shutDown\` delegate \`registerAll()\` / \`unregisterAll()\` for all 8 overlays. Registration order preserved exactly.
- **\`SceneObjectRouter\`** (98 LOC) — pure pass-through \`@Subscribe\` handlers for wall/decorative/ground object spawn+despawn (6 handlers). Registered via \`eventBus.register/unregister\` in plugin lifecycle. Handler bodies are byte-for-byte identical to what they replace.

Plugin class: **2,192 → 2,146 LOC** (−46). Real structural win is the +203 LOC of cohesive service classes.

## What was NOT extracted (and why)
Full \`EventCoordinator\` extraction was scoped but judged unsafe in a single pass. The plugin's 28 \`@Subscribe\` methods are deeply entangled with ~15 plugin-private fields (\`lastObtainedCount\`, \`scanSettleCountdown\`, \`pendingPanelRebuild\`, \`rankedSourcesDirty\`, \`lastMessagedStepIndex\`, \`authoringLogWriter\`, etc.) and private helpers (\`authoringLog\`, \`rebuildSourcesWithMissingItems\`, \`activateGuidance\`). Extracting would require ~20 package-private accessors — worse cohesion than the status quo.

**Follow-up PR shape:** first extract plugin-private state into a \`PluginStateHolder\`, then an \`EventCoordinator\` can consume it cleanly. Deliberately deferred rather than half-done.

## Behavior preservation
Non-negotiable for this refactor. Overlay registration order preserved. \`@Subscribe\` subscriber object identity changed but handler bodies unchanged. No config, API, or performance changes.

## Test plan
- [x] \`./gradlew test\` green after every commit (not just final)
- [x] \`./gradlew build\` green

Tier 3 of tiered refinement roadmap.