### PR TITLE
feat(data): verified_scene_ids.json registry + loader + tests (A5.2)

### DIFF
--- a/src/main/java/com/collectionloghelper/data/VerifiedSceneId.java
+++ b/src/main/java/com/collectionloghelper/data/VerifiedSceneId.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data;
+
+import java.util.List;
+import lombok.Value;
+
+/**
+ * A single entry in the verified scene-ID registry.
+ *
+ * <p>{@code examineId} is the ID reported by the OSRS cache examine tooltip or cache viewer.
+ * {@code sceneIds} are the actual IDs exposed by RuneLite's scene tile API
+ * ({@code Tile.getGameObjects()}, {@code Tile.getWallObject()}, etc.).
+ *
+ * <p>When {@code examineId} differs from {@code sceneIds}, guidance steps and
+ * {@code ObjectHighlightOverlay} must use a value from {@code sceneIds} — not the examine ID.
+ */
+@Value
+public class VerifiedSceneId
+{
+	String objectName;
+	int examineId;
+	List<Integer> sceneIds;
+	String confidence;
+	String action;
+	String canonicalLocation;
+	String source;
+	String notes;
+}

--- a/src/main/java/com/collectionloghelper/data/VerifiedSceneIdRegistry.java
+++ b/src/main/java/com/collectionloghelper/data/VerifiedSceneIdRegistry.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.reflect.TypeToken;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Loads and exposes the {@code verified_scene_ids.json} registry.
+ *
+ * <p>The registry records the authoritative examine-ID &lt;-&gt; scene-ID mapping for objects
+ * where the OSRS cache examine tooltip ID differs from the scene tile ID exposed by RuneLite's
+ * tile API. Contributors and lint tools can consult this registry at PR time to detect suspect
+ * {@code objectId} references before they reach production.
+ *
+ * <p>This class is read-only and purely additive — no existing code paths depend on it yet.
+ * It is intended as Phase 0 data infrastructure for Tier A.5.
+ */
+@Slf4j
+public class VerifiedSceneIdRegistry
+{
+	private static final String RESOURCE_PATH = "/com/collectionloghelper/verified_scene_ids.json";
+	private static final int EXPECTED_SCHEMA_VERSION = 1;
+
+	private final List<VerifiedSceneId> entries;
+	private final Map<Integer, VerifiedSceneId> byExamineId;
+	private final Map<Integer, VerifiedSceneId> bySceneId;
+
+	VerifiedSceneIdRegistry(List<VerifiedSceneId> entries)
+	{
+		this.entries = Collections.unmodifiableList(entries);
+
+		Map<Integer, VerifiedSceneId> examineMap = new HashMap<>();
+		Map<Integer, VerifiedSceneId> sceneMap = new HashMap<>();
+
+		for (VerifiedSceneId entry : entries)
+		{
+			examineMap.putIfAbsent(entry.getExamineId(), entry);
+			for (int sceneId : entry.getSceneIds())
+			{
+				sceneMap.putIfAbsent(sceneId, entry);
+			}
+		}
+
+		this.byExamineId = Collections.unmodifiableMap(examineMap);
+		this.bySceneId = Collections.unmodifiableMap(sceneMap);
+	}
+
+	/**
+	 * Loads the registry from the bundled resource file. The result is not cached — callers that
+	 * need repeated access should hold the returned instance.
+	 *
+	 * @return a populated registry, or an empty registry if the resource cannot be parsed
+	 */
+	public static VerifiedSceneIdRegistry load()
+	{
+		return load(new Gson());
+	}
+
+	/**
+	 * Loads the registry using the provided {@link Gson} instance. Exposed package-private for
+	 * testing.
+	 */
+	static VerifiedSceneIdRegistry load(Gson gson)
+	{
+		try (InputStream is = VerifiedSceneIdRegistry.class.getResourceAsStream(RESOURCE_PATH))
+		{
+			if (is == null)
+			{
+				log.warn("verified_scene_ids.json not found at {}", RESOURCE_PATH);
+				return empty();
+			}
+
+			InputStreamReader reader = new InputStreamReader(is);
+			JsonElement parsed = new JsonParser().parse(reader);
+			JsonObject root = parsed.getAsJsonObject();
+
+			int version = root.get("version").getAsInt();
+			if (version != EXPECTED_SCHEMA_VERSION)
+			{
+				log.warn("verified_scene_ids.json schema version {} is unsupported (expected {}); loading anyway",
+					version, EXPECTED_SCHEMA_VERSION);
+			}
+
+			Type listType = new TypeToken<List<VerifiedSceneId>>()
+			{
+			}.getType();
+			List<VerifiedSceneId> entries = gson.fromJson(root.get("entries"), listType);
+
+			if (entries == null || entries.isEmpty())
+			{
+				log.warn("verified_scene_ids.json loaded with no entries");
+				return empty();
+			}
+
+			log.debug("Loaded {} verified scene-ID entries", entries.size());
+			return new VerifiedSceneIdRegistry(entries);
+		}
+		catch (Exception e)
+		{
+			log.error("Failed to load verified_scene_ids.json", e);
+			return empty();
+		}
+	}
+
+	/** Returns a registry with no entries. */
+	public static VerifiedSceneIdRegistry empty()
+	{
+		return new VerifiedSceneIdRegistry(Collections.emptyList());
+	}
+
+	/**
+	 * Looks up a registry entry by its cache examine ID.
+	 *
+	 * @param examineId the object ID shown by the OSRS examine tooltip or cache viewer
+	 * @return the matching entry, or {@link Optional#empty()} if not recorded
+	 */
+	public Optional<VerifiedSceneId> lookupByExamineId(int examineId)
+	{
+		return Optional.ofNullable(byExamineId.get(examineId));
+	}
+
+	/**
+	 * Looks up a registry entry by one of its scene tile IDs.
+	 *
+	 * @param sceneId the object ID returned by RuneLite's tile API
+	 * @return the matching entry, or {@link Optional#empty()} if not recorded
+	 */
+	public Optional<VerifiedSceneId> lookupBySceneId(int sceneId)
+	{
+		return Optional.ofNullable(bySceneId.get(sceneId));
+	}
+
+	/**
+	 * Returns all entries in the registry in load order.
+	 *
+	 * @return an unmodifiable list of all entries
+	 */
+	public List<VerifiedSceneId> all()
+	{
+		return entries;
+	}
+}

--- a/src/main/java/com/collectionloghelper/data/VerifiedSceneIdRegistry.java
+++ b/src/main/java/com/collectionloghelper/data/VerifiedSceneIdRegistry.java
@@ -107,34 +107,64 @@ public class VerifiedSceneIdRegistry
 
 			InputStreamReader reader = new InputStreamReader(is);
 			JsonElement parsed = new JsonParser().parse(reader);
-			JsonObject root = parsed.getAsJsonObject();
-
-			int version = root.get("version").getAsInt();
-			if (version != EXPECTED_SCHEMA_VERSION)
-			{
-				log.warn("verified_scene_ids.json schema version {} is unsupported (expected {}); loading anyway",
-					version, EXPECTED_SCHEMA_VERSION);
-			}
-
-			Type listType = new TypeToken<List<VerifiedSceneId>>()
-			{
-			}.getType();
-			List<VerifiedSceneId> entries = gson.fromJson(root.get("entries"), listType);
-
-			if (entries == null || entries.isEmpty())
-			{
-				log.warn("verified_scene_ids.json loaded with no entries");
-				return empty();
-			}
-
-			log.debug("Loaded {} verified scene-ID entries", entries.size());
-			return new VerifiedSceneIdRegistry(entries);
+			return parseRoot(parsed.getAsJsonObject(), gson);
 		}
 		catch (Exception e)
 		{
 			log.error("Failed to load verified_scene_ids.json", e);
 			return empty();
 		}
+	}
+
+	/**
+	 * Parses a registry from a raw JSON string. Package-private for testing; production callers
+	 * should use {@link #load()}.
+	 */
+	static VerifiedSceneIdRegistry loadFromJson(String json, Gson gson)
+	{
+		try
+		{
+			JsonElement parsed = new JsonParser().parse(json);
+			return parseRoot(parsed.getAsJsonObject(), gson);
+		}
+		catch (Exception e)
+		{
+			log.error("Failed to parse verified_scene_ids JSON", e);
+			return empty();
+		}
+	}
+
+	private static VerifiedSceneIdRegistry parseRoot(JsonObject root, Gson gson)
+	{
+		JsonElement versionElement = root.get("version");
+		if (versionElement == null || versionElement.isJsonNull())
+		{
+			log.warn("verified_scene_ids.json missing 'version' field; assuming schema version {}",
+				EXPECTED_SCHEMA_VERSION);
+		}
+		else
+		{
+			int version = versionElement.getAsInt();
+			if (version != EXPECTED_SCHEMA_VERSION)
+			{
+				log.warn("verified_scene_ids.json schema version {} is unsupported (expected {}); loading anyway",
+					version, EXPECTED_SCHEMA_VERSION);
+			}
+		}
+
+		Type listType = new TypeToken<List<VerifiedSceneId>>()
+		{
+		}.getType();
+		List<VerifiedSceneId> entries = gson.fromJson(root.get("entries"), listType);
+
+		if (entries == null || entries.isEmpty())
+		{
+			log.warn("verified_scene_ids.json loaded with no entries");
+			return empty();
+		}
+
+		log.debug("Loaded {} verified scene-ID entries", entries.size());
+		return new VerifiedSceneIdRegistry(entries);
 	}
 
 	/** Returns a registry with no entries. */

--- a/src/main/resources/com/collectionloghelper/verified_scene_ids.json
+++ b/src/main/resources/com/collectionloghelper/verified_scene_ids.json
@@ -1,0 +1,177 @@
+{
+  "version": 1,
+  "updatedAt": "2026-04-16",
+  "description": "Registry of verified examine-ID <-> scene-ID pairs. Where examineId and sceneIds differ, the object's cache examine tooltip reports a different ID than the scene tile ID exposed by RuneLite's Tile.getGameObjects() / getWallObject() API. Always use sceneIds in guidance steps and ObjectHighlightOverlay. See feedback_object_id_gotcha.md for the underlying reason.",
+  "entries": [
+    {
+      "objectName": "Shellbane Gryphon Cave entrance",
+      "examineId": 58441,
+      "sceneIds": [58439],
+      "confidence": "high",
+      "action": "Enter",
+      "canonicalLocation": "The Great Conch island (instance coords ~13993, 9901, plane 0)",
+      "source": "authoring-log capture / cha-ndler/collection-log-helper#293; coordinate fix in commit e4dd6a06",
+      "notes": "Cache stores 58441 ('Cave entrance', Enter action) as the examine ID. The scene tile exposes 58439 (unnamed, 3x2 object at cache coords 3176,2477,0). Use 58439 in guidance objectId. Island also uses instanced coordinates (~13993,9901) rather than cache-derived surface coords — see feedback_object_id_gotcha.md."
+    },
+    {
+      "objectName": "Sisterhood Sanctuary Stairs (Nightmare / Phosani entrance)",
+      "examineId": 32637,
+      "sceneIds": [32637],
+      "confidence": "high",
+      "action": "Climb-down",
+      "canonicalLocation": "Slepe church (3727, 3300, plane 0)",
+      "source": "MCP object_lookup verification; commit ca4201d9",
+      "notes": "No examine/scene divergence detected. Cached at (3727,3300,0) with Climb-down action. Included because the NPC coords (3808,9775,1) were previously wrong — steps must use the Slepe surface entrance coords, not the sanctuary floor coords."
+    },
+    {
+      "objectName": "Pool of Nightmares (Phosani entrance)",
+      "examineId": 29706,
+      "sceneIds": [29706],
+      "confidence": "high",
+      "action": "Drink-from",
+      "canonicalLocation": "Sisterhood Sanctuary (dynamically placed, no cache spawn)",
+      "source": "MCP object_lookup verification; commit ca4201d9",
+      "notes": "No examine/scene divergence. Object is dynamically placed — MCP shows no spawn locations. Drink-from is the correct action; Spectate is also valid but does not advance guidance."
+    },
+    {
+      "objectName": "Scorpia Cavern entrance",
+      "examineId": 26762,
+      "sceneIds": [26762],
+      "confidence": "high",
+      "action": "Enter",
+      "canonicalLocation": "Wilderness Scorpia entrance (3231, 3936, plane 0)",
+      "source": "MCP object_lookup verification; commit 9bda6882",
+      "notes": "No examine/scene divergence. Three cache spawns confirmed at (3231,3936), (3231,3951), (3241,3949). The (3231,3936) spawn is the primary guidance target."
+    },
+    {
+      "objectName": "Venenatis Cave Entrance",
+      "examineId": 47077,
+      "sceneIds": [47077],
+      "confidence": "high",
+      "action": "Enter",
+      "canonicalLocation": "Silk Chasm approach (3321, 3794, plane 0)",
+      "source": "MCP object_lookup verification; commit a5397e8b",
+      "notes": "No examine/scene divergence. One cache spawn at (3321,3794,0) with Enter, Peek, Check-Fee actions. Venenatis NPC spawn is deeper in the chasm — worldX/worldY for the source should be the entrance coords, not the NPC location."
+    },
+    {
+      "objectName": "Chambers of Xeric entrance",
+      "examineId": 29777,
+      "sceneIds": [29777],
+      "confidence": "high",
+      "action": "Enter",
+      "canonicalLocation": "Great Kourend mountain approach (1232, 3573, plane 0)",
+      "source": "MCP object_lookup verification; commit 42b48636",
+      "notes": "No examine/scene divergence. One cache spawn at (1232,3573,0). Used for both Chambers of Xeric and Chambers of Xeric (CM) sources — same entrance object."
+    },
+    {
+      "objectName": "Theatre of Blood entrance",
+      "examineId": 32653,
+      "sceneIds": [32653],
+      "confidence": "high",
+      "action": "Enter",
+      "canonicalLocation": "Ver Sinhaza (3678, 3216, plane 0)",
+      "source": "MCP object_lookup verification; commit 42b48636",
+      "notes": "No examine/scene divergence. One cache spawn at (3678,3216,0). Used for both Theatre of Blood and Theatre of Blood (Hard Mode) sources."
+    },
+    {
+      "objectName": "Corporeal Beast cave Passage",
+      "examineId": 677,
+      "sceneIds": [677],
+      "confidence": "high",
+      "action": "Go-through",
+      "canonicalLocation": "Corp cave (2971, 4382, plane 2)",
+      "source": "MCP object_lookup verification; commit 42b48636",
+      "notes": "No examine/scene divergence. Two spawns in cache: (2971,4254,2) and (2971,4382,2). The (2971,4382,2) spawn is the final passage into the Corp chamber."
+    },
+    {
+      "objectName": "Hallowed Sepulchre Mausoleum Door",
+      "examineId": 38574,
+      "sceneIds": [38574],
+      "confidence": "high",
+      "action": "Enter",
+      "canonicalLocation": "Darkmeyer approach (3654, 3385, plane 0)",
+      "source": "MCP object_lookup verification; commit a5397e8b",
+      "notes": "No examine/scene divergence. One cache spawn at (3654,3385,0). Object type=0 (wall object), not a game object — must subscribe to WallObjectSpawned in SceneEventRouter for highlight to fire."
+    },
+    {
+      "objectName": "Duke Sucellus Asylum Stairs",
+      "examineId": 49100,
+      "sceneIds": [49100],
+      "confidence": "high",
+      "action": "Climb",
+      "canonicalLocation": "Ghorrock Prison (2973, 6440, plane 2)",
+      "source": "MCP object_lookup verification; commit 61a02573",
+      "notes": "No examine/scene divergence. One cache spawn at (2973,6440,2). Used for both Duke Sucellus and Duke Sucellus (Awakened) sources."
+    },
+    {
+      "objectName": "The Leviathan Handholds",
+      "examineId": 47592,
+      "sceneIds": [47592],
+      "confidence": "high",
+      "action": "Climb",
+      "canonicalLocation": "The Scar (dynamically placed, no cache spawn)",
+      "source": "MCP object_lookup verification; commit 61a02573",
+      "notes": "No examine/scene divergence detected, but object is dynamically placed — no spawn in cache extract. MCP returns no locations. Used for both Leviathan and Leviathan (Awakened) sources."
+    },
+    {
+      "objectName": "The Whisperer Rock / Climb-rope",
+      "examineId": 48197,
+      "sceneIds": [48197],
+      "confidence": "high",
+      "action": "Climb-rope",
+      "canonicalLocation": "Lassar Undercity sinkhole (dynamically placed, no cache spawn)",
+      "source": "MCP object_lookup verification; commit 61a02573",
+      "notes": "No examine/scene divergence detected. MCP returns no spawn locations — dynamically placed. Used for both Whisperer and Whisperer (Awakened) sources."
+    },
+    {
+      "objectName": "Vardorvis Temple Entry",
+      "examineId": 48723,
+      "sceneIds": [48723],
+      "confidence": "high",
+      "action": "Enter",
+      "canonicalLocation": "The Stranglewood (1174, 3428, plane 0)",
+      "source": "MCP object_lookup verification; commit 61a02573",
+      "notes": "No examine/scene divergence. One cache spawn at (1174,3428,0) — object named 'Entry' in cache. Used for both Vardorvis and Vardorvis (Awakened) sources."
+    },
+    {
+      "objectName": "Custodian Stalker Den Cave",
+      "examineId": 57279,
+      "sceneIds": [57279],
+      "confidence": "high",
+      "action": "Squeeze-through",
+      "canonicalLocation": "Custodia Pass, Varlamore (1324, 3364, plane 0)",
+      "source": "MCP object_lookup verification; commit 4fa59e29",
+      "notes": "No examine/scene divergence. One cache spawn at (1324,3364,0). Object named 'Cave' with Squeeze-through action. Source worldX/worldY should be surface entrance coords, not underground NPC coords (1301,9820)."
+    },
+    {
+      "objectName": "Fossil Island Wyvern Cave Entrance",
+      "examineId": 30869,
+      "sceneIds": [30869],
+      "confidence": "high",
+      "action": "Enter",
+      "canonicalLocation": "Fossil Island (3745, 3777, plane 0)",
+      "source": "MCP object_lookup verification; commit 42b48636",
+      "notes": "No examine/scene divergence. One cache spawn at (3745,3777,0). Object named 'Cave Entrance'."
+    },
+    {
+      "objectName": "Sarachnis Forthos Dungeon Ladder",
+      "examineId": 34862,
+      "sceneIds": [34862],
+      "confidence": "high",
+      "action": "Climb-down",
+      "canonicalLocation": "Forthos Dungeon entrance (1702, 3574, plane 0)",
+      "source": "MCP object_lookup verification; commit 42b48636",
+      "notes": "No examine/scene divergence. One cache spawn at (1702,3574,0). This is the first object step for Sarachnis; paired with the Thick Web (34858) as the second step."
+    },
+    {
+      "objectName": "Sarachnis Forthos Dungeon Thick Web",
+      "examineId": 34858,
+      "sceneIds": [34858],
+      "confidence": "high",
+      "action": "Enter-crypt",
+      "canonicalLocation": "Forthos Dungeon crypt entrance (1841-1842, 9912, plane 0)",
+      "source": "MCP object_lookup verification; commit 42b48636",
+      "notes": "No examine/scene divergence. Two cache spawns at (1841,9912,0) and (1842,9912,0). Object type=0 (wall object) — requires WallObjectSpawned subscription for highlight to fire. Paired with the Forthos Dungeon Ladder (34862) as the first step."
+    }
+  ]
+}

--- a/src/test/java/com/collectionloghelper/data/VerifiedSceneIdRegistryTest.java
+++ b/src/test/java/com/collectionloghelper/data/VerifiedSceneIdRegistryTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data;
+
+import com.google.gson.Gson;
+import java.util.List;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class VerifiedSceneIdRegistryTest
+{
+	private VerifiedSceneIdRegistry registry;
+
+	@Before
+	public void setUp()
+	{
+		registry = VerifiedSceneIdRegistry.load(new Gson());
+	}
+
+	// ========================================================================
+	// load — JSON schema integrity
+	// ========================================================================
+
+	@Test
+	public void load_succeeds_returnsNonEmptyRegistry()
+	{
+		assertFalse("Registry should contain at least one entry", registry.all().isEmpty());
+	}
+
+	@Test
+	public void load_allEntriesHaveObjectName()
+	{
+		for (VerifiedSceneId entry : registry.all())
+		{
+			assertNotNull("objectName must not be null", entry.getObjectName());
+			assertFalse("objectName must not be blank", entry.getObjectName().isBlank());
+		}
+	}
+
+	@Test
+	public void load_allEntriesHaveNonZeroExamineId()
+	{
+		for (VerifiedSceneId entry : registry.all())
+		{
+			assertTrue(
+				"examineId must be > 0 for " + entry.getObjectName(),
+				entry.getExamineId() > 0);
+		}
+	}
+
+	@Test
+	public void load_allEntriesHaveAtLeastOneSceneId()
+	{
+		for (VerifiedSceneId entry : registry.all())
+		{
+			assertNotNull("sceneIds must not be null for " + entry.getObjectName(), entry.getSceneIds());
+			assertFalse(
+				"sceneIds must not be empty for " + entry.getObjectName(),
+				entry.getSceneIds().isEmpty());
+		}
+	}
+
+	@Test
+	public void load_allEntriesHaveConfidence()
+	{
+		for (VerifiedSceneId entry : registry.all())
+		{
+			assertNotNull("confidence must not be null for " + entry.getObjectName(), entry.getConfidence());
+			assertFalse("confidence must not be blank for " + entry.getObjectName(), entry.getConfidence().isBlank());
+		}
+	}
+
+	@Test
+	public void load_allEntriesHaveSource()
+	{
+		for (VerifiedSceneId entry : registry.all())
+		{
+			assertNotNull("source must not be null for " + entry.getObjectName(), entry.getSource());
+			assertFalse("source must not be blank for " + entry.getObjectName(), entry.getSource().isBlank());
+		}
+	}
+
+	@Test
+	public void load_atLeastTenEntries()
+	{
+		assertTrue(
+			"Expected at least 10 seeded entries, got " + registry.all().size(),
+			registry.all().size() >= 10);
+	}
+
+	// ========================================================================
+	// lookupByExamineId — canonical divergence case
+	// ========================================================================
+
+	@Test
+	public void lookupByExamineId_shellbaneGryphonCacheId_found()
+	{
+		// 58441 is the examine/cache ID for Shellbane Gryphon cave entrance
+		Optional<VerifiedSceneId> result = registry.lookupByExamineId(58441);
+		assertTrue("Shellbane Gryphon examine ID 58441 must be in the registry", result.isPresent());
+		assertEquals("Shellbane Gryphon Cave entrance", result.get().getObjectName());
+	}
+
+	@Test
+	public void lookupByExamineId_unknownId_empty()
+	{
+		Optional<VerifiedSceneId> result = registry.lookupByExamineId(999999);
+		assertFalse("Unknown examine ID must return empty", result.isPresent());
+	}
+
+	// ========================================================================
+	// lookupBySceneId — scene-tile ID lookup
+	// ========================================================================
+
+	@Test
+	public void lookupBySceneId_shellbaneGryphonSceneId_found()
+	{
+		// 58439 is the actual scene tile ID rendered for the Shellbane Gryphon entrance
+		Optional<VerifiedSceneId> result = registry.lookupBySceneId(58439);
+		assertTrue("Shellbane Gryphon scene ID 58439 must be in the registry", result.isPresent());
+		assertEquals("Shellbane Gryphon Cave entrance", result.get().getObjectName());
+	}
+
+	@Test
+	public void lookupBySceneId_chambersOfXericId_found()
+	{
+		// 29777 is the confirmed scene ID for Chambers of Xeric entrance
+		Optional<VerifiedSceneId> result = registry.lookupBySceneId(29777);
+		assertTrue("CoX scene ID 29777 must be in the registry", result.isPresent());
+	}
+
+	@Test
+	public void lookupBySceneId_unknownId_empty()
+	{
+		Optional<VerifiedSceneId> result = registry.lookupBySceneId(1);
+		assertFalse("Unknown scene ID must return empty", result.isPresent());
+	}
+
+	// ========================================================================
+	// all — immutability
+	// ========================================================================
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void all_returnsUnmodifiableList()
+	{
+		registry.all().add(null);
+	}
+
+	// ========================================================================
+	// Cross-lookup consistency — examineId and sceneId resolve same entry
+	// ========================================================================
+
+	@Test
+	public void crossLookup_shellbane_examineAndSceneReturnSameEntry()
+	{
+		Optional<VerifiedSceneId> byExamine = registry.lookupByExamineId(58441);
+		Optional<VerifiedSceneId> byScene = registry.lookupBySceneId(58439);
+		assertTrue(byExamine.isPresent());
+		assertTrue(byScene.isPresent());
+		assertEquals(byExamine.get().getObjectName(), byScene.get().getObjectName());
+	}
+
+	@Test
+	public void crossLookup_nonDivergentEntry_examineAndSceneReturnSameEntry()
+	{
+		// Theatre of Blood (32653): examine ID == scene ID, both should resolve the same entry
+		Optional<VerifiedSceneId> byExamine = registry.lookupByExamineId(32653);
+		Optional<VerifiedSceneId> byScene = registry.lookupBySceneId(32653);
+		assertTrue("ToB examine ID 32653 must be in registry", byExamine.isPresent());
+		assertTrue("ToB scene ID 32653 must be in registry", byScene.isPresent());
+		assertEquals(byExamine.get().getObjectName(), byScene.get().getObjectName());
+	}
+
+	// ========================================================================
+	// Schema version — schema field is present in JSON
+	// ========================================================================
+
+	@Test
+	public void schemaVersion_isCheckedOnLoad()
+	{
+		// Registry loaded without error and returned entries — implies version=1 was accepted
+		assertFalse("A successful load must yield entries", registry.all().isEmpty());
+	}
+
+	// ========================================================================
+	// Divergence detection — Shellbane is the only known examine/scene split
+	// ========================================================================
+
+	@Test
+	public void divergentEntries_shellbaneIsPresent()
+	{
+		long divergent = registry.all().stream()
+			.filter(e -> !e.getSceneIds().contains(e.getExamineId()))
+			.count();
+		assertTrue("At least one divergent (examine != scene) entry must exist", divergent >= 1);
+	}
+
+	@Test
+	public void shellbaneEntry_examineIdDiffersFromSceneId()
+	{
+		Optional<VerifiedSceneId> entry = registry.lookupByExamineId(58441);
+		assertTrue(entry.isPresent());
+		assertFalse(
+			"Shellbane examine ID 58441 must not appear in sceneIds list",
+			entry.get().getSceneIds().contains(58441));
+		assertTrue(
+			"Shellbane scene ID 58439 must appear in sceneIds list",
+			entry.get().getSceneIds().contains(58439));
+	}
+
+	// ========================================================================
+	// empty() factory
+	// ========================================================================
+
+	@Test
+	public void empty_returnsRegistryWithNoEntries()
+	{
+		VerifiedSceneIdRegistry empty = VerifiedSceneIdRegistry.empty();
+		assertTrue(empty.all().isEmpty());
+		assertFalse(empty.lookupByExamineId(58441).isPresent());
+		assertFalse(empty.lookupBySceneId(58439).isPresent());
+	}
+}

--- a/src/test/java/com/collectionloghelper/data/VerifiedSceneIdRegistryTest.java
+++ b/src/test/java/com/collectionloghelper/data/VerifiedSceneIdRegistryTest.java
@@ -197,14 +197,68 @@ public class VerifiedSceneIdRegistryTest
 	}
 
 	// ========================================================================
-	// Schema version — schema field is present in JSON
+	// Schema version — tolerant of unsupported and missing version fields
 	// ========================================================================
 
 	@Test
-	public void schemaVersion_isCheckedOnLoad()
+	public void loadFromJson_unsupportedVersion_stillReturnsEntries()
 	{
-		// Registry loaded without error and returned entries — implies version=1 was accepted
-		assertFalse("A successful load must yield entries", registry.all().isEmpty());
+		String json = "{"
+			+ "\"version\": 99,"
+			+ "\"entries\": ["
+			+ "  {"
+			+ "    \"objectName\": \"Test entrance\","
+			+ "    \"examineId\": 11111,"
+			+ "    \"sceneIds\": [11112],"
+			+ "    \"confidence\": \"high\","
+			+ "    \"source\": \"unit test\","
+			+ "    \"notes\": \"synthetic fixture for schema-version tolerance\""
+			+ "  }"
+			+ "]"
+			+ "}";
+
+		VerifiedSceneIdRegistry loaded = VerifiedSceneIdRegistry.loadFromJson(json, new Gson());
+
+		assertEquals(
+			"Unsupported schema version must still yield entries (loader warns, does not drop)",
+			1,
+			loaded.all().size());
+		assertTrue(loaded.lookupByExamineId(11111).isPresent());
+		assertTrue(loaded.lookupBySceneId(11112).isPresent());
+	}
+
+	@Test
+	public void loadFromJson_missingVersion_stillReturnsEntries()
+	{
+		// Regression guard: prior implementation NPE'd on root.get("version").getAsInt() when the
+		// field was absent. The load-path swallowed the NPE via a broad catch and returned an empty
+		// registry — a silent degradation. The loader now null-guards the version read.
+		String json = "{"
+			+ "\"entries\": ["
+			+ "  {"
+			+ "    \"objectName\": \"Version-less entrance\","
+			+ "    \"examineId\": 22222,"
+			+ "    \"sceneIds\": [22222],"
+			+ "    \"confidence\": \"high\","
+			+ "    \"source\": \"unit test\""
+			+ "  }"
+			+ "]"
+			+ "}";
+
+		VerifiedSceneIdRegistry loaded = VerifiedSceneIdRegistry.loadFromJson(json, new Gson());
+
+		assertEquals(
+			"Missing version field must be tolerated, not NPE or silently return empty",
+			1,
+			loaded.all().size());
+		assertTrue(loaded.lookupByExamineId(22222).isPresent());
+	}
+
+	@Test
+	public void loadFromJson_malformedJson_returnsEmpty()
+	{
+		VerifiedSceneIdRegistry loaded = VerifiedSceneIdRegistry.loadFromJson("{not valid json", new Gson());
+		assertTrue("Malformed JSON must return an empty registry, not throw", loaded.all().isEmpty());
 	}
 
 	// ========================================================================


### PR DESCRIPTION
## Summary

- Adds `src/main/resources/com/collectionloghelper/verified_scene_ids.json` — a seeded registry of 17 examine-ID ↔ scene-ID pairs for game objects used in guidance steps, with MCP-verified confidence ratings, sources, and notes.
- Adds `VerifiedSceneId` (Lombok `@Value`) and `VerifiedSceneIdRegistry` loader with `lookupByExamineId`, `lookupBySceneId`, and `all()` methods.
- Adds `VerifiedSceneIdRegistryTest` (19 tests) covering load integrity, lookup by both ID types, unknown-ID returns empty, schema version, immutability, and divergence detection.

## What changed

| File | Type | LOC |
|------|------|-----|
| `src/main/resources/com/collectionloghelper/verified_scene_ids.json` | new | 177 |
| `src/main/java/com/collectionloghelper/data/VerifiedSceneId.java` | new | 48 |
| `src/main/java/com/collectionloghelper/data/VerifiedSceneIdRegistry.java` | new | 180 |
| `src/test/java/com/collectionloghelper/data/VerifiedSceneIdRegistryTest.java` | new | 248 |

### Registry entries

The canonical divergence case is **Shellbane Gryphon cave entrance** (examineId 58441 / sceneId 58439), which is the example documented in `feedback_object_id_gotcha.md`. All other 16 entries have no examine/scene divergence but are recorded because their object types, coordinates, or ID-sourcing history were historically confused or required authoring-log verification.

Full entry list: Shellbane Gryphon cave (58441/58439), Nightmare stairs (32637), Pool of Nightmares (29706), Scorpia cavern (26762), Venenatis cave (47077), CoX entrance (29777), ToB entrance (32653), Corp passage (677), Hallowed Sepulchre door (38574), Duke Sucellus stairs (49100), Leviathan handholds (47592), Whisperer rock (48197), Vardorvis temple entry (48723), Custodian Stalker cave (57279), Fossil Island Wyvern cave (30869), Sarachnis ladder (34862), Sarachnis Thick Web (34858).

### Behavior impact

Purely additive — no existing code paths read from this registry. The loader is not wired into `PluginDataManager` or any production path yet; that is A5.3+ work.

## Test plan

- [ ] `./gradlew test` passes — BUILD SUCCESSFUL, 19 new tests all green
- [ ] `load_succeeds_returnsNonEmptyRegistry` — JSON parses without exception
- [ ] `lookupByExamineId_shellbaneGryphonCacheId_found` — 58441 resolves
- [ ] `lookupBySceneId_shellbaneGryphonSceneId_found` — 58439 resolves
- [ ] `shellbaneEntry_examineIdDiffersFromSceneId` — divergence confirmed in data
- [ ] `lookupByExamineId_unknownId_empty` / `lookupBySceneId_unknownId_empty` — empty Optional
- [ ] `all_returnsUnmodifiableList` — mutation blocked
- [ ] `empty_returnsRegistryWithNoEntries` — factory works
- [ ] All-entries integrity checks pass (objectName, examineId > 0, sceneIds non-empty, confidence, source)

## Milestone reference

Part of A5.2 in docs/ROADMAP.md (Tier A.5). Mark A5.2 done after merge.