### PR TITLE
docs: mark A2, A3, A4 done in status log

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -493,9 +493,9 @@ Focus: god-object decomposition, build hardening, test expansion. Resulted in th
 **Tier A — Production polish for Plugin Hub resubmission**
 
 - [ ] A1 — Panel decomposition                          status: planned       owner: —          updated: 2026-04-16
-- [ ] A2 — Plugin class <1,000 LOC                       status: planned       owner: —          updated: 2026-04-16  note: currently 1,281 LOC
-- [ ] A3 — Issue triage & labels                         status: planned       owner: —          updated: 2026-04-16
-- [ ] A4 — Plugin Hub self-review doc                    status: planned       owner: —          updated: 2026-04-16
+- [x] A2 — Plugin class <1,000 LOC                       status: done          owner: cha-ndler  updated: 2026-04-17  pr: #347  note: 1,281 → 904 LOC via GuidanceEventRouter extraction
+- [x] A3 — Issue triage & labels                         status: done          owner: cha-ndler  updated: 2026-04-17  note: GitHub-only — summary in #345; 10 labels created, #319 closed, #323/#314/#306/#134 labeled
+- [x] A4 — Plugin Hub self-review doc                    status: done          owner: cha-ndler  updated: 2026-04-17  pr: #346  note: 27 green / 3 yellow / 2 red — docs/plugin-hub-review.md
 - [x] A5 — Screenshots refresh                           status: done          owner: cha-ndler  updated: 2026-04-16  note: docs/screenshots/ populated
 - [ ] A6 — Tag v1.0.0-hub, wait a week, resubmit         status: planned       owner: —          updated: 2026-04-16
 


### PR DESCRIPTION
## Summary

Batched ROADMAP.md status update after Wave 1 of Tier A polish. Three-line diff.

- **A2** `[ ]` planned → `[x]` done — PR #347 (plugin class 1,281 → 904 LOC via `GuidanceEventRouter` extraction)
- **A3** `[ ]` planned → `[x]` done — GitHub-only milestone (summary issue #345; 10 labels created, #319 closed, #323/#314/#306/#134 labeled)
- **A4** `[ ]` planned → `[x]` done — PR #346 (`docs/plugin-hub-review.md`; 27 green / 3 yellow / 2 red)

## Test plan

- [x] No code changes — docs only
- [x] `git diff origin/master -- docs/ROADMAP.md` shows exactly 3 line changes