### PR TITLE
refactor: extract GuidanceEventRouter to bring plugin class below 1,000 LOC

### DIFF
--- a/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
@@ -26,10 +26,8 @@ package com.collectionloghelper;
 
 import com.collectionloghelper.data.CollectionLogItem;
 import com.collectionloghelper.data.CollectionLogSource;
-import com.collectionloghelper.data.CompletionCondition;
 import com.collectionloghelper.data.DataSyncState;
 import com.collectionloghelper.data.DropRateDatabase;
-import com.collectionloghelper.data.GuidanceStep;
 import com.collectionloghelper.data.PlayerBankState;
 import com.collectionloghelper.data.PlayerCollectionState;
 import com.collectionloghelper.data.PlayerInventoryState;
@@ -44,6 +42,7 @@ import com.collectionloghelper.efficiency.SlayerStrategyCalculator;
 import com.collectionloghelper.guidance.GuidanceOverlayCoordinator;
 import com.collectionloghelper.guidance.GuidanceSequencer;
 import com.collectionloghelper.lifecycle.AuthoringLogger;
+import com.collectionloghelper.lifecycle.GuidanceEventRouter;
 import com.collectionloghelper.lifecycle.GuidanceUIState;
 import com.collectionloghelper.lifecycle.OverlayRegistry;
 import com.collectionloghelper.lifecycle.SceneEventRouter;
@@ -63,33 +62,22 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
-import net.runelite.api.MenuAction;
 import net.runelite.api.NPC;
 import net.runelite.api.Player;
 import net.runelite.api.WorldEntity;
 import net.runelite.api.WorldView;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
-import net.runelite.api.events.ActorDeath;
-import net.runelite.api.events.AnimationChanged;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
-import net.runelite.api.events.HitsplatApplied;
-import net.runelite.api.events.InteractingChanged;
 import net.runelite.api.events.ItemContainerChanged;
-import net.runelite.api.events.MenuEntryAdded;
-import net.runelite.api.events.MenuOptionClicked;
-import net.runelite.api.events.NpcDespawned;
-import net.runelite.api.events.NpcSpawned;
 import net.runelite.api.events.ScriptPreFired;
 import net.runelite.api.ScriptEvent;
 import net.runelite.api.events.StatChanged;
 import net.runelite.api.events.VarbitChanged;
-import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.gameval.InventoryID;
 import net.runelite.api.gameval.ItemID;
-import net.runelite.api.widgets.Widget;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.chat.ChatCommandManager;
 import net.runelite.client.config.ConfigManager;
@@ -116,8 +104,6 @@ public class CollectionLogHelperPlugin extends Plugin
 {
 	private static final Pattern COLLECTION_LOG_PATTERN =
 		Pattern.compile("New item added to your collection log: (.*)");
-
-	private static final String MENU_OPTION_GUIDE = "Collection Log Guide";
 
 	@Inject
 	private Client client;
@@ -209,6 +195,9 @@ public class CollectionLogHelperPlugin extends Plugin
 	@Inject
 	private GuidanceUIState guidanceUIState;
 
+	@Inject
+	private GuidanceEventRouter guidanceEventRouter;
+
 
 	private CollectionLogHelperPanel panel;
 	private NavigationButton navButton;
@@ -219,11 +208,8 @@ public class CollectionLogHelperPlugin extends Plugin
 	private volatile boolean pendingTravelVarbitRefresh = false;
 	private BufferedImage collectionLogIcon;
 
-	// Auto-sync state: triggered when collection log widget opens
-	private boolean autoSyncPending;
+	// Deferred cache-fresh check: set once the full sync completes
 	private boolean hasCompletedFullSync;
-	private boolean syncReminderSent;
-	private int loginTickDelay;
 
 	/**
 	 * Player location cached on the client thread each game tick.
@@ -239,9 +225,6 @@ public class CollectionLogHelperPlugin extends Plugin
 	/** Cached ranked efficiency list — recomputed only when dirty. */
 	private List<ScoredItem> cachedRankedSources;
 	private boolean rankedSourcesDirty = true;
-
-	/** Writer for guidance authoring event log. Opened when authoring mode enabled. */
-	private java.io.PrintWriter authoringLogWriter;
 
 	@Override
 	protected void startUp() throws Exception
@@ -294,6 +277,9 @@ public class CollectionLogHelperPlugin extends Plugin
 		overlayRegistry.registerAll();
 		sceneEventRouter.setAuthoringLogger(msg -> authoringLogger.log("%s", msg));
 		eventBus.register(sceneEventRouter);
+		guidanceEventRouter.setMissingItemsSupplier(() -> sourcesWithMissingItems);
+		guidanceEventRouter.setActivateGuidanceCallback(this::activateGuidance);
+		eventBus.register(guidanceEventRouter);
 
 		// If already logged in (e.g., plugin enabled mid-session), load state
 		if (client.getGameState() == GameState.LOGGED_IN)
@@ -331,6 +317,7 @@ public class CollectionLogHelperPlugin extends Plugin
 		clientToolbar.removeNavigation(navButton);
 		overlayRegistry.unregisterAll();
 		eventBus.unregister(sceneEventRouter);
+		eventBus.unregister(guidanceEventRouter);
 		deactivateGuidance();
 		syncStateCoordinator.reset();
 		sourcesWithMissingItems.clear();
@@ -498,24 +485,6 @@ public class CollectionLogHelperPlugin extends Plugin
 	}
 
 	@Subscribe
-	public void onActorDeath(ActorDeath event)
-	{
-		if (!guidanceSequencer.isActive())
-		{
-			return;
-		}
-		if (event.getActor() instanceof NPC)
-		{
-			NPC npc = (NPC) event.getActor();
-			if (config.guidanceAuthoring())
-			{
-				authoringLogger.log("DEATH npcId=%d name='%s'", npc.getId(), npc.getName());
-			}
-			guidanceSequencer.onNpcDeath(npc.getId());
-		}
-	}
-
-	@Subscribe
 	public void onChatMessage(ChatMessage event)
 	{
 		if (event.getType() != ChatMessageType.GAMEMESSAGE
@@ -630,53 +599,6 @@ public class CollectionLogHelperPlugin extends Plugin
 				panel.updateClueSummary(playerBankState);
 			}
 		}
-	}
-
-	@Subscribe
-	public void onWidgetLoaded(WidgetLoaded event)
-	{
-		// Capture dialog widget text for authoring mode
-		if (config.guidanceAuthoring())
-		{
-			// Player dialog choices (group 219)
-			if (event.getGroupId() == 219)
-			{
-				clientThread.invokeLater(() ->
-				{
-					Widget container = client.getWidget(219, 1);
-					if (container != null)
-					{
-						Widget[] children = container.getDynamicChildren();
-						if (children != null)
-						{
-							StringBuilder sb = new StringBuilder("DIALOG_OPTIONS");
-							for (Widget child : children)
-							{
-								if (child != null && child.getText() != null && !child.getText().isEmpty())
-								{
-									sb.append(" '").append(child.getText()).append("'");
-								}
-							}
-							authoringLogger.log(sb.toString());
-						}
-					}
-				});
-			}
-			// NPC dialog (group 231)
-			if (event.getGroupId() == 231)
-			{
-				clientThread.invokeLater(() ->
-				{
-					Widget textWidget = client.getWidget(231, 4);
-					if (textWidget != null && textWidget.getText() != null)
-					{
-						authoringLogger.log("DIALOG_NPC text='%s'", textWidget.getText());
-					}
-				});
-			}
-		}
-
-		syncStateCoordinator.onWidgetLoaded(event.getGroupId());
 	}
 
 	@Subscribe
@@ -869,141 +791,6 @@ public class CollectionLogHelperPlugin extends Plugin
 			database, collectionState);
 	}
 
-	@Subscribe
-	public void onMenuEntryAdded(MenuEntryAdded event)
-	{
-		if (!config.showOverlays())
-		{
-			return;
-		}
-
-		int type = event.getType();
-		if (type < MenuAction.NPC_FIRST_OPTION.getId() || type > MenuAction.NPC_FIFTH_OPTION.getId())
-		{
-			return;
-		}
-
-		NPC npc = event.getMenuEntry().getNpc();
-		if (npc == null)
-		{
-			return;
-		}
-
-		int npcId = npc.getId();
-		CollectionLogSource source = database.getSourceByNpcId(npcId);
-		if (source == null)
-		{
-			return;
-		}
-
-		// Skip if guidance is already active for this source
-		if (guidanceCoordinator.isSourceGuided(source))
-		{
-			return;
-		}
-
-		// Check if source has any missing items (O(1) cached lookup)
-		if (!sourcesWithMissingItems.contains(source.getName()))
-		{
-			return;
-		}
-
-		client.getMenu().createMenuEntry(-1)
-			.setOption(MENU_OPTION_GUIDE)
-			.setTarget(event.getTarget())
-			.setType(MenuAction.RUNELITE)
-			.setIdentifier(npcId);
-	}
-
-	@Subscribe
-	public void onMenuOptionClicked(MenuOptionClicked event)
-	{
-		MenuAction action = event.getMenuAction();
-
-		// Handle "Collection Log Guide" right-click menu action
-		if (action == MenuAction.RUNELITE && MENU_OPTION_GUIDE.equals(event.getMenuOption()))
-		{
-			CollectionLogSource source = database.getSourceByNpcId(event.getId());
-			if (source != null)
-			{
-				activateGuidance(source);
-			}
-			return;
-		}
-
-		// Authoring mode: log all interactions regardless of guidance state
-		if (config.guidanceAuthoring())
-		{
-			authoringLogger.log("MENU option='%s' target='%s' action=%s id=%d param0=%d param1=%d",
-				event.getMenuOption(), event.getMenuTarget(), action,
-				event.getId(), event.getParam0(), event.getParam1());
-
-			if (action == MenuAction.GAME_OBJECT_FIRST_OPTION || action == MenuAction.GAME_OBJECT_SECOND_OPTION
-				|| action == MenuAction.GAME_OBJECT_THIRD_OPTION || action == MenuAction.GAME_OBJECT_FOURTH_OPTION
-				|| action == MenuAction.GAME_OBJECT_FIFTH_OPTION)
-			{
-				authoringLogger.log("OBJECT id=%d option='%s'", event.getId(), event.getMenuOption());
-			}
-			else if (action == MenuAction.NPC_FIRST_OPTION || action == MenuAction.NPC_SECOND_OPTION
-				|| action == MenuAction.NPC_THIRD_OPTION || action == MenuAction.NPC_FOURTH_OPTION
-				|| action == MenuAction.NPC_FIFTH_OPTION)
-			{
-				NPC npc = event.getMenuEntry().getNpc();
-				if (npc != null)
-				{
-					authoringLogger.log("NPC id=%d name='%s' option='%s'",
-						npc.getId(), npc.getName(), event.getMenuOption());
-				}
-			}
-			else if (action == MenuAction.WIDGET_TARGET_ON_GAME_OBJECT)
-			{
-				authoringLogger.log("USE_ITEM_ON_OBJECT objectId=%d itemId=%d", event.getId(), event.getParam0());
-			}
-			else if (action == MenuAction.WIDGET_TARGET_ON_NPC)
-			{
-				authoringLogger.log("USE_ITEM_ON_NPC npcIndex=%d", event.getId());
-			}
-			else if (action == MenuAction.WIDGET_TARGET_ON_WIDGET)
-			{
-				authoringLogger.log("USE_ITEM_ON_ITEM param0=%d param1=%d", event.getParam0(), event.getParam1());
-			}
-		}
-
-		if (!guidanceSequencer.isActive())
-		{
-			return;
-		}
-
-		// Track cumulative use-item-on-object actions for guidance (e.g., Trouble Brewing hopper)
-		if (action == MenuAction.WIDGET_TARGET_ON_GAME_OBJECT)
-		{
-			CollectionLogSource source = guidanceSequencer.getActiveSource();
-			if (source != null && source.getCumulativeTrackItemId() > 0
-					&& source.getCumulativeTrackObjectIds() != null)
-			{
-				int objectId = event.getId();
-				int itemId = event.getParam0();
-				if (itemId == source.getCumulativeTrackItemId()
-						&& source.getCumulativeTrackObjectIds().contains(objectId))
-				{
-					guidanceSequencer.onTrackedAction();
-				}
-			}
-		}
-
-		// Detect NPC interactions for NPC_TALKED_TO completion condition.
-		if (action == MenuAction.NPC_FIRST_OPTION || action == MenuAction.NPC_SECOND_OPTION
-			|| action == MenuAction.NPC_THIRD_OPTION || action == MenuAction.NPC_FOURTH_OPTION
-			|| action == MenuAction.NPC_FIFTH_OPTION)
-		{
-			NPC npc = event.getMenuEntry().getNpc();
-			if (npc != null)
-			{
-				guidanceSequencer.onNpcInteracted(npc.getId());
-			}
-		}
-	}
-
 	/**
 	 * Resolve the player's real-world location, transforming boat-local
 	 * coordinates when the player is inside a sailing WorldEntity.
@@ -1056,170 +843,6 @@ public class CollectionLogHelperPlugin extends Plugin
 			log.debug("WorldEntity transform failed, using fallback location", e);
 		}
 		return fallback;
-	}
-
-	// ---- Guidance Authoring Event Logger ----
-
-	private void authoringLog(String format, Object... args)
-	{
-		if (!config.guidanceAuthoring())
-		{
-			return;
-		}
-		if (authoringLogWriter == null)
-		{
-			java.io.File logFile = pluginDataManager.getFile("authoring-log.txt");
-			if (logFile == null)
-			{
-				logFile = new java.io.File(
-					net.runelite.client.RuneLite.RUNELITE_DIR, "clh-authoring-log.txt");
-			}
-			try
-			{
-				authoringLogWriter = new java.io.PrintWriter(
-					new java.io.FileWriter(logFile, true), true);
-				authoringLogWriter.printf("=== Authoring session started %s ===%n",
-					java.time.LocalDateTime.now().format(
-						java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
-			}
-			catch (java.io.IOException e)
-			{
-				log.error("Failed to open authoring log", e);
-				return;
-			}
-		}
-		WorldPoint loc = cachedPlayerLocation;
-		String locStr = loc != null
-			? String.format("[%d,%d,%d]", loc.getX(), loc.getY(), loc.getPlane()) : "[?,?,?]";
-		String timestamp = java.time.LocalTime.now().format(
-			java.time.format.DateTimeFormatter.ofPattern("HH:mm:ss"));
-		authoringLogWriter.printf("%s %s %s%n", timestamp, locStr, String.format(format, args));
-	}
-
-	/** Logs inventory or equipment container changes with slot names for equipment. */
-	private void logContainerChange(ItemContainerChanged event)
-	{
-		int containerId = event.getContainerId();
-		if (containerId == InventoryID.INV)
-		{
-			net.runelite.api.ItemContainer c = client.getItemContainer(InventoryID.INV);
-			if (c == null)
-			{
-				return;
-			}
-			StringBuilder sb = new StringBuilder("INVENTORY");
-			for (net.runelite.api.Item item : c.getItems())
-			{
-				if (item.getId() > 0 && item.getQuantity() > 0)
-				{
-					sb.append(String.format(" %d x%d", item.getId(), item.getQuantity()));
-				}
-			}
-			authoringLog(sb.toString());
-		}
-		else if (containerId == InventoryID.WORN)
-		{
-			net.runelite.api.ItemContainer c = client.getItemContainer(InventoryID.WORN);
-			if (c == null)
-			{
-				return;
-			}
-			String[] slotNames = {"Head", "Cape", "Amulet", "Weapon", "Body",
-				"Shield", "?", "Legs", "?", "Gloves", "Boots", "?", "Ring", "Ammo"};
-			StringBuilder sb = new StringBuilder("EQUIPMENT");
-			net.runelite.api.Item[] items = c.getItems();
-			for (int i = 0; i < items.length && i < slotNames.length; i++)
-			{
-				if (items[i].getId() > 0)
-				{
-					sb.append(String.format(" %s=%d", slotNames[i], items[i].getId()));
-				}
-			}
-			authoringLog(sb.toString());
-		}
-	}
-
-	@Subscribe
-	public void onAnimationChanged(AnimationChanged event)
-	{
-		if (!config.guidanceAuthoring() || event.getActor() != client.getLocalPlayer())
-		{
-			return;
-		}
-		int animId = client.getLocalPlayer().getAnimation();
-		if (animId != -1)
-		{
-			authoringLogger.log("ANIMATION player=%d", animId);
-		}
-	}
-
-	@Subscribe
-	public void onNpcSpawned(NpcSpawned event)
-	{
-		NPC npc = event.getNpc();
-
-		if (config.guidanceAuthoring())
-		{
-			authoringLogger.log("NPC_SPAWN id=%d name='%s' index=%d", npc.getId(), npc.getName(), npc.getIndex());
-		}
-
-		// Track the spawned NPC if it matches the current guidance step's target
-		guidanceCoordinator.onNpcSpawned(npc);
-	}
-
-	@Subscribe
-	public void onNpcDespawned(NpcDespawned event)
-	{
-		NPC npc = event.getNpc();
-
-		if (config.guidanceAuthoring())
-		{
-			authoringLogger.log("NPC_DESPAWN id=%d name='%s'", npc.getId(), npc.getName());
-		}
-
-		// Clear tracked NPC if it despawned
-		guidanceCoordinator.onNpcDespawned(npc);
-	}
-
-	@Subscribe
-	public void onInteractingChanged(InteractingChanged event)
-	{
-		if (!guidanceSequencer.isActive())
-		{
-			return;
-		}
-
-		if (event.getSource() == client.getLocalPlayer() && event.getTarget() instanceof NPC)
-		{
-			NPC npc = (NPC) event.getTarget();
-			GuidanceStep step = guidanceSequencer.getRawCurrentStep();
-			if (step != null && step.getCompletionCondition() == CompletionCondition.NPC_TALKED_TO
-				&& step.getCompletionNpcId() == npc.getId())
-			{
-				guidanceSequencer.onNpcInteracted(npc.getId());
-			}
-		}
-	}
-
-	@Subscribe
-	public void onHitsplatApplied(HitsplatApplied event)
-	{
-		if (!config.guidanceAuthoring())
-		{
-			return;
-		}
-		if (event.getActor() == client.getLocalPlayer())
-		{
-			authoringLogger.log("HITSPLAT_RECEIVED type=%d amount=%d",
-				event.getHitsplat().getHitsplatType(), event.getHitsplat().getAmount());
-		}
-		else if (event.getActor() instanceof NPC)
-		{
-			NPC npc = (NPC) event.getActor();
-			authoringLogger.log("HITSPLAT_DEALT npcId=%d name='%s' type=%d amount=%d",
-				npc.getId(), npc.getName(),
-				event.getHitsplat().getHitsplatType(), event.getHitsplat().getAmount());
-		}
 	}
 
 	private void onClhCommand(ChatMessage chatMessage, String message)

--- a/src/main/java/com/collectionloghelper/lifecycle/GuidanceEventRouter.java
+++ b/src/main/java/com/collectionloghelper/lifecycle/GuidanceEventRouter.java
@@ -1,0 +1,452 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.lifecycle;
+
+import com.collectionloghelper.CollectionLogHelperConfig;
+import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.data.CompletionCondition;
+import com.collectionloghelper.data.DropRateDatabase;
+import com.collectionloghelper.data.GuidanceStep;
+import com.collectionloghelper.guidance.GuidanceOverlayCoordinator;
+import com.collectionloghelper.guidance.GuidanceSequencer;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.MenuAction;
+import net.runelite.api.NPC;
+import net.runelite.api.events.ActorDeath;
+import net.runelite.api.events.AnimationChanged;
+import net.runelite.api.events.HitsplatApplied;
+import net.runelite.api.events.InteractingChanged;
+import net.runelite.api.events.MenuEntryAdded;
+import net.runelite.api.events.MenuOptionClicked;
+import net.runelite.api.events.NpcDespawned;
+import net.runelite.api.events.NpcSpawned;
+import net.runelite.api.events.WidgetLoaded;
+import net.runelite.api.widgets.Widget;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.eventbus.Subscribe;
+
+/**
+ * Routes guidance- and authoring-specific events that were previously handled
+ * inline in {@code CollectionLogHelperPlugin}.
+ *
+ * <p>Covers:
+ * <ul>
+ *   <li>{@code onActorDeath} — forwards NPC deaths to the guidance sequencer</li>
+ *   <li>{@code onAnimationChanged} — authoring log only</li>
+ *   <li>{@code onNpcSpawned} / {@code onNpcDespawned} — authoring log + coordinator NPC tracking</li>
+ *   <li>{@code onInteractingChanged} — guidance NPC_TALKED_TO condition</li>
+ *   <li>{@code onHitsplatApplied} — authoring log only</li>
+ *   <li>{@code onWidgetLoaded} — authoring dialog capture + sync coordinator delegation</li>
+ *   <li>{@code onMenuEntryAdded} — "Collection Log Guide" right-click injection</li>
+ *   <li>{@code onMenuOptionClicked} — guidance activation + authoring interaction log</li>
+ * </ul>
+ *
+ * <p>Must be registered on the EventBus via {@code eventBus.register(this)} in
+ * {@code Plugin.startUp()} and unregistered in {@code Plugin.shutDown()}.
+ *
+ * <p>Two callbacks must be set via setters in {@code startUp()} before
+ * the router receives any events:
+ * <ul>
+ *   <li>{@link #setMissingItemsSupplier(Supplier)} — supplies the cached set of source
+ *       names that have at least one unobtained item (owned by the plugin)</li>
+ *   <li>{@link #setActivateGuidanceCallback(Consumer)} — invokes
+ *       {@code CollectionLogHelperPlugin.activateGuidance()} without a direct
+ *       plugin reference</li>
+ * </ul>
+ */
+@Slf4j
+@Singleton
+public class GuidanceEventRouter
+{
+	/** Right-click menu option label injected onto NPCs with incomplete collection log entries. */
+	static final String MENU_OPTION_GUIDE = "Collection Log Guide";
+
+	private final Client client;
+	private final ClientThread clientThread;
+	private final CollectionLogHelperConfig config;
+	private final AuthoringLogger authoringLogger;
+	private final GuidanceSequencer guidanceSequencer;
+	private final GuidanceOverlayCoordinator guidanceCoordinator;
+	private final SyncStateCoordinator syncStateCoordinator;
+	private final DropRateDatabase database;
+
+	/**
+	 * Supplies the live set of source names with at least one missing item.
+	 * Set once by the plugin in {@code startUp()}.
+	 */
+	private Supplier<Set<String>> missingItemsSupplier;
+
+	/**
+	 * Callback to activate guidance for a source — delegates to
+	 * {@code CollectionLogHelperPlugin.activateGuidance(CollectionLogSource)}.
+	 * Set once by the plugin in {@code startUp()}.
+	 */
+	private Consumer<CollectionLogSource> activateGuidanceCallback;
+
+	@Inject
+	public GuidanceEventRouter(
+		Client client,
+		ClientThread clientThread,
+		CollectionLogHelperConfig config,
+		AuthoringLogger authoringLogger,
+		GuidanceSequencer guidanceSequencer,
+		GuidanceOverlayCoordinator guidanceCoordinator,
+		SyncStateCoordinator syncStateCoordinator,
+		DropRateDatabase database)
+	{
+		this.client = client;
+		this.clientThread = clientThread;
+		this.config = config;
+		this.authoringLogger = authoringLogger;
+		this.guidanceSequencer = guidanceSequencer;
+		this.guidanceCoordinator = guidanceCoordinator;
+		this.syncStateCoordinator = syncStateCoordinator;
+		this.database = database;
+	}
+
+	/**
+	 * Sets the supplier that returns the cached set of source names with missing items.
+	 * Must be called from {@code Plugin.startUp()} before any events are processed.
+	 */
+	public void setMissingItemsSupplier(Supplier<Set<String>> supplier)
+	{
+		this.missingItemsSupplier = supplier;
+	}
+
+	/**
+	 * Sets the callback used to activate guidance for a source.
+	 * Must be called from {@code Plugin.startUp()} before any events are processed.
+	 */
+	public void setActivateGuidanceCallback(Consumer<CollectionLogSource> callback)
+	{
+		this.activateGuidanceCallback = callback;
+	}
+
+	// ── Actor death ─────────────────────────────────────────────────────────
+
+	@Subscribe
+	public void onActorDeath(ActorDeath event)
+	{
+		if (!guidanceSequencer.isActive())
+		{
+			return;
+		}
+		if (event.getActor() instanceof NPC)
+		{
+			NPC npc = (NPC) event.getActor();
+			if (config.guidanceAuthoring())
+			{
+				authoringLogger.log("DEATH npcId=%d name='%s'", npc.getId(), npc.getName());
+			}
+			guidanceSequencer.onNpcDeath(npc.getId());
+		}
+	}
+
+	// ── Animation ────────────────────────────────────────────────────────────
+
+	@Subscribe
+	public void onAnimationChanged(AnimationChanged event)
+	{
+		if (!config.guidanceAuthoring() || event.getActor() != client.getLocalPlayer())
+		{
+			return;
+		}
+		int animId = client.getLocalPlayer().getAnimation();
+		if (animId != -1)
+		{
+			authoringLogger.log("ANIMATION player=%d", animId);
+		}
+	}
+
+	// ── NPC lifecycle ─────────────────────────────────────────────────────────
+
+	@Subscribe
+	public void onNpcSpawned(NpcSpawned event)
+	{
+		NPC npc = event.getNpc();
+
+		if (config.guidanceAuthoring())
+		{
+			authoringLogger.log("NPC_SPAWN id=%d name='%s' index=%d", npc.getId(), npc.getName(), npc.getIndex());
+		}
+
+		// Track the spawned NPC if it matches the current guidance step's target
+		guidanceCoordinator.onNpcSpawned(npc);
+	}
+
+	@Subscribe
+	public void onNpcDespawned(NpcDespawned event)
+	{
+		NPC npc = event.getNpc();
+
+		if (config.guidanceAuthoring())
+		{
+			authoringLogger.log("NPC_DESPAWN id=%d name='%s'", npc.getId(), npc.getName());
+		}
+
+		// Clear tracked NPC if it despawned
+		guidanceCoordinator.onNpcDespawned(npc);
+	}
+
+	// ── Interaction ──────────────────────────────────────────────────────────
+
+	@Subscribe
+	public void onInteractingChanged(InteractingChanged event)
+	{
+		if (!guidanceSequencer.isActive())
+		{
+			return;
+		}
+
+		if (event.getSource() == client.getLocalPlayer() && event.getTarget() instanceof NPC)
+		{
+			NPC npc = (NPC) event.getTarget();
+			GuidanceStep step = guidanceSequencer.getRawCurrentStep();
+			if (step != null && step.getCompletionCondition() == CompletionCondition.NPC_TALKED_TO
+				&& step.getCompletionNpcId() == npc.getId())
+			{
+				guidanceSequencer.onNpcInteracted(npc.getId());
+			}
+		}
+	}
+
+	// ── Hitsplat ─────────────────────────────────────────────────────────────
+
+	@Subscribe
+	public void onHitsplatApplied(HitsplatApplied event)
+	{
+		if (!config.guidanceAuthoring())
+		{
+			return;
+		}
+		if (event.getActor() == client.getLocalPlayer())
+		{
+			authoringLogger.log("HITSPLAT_RECEIVED type=%d amount=%d",
+				event.getHitsplat().getHitsplatType(), event.getHitsplat().getAmount());
+		}
+		else if (event.getActor() instanceof NPC)
+		{
+			NPC npc = (NPC) event.getActor();
+			authoringLogger.log("HITSPLAT_DEALT npcId=%d name='%s' type=%d amount=%d",
+				npc.getId(), npc.getName(),
+				event.getHitsplat().getHitsplatType(), event.getHitsplat().getAmount());
+		}
+	}
+
+	// ── Widget loaded ─────────────────────────────────────────────────────────
+
+	@Subscribe
+	public void onWidgetLoaded(WidgetLoaded event)
+	{
+		// Capture dialog widget text for authoring mode
+		if (config.guidanceAuthoring())
+		{
+			// Player dialog choices (group 219)
+			if (event.getGroupId() == 219)
+			{
+				clientThread.invokeLater(() ->
+				{
+					Widget container = client.getWidget(219, 1);
+					if (container != null)
+					{
+						Widget[] children = container.getDynamicChildren();
+						if (children != null)
+						{
+							StringBuilder sb = new StringBuilder("DIALOG_OPTIONS");
+							for (Widget child : children)
+							{
+								if (child != null && child.getText() != null && !child.getText().isEmpty())
+								{
+									sb.append(" '").append(child.getText()).append("'");
+								}
+							}
+							authoringLogger.log(sb.toString());
+						}
+					}
+				});
+			}
+			// NPC dialog (group 231)
+			if (event.getGroupId() == 231)
+			{
+				clientThread.invokeLater(() ->
+				{
+					Widget textWidget = client.getWidget(231, 4);
+					if (textWidget != null && textWidget.getText() != null)
+					{
+						authoringLogger.log("DIALOG_NPC text='%s'", textWidget.getText());
+					}
+				});
+			}
+		}
+
+		syncStateCoordinator.onWidgetLoaded(event.getGroupId());
+	}
+
+	// ── Menu entry injection ──────────────────────────────────────────────────
+
+	@Subscribe
+	public void onMenuEntryAdded(MenuEntryAdded event)
+	{
+		if (!config.showOverlays())
+		{
+			return;
+		}
+
+		int type = event.getType();
+		if (type < MenuAction.NPC_FIRST_OPTION.getId() || type > MenuAction.NPC_FIFTH_OPTION.getId())
+		{
+			return;
+		}
+
+		NPC npc = event.getMenuEntry().getNpc();
+		if (npc == null)
+		{
+			return;
+		}
+
+		int npcId = npc.getId();
+		CollectionLogSource source = database.getSourceByNpcId(npcId);
+		if (source == null)
+		{
+			return;
+		}
+
+		// Skip if guidance is already active for this source
+		if (guidanceCoordinator.isSourceGuided(source))
+		{
+			return;
+		}
+
+		// Check if source has any missing items (O(1) cached lookup)
+		Set<String> missingItems = missingItemsSupplier != null ? missingItemsSupplier.get() : null;
+		if (missingItems == null || !missingItems.contains(source.getName()))
+		{
+			return;
+		}
+
+		client.getMenu().createMenuEntry(-1)
+			.setOption(MENU_OPTION_GUIDE)
+			.setTarget(event.getTarget())
+			.setType(MenuAction.RUNELITE)
+			.setIdentifier(npcId);
+	}
+
+	// ── Menu option click ─────────────────────────────────────────────────────
+
+	@Subscribe
+	public void onMenuOptionClicked(MenuOptionClicked event)
+	{
+		MenuAction action = event.getMenuAction();
+
+		// Handle "Collection Log Guide" right-click menu action
+		if (action == MenuAction.RUNELITE && MENU_OPTION_GUIDE.equals(event.getMenuOption()))
+		{
+			CollectionLogSource source = database.getSourceByNpcId(event.getId());
+			if (source != null && activateGuidanceCallback != null)
+			{
+				activateGuidanceCallback.accept(source);
+			}
+			return;
+		}
+
+		// Authoring mode: log all interactions regardless of guidance state
+		if (config.guidanceAuthoring())
+		{
+			authoringLogger.log("MENU option='%s' target='%s' action=%s id=%d param0=%d param1=%d",
+				event.getMenuOption(), event.getMenuTarget(), action,
+				event.getId(), event.getParam0(), event.getParam1());
+
+			if (action == MenuAction.GAME_OBJECT_FIRST_OPTION || action == MenuAction.GAME_OBJECT_SECOND_OPTION
+				|| action == MenuAction.GAME_OBJECT_THIRD_OPTION || action == MenuAction.GAME_OBJECT_FOURTH_OPTION
+				|| action == MenuAction.GAME_OBJECT_FIFTH_OPTION)
+			{
+				authoringLogger.log("OBJECT id=%d option='%s'", event.getId(), event.getMenuOption());
+			}
+			else if (action == MenuAction.NPC_FIRST_OPTION || action == MenuAction.NPC_SECOND_OPTION
+				|| action == MenuAction.NPC_THIRD_OPTION || action == MenuAction.NPC_FOURTH_OPTION
+				|| action == MenuAction.NPC_FIFTH_OPTION)
+			{
+				NPC npc = event.getMenuEntry().getNpc();
+				if (npc != null)
+				{
+					authoringLogger.log("NPC id=%d name='%s' option='%s'",
+						npc.getId(), npc.getName(), event.getMenuOption());
+				}
+			}
+			else if (action == MenuAction.WIDGET_TARGET_ON_GAME_OBJECT)
+			{
+				authoringLogger.log("USE_ITEM_ON_OBJECT objectId=%d itemId=%d", event.getId(), event.getParam0());
+			}
+			else if (action == MenuAction.WIDGET_TARGET_ON_NPC)
+			{
+				authoringLogger.log("USE_ITEM_ON_NPC npcIndex=%d", event.getId());
+			}
+			else if (action == MenuAction.WIDGET_TARGET_ON_WIDGET)
+			{
+				authoringLogger.log("USE_ITEM_ON_ITEM param0=%d param1=%d", event.getParam0(), event.getParam1());
+			}
+		}
+
+		if (!guidanceSequencer.isActive())
+		{
+			return;
+		}
+
+		// Track cumulative use-item-on-object actions for guidance (e.g., Trouble Brewing hopper)
+		if (action == MenuAction.WIDGET_TARGET_ON_GAME_OBJECT)
+		{
+			CollectionLogSource source = guidanceSequencer.getActiveSource();
+			if (source != null && source.getCumulativeTrackItemId() > 0
+					&& source.getCumulativeTrackObjectIds() != null)
+			{
+				int objectId = event.getId();
+				int itemId = event.getParam0();
+				if (itemId == source.getCumulativeTrackItemId()
+						&& source.getCumulativeTrackObjectIds().contains(objectId))
+				{
+					guidanceSequencer.onTrackedAction();
+				}
+			}
+		}
+
+		// Detect NPC interactions for NPC_TALKED_TO completion condition.
+		if (action == MenuAction.NPC_FIRST_OPTION || action == MenuAction.NPC_SECOND_OPTION
+			|| action == MenuAction.NPC_THIRD_OPTION || action == MenuAction.NPC_FOURTH_OPTION
+			|| action == MenuAction.NPC_FIFTH_OPTION)
+		{
+			NPC npc = event.getMenuEntry().getNpc();
+			if (npc != null)
+			{
+				guidanceSequencer.onNpcInteracted(npc.getId());
+			}
+		}
+	}
+}

--- a/src/test/java/com/collectionloghelper/lifecycle/GuidanceEventRouterTest.java
+++ b/src/test/java/com/collectionloghelper/lifecycle/GuidanceEventRouterTest.java
@@ -1,0 +1,718 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.lifecycle;
+
+import com.collectionloghelper.CollectionLogHelperConfig;
+import com.collectionloghelper.data.CollectionLogCategory;
+import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.data.CompletionCondition;
+import com.collectionloghelper.data.DropRateDatabase;
+import com.collectionloghelper.data.GuidanceStep;
+import com.collectionloghelper.guidance.GuidanceOverlayCoordinator;
+import com.collectionloghelper.guidance.GuidanceSequencer;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+import net.runelite.api.Actor;
+import net.runelite.api.Client;
+import net.runelite.api.Hitsplat;
+import net.runelite.api.Menu;
+import net.runelite.api.MenuAction;
+import net.runelite.api.MenuEntry;
+import net.runelite.api.NPC;
+import net.runelite.api.Player;
+import net.runelite.api.events.ActorDeath;
+import net.runelite.api.events.AnimationChanged;
+import net.runelite.api.events.HitsplatApplied;
+import net.runelite.api.events.InteractingChanged;
+import net.runelite.api.events.MenuEntryAdded;
+import net.runelite.api.events.MenuOptionClicked;
+import net.runelite.api.events.NpcDespawned;
+import net.runelite.api.events.NpcSpawned;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GuidanceEventRouterTest
+{
+	@Mock
+	private Client client;
+
+	@Mock
+	private net.runelite.client.callback.ClientThread clientThread;
+
+	@Mock
+	private CollectionLogHelperConfig config;
+
+	@Mock
+	private AuthoringLogger authoringLogger;
+
+	@Mock
+	private GuidanceSequencer guidanceSequencer;
+
+	@Mock
+	private GuidanceOverlayCoordinator guidanceCoordinator;
+
+	@Mock
+	private SyncStateCoordinator syncStateCoordinator;
+
+	@Mock
+	private DropRateDatabase database;
+
+	@Mock
+	private NPC npc;
+
+	@Mock
+	private Player localPlayer;
+
+	@Mock
+	private Hitsplat hitsplat;
+
+	private GuidanceEventRouter router;
+	private Set<String> missingItems;
+
+	// ---- factory helpers ----
+
+	/** Minimal GuidanceStep with NPC_TALKED_TO condition. */
+	private static GuidanceStep makeNpcTalkedToStep(int npcId)
+	{
+		return new GuidanceStep(
+			"Talk to NPC",
+			0, 0, 0,
+			0, null, null,
+			null, null,
+			CompletionCondition.NPC_TALKED_TO,
+			0, 0, 0, npcId,
+			null,  // completionNpcIds
+			null,  // worldMessage
+			0, null, null,
+			null, null,
+			null,
+			0, 0,
+			false,
+			0,     // objectMaxDistance
+			null,  // objectFilterTiles
+			null,  // highlightWidgetIds
+			0, 0,  // loopBackToStep, loopCount
+			null,  // skipIfHasAnyItemIds
+			null,  // dynamicItemObjectTiers
+			null,  // completionZone
+			null   // conditionalAlternatives
+		);
+	}
+
+	/**
+	 * Minimal CollectionLogSource with just a name (for menu-entry tests).
+	 */
+	private static CollectionLogSource makeSource(String name)
+	{
+		return new CollectionLogSource(
+			name,
+			CollectionLogCategory.BOSSES,
+			0, 0, 0,   // worldX, worldY, worldPlane
+			0, 0,      // killTimeSeconds, ironKillTimeSeconds
+			null,      // locationDescription
+			null,      // waypoints
+			null,      // rewardType
+			0.0,       // pointsPerHour
+			null,      // mutuallyExclusiveSources
+			0,         // rollsPerKill
+			false,     // aggregated
+			0,         // afkLevel
+			null,      // travelTip
+			0,         // npcId
+			null,      // interactAction
+			null,      // dialogOptions
+			null,      // guidanceSteps
+			null,      // requirements
+			0,         // cumulativeTrackItemId
+			null,      // cumulativeTrackObjectIds
+			0,         // cumulativeTrackThreshold
+			null       // items
+		);
+	}
+
+	/**
+	 * CollectionLogSource with cumulative-track fields set (for track-action test).
+	 */
+	private static CollectionLogSource makeSourceWithTrack(int trackItemId, List<Integer> objectIds)
+	{
+		return new CollectionLogSource(
+			"Track Source",
+			CollectionLogCategory.BOSSES,
+			0, 0, 0,
+			0, 0,
+			null,
+			null,
+			null,
+			0.0,
+			null,
+			0,
+			false,
+			0,
+			null,
+			0,
+			null,
+			null,
+			null,
+			null,
+			trackItemId,
+			objectIds,
+			0,
+			null
+		);
+	}
+
+	@Before
+	public void setUp()
+	{
+		router = new GuidanceEventRouter(
+			client, clientThread, config, authoringLogger,
+			guidanceSequencer, guidanceCoordinator, syncStateCoordinator, database);
+		missingItems = new HashSet<>();
+		router.setMissingItemsSupplier(() -> missingItems);
+		router.setActivateGuidanceCallback(s -> {});
+
+		// Default: authoring off, sequencer inactive
+		when(config.guidanceAuthoring()).thenReturn(false);
+		when(guidanceSequencer.isActive()).thenReturn(false);
+		when(client.getLocalPlayer()).thenReturn(localPlayer);
+	}
+
+	// ========================================================================
+	// onActorDeath
+	// ========================================================================
+
+	@Test
+	public void testOnActorDeathForwardsNpcDeathToSequencer()
+	{
+		// Arrange
+		when(guidanceSequencer.isActive()).thenReturn(true);
+		when(npc.getId()).thenReturn(1234);
+		ActorDeath event = new ActorDeath(npc);
+
+		// Act
+		router.onActorDeath(event);
+
+		// Assert
+		verify(guidanceSequencer).onNpcDeath(1234);
+	}
+
+	@Test
+	public void testOnActorDeathIgnoredWhenSequencerInactive()
+	{
+		// Arrange
+		when(guidanceSequencer.isActive()).thenReturn(false);
+		ActorDeath event = new ActorDeath(npc);
+
+		// Act
+		router.onActorDeath(event);
+
+		// Assert
+		verify(guidanceSequencer, never()).onNpcDeath(anyInt());
+	}
+
+	@Test
+	public void testOnActorDeathLogsWhenAuthoringEnabled()
+	{
+		// Arrange
+		when(guidanceSequencer.isActive()).thenReturn(true);
+		when(config.guidanceAuthoring()).thenReturn(true);
+		when(npc.getId()).thenReturn(42);
+		when(npc.getName()).thenReturn("Guard");
+		ActorDeath event = new ActorDeath(npc);
+
+		// Act
+		router.onActorDeath(event);
+
+		// Assert
+		verify(authoringLogger).log(anyString(), eq(42), eq("Guard"));
+	}
+
+	@Test
+	public void testOnActorDeathSkipsNonNpcActor()
+	{
+		// Arrange
+		when(guidanceSequencer.isActive()).thenReturn(true);
+		Actor nonNpc = mock(Actor.class);
+		ActorDeath event = new ActorDeath(nonNpc);
+
+		// Act
+		router.onActorDeath(event);
+
+		// Assert
+		verify(guidanceSequencer, never()).onNpcDeath(anyInt());
+	}
+
+	// ========================================================================
+	// onAnimationChanged
+	// ========================================================================
+
+	@Test
+	public void testOnAnimationChangedLogsWhenAuthoringAndLocalPlayer()
+	{
+		// Arrange
+		when(config.guidanceAuthoring()).thenReturn(true);
+		when(localPlayer.getAnimation()).thenReturn(832);
+		AnimationChanged event = new AnimationChanged();
+		event.setActor(localPlayer);
+
+		// Act
+		router.onAnimationChanged(event);
+
+		// Assert
+		verify(authoringLogger).log(anyString(), eq(832));
+	}
+
+	@Test
+	public void testOnAnimationChangedSkipsNonLocalPlayer()
+	{
+		// Arrange
+		when(config.guidanceAuthoring()).thenReturn(true);
+		NPC otherActor = mock(NPC.class);
+		AnimationChanged event = new AnimationChanged();
+		event.setActor(otherActor);
+
+		// Act
+		router.onAnimationChanged(event);
+
+		// Assert — no log calls
+		verifyNoInteractions(authoringLogger);
+	}
+
+	@Test
+	public void testOnAnimationChangedSkipsWhenAuthoringOff()
+	{
+		// Arrange
+		when(config.guidanceAuthoring()).thenReturn(false);
+		AnimationChanged event = new AnimationChanged();
+		event.setActor(localPlayer);
+
+		// Act
+		router.onAnimationChanged(event);
+
+		// Assert
+		verifyNoInteractions(authoringLogger);
+	}
+
+	// ========================================================================
+	// onNpcSpawned / onNpcDespawned
+	// ========================================================================
+
+	@Test
+	public void testOnNpcSpawnedForwardsToCoordinator()
+	{
+		// Arrange
+		NpcSpawned event = new NpcSpawned(npc);
+
+		// Act
+		router.onNpcSpawned(event);
+
+		// Assert
+		verify(guidanceCoordinator).onNpcSpawned(npc);
+	}
+
+	@Test
+	public void testOnNpcSpawnedLogsWhenAuthoringEnabled()
+	{
+		// Arrange
+		when(config.guidanceAuthoring()).thenReturn(true);
+		when(npc.getId()).thenReturn(100);
+		when(npc.getName()).thenReturn("Goblin");
+		when(npc.getIndex()).thenReturn(5);
+		NpcSpawned event = new NpcSpawned(npc);
+
+		// Act
+		router.onNpcSpawned(event);
+
+		// Assert
+		verify(authoringLogger).log(anyString(), eq(100), eq("Goblin"), eq(5));
+	}
+
+	@Test
+	public void testOnNpcDespawnedForwardsToCoordinator()
+	{
+		// Arrange
+		NpcDespawned event = new NpcDespawned(npc);
+
+		// Act
+		router.onNpcDespawned(event);
+
+		// Assert
+		verify(guidanceCoordinator).onNpcDespawned(npc);
+	}
+
+	@Test
+	public void testOnNpcDespawnedLogsWhenAuthoringEnabled()
+	{
+		// Arrange
+		when(config.guidanceAuthoring()).thenReturn(true);
+		when(npc.getId()).thenReturn(200);
+		when(npc.getName()).thenReturn("Rat");
+		NpcDespawned event = new NpcDespawned(npc);
+
+		// Act
+		router.onNpcDespawned(event);
+
+		// Assert
+		verify(authoringLogger).log(anyString(), eq(200), eq("Rat"));
+	}
+
+	// ========================================================================
+	// onInteractingChanged
+	// ========================================================================
+
+	@Test
+	public void testOnInteractingChangedForwardsNpcInteractionWhenConditionMatches()
+	{
+		// Arrange
+		when(guidanceSequencer.isActive()).thenReturn(true);
+		GuidanceStep step = makeNpcTalkedToStep(999);
+		when(guidanceSequencer.getRawCurrentStep()).thenReturn(step);
+		when(npc.getId()).thenReturn(999);
+
+		InteractingChanged event = new InteractingChanged(localPlayer, npc);
+
+		// Act
+		router.onInteractingChanged(event);
+
+		// Assert
+		verify(guidanceSequencer).onNpcInteracted(999);
+	}
+
+	@Test
+	public void testOnInteractingChangedIgnoredWhenSequencerInactive()
+	{
+		// Arrange
+		when(guidanceSequencer.isActive()).thenReturn(false);
+		InteractingChanged event = new InteractingChanged(localPlayer, npc);
+
+		// Act
+		router.onInteractingChanged(event);
+
+		// Assert
+		verify(guidanceSequencer, never()).onNpcInteracted(anyInt());
+	}
+
+	@Test
+	public void testOnInteractingChangedIgnoredWhenNpcIdMismatch()
+	{
+		// Arrange
+		when(guidanceSequencer.isActive()).thenReturn(true);
+		GuidanceStep step = makeNpcTalkedToStep(100); // step expects NPC 100
+		when(guidanceSequencer.getRawCurrentStep()).thenReturn(step);
+		when(npc.getId()).thenReturn(999); // different NPC
+
+		InteractingChanged event = new InteractingChanged(localPlayer, npc);
+
+		// Act
+		router.onInteractingChanged(event);
+
+		// Assert
+		verify(guidanceSequencer, never()).onNpcInteracted(anyInt());
+	}
+
+	// ========================================================================
+	// onHitsplatApplied
+	// ========================================================================
+
+	@Test
+	public void testOnHitsplatAppliedLogsReceivedOnLocalPlayer()
+	{
+		// Arrange
+		when(config.guidanceAuthoring()).thenReturn(true);
+		when(hitsplat.getHitsplatType()).thenReturn(1);
+		when(hitsplat.getAmount()).thenReturn(10);
+		HitsplatApplied event = new HitsplatApplied();
+		event.setActor(localPlayer);
+		event.setHitsplat(hitsplat);
+
+		// Act
+		router.onHitsplatApplied(event);
+
+		// Assert
+		verify(authoringLogger).log(anyString(), eq(1), eq(10));
+	}
+
+	@Test
+	public void testOnHitsplatAppliedLogsDealtOnNpc()
+	{
+		// Arrange
+		when(config.guidanceAuthoring()).thenReturn(true);
+		when(npc.getId()).thenReturn(55);
+		when(npc.getName()).thenReturn("Spider");
+		when(hitsplat.getHitsplatType()).thenReturn(2);
+		when(hitsplat.getAmount()).thenReturn(15);
+		HitsplatApplied event = new HitsplatApplied();
+		event.setActor(npc);
+		event.setHitsplat(hitsplat);
+
+		// Act
+		router.onHitsplatApplied(event);
+
+		// Assert
+		verify(authoringLogger).log(anyString(), eq(55), eq("Spider"), eq(2), eq(15));
+	}
+
+	@Test
+	public void testOnHitsplatAppliedSkipsWhenAuthoringOff()
+	{
+		// Arrange
+		when(config.guidanceAuthoring()).thenReturn(false);
+		HitsplatApplied event = new HitsplatApplied();
+		event.setActor(localPlayer);
+		event.setHitsplat(hitsplat);
+
+		// Act
+		router.onHitsplatApplied(event);
+
+		// Assert
+		verifyNoInteractions(authoringLogger);
+	}
+
+	// ========================================================================
+	// onMenuEntryAdded
+	// ========================================================================
+
+	@Test
+	public void testOnMenuEntryAddedInjectsGuideOptionWhenSourceHasMissingItems()
+	{
+		// Arrange
+		CollectionLogSource source = makeSource("Goblin Village");
+		when(config.showOverlays()).thenReturn(true);
+		when(npc.getId()).thenReturn(777);
+		when(database.getSourceByNpcId(777)).thenReturn(source);
+		when(guidanceCoordinator.isSourceGuided(source)).thenReturn(false);
+		missingItems.add("Goblin Village");
+
+		MenuEntry menuEntry = mock(MenuEntry.class);
+		when(menuEntry.getNpc()).thenReturn(npc);
+		when(menuEntry.getType()).thenReturn(MenuAction.NPC_FIRST_OPTION);
+
+		Menu menu = mock(Menu.class);
+		MenuEntry newEntry = mock(MenuEntry.class);
+		when(client.getMenu()).thenReturn(menu);
+		when(menu.createMenuEntry(-1)).thenReturn(newEntry);
+		when(newEntry.setOption(any())).thenReturn(newEntry);
+		when(newEntry.setTarget(any())).thenReturn(newEntry);
+		when(newEntry.setType(any())).thenReturn(newEntry);
+		when(newEntry.setIdentifier(anyInt())).thenReturn(newEntry);
+
+		MenuEntryAdded event = new MenuEntryAdded(menuEntry);
+
+		// Act
+		router.onMenuEntryAdded(event);
+
+		// Assert
+		verify(menu).createMenuEntry(-1);
+		verify(newEntry).setOption(GuidanceEventRouter.MENU_OPTION_GUIDE);
+	}
+
+	@Test
+	public void testOnMenuEntryAddedSkipsWhenOverlaysDisabled()
+	{
+		// Arrange
+		when(config.showOverlays()).thenReturn(false);
+		MenuEntry menuEntry = mock(MenuEntry.class);
+		MenuEntryAdded event = new MenuEntryAdded(menuEntry);
+
+		// Act
+		router.onMenuEntryAdded(event);
+
+		// Assert
+		verify(client, never()).getMenu();
+	}
+
+	@Test
+	public void testOnMenuEntryAddedSkipsWhenSourceAlreadyGuided()
+	{
+		// Arrange
+		CollectionLogSource source = makeSource("Some Source");
+		when(config.showOverlays()).thenReturn(true);
+		when(npc.getId()).thenReturn(888);
+		when(database.getSourceByNpcId(888)).thenReturn(source);
+		when(guidanceCoordinator.isSourceGuided(source)).thenReturn(true);
+		missingItems.add("Some Source");
+
+		MenuEntry menuEntry = mock(MenuEntry.class);
+		when(menuEntry.getNpc()).thenReturn(npc);
+		when(menuEntry.getType()).thenReturn(MenuAction.NPC_FIRST_OPTION);
+		MenuEntryAdded event = new MenuEntryAdded(menuEntry);
+
+		// Act
+		router.onMenuEntryAdded(event);
+
+		// Assert
+		verify(client, never()).getMenu();
+	}
+
+	@Test
+	public void testOnMenuEntryAddedSkipsWhenNoMissingItems()
+	{
+		// Arrange
+		CollectionLogSource source = makeSource("Already Complete Source");
+		when(config.showOverlays()).thenReturn(true);
+		when(npc.getId()).thenReturn(999);
+		when(database.getSourceByNpcId(999)).thenReturn(source);
+		when(guidanceCoordinator.isSourceGuided(source)).thenReturn(false);
+		// missingItems is empty — source not in it
+
+		MenuEntry menuEntry = mock(MenuEntry.class);
+		when(menuEntry.getNpc()).thenReturn(npc);
+		when(menuEntry.getType()).thenReturn(MenuAction.NPC_FIRST_OPTION);
+		MenuEntryAdded event = new MenuEntryAdded(menuEntry);
+
+		// Act
+		router.onMenuEntryAdded(event);
+
+		// Assert
+		verify(client, never()).getMenu();
+	}
+
+	// ========================================================================
+	// onMenuOptionClicked — guidance activation
+	// ========================================================================
+
+	@Test
+	public void testOnMenuOptionClickedActivatesGuidanceForGuideOption()
+	{
+		// Arrange
+		CollectionLogSource source = makeSource("Test Source");
+		when(database.getSourceByNpcId(111)).thenReturn(source);
+		Consumer<CollectionLogSource> activateCallback = mock(Consumer.class);
+		router.setActivateGuidanceCallback(activateCallback);
+
+		MenuEntry menuEntry = mock(MenuEntry.class);
+		when(menuEntry.getType()).thenReturn(MenuAction.RUNELITE);
+		when(menuEntry.getOption()).thenReturn(GuidanceEventRouter.MENU_OPTION_GUIDE);
+		when(menuEntry.getIdentifier()).thenReturn(111);
+		MenuOptionClicked event = new MenuOptionClicked(menuEntry);
+
+		// Act
+		router.onMenuOptionClicked(event);
+
+		// Assert
+		verify(activateCallback).accept(source);
+	}
+
+	@Test
+	public void testOnMenuOptionClickedDoesNotActivateWhenSourceNotFound()
+	{
+		// Arrange
+		when(database.getSourceByNpcId(anyInt())).thenReturn(null);
+		Consumer<CollectionLogSource> activateCallback = mock(Consumer.class);
+		router.setActivateGuidanceCallback(activateCallback);
+
+		MenuEntry menuEntry = mock(MenuEntry.class);
+		when(menuEntry.getType()).thenReturn(MenuAction.RUNELITE);
+		when(menuEntry.getOption()).thenReturn(GuidanceEventRouter.MENU_OPTION_GUIDE);
+		MenuOptionClicked event = new MenuOptionClicked(menuEntry);
+
+		// Act
+		router.onMenuOptionClicked(event);
+
+		// Assert
+		verify(activateCallback, never()).accept(any());
+	}
+
+	@Test
+	public void testOnMenuOptionClickedForwardsCumulativeTrackAction()
+	{
+		// Arrange
+		List<Integer> objectIds = Arrays.asList(1000, 1001);
+		CollectionLogSource source = makeSourceWithTrack(500, objectIds);
+		when(guidanceSequencer.isActive()).thenReturn(true);
+		when(guidanceSequencer.getActiveSource()).thenReturn(source);
+
+		MenuEntry menuEntry = mock(MenuEntry.class);
+		when(menuEntry.getType()).thenReturn(MenuAction.WIDGET_TARGET_ON_GAME_OBJECT);
+		when(menuEntry.getIdentifier()).thenReturn(1000); // matching object ID
+		when(menuEntry.getParam0()).thenReturn(500);       // matching item ID
+		MenuOptionClicked event = new MenuOptionClicked(menuEntry);
+
+		// Act
+		router.onMenuOptionClicked(event);
+
+		// Assert
+		verify(guidanceSequencer).onTrackedAction();
+	}
+
+	@Test
+	public void testOnMenuOptionClickedForwardsNpcInteraction()
+	{
+		// Arrange
+		when(guidanceSequencer.isActive()).thenReturn(true);
+		when(npc.getId()).thenReturn(321);
+		MenuEntry menuEntry = mock(MenuEntry.class);
+		when(menuEntry.getNpc()).thenReturn(npc);
+		when(menuEntry.getType()).thenReturn(MenuAction.NPC_FIRST_OPTION);
+		MenuOptionClicked event = new MenuOptionClicked(menuEntry);
+
+		// Act
+		router.onMenuOptionClicked(event);
+
+		// Assert
+		verify(guidanceSequencer).onNpcInteracted(321);
+	}
+
+	// ========================================================================
+	// Setter null-safety
+	// ========================================================================
+
+	@Test
+	public void testMissingItemsSupplierNullSafety()
+	{
+		// Arrange — null supplier
+		router.setMissingItemsSupplier(null);
+		CollectionLogSource source = makeSource("Some Source");
+		when(config.showOverlays()).thenReturn(true);
+		when(npc.getId()).thenReturn(777);
+		when(database.getSourceByNpcId(777)).thenReturn(source);
+		when(guidanceCoordinator.isSourceGuided(source)).thenReturn(false);
+
+		MenuEntry menuEntry = mock(MenuEntry.class);
+		when(menuEntry.getNpc()).thenReturn(npc);
+		when(menuEntry.getType()).thenReturn(MenuAction.NPC_FIRST_OPTION);
+		MenuEntryAdded event = new MenuEntryAdded(menuEntry);
+
+		// Act — should not throw
+		router.onMenuEntryAdded(event);
+
+		// Assert — no menu entry added when supplier is null
+		verify(client, never()).getMenu();
+	}
+}


### PR DESCRIPTION
## Summary

- Extracts `GuidanceEventRouter` from `CollectionLogHelperPlugin` to drop the plugin class from 1,281 to **904 LOC**. Closes A2 in docs/ROADMAP.md.
- Also removes two dead private methods (`authoringLog`, `logContainerChange`) that were superseded by `AuthoringLogger` in a prior PR but never cleaned up.

## LOC before / after

| File | Before | After |
|------|--------|-------|
| `CollectionLogHelperPlugin.java` | 1,281 | **904** |
| `GuidanceEventRouter.java` | — | 452 (new) |

## @Subscribe handlers moved

| Event | New location |
|-------|-------------|
| `ActorDeath` | `GuidanceEventRouter` |
| `AnimationChanged` | `GuidanceEventRouter` |
| `NpcSpawned` | `GuidanceEventRouter` |
| `NpcDespawned` | `GuidanceEventRouter` |
| `InteractingChanged` | `GuidanceEventRouter` |
| `HitsplatApplied` | `GuidanceEventRouter` |
| `WidgetLoaded` | `GuidanceEventRouter` |
| `MenuEntryAdded` | `GuidanceEventRouter` |
| `MenuOptionClicked` | `GuidanceEventRouter` |

## Design

`GuidanceEventRouter` mirrors `SceneEventRouter`'s shape:
- `@Singleton`, constructor-injected deps, registered on `EventBus` in `startUp()` / unregistered in `shutDown()`
- Two post-init setters called from `startUp()`: `setMissingItemsSupplier(() -> sourcesWithMissingItems)` and `setActivateGuidanceCallback(this::activateGuidance)` — same pattern as `SceneEventRouter.setAuthoringLogger(...)`

## Test plan

- 26 new tests in `GuidanceEventRouterTest` — all green
- All 420 pre-existing tests still green (446 total)
- `./gradlew build` clean

## Milestone reference

Part of A2 in docs/ROADMAP.md (Tier A — Plugin Hub resubmission polish). Mark A2 done after merge.