### PR TITLE
test: add 63 tests for OverlayRegistry, SceneObjectRouter, PluginDataManager, DataSyncState

### DIFF
--- a/src/test/java/com/collectionloghelper/data/DataSyncStateTest.java
+++ b/src/test/java/com/collectionloghelper/data/DataSyncStateTest.java
@@ -167,4 +167,159 @@ public class DataSyncStateTest
 		syncState.setLoginTimestamp(ts);
 		assertEquals(ts, syncState.getLoginTimestamp());
 	}
+
+	// ========================================================================
+	// State transitions — SYNCED back to UNSYNCED
+	// ========================================================================
+
+	@Test
+	public void transitionFromSyncedBackToUnsynced_collectionLog()
+	{
+		// Arrange — fully synced
+		syncState.setCollectionLogSynced(true);
+		syncState.setBankScanned(true);
+		assertTrue(syncState.isFullySynced());
+
+		// Act — un-sync the collection log
+		syncState.setCollectionLogSynced(false);
+
+		// Assert
+		assertFalse(syncState.isCollectionLogSynced());
+		assertFalse(syncState.isFullySynced());
+		assertTrue(syncState.isBankScanned()); // bank state unchanged
+	}
+
+	@Test
+	public void transitionFromSyncedBackToUnsynced_bank()
+	{
+		// Arrange — fully synced
+		syncState.setCollectionLogSynced(true);
+		syncState.setBankScanned(true);
+		assertTrue(syncState.isFullySynced());
+
+		// Act — un-sync the bank
+		syncState.setBankScanned(false);
+
+		// Assert
+		assertFalse(syncState.isBankScanned());
+		assertFalse(syncState.isFullySynced());
+		assertTrue(syncState.isCollectionLogSynced()); // collection log unchanged
+	}
+
+	@Test
+	public void transitionFromSyncedToUnsyncedAndBackToSynced()
+	{
+		// Arrange — start fully synced
+		syncState.setCollectionLogSynced(true);
+		syncState.setBankScanned(true);
+
+		// Act — intermediate unsynced state
+		syncState.setCollectionLogSynced(false);
+		assertFalse(syncState.isFullySynced());
+
+		// Act — re-sync
+		syncState.setCollectionLogSynced(true);
+
+		// Assert
+		assertTrue(syncState.isFullySynced());
+	}
+
+	// ========================================================================
+	// Reset transitions
+	// ========================================================================
+
+	@Test
+	public void resetAfterFullSync_returnsToInitialState()
+	{
+		// Arrange
+		syncState.setCollectionLogSynced(true);
+		syncState.setBankScanned(true);
+		syncState.setLoginTimestamp(999_000L);
+
+		// Act
+		syncState.reset();
+
+		// Assert — back to clean initial state
+		assertFalse(syncState.isCollectionLogSynced());
+		assertFalse(syncState.isBankScanned());
+		assertFalse(syncState.isFullySynced());
+		assertEquals(0, syncState.getLoginTimestamp());
+		assertFalse(syncState.isReminderExpired());
+	}
+
+	@Test
+	public void resetIsIdempotent()
+	{
+		// Arrange
+		syncState.setCollectionLogSynced(true);
+		syncState.reset();
+
+		// Act — second reset on already-clean state
+		syncState.reset();
+
+		// Assert
+		assertFalse(syncState.isCollectionLogSynced());
+		assertFalse(syncState.isBankScanned());
+		assertEquals(0, syncState.getLoginTimestamp());
+	}
+
+	// ========================================================================
+	// isReminderExpired boundary values
+	// ========================================================================
+
+	@Test
+	public void isReminderExpired_negativeTimestamp_returnsFalse()
+	{
+		// loginTimestamp <= 0 should never expire
+		syncState.setLoginTimestamp(-1L);
+		assertFalse(syncState.isReminderExpired());
+	}
+
+	@Test
+	public void isReminderExpired_justOverThreshold_returnsTrue()
+	{
+		// Login was 2 minutes + 1 ms ago — should be expired
+		syncState.setLoginTimestamp(System.currentTimeMillis() - 120_001);
+		assertTrue(syncState.isReminderExpired());
+	}
+
+	@Test
+	public void isReminderExpired_afterReset_returnsFalse()
+	{
+		// Arrange — set old timestamp, trigger expiry
+		syncState.setLoginTimestamp(System.currentTimeMillis() - 180_000);
+		assertTrue(syncState.isReminderExpired());
+
+		// Act
+		syncState.reset();
+
+		// Assert — reset clears timestamp so reminder no longer expired
+		assertFalse(syncState.isReminderExpired());
+	}
+
+	// ========================================================================
+	// isFullySynced — flag independence
+	// ========================================================================
+
+	@Test
+	public void isFullySynced_setTrueThenFalseForOneFlag_remainsFalse()
+	{
+		// Toggle collectionLog true/false while bank stays true
+		syncState.setBankScanned(true);
+		syncState.setCollectionLogSynced(true);
+		assertTrue(syncState.isFullySynced());
+
+		syncState.setCollectionLogSynced(false);
+		assertFalse(syncState.isFullySynced());
+	}
+
+	@Test
+	public void isFullySynced_independentOfLoginTimestamp()
+	{
+		// loginTimestamp should not affect isFullySynced
+		syncState.setCollectionLogSynced(true);
+		syncState.setBankScanned(true);
+		syncState.setLoginTimestamp(0L);
+		assertTrue(syncState.isFullySynced());
+	}
 }

--- a/src/test/java/com/collectionloghelper/data/PluginDataManagerTest.java
+++ b/src/test/java/com/collectionloghelper/data/PluginDataManagerTest.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data;
+
+import java.lang.reflect.Constructor;
+import net.runelite.api.Client;
+import net.runelite.api.Player;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PluginDataManagerTest
+{
+	@Mock
+	private Client client;
+
+	@Mock
+	private Player localPlayer;
+
+	private PluginDataManager manager;
+
+	@Before
+	public void setUp() throws Exception
+	{
+		Constructor<PluginDataManager> ctor = PluginDataManager.class.getDeclaredConstructor(Client.class);
+		ctor.setAccessible(true);
+		manager = ctor.newInstance(client);
+	}
+
+	// ========================================================================
+	// sanitizeFileName (package-private static — testable directly)
+	// ========================================================================
+
+	@Test
+	public void testSanitizeFileName_normalName()
+	{
+		assertEquals("Zezima", PluginDataManager.sanitizeFileName("Zezima"));
+	}
+
+	@Test
+	public void testSanitizeFileName_nameWithSpaces()
+	{
+		assertEquals("Iron Man", PluginDataManager.sanitizeFileName("Iron Man"));
+	}
+
+	@Test
+	public void testSanitizeFileName_nameWithHyphen()
+	{
+		assertEquals("Iron-Man", PluginDataManager.sanitizeFileName("Iron-Man"));
+	}
+
+	@Test
+	public void testSanitizeFileName_nameWithUnderscore()
+	{
+		assertEquals("Iron_Man", PluginDataManager.sanitizeFileName("Iron_Man"));
+	}
+
+	@Test
+	public void testSanitizeFileName_specialCharsReplaced()
+	{
+		// Angle brackets, slashes, and other filesystem-unsafe chars → underscore
+		String sanitized = PluginDataManager.sanitizeFileName("Player<test>/name");
+		assertFalse("Special chars should be replaced", sanitized.contains("<"));
+		assertFalse("Special chars should be replaced", sanitized.contains(">"));
+		assertFalse("Slash should be replaced", sanitized.contains("/"));
+	}
+
+	@Test
+	public void testSanitizeFileName_numberOnlyName()
+	{
+		assertEquals("12345", PluginDataManager.sanitizeFileName("12345"));
+	}
+
+	@Test
+	public void testSanitizeFileName_trimLeadingTrailingSpaces()
+	{
+		assertEquals("Trim Me", PluginDataManager.sanitizeFileName("  Trim Me  "));
+	}
+
+	@Test
+	public void testSanitizeFileName_mixedCase()
+	{
+		assertEquals("ABCdef123", PluginDataManager.sanitizeFileName("ABCdef123"));
+	}
+
+	// ========================================================================
+	// init() — player name not available
+	// ========================================================================
+
+	@Test
+	public void testInit_playerNameNull_returnsFalse()
+	{
+		// Arrange — localPlayer is null
+		when(client.getLocalPlayer()).thenReturn(null);
+
+		// Act
+		boolean result = manager.init();
+
+		// Assert
+		assertFalse(result);
+	}
+
+	@Test
+	public void testInit_playerNameNull_characterDirRemainsNull()
+	{
+		// Arrange
+		when(client.getLocalPlayer()).thenReturn(null);
+
+		// Act
+		manager.init();
+
+		// Assert
+		assertNull(manager.getCharacterDir());
+	}
+
+	@Test
+	public void testInit_playerNameEmpty_returnsFalse()
+	{
+		// Arrange
+		when(client.getLocalPlayer()).thenReturn(localPlayer);
+		when(localPlayer.getName()).thenReturn("");
+
+		// Act
+		boolean result = manager.init();
+
+		// Assert
+		assertFalse(result);
+	}
+
+	@Test
+	public void testInit_playerNotNull_butNameIsNull_returnsFalse()
+	{
+		// Arrange
+		when(client.getLocalPlayer()).thenReturn(localPlayer);
+		when(localPlayer.getName()).thenReturn(null);
+
+		// Act
+		boolean result = manager.init();
+
+		// Assert
+		assertFalse(result);
+	}
+
+	// ========================================================================
+	// reset()
+	// ========================================================================
+
+	@Test
+	public void testReset_clearsCharacterDir()
+	{
+		// Arrange — put the manager into a known state by calling reset after a partial init
+		manager.reset();
+
+		// Assert
+		assertNull(manager.getCharacterDir());
+	}
+
+	@Test
+	public void testReset_clearsCurrentPlayerName()
+	{
+		// Arrange
+		manager.reset();
+
+		// Assert
+		assertNull(manager.getCurrentPlayerName());
+	}
+
+	@Test
+	public void testReset_afterNoInit_isIdempotent()
+	{
+		// Act — reset when never initialized
+		manager.reset();
+		manager.reset();
+
+		// Assert — no exception, state is null
+		assertNull(manager.getCharacterDir());
+		assertNull(manager.getCurrentPlayerName());
+	}
+
+	// ========================================================================
+	// getFile()
+	// ========================================================================
+
+	@Test
+	public void testGetFile_whenNotInitialized_returnsNull()
+	{
+		// Arrange — not initialized
+		assertNull(manager.getCharacterDir());
+
+		// Act
+		java.io.File file = manager.getFile("efficiency-export.txt");
+
+		// Assert
+		assertNull(file);
+	}
+
+	// ========================================================================
+	// getCurrentPlayerName()
+	// ========================================================================
+
+	@Test
+	public void testGetCurrentPlayerName_initiallyNull()
+	{
+		assertNull(manager.getCurrentPlayerName());
+	}
+}

--- a/src/test/java/com/collectionloghelper/lifecycle/OverlayRegistryTest.java
+++ b/src/test/java/com/collectionloghelper/lifecycle/OverlayRegistryTest.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.lifecycle;
+
+import com.collectionloghelper.overlay.DialogHighlightOverlay;
+import com.collectionloghelper.overlay.GroundItemHighlightOverlay;
+import com.collectionloghelper.overlay.GuidanceMinimapOverlay;
+import com.collectionloghelper.overlay.GuidanceOverlay;
+import com.collectionloghelper.overlay.ItemHighlightOverlay;
+import com.collectionloghelper.overlay.ObjectHighlightOverlay;
+import com.collectionloghelper.overlay.WidgetHighlightOverlay;
+import com.collectionloghelper.overlay.WorldMapRouteOverlay;
+import net.runelite.client.ui.overlay.OverlayManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class OverlayRegistryTest
+{
+	@Mock
+	private OverlayManager overlayManager;
+	@Mock
+	private GuidanceOverlay guidanceOverlay;
+	@Mock
+	private GuidanceMinimapOverlay guidanceMinimapOverlay;
+	@Mock
+	private DialogHighlightOverlay dialogHighlightOverlay;
+	@Mock
+	private ObjectHighlightOverlay objectHighlightOverlay;
+	@Mock
+	private ItemHighlightOverlay itemHighlightOverlay;
+	@Mock
+	private WorldMapRouteOverlay worldMapRouteOverlay;
+	@Mock
+	private GroundItemHighlightOverlay groundItemHighlightOverlay;
+	@Mock
+	private WidgetHighlightOverlay widgetHighlightOverlay;
+
+	private OverlayRegistry registry;
+
+	@Before
+	public void setUp()
+	{
+		registry = new OverlayRegistry(
+			overlayManager,
+			guidanceOverlay,
+			guidanceMinimapOverlay,
+			dialogHighlightOverlay,
+			objectHighlightOverlay,
+			itemHighlightOverlay,
+			worldMapRouteOverlay,
+			groundItemHighlightOverlay,
+			widgetHighlightOverlay
+		);
+	}
+
+	// ========================================================================
+	// registerAll
+	// ========================================================================
+
+	@Test
+	public void testRegisterAllAddsGuidanceOverlay()
+	{
+		// Act
+		registry.registerAll();
+
+		// Assert
+		verify(overlayManager).add(guidanceOverlay);
+	}
+
+	@Test
+	public void testRegisterAllAddsGuidanceMinimapOverlay()
+	{
+		registry.registerAll();
+		verify(overlayManager).add(guidanceMinimapOverlay);
+	}
+
+	@Test
+	public void testRegisterAllAddsDialogHighlightOverlay()
+	{
+		registry.registerAll();
+		verify(overlayManager).add(dialogHighlightOverlay);
+	}
+
+	@Test
+	public void testRegisterAllAddsObjectHighlightOverlay()
+	{
+		registry.registerAll();
+		verify(overlayManager).add(objectHighlightOverlay);
+	}
+
+	@Test
+	public void testRegisterAllAddsItemHighlightOverlay()
+	{
+		registry.registerAll();
+		verify(overlayManager).add(itemHighlightOverlay);
+	}
+
+	@Test
+	public void testRegisterAllAddsWorldMapRouteOverlay()
+	{
+		registry.registerAll();
+		verify(overlayManager).add(worldMapRouteOverlay);
+	}
+
+	@Test
+	public void testRegisterAllAddsGroundItemHighlightOverlay()
+	{
+		registry.registerAll();
+		verify(overlayManager).add(groundItemHighlightOverlay);
+	}
+
+	@Test
+	public void testRegisterAllAddsWidgetHighlightOverlay()
+	{
+		registry.registerAll();
+		verify(overlayManager).add(widgetHighlightOverlay);
+	}
+
+	@Test
+	public void testRegisterAllAddsEightOverlays()
+	{
+		// Arrange + Act
+		registry.registerAll();
+
+		// Assert — exactly 8 add() calls, no more
+		verify(overlayManager, times(8)).add(any());
+	}
+
+	@Test
+	public void testRegisterAllPreservesRegistrationOrder()
+	{
+		// Arrange
+		InOrder inOrder = inOrder(overlayManager);
+
+		// Act
+		registry.registerAll();
+
+		// Assert — order preserved from source
+		inOrder.verify(overlayManager).add(guidanceOverlay);
+		inOrder.verify(overlayManager).add(guidanceMinimapOverlay);
+		inOrder.verify(overlayManager).add(dialogHighlightOverlay);
+		inOrder.verify(overlayManager).add(objectHighlightOverlay);
+		inOrder.verify(overlayManager).add(itemHighlightOverlay);
+		inOrder.verify(overlayManager).add(worldMapRouteOverlay);
+		inOrder.verify(overlayManager).add(groundItemHighlightOverlay);
+		inOrder.verify(overlayManager).add(widgetHighlightOverlay);
+	}
+
+	// ========================================================================
+	// unregisterAll
+	// ========================================================================
+
+	@Test
+	public void testUnregisterAllRemovesEightOverlays()
+	{
+		registry.unregisterAll();
+		verify(overlayManager, times(8)).remove(any());
+	}
+
+	@Test
+	public void testUnregisterAllRemovesGuidanceOverlay()
+	{
+		registry.unregisterAll();
+		verify(overlayManager).remove(guidanceOverlay);
+	}
+
+	@Test
+	public void testUnregisterAllRemovesGuidanceMinimapOverlay()
+	{
+		registry.unregisterAll();
+		verify(overlayManager).remove(guidanceMinimapOverlay);
+	}
+
+	@Test
+	public void testUnregisterAllRemovesDialogHighlightOverlay()
+	{
+		registry.unregisterAll();
+		verify(overlayManager).remove(dialogHighlightOverlay);
+	}
+
+	@Test
+	public void testUnregisterAllRemovesObjectHighlightOverlay()
+	{
+		registry.unregisterAll();
+		verify(overlayManager).remove(objectHighlightOverlay);
+	}
+
+	@Test
+	public void testUnregisterAllRemovesItemHighlightOverlay()
+	{
+		registry.unregisterAll();
+		verify(overlayManager).remove(itemHighlightOverlay);
+	}
+
+	@Test
+	public void testUnregisterAllRemovesWorldMapRouteOverlay()
+	{
+		registry.unregisterAll();
+		verify(overlayManager).remove(worldMapRouteOverlay);
+	}
+
+	@Test
+	public void testUnregisterAllRemovesGroundItemHighlightOverlay()
+	{
+		registry.unregisterAll();
+		verify(overlayManager).remove(groundItemHighlightOverlay);
+	}
+
+	@Test
+	public void testUnregisterAllRemovesWidgetHighlightOverlay()
+	{
+		registry.unregisterAll();
+		verify(overlayManager).remove(widgetHighlightOverlay);
+	}
+
+	@Test
+	public void testUnregisterAllPreservesRemovalOrder()
+	{
+		InOrder inOrder = inOrder(overlayManager);
+
+		registry.unregisterAll();
+
+		inOrder.verify(overlayManager).remove(guidanceOverlay);
+		inOrder.verify(overlayManager).remove(guidanceMinimapOverlay);
+		inOrder.verify(overlayManager).remove(dialogHighlightOverlay);
+		inOrder.verify(overlayManager).remove(objectHighlightOverlay);
+		inOrder.verify(overlayManager).remove(itemHighlightOverlay);
+		inOrder.verify(overlayManager).remove(worldMapRouteOverlay);
+		inOrder.verify(overlayManager).remove(groundItemHighlightOverlay);
+		inOrder.verify(overlayManager).remove(widgetHighlightOverlay);
+	}
+
+	// ========================================================================
+	// Symmetry
+	// ========================================================================
+
+	@Test
+	public void testRegisterThenUnregisterIsSymmetric()
+	{
+		// Arrange + Act
+		registry.registerAll();
+		registry.unregisterAll();
+
+		// Assert — each overlay added exactly once and removed exactly once
+		verify(overlayManager, times(1)).add(guidanceOverlay);
+		verify(overlayManager, times(1)).remove(guidanceOverlay);
+		verify(overlayManager, times(1)).add(guidanceMinimapOverlay);
+		verify(overlayManager, times(1)).remove(guidanceMinimapOverlay);
+		verify(overlayManager, times(1)).add(widgetHighlightOverlay);
+		verify(overlayManager, times(1)).remove(widgetHighlightOverlay);
+	}
+
+	@Test
+	public void testRegisterAllCalledTwiceInvokesAddTwice()
+	{
+		// Arrange + Act — simulates calling startUp twice (shouldn't happen but documents behavior)
+		registry.registerAll();
+		registry.registerAll();
+
+		// Assert — add called twice for each overlay
+		verify(overlayManager, times(2)).add(guidanceOverlay);
+		verify(overlayManager, times(2)).add(widgetHighlightOverlay);
+	}
+
+	@Test
+	public void testUnregisterAllCalledWithoutRegisterStillInvokesRemove()
+	{
+		// Unregistering without prior registration should still call remove (OverlayManager handles no-op)
+		registry.unregisterAll();
+		verify(overlayManager, times(1)).remove(guidanceOverlay);
+		verify(overlayManager, times(1)).remove(widgetHighlightOverlay);
+	}
+}

--- a/src/test/java/com/collectionloghelper/lifecycle/SceneObjectRouterTest.java
+++ b/src/test/java/com/collectionloghelper/lifecycle/SceneObjectRouterTest.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.lifecycle;
+
+import com.collectionloghelper.overlay.ObjectHighlightOverlay;
+import net.runelite.api.DecorativeObject;
+import net.runelite.api.GroundObject;
+import net.runelite.api.WallObject;
+import net.runelite.api.events.DecorativeObjectDespawned;
+import net.runelite.api.events.DecorativeObjectSpawned;
+import net.runelite.api.events.GroundObjectDespawned;
+import net.runelite.api.events.GroundObjectSpawned;
+import net.runelite.api.events.WallObjectDespawned;
+import net.runelite.api.events.WallObjectSpawned;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SceneObjectRouterTest
+{
+	@Mock
+	private ObjectHighlightOverlay objectHighlightOverlay;
+
+	@Mock
+	private WallObject wallObject;
+
+	@Mock
+	private DecorativeObject decorativeObject;
+
+	@Mock
+	private GroundObject groundObject;
+
+	private SceneObjectRouter router;
+
+	@Before
+	public void setUp()
+	{
+		router = new SceneObjectRouter(objectHighlightOverlay);
+	}
+
+	// ========================================================================
+	// WallObject routing
+	// ========================================================================
+
+	@Test
+	public void testOnWallObjectSpawnedForwardsToOverlay()
+	{
+		// Arrange
+		WallObjectSpawned event = new WallObjectSpawned();
+		event.setWallObject(wallObject);
+
+		// Act
+		router.onWallObjectSpawned(event);
+
+		// Assert
+		verify(objectHighlightOverlay).onObjectSpawned(wallObject);
+	}
+
+	@Test
+	public void testOnWallObjectDespawnedForwardsToOverlay()
+	{
+		// Arrange
+		WallObjectDespawned event = new WallObjectDespawned();
+		event.setWallObject(wallObject);
+
+		// Act
+		router.onWallObjectDespawned(event);
+
+		// Assert
+		verify(objectHighlightOverlay).onObjectDespawned(wallObject);
+	}
+
+	@Test
+	public void testOnWallObjectSpawnedDoesNotForwardDecorativeOrGround()
+	{
+		// Arrange
+		WallObjectSpawned event = new WallObjectSpawned();
+		event.setWallObject(wallObject);
+
+		// Act
+		router.onWallObjectSpawned(event);
+
+		// Assert — no calls with decorative or ground object
+		verify(objectHighlightOverlay, never()).onObjectSpawned(decorativeObject);
+		verify(objectHighlightOverlay, never()).onObjectSpawned(groundObject);
+	}
+
+	// ========================================================================
+	// DecorativeObject routing
+	// ========================================================================
+
+	@Test
+	public void testOnDecorativeObjectSpawnedForwardsToOverlay()
+	{
+		// Arrange
+		DecorativeObjectSpawned event = new DecorativeObjectSpawned();
+		event.setDecorativeObject(decorativeObject);
+
+		// Act
+		router.onDecorativeObjectSpawned(event);
+
+		// Assert
+		verify(objectHighlightOverlay).onObjectSpawned(decorativeObject);
+	}
+
+	@Test
+	public void testOnDecorativeObjectDespawnedForwardsToOverlay()
+	{
+		// Arrange
+		DecorativeObjectDespawned event = new DecorativeObjectDespawned();
+		event.setDecorativeObject(decorativeObject);
+
+		// Act
+		router.onDecorativeObjectDespawned(event);
+
+		// Assert
+		verify(objectHighlightOverlay).onObjectDespawned(decorativeObject);
+	}
+
+	@Test
+	public void testOnDecorativeObjectSpawnedDoesNotForwardWallOrGround()
+	{
+		// Arrange
+		DecorativeObjectSpawned event = new DecorativeObjectSpawned();
+		event.setDecorativeObject(decorativeObject);
+
+		// Act
+		router.onDecorativeObjectSpawned(event);
+
+		// Assert
+		verify(objectHighlightOverlay, never()).onObjectSpawned(wallObject);
+		verify(objectHighlightOverlay, never()).onObjectSpawned(groundObject);
+	}
+
+	// ========================================================================
+	// GroundObject routing
+	// ========================================================================
+
+	@Test
+	public void testOnGroundObjectSpawnedForwardsToOverlay()
+	{
+		// Arrange
+		GroundObjectSpawned event = new GroundObjectSpawned();
+		event.setGroundObject(groundObject);
+
+		// Act
+		router.onGroundObjectSpawned(event);
+
+		// Assert
+		verify(objectHighlightOverlay).onObjectSpawned(groundObject);
+	}
+
+	@Test
+	public void testOnGroundObjectDespawnedForwardsToOverlay()
+	{
+		// Arrange
+		GroundObjectDespawned event = new GroundObjectDespawned();
+		event.setGroundObject(groundObject);
+
+		// Act
+		router.onGroundObjectDespawned(event);
+
+		// Assert
+		verify(objectHighlightOverlay).onObjectDespawned(groundObject);
+	}
+
+	@Test
+	public void testOnGroundObjectSpawnedDoesNotForwardWallOrDecorative()
+	{
+		// Arrange
+		GroundObjectSpawned event = new GroundObjectSpawned();
+		event.setGroundObject(groundObject);
+
+		// Act
+		router.onGroundObjectSpawned(event);
+
+		// Assert
+		verify(objectHighlightOverlay, never()).onObjectSpawned(wallObject);
+		verify(objectHighlightOverlay, never()).onObjectSpawned(decorativeObject);
+	}
+
+	// ========================================================================
+	// No cross-contamination between spawn and despawn
+	// ========================================================================
+
+	@Test
+	public void testSpawnEventDoesNotTriggerDespawn()
+	{
+		// Arrange
+		WallObjectSpawned event = new WallObjectSpawned();
+		event.setWallObject(wallObject);
+
+		// Act
+		router.onWallObjectSpawned(event);
+
+		// Assert
+		verify(objectHighlightOverlay, never()).onObjectDespawned(any());
+	}
+
+	@Test
+	public void testDespawnEventDoesNotTriggerSpawn()
+	{
+		// Arrange
+		WallObjectDespawned event = new WallObjectDespawned();
+		event.setWallObject(wallObject);
+
+		// Act
+		router.onWallObjectDespawned(event);
+
+		// Assert
+		verify(objectHighlightOverlay, never()).onObjectSpawned(any());
+	}
+
+	// ========================================================================
+	// Multiple events in sequence
+	// ========================================================================
+
+	@Test
+	public void testMultipleSpawnEventsForwardInOrder()
+	{
+		// Arrange
+		WallObjectSpawned wallEvent = new WallObjectSpawned();
+		wallEvent.setWallObject(wallObject);
+		DecorativeObjectSpawned decEvent = new DecorativeObjectSpawned();
+		decEvent.setDecorativeObject(decorativeObject);
+
+		// Act
+		router.onWallObjectSpawned(wallEvent);
+		router.onDecorativeObjectSpawned(decEvent);
+
+		// Assert — both forwarded independently
+		verify(objectHighlightOverlay, times(1)).onObjectSpawned(wallObject);
+		verify(objectHighlightOverlay, times(1)).onObjectSpawned(decorativeObject);
+	}
+
+	@Test
+	public void testSpawnAndDespawnPairForwardsBoth()
+	{
+		// Arrange
+		GroundObjectSpawned spawnEvent = new GroundObjectSpawned();
+		spawnEvent.setGroundObject(groundObject);
+		GroundObjectDespawned despawnEvent = new GroundObjectDespawned();
+		despawnEvent.setGroundObject(groundObject);
+
+		// Act
+		router.onGroundObjectSpawned(spawnEvent);
+		router.onGroundObjectDespawned(despawnEvent);
+
+		// Assert
+		verify(objectHighlightOverlay, times(1)).onObjectSpawned(groundObject);
+		verify(objectHighlightOverlay, times(1)).onObjectDespawned(groundObject);
+	}
+}


### PR DESCRIPTION
## Summary
Adds 63 new tests across 4 test classes, raising total from **440 to 503 tests**:

| Test Class | Tests | Coverage |
|------------|-------|----------|
| `OverlayRegistryTest` (new) | 23 | registerAll/unregisterAll lifecycle, ordering, symmetry, idempotency |
| `SceneObjectRouterTest` (new) | 13 | All 6 @Subscribe handler forwarding, no cross-contamination |
| `PluginDataManagerTest` (new) | 17 | sanitizeFileName (8 cases), init/reset/getFile edge cases |
| `DataSyncStateTest` (+10) | 10 | Synced→unsynced transitions, reset idempotency, isReminderExpired boundary values |

## What is NOT covered (and why)
- Overlay render methods — require Graphics2D mock + RuneLite rendering pipeline; impractical
- Panel (Swing) — requires headless AWT context; deferred
- Plugin @Subscribe integration — requires full RuneLite client injection; deferred to integration test harness

## Test plan
- [x] `./gradlew test` passes (503/503)
- [x] All new tests follow existing JUnit 4 + Mockito patterns

Phase 5 of v2.0 PRD.