### PR TITLE
refactor: extract GuidanceUIState from plugin class

### DIFF
--- a/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
@@ -45,6 +45,7 @@ import com.collectionloghelper.efficiency.ScoredItem;
 import com.collectionloghelper.efficiency.SlayerStrategyCalculator;
 import com.collectionloghelper.guidance.GuidanceSequencer;
 import com.collectionloghelper.lifecycle.AuthoringLogger;
+import com.collectionloghelper.lifecycle.GuidanceUIState;
 import com.collectionloghelper.lifecycle.OverlayRegistry;
 import com.collectionloghelper.lifecycle.SceneEventRouter;
 import com.collectionloghelper.lifecycle.SyncStateCoordinator;
@@ -246,6 +247,9 @@ public class CollectionLogHelperPlugin extends Plugin
 	@Inject
 	private SyncStateCoordinator syncStateCoordinator;
 
+	@Inject
+	private GuidanceUIState guidanceUIState;
+
 
 	private CollectionLogHelperPanel panel;
 	private NavigationButton navButton;
@@ -255,8 +259,6 @@ public class CollectionLogHelperPlugin extends Plugin
 	private volatile boolean pendingRequirementsRefresh = false;
 	private volatile boolean pendingTravelVarbitRefresh = false;
 	private BufferedImage collectionLogIcon;
-	private CollectionLogWorldMapPoint activeMapPoint;
-	private GuidanceInfoBox activeInfoBox;
 
 	/**
 	 * Player location cached on the client thread each game tick.
@@ -264,11 +266,6 @@ public class CollectionLogHelperPlugin extends Plugin
 	 */
 	private volatile WorldPoint cachedPlayerLocation;
 
-	/** Tracks the last guidance step index for which a worldMessage was sent (prevents spam on re-notify). */
-	private int lastMessagedStepIndex = -1;
-
-	/** Pending ShortestPath target — set after "clear", sent as "path" on the next game tick. */
-	private WorldPoint pendingShortestPathTarget;
 	private boolean slayerRefreshPending;
 
 	/** Coalesces multiple panel.rebuild() calls into a single rebuild per game tick. */
@@ -277,9 +274,6 @@ public class CollectionLogHelperPlugin extends Plugin
 	/** Cached ranked efficiency list — recomputed only when dirty. */
 	private List<ScoredItem> cachedRankedSources;
 	private boolean rankedSourcesDirty = true;
-
-	/** Tracked NPC for guidance overlay — maintained via NpcSpawned/NpcDespawned events. */
-	private volatile NPC trackedGuidanceNpc;
 
 	@Override
 	protected void startUp() throws Exception
@@ -747,10 +741,10 @@ public class CollectionLogHelperPlugin extends Plugin
 		}
 
 		// Dispatch deferred ShortestPath "path" message (1-tick after "clear")
-		if (pendingShortestPathTarget != null)
+		if (guidanceUIState.getPendingShortestPathTarget() != null)
 		{
-			WorldPoint target = pendingShortestPathTarget;
-			pendingShortestPathTarget = null;
+			WorldPoint target = guidanceUIState.getPendingShortestPathTarget();
+			guidanceUIState.setPendingShortestPathTarget(null);
 			Map<String, Object> data = new HashMap<>();
 			if (client.getLocalPlayer() != null)
 			{
@@ -834,7 +828,7 @@ public class CollectionLogHelperPlugin extends Plugin
 
 	private void updateWorldMapArrow()
 	{
-		if (activeMapPoint == null)
+		if (guidanceUIState.getActiveMapPoint() == null)
 		{
 			return;
 		}
@@ -851,7 +845,7 @@ public class CollectionLogHelperPlugin extends Plugin
 			return;
 		}
 
-		WorldPoint target = activeMapPoint.getWorldPoint();
+		WorldPoint target = guidanceUIState.getActiveMapPoint().getWorldPoint();
 		int dx = target.getX() - mapCenter.getX();
 		// World map Y is inverted (higher Y = further north = up on map)
 		int dy = target.getY() - mapCenter.getY();
@@ -875,7 +869,7 @@ public class CollectionLogHelperPlugin extends Plugin
 			degrees = dy > 0 ? 225 : 135;
 		}
 
-		activeMapPoint.rotateArrow(degrees);
+		guidanceUIState.getActiveMapPoint().rotateArrow(degrees);
 	}
 
 	public void activateGuidance(CollectionLogSource source)
@@ -920,11 +914,12 @@ public class CollectionLogHelperPlugin extends Plugin
 			if (!source.getItems().isEmpty())
 			{
 				BufferedImage icon = itemManager.getImage(source.getItems().get(0).getItemId());
-				activeInfoBox = new GuidanceInfoBox(icon, this);
-				activeInfoBox.setStepText("1/" + guidanceSequencer.getTotalSteps());
-				activeInfoBox.setTooltipText(source.getName() + ": "
+				GuidanceInfoBox newInfoBox = new GuidanceInfoBox(icon, this);
+				newInfoBox.setStepText("1/" + guidanceSequencer.getTotalSteps());
+				newInfoBox.setTooltipText(source.getName() + ": "
 					+ (step != null ? step.getDescription() : ""));
-				infoBoxManager.addInfoBox(activeInfoBox);
+				infoBoxManager.addInfoBox(newInfoBox);
+				guidanceUIState.setActiveInfoBox(newInfoBox);
 			}
 			log.debug("Multi-step guidance activated for {} ({} steps)",
 				source.getName(), source.getGuidanceSteps().size());
@@ -975,9 +970,9 @@ public class CollectionLogHelperPlugin extends Plugin
 		// Send world message hint if this step has one (only once per step, not on re-notify)
 		int stepIndex = guidanceSequencer.getCurrentIndex();
 		if (step.getWorldMessage() != null && !step.getWorldMessage().isEmpty()
-			&& stepIndex != lastMessagedStepIndex)
+			&& stepIndex != guidanceUIState.getLastMessagedStepIndex())
 		{
-			lastMessagedStepIndex = stepIndex;
+			guidanceUIState.setLastMessagedStepIndex(stepIndex);
 			clientThread.invokeLater(() ->
 				client.addChatMessage(ChatMessageType.GAMEMESSAGE, "",
 					"<col=00c8c8>[Collection Log Helper]</col> " + step.getWorldMessage(),
@@ -1057,12 +1052,12 @@ public class CollectionLogHelperPlugin extends Plugin
 			dialogHighlightOverlay.setGuidanceActive(true);
 			guidanceMinimapOverlay.setTargetPoint(worldPoint);
 			worldMapRouteOverlay.setTargetPoint(worldPoint);
-			if (activeMapPoint != null)
+			if (guidanceUIState.getActiveMapPoint() != null)
 			{
-				worldMapPointManager.remove(activeMapPoint);
+				worldMapPointManager.remove(guidanceUIState.getActiveMapPoint());
 			}
-			activeMapPoint = new CollectionLogWorldMapPoint(worldPoint, step.getDescription(), collectionLogIcon);
-			worldMapPointManager.add(activeMapPoint);
+			guidanceUIState.setActiveMapPoint(new CollectionLogWorldMapPoint(worldPoint, step.getDescription(), collectionLogIcon));
+			worldMapPointManager.add(guidanceUIState.getActiveMapPoint());
 
 			clientThread.invokeLater(() ->
 			{
@@ -1078,7 +1073,7 @@ public class CollectionLogHelperPlugin extends Plugin
 				if (config.useShortestPath())
 				{
 					eventBus.post(new PluginMessage("shortestpath", "clear"));
-					pendingShortestPathTarget = worldPoint;
+					guidanceUIState.setPendingShortestPathTarget(worldPoint);
 				}
 			});
 		}
@@ -1093,10 +1088,10 @@ public class CollectionLogHelperPlugin extends Plugin
 			guidanceOverlay.setTravelTip(null);
 			guidanceMinimapOverlay.setTargetPoint(null);
 			worldMapRouteOverlay.setTargetPoint(null);
-			if (activeMapPoint != null)
+			if (guidanceUIState.getActiveMapPoint() != null)
 			{
-				worldMapPointManager.remove(activeMapPoint);
-				activeMapPoint = null;
+				worldMapPointManager.remove(guidanceUIState.getActiveMapPoint());
+				guidanceUIState.setActiveMapPoint(null);
 			}
 			guidanceOverlay.setClueGuidanceText(step.getDescription());
 			clientThread.invokeLater(() ->
@@ -1198,12 +1193,12 @@ public class CollectionLogHelperPlugin extends Plugin
 		dialogHighlightOverlay.setGuidanceActive(true);
 		guidanceMinimapOverlay.setTargetPoint(worldPoint);
 		worldMapRouteOverlay.setTargetPoint(worldPoint);
-		if (activeMapPoint != null)
+		if (guidanceUIState.getActiveMapPoint() != null)
 		{
-			worldMapPointManager.remove(activeMapPoint);
+			worldMapPointManager.remove(guidanceUIState.getActiveMapPoint());
 		}
-		activeMapPoint = new CollectionLogWorldMapPoint(worldPoint, displayName, collectionLogIcon);
-		worldMapPointManager.add(activeMapPoint);
+		guidanceUIState.setActiveMapPoint(new CollectionLogWorldMapPoint(worldPoint, displayName, collectionLogIcon));
+		worldMapPointManager.add(guidanceUIState.getActiveMapPoint());
 
 		clientThread.invokeLater(() ->
 		{
@@ -1217,14 +1212,14 @@ public class CollectionLogHelperPlugin extends Plugin
 			if (config.useShortestPath())
 			{
 				eventBus.post(new PluginMessage("shortestpath", "clear"));
-				pendingShortestPathTarget = worldPoint;
+				guidanceUIState.setPendingShortestPathTarget(worldPoint);
 			}
 		});
 	}
 
 	private void clearGuidanceOverlays()
 	{
-		trackedGuidanceNpc = null;
+		guidanceUIState.setTrackedGuidanceNpc(null);
 		guidanceOverlay.clearTarget();
 		guidanceMinimapOverlay.clearTarget();
 		worldMapRouteOverlay.clearTarget();
@@ -1234,7 +1229,7 @@ public class CollectionLogHelperPlugin extends Plugin
 		groundItemHighlightOverlay.clearTargets();
 		widgetHighlightOverlay.clearHighlights();
 		clientThread.invokeLater(() -> client.clearHintArrow());
-		activeMapPoint = null;
+		guidanceUIState.setActiveMapPoint(null);
 		worldMapPointManager.removeIf(CollectionLogWorldMapPoint.class::isInstance);
 		if (panel != null)
 		{
@@ -1248,7 +1243,7 @@ public class CollectionLogHelperPlugin extends Plugin
 	 */
 	private void scanForTrackedNpc(GuidanceStep step)
 	{
-		trackedGuidanceNpc = null;
+		guidanceUIState.setTrackedGuidanceNpc(null);
 		guidanceOverlay.setTrackedNpc(null);
 
 		if (step == null || step.getNpcId() <= 0)
@@ -1268,7 +1263,7 @@ public class CollectionLogHelperPlugin extends Plugin
 			{
 				if (npc != null && npc.getId() == targetNpcId)
 				{
-					trackedGuidanceNpc = npc;
+					guidanceUIState.setTrackedGuidanceNpc(npc);
 					guidanceOverlay.setTrackedNpc(npc);
 					break;
 				}
@@ -1288,11 +1283,11 @@ public class CollectionLogHelperPlugin extends Plugin
 		scanForTrackedNpc(step);
 
 		// Update InfoBox progress
-		if (activeInfoBox != null)
+		if (guidanceUIState.getActiveInfoBox() != null)
 		{
 			int current = guidanceSequencer.getCurrentIndex() + 1;
 			int total = guidanceSequencer.getTotalSteps();
-			activeInfoBox.setStepText(current + "/" + total);
+			guidanceUIState.getActiveInfoBox().setStepText(current + "/" + total);
 			String tooltip = step.getDescription();
 			if (guidanceSequencer.getCumulativeTrackThreshold() > 0)
 			{
@@ -1300,10 +1295,10 @@ public class CollectionLogHelperPlugin extends Plugin
 					+ "/" + guidanceSequencer.getCumulativeTrackThreshold()
 					+ " actions tracked";
 			}
-			activeInfoBox.setTooltipText(tooltip);
+			guidanceUIState.getActiveInfoBox().setTooltipText(tooltip);
 			if (current == total)
 			{
-				activeInfoBox.setTextColor(java.awt.Color.GREEN);
+				guidanceUIState.getActiveInfoBox().setTextColor(java.awt.Color.GREEN);
 			}
 		}
 
@@ -1356,13 +1351,11 @@ public class CollectionLogHelperPlugin extends Plugin
 
 	public void deactivateGuidance()
 	{
-		lastMessagedStepIndex = -1;
-		trackedGuidanceNpc = null;
-		if (activeInfoBox != null)
+		if (guidanceUIState.getActiveInfoBox() != null)
 		{
-			infoBoxManager.removeInfoBox(activeInfoBox);
-			activeInfoBox = null;
+			infoBoxManager.removeInfoBox(guidanceUIState.getActiveInfoBox());
 		}
+		guidanceUIState.clearAll();
 		guidanceSequencer.stopSequence();
 		guidanceOverlay.clearTarget();
 		guidanceMinimapOverlay.clearTarget();
@@ -1372,8 +1365,6 @@ public class CollectionLogHelperPlugin extends Plugin
 		itemHighlightOverlay.clearTarget();
 		groundItemHighlightOverlay.clearTargets();
 		widgetHighlightOverlay.clearHighlights();
-		activeMapPoint = null;
-		pendingShortestPathTarget = null;
 		worldMapPointManager.removeIf(CollectionLogWorldMapPoint.class::isInstance);
 
 		clientThread.invokeLater(() ->
@@ -1657,12 +1648,12 @@ public class CollectionLogHelperPlugin extends Plugin
 		}
 
 		// Track the spawned NPC if it matches the current guidance step's target
-		if (guidanceSequencer.isActive() && trackedGuidanceNpc == null)
+		if (guidanceSequencer.isActive() && guidanceUIState.getTrackedGuidanceNpc() == null)
 		{
 			GuidanceStep step = guidanceSequencer.getRawCurrentStep();
 			if (step != null && step.getNpcId() > 0 && npc.getId() == step.getNpcId())
 			{
-				trackedGuidanceNpc = npc;
+				guidanceUIState.setTrackedGuidanceNpc(npc);
 				guidanceOverlay.setTrackedNpc(npc);
 			}
 		}
@@ -1679,9 +1670,9 @@ public class CollectionLogHelperPlugin extends Plugin
 		}
 
 		// Clear tracked NPC if it despawned
-		if (npc == trackedGuidanceNpc)
+		if (npc == guidanceUIState.getTrackedGuidanceNpc())
 		{
-			trackedGuidanceNpc = null;
+			guidanceUIState.setTrackedGuidanceNpc(null);
 			guidanceOverlay.setTrackedNpc(null);
 		}
 	}

--- a/src/main/java/com/collectionloghelper/lifecycle/GuidanceUIState.java
+++ b/src/main/java/com/collectionloghelper/lifecycle/GuidanceUIState.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.lifecycle;
+
+import com.collectionloghelper.overlay.CollectionLogWorldMapPoint;
+import com.collectionloghelper.overlay.GuidanceInfoBox;
+import javax.inject.Singleton;
+import net.runelite.api.NPC;
+import net.runelite.api.coords.WorldPoint;
+
+/**
+ * Holds the 5 mutable guidance UI fields that were previously scattered across
+ * CollectionLogHelperPlugin. Extracted here so guidance state has a single home
+ * and the plugin class is smaller.
+ *
+ * <p>Thread-safety note: {@link #trackedGuidanceNpc} is {@code volatile} because
+ * it is written on the client thread (NpcSpawned/NpcDespawned events and
+ * scanForTrackedNpc) and read on the EDT by overlay render methods.
+ */
+@Singleton
+public class GuidanceUIState
+{
+	private CollectionLogWorldMapPoint activeMapPoint;
+	private GuidanceInfoBox activeInfoBox;
+
+	/**
+	 * Written on client thread, read on EDT by overlay render — must stay volatile.
+	 */
+	private volatile NPC trackedGuidanceNpc;
+
+	private int lastMessagedStepIndex = -1;
+	private WorldPoint pendingShortestPathTarget;
+
+	public CollectionLogWorldMapPoint getActiveMapPoint()
+	{
+		return activeMapPoint;
+	}
+
+	public void setActiveMapPoint(CollectionLogWorldMapPoint activeMapPoint)
+	{
+		this.activeMapPoint = activeMapPoint;
+	}
+
+	public GuidanceInfoBox getActiveInfoBox()
+	{
+		return activeInfoBox;
+	}
+
+	public void setActiveInfoBox(GuidanceInfoBox activeInfoBox)
+	{
+		this.activeInfoBox = activeInfoBox;
+	}
+
+	public NPC getTrackedGuidanceNpc()
+	{
+		return trackedGuidanceNpc;
+	}
+
+	public void setTrackedGuidanceNpc(NPC trackedGuidanceNpc)
+	{
+		this.trackedGuidanceNpc = trackedGuidanceNpc;
+	}
+
+	public int getLastMessagedStepIndex()
+	{
+		return lastMessagedStepIndex;
+	}
+
+	public void setLastMessagedStepIndex(int lastMessagedStepIndex)
+	{
+		this.lastMessagedStepIndex = lastMessagedStepIndex;
+	}
+
+	public WorldPoint getPendingShortestPathTarget()
+	{
+		return pendingShortestPathTarget;
+	}
+
+	public void setPendingShortestPathTarget(WorldPoint pendingShortestPathTarget)
+	{
+		this.pendingShortestPathTarget = pendingShortestPathTarget;
+	}
+
+	/**
+	 * Resets all 5 guidance UI fields to their default/null values.
+	 * Call when deactivating guidance or shutting down the plugin.
+	 */
+	public void clearAll()
+	{
+		activeMapPoint = null;
+		activeInfoBox = null;
+		trackedGuidanceNpc = null;
+		lastMessagedStepIndex = -1;
+		pendingShortestPathTarget = null;
+	}
+}


### PR DESCRIPTION
## Summary
Extracts 5 guidance-related mutable fields into `lifecycle/GuidanceUIState.java` (118 LOC).

**Moved**: `activeMapPoint`, `activeInfoBox`, `trackedGuidanceNpc` (volatile preserved), `lastMessagedStepIndex`, `pendingShortestPathTarget`
**Updated**: 20 call sites across guidance overlay methods
**Plugin LOC**: 2,086 → 2,077 (-9; real win comes in P4 when methods follow)

Part 3 of 4. Merge after P2. Enables P4 (GuidanceOverlayCoordinator).

## Test plan
- [x] All 503 tests pass
- [x] `./gradlew build` green