### PR TITLE
chore: replace personal name with GitHub alias in copyright headers

### DIFF
--- a/src/main/java/com/collectionloghelper/AccountType.java
+++ b/src/main/java/com/collectionloghelper/AccountType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/AfkFilter.java
+++ b/src/main/java/com/collectionloghelper/AfkFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/CollectionLogHelperConfig.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/EfficientSortMode.java
+++ b/src/main/java/com/collectionloghelper/EfficientSortMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/NpcHighlightStyle.java
+++ b/src/main/java/com/collectionloghelper/NpcHighlightStyle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/RaidTeamSize.java
+++ b/src/main/java/com/collectionloghelper/RaidTeamSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/data/ClueItemDatabase.java
+++ b/src/main/java/com/collectionloghelper/data/ClueItemDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/data/CollectionLogCategory.java
+++ b/src/main/java/com/collectionloghelper/data/CollectionLogCategory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/data/CollectionLogItem.java
+++ b/src/main/java/com/collectionloghelper/data/CollectionLogItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/data/CollectionLogSource.java
+++ b/src/main/java/com/collectionloghelper/data/CollectionLogSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/data/CompletionCondition.java
+++ b/src/main/java/com/collectionloghelper/data/CompletionCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/data/ConditionalAlternative.java
+++ b/src/main/java/com/collectionloghelper/data/ConditionalAlternative.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/data/DataSyncState.java
+++ b/src/main/java/com/collectionloghelper/data/DataSyncState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/data/DropRateDatabase.java
+++ b/src/main/java/com/collectionloghelper/data/DropRateDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/data/GuidanceStep.java
+++ b/src/main/java/com/collectionloghelper/data/GuidanceStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/data/ItemObjectTier.java
+++ b/src/main/java/com/collectionloghelper/data/ItemObjectTier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/data/PlayerBankState.java
+++ b/src/main/java/com/collectionloghelper/data/PlayerBankState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/data/PlayerCollectionState.java
+++ b/src/main/java/com/collectionloghelper/data/PlayerCollectionState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/data/PlayerInventoryState.java
+++ b/src/main/java/com/collectionloghelper/data/PlayerInventoryState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/data/PlayerTravelCapabilities.java
+++ b/src/main/java/com/collectionloghelper/data/PlayerTravelCapabilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/data/PluginDataManager.java
+++ b/src/main/java/com/collectionloghelper/data/PluginDataManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/data/RequirementsChecker.java
+++ b/src/main/java/com/collectionloghelper/data/RequirementsChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/data/RewardType.java
+++ b/src/main/java/com/collectionloghelper/data/RewardType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/data/SkillRequirement.java
+++ b/src/main/java/com/collectionloghelper/data/SkillRequirement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/data/SlayerCreatureDatabase.java
+++ b/src/main/java/com/collectionloghelper/data/SlayerCreatureDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/data/SlayerMasterDatabase.java
+++ b/src/main/java/com/collectionloghelper/data/SlayerMasterDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/data/SlayerTaskState.java
+++ b/src/main/java/com/collectionloghelper/data/SlayerTaskState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/data/SourceRequirements.java
+++ b/src/main/java/com/collectionloghelper/data/SourceRequirements.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/data/Waypoint.java
+++ b/src/main/java/com/collectionloghelper/data/Waypoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/data/Zone.java
+++ b/src/main/java/com/collectionloghelper/data/Zone.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/efficiency/ClueCompletionEstimator.java
+++ b/src/main/java/com/collectionloghelper/efficiency/ClueCompletionEstimator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/efficiency/EfficiencyCalculator.java
+++ b/src/main/java/com/collectionloghelper/efficiency/EfficiencyCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/efficiency/ScoredItem.java
+++ b/src/main/java/com/collectionloghelper/efficiency/ScoredItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/efficiency/SlayerStrategyCalculator.java
+++ b/src/main/java/com/collectionloghelper/efficiency/SlayerStrategyCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/guidance/GuidanceSequencer.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceSequencer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/overlay/CollectionLogWorldMapPoint.java
+++ b/src/main/java/com/collectionloghelper/overlay/CollectionLogWorldMapPoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/overlay/DialogHighlightOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/DialogHighlightOverlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/overlay/GroundItemHighlightOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/GroundItemHighlightOverlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/overlay/GuidanceInfoBox.java
+++ b/src/main/java/com/collectionloghelper/overlay/GuidanceInfoBox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/overlay/GuidanceMinimapOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/GuidanceMinimapOverlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/overlay/GuidanceOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/GuidanceOverlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/overlay/ItemHighlightOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/ItemHighlightOverlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/overlay/ObjectHighlightOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/ObjectHighlightOverlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/overlay/OverlayTooltipHelper.java
+++ b/src/main/java/com/collectionloghelper/overlay/OverlayTooltipHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/overlay/WidgetHighlightOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/WidgetHighlightOverlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/overlay/WorldMapRouteOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/WorldMapRouteOverlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/ui/CategorySummaryPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/CategorySummaryPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/ui/ItemDetailPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/ItemDetailPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/collectionloghelper/ui/ItemRowPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/ItemRowPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/com/collectionloghelper/CollectionLogHelperPluginTest.java
+++ b/src/test/java/com/collectionloghelper/CollectionLogHelperPluginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/com/collectionloghelper/data/ClueItemDatabaseTest.java
+++ b/src/test/java/com/collectionloghelper/data/ClueItemDatabaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/com/collectionloghelper/data/CollectionLogSourceTest.java
+++ b/src/test/java/com/collectionloghelper/data/CollectionLogSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/com/collectionloghelper/data/DataSyncStateTest.java
+++ b/src/test/java/com/collectionloghelper/data/DataSyncStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/com/collectionloghelper/data/DropRateDatabaseTest.java
+++ b/src/test/java/com/collectionloghelper/data/DropRateDatabaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/com/collectionloghelper/data/PlayerBankStateTest.java
+++ b/src/test/java/com/collectionloghelper/data/PlayerBankStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/com/collectionloghelper/data/PlayerInventoryStateTest.java
+++ b/src/test/java/com/collectionloghelper/data/PlayerInventoryStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/com/collectionloghelper/data/PlayerTravelCapabilitiesTest.java
+++ b/src/test/java/com/collectionloghelper/data/PlayerTravelCapabilitiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/com/collectionloghelper/data/RequirementsCheckerTest.java
+++ b/src/test/java/com/collectionloghelper/data/RequirementsCheckerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/com/collectionloghelper/data/SlayerCreatureDatabaseTest.java
+++ b/src/test/java/com/collectionloghelper/data/SlayerCreatureDatabaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/com/collectionloghelper/data/SlayerTaskStateTest.java
+++ b/src/test/java/com/collectionloghelper/data/SlayerTaskStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/com/collectionloghelper/efficiency/ClueCompletionEstimatorTest.java
+++ b/src/test/java/com/collectionloghelper/efficiency/ClueCompletionEstimatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/com/collectionloghelper/efficiency/EfficiencyCalculatorTest.java
+++ b/src/test/java/com/collectionloghelper/efficiency/EfficiencyCalculatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/com/collectionloghelper/efficiency/SlayerStrategyCalculatorTest.java
+++ b/src/test/java/com/collectionloghelper/efficiency/SlayerStrategyCalculatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Chandler
+ * Copyright (c) 2025, cha-ndler
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
## Summary

Replace `Copyright (c) 2025, Chandler` with `Copyright (c) 2025, cha-ndler` in all 66 source and test files to align copyright headers with the public GitHub identity.

## Changes

- Updated copyright header author in 51 `src/main/java/` files
- Updated copyright header author in 15 `src/test/java/` files

## Testing

- No behavioral change — copyright headers only
- `./gradlew test` passes
- `./gradlew build` passes