### PR TITLE
docs: mark A5.2 and A5.4 done in status log

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -502,9 +502,9 @@ Focus: god-object decomposition, build hardening, test expansion. Resulted in th
 **Tier A.5 — Data sourcing infrastructure**
 
 - [x] A5.1 — `varbit_lookup` MCP tool                    status: done          owner: cha-ndler  updated: 2026-04-16  note: closed by runelite-dev-toolkit v0.2.0 — varbit_lookup MCP tool
-- [ ] A5.2 — `verified_scene_ids.json` registry          status: planned       owner: —          updated: 2026-04-16
+- [x] A5.2 — `verified_scene_ids.json` registry          status: done          owner: cha-ndler  updated: 2026-04-17  pr: #342
 - [x] A5.3 — `cache_diff_check` MCP tool                 status: done          owner: cha-ndler  updated: 2026-04-16  note: closed by runelite-dev-toolkit v0.2.0 — cache_diff_check MCP tool
-- [ ] A5.4 — Tiered sourcing strategy in CONTRIBUTING    status: planned       owner: —          updated: 2026-04-16
+- [x] A5.4 — Tiered sourcing strategy in CONTRIBUTING    status: done          owner: cha-ndler  updated: 2026-04-17  pr: #341
 - [x] A5.5 — In-game authoring playbook generator        status: done          owner: cha-ndler  updated: 2026-04-16  note: closed by runelite-dev-toolkit v0.2.0 — authoring_playbook MCP tool
 - [x] A5.6 — Data confidence brain (D-06)                status: done          owner: cha-ndler  updated: 2026-04-16  note: closed by runelite-dev-toolkit v0.2.0 — data_source_router + precedence.json (auto-tuner deferred)
 


### PR DESCRIPTION
## Summary

Two-line status bump after merges of #341 and #342.

- **A5.2** `[ ]` planned → `[x]` done (PR #342 — verified_scene_ids.json registry)
- **A5.4** `[ ]` planned → `[x]` done (PR #341 — CONTRIBUTING data tiers section)

A5.1/A5.3/A5.5/A5.6 were already marked `[x]` done on master by #343 (delegated to cha-ndler/runelite-dev-toolkit v0.2.0) and are not touched here.

## Test plan

- [x] No code changes — docs only
- [x] `git diff origin/master -- docs/ROADMAP.md` shows exactly 2 line changes