### PR TITLE
docs(roadmap): close A5.1/A5.3/A5.5/A5.6 — toolkit v0.2.0 shipped

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -501,12 +501,12 @@ Focus: god-object decomposition, build hardening, test expansion. Resulted in th
 
 **Tier A.5 — Data sourcing infrastructure**
 
-- [ ] A5.1 — `varbit_lookup` MCP tool                    status: planned       owner: —          updated: 2026-04-16
+- [x] A5.1 — `varbit_lookup` MCP tool                    status: done          owner: cha-ndler  updated: 2026-04-16  note: closed by runelite-dev-toolkit v0.2.0 — varbit_lookup MCP tool
 - [ ] A5.2 — `verified_scene_ids.json` registry          status: planned       owner: —          updated: 2026-04-16
-- [ ] A5.3 — `cache_diff_check` MCP tool                 status: planned       owner: —          updated: 2026-04-16
+- [x] A5.3 — `cache_diff_check` MCP tool                 status: done          owner: cha-ndler  updated: 2026-04-16  note: closed by runelite-dev-toolkit v0.2.0 — cache_diff_check MCP tool
 - [ ] A5.4 — Tiered sourcing strategy in CONTRIBUTING    status: planned       owner: —          updated: 2026-04-16
-- [ ] A5.5 — In-game authoring playbook generator        status: planned       owner: —          updated: 2026-04-16
-- [ ] A5.6 — Data confidence brain (D-06)                status: planned       owner: —          updated: 2026-04-16
+- [x] A5.5 — In-game authoring playbook generator        status: done          owner: cha-ndler  updated: 2026-04-16  note: closed by runelite-dev-toolkit v0.2.0 — authoring_playbook MCP tool
+- [x] A5.6 — Data confidence brain (D-06)                status: done          owner: cha-ndler  updated: 2026-04-16  note: closed by runelite-dev-toolkit v0.2.0 — data_source_router + precedence.json (auto-tuner deferred)
 
 **Tier B — Guidance depth parity with Quest Helper**
 


### PR DESCRIPTION
## Summary
- Flip CLH A5.1 (varbit_lookup), A5.3 (cache_diff_check), A5.5 (authoring_playbook), and A5.6 (data_source_router + precedence.json) from planned to done.
- All four closed by [runelite-dev-toolkit v0.2.0](https://github.com/cha-ndler/runelite-dev-toolkit/releases/tag/v0.2.0) — four new MCP tools landed in a single release, 104 tests / 38 suites / 0 failures on that side.
- Data confidence brain auto-tuner (D-06 follow-up) deferred until a month of conflict log data accumulates.

## What this does not cover
- **A5.2** status-log flip: the registry content landed via #342, but the status line is unchanged here and needs a separate housekeeping pass. The canonical home for `verified_scene_ids.json` was decided as the toolkit repo — reconciling the two copies is follow-up work.
- **A5.4**: tiered-sourcing CONTRIBUTING doc still in-flight on the pipeline.

## Test plan
- [ ] Verify the toolkit release link resolves.
- [ ] Confirm the four `note:` citations in the status log render cleanly in the rendered markdown.