### PR TITLE
refactor(panel): decompose CollectionLogHelperPanel into per-mode controllers (A1)

### DIFF
--- a/src/main/java/com/collectionloghelper/ui/CategorySummaryPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/CategorySummaryPanel.java
@@ -42,7 +42,7 @@ import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
 
-class CategorySummaryPanel extends JPanel
+public class CategorySummaryPanel extends JPanel
 {
 	private static final Color PROGRESS_BAR_COLOR = new Color(0, 200, 0);
 	private static final Color PROGRESS_BG_COLOR = new Color(60, 60, 60);
@@ -63,7 +63,7 @@ class CategorySummaryPanel extends JPanel
 	private ItemClickHandler lazyClickHandler;
 	private boolean lazyHideObtained;
 
-	CategorySummaryPanel(CollectionLogCategory category, List<CollectionLogSource> sources,
+	public CategorySummaryPanel(CollectionLogCategory category, List<CollectionLogSource> sources,
 		PlayerCollectionState collectionState, RequirementsChecker requirementsChecker,
 		ItemManager itemManager, ItemClickHandler clickHandler, boolean hideObtained)
 	{
@@ -197,7 +197,7 @@ class CategorySummaryPanel extends JPanel
 			categoryName, obtained, total));
 	}
 
-	interface ItemClickHandler
+	public interface ItemClickHandler
 	{
 		void onItemClicked(CollectionLogItem item, CollectionLogSource source);
 	}

--- a/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
@@ -44,6 +44,7 @@ import com.collectionloghelper.efficiency.ScoredItem;
 import com.collectionloghelper.efficiency.SlayerStrategyCalculator;
 import com.collectionloghelper.ui.mode.PanelModeController;
 import com.collectionloghelper.ui.mode.PanelShellContext;
+import com.collectionloghelper.ui.mode.PetHuntModeController;
 import com.collectionloghelper.ui.mode.StatisticsModeController;
 import java.util.EnumMap;
 import java.util.Map;
@@ -583,6 +584,9 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 		// Mode controllers — populated once, dispatched from rebuild()
 		modeControllers.put(Mode.STATISTICS,
 			new StatisticsModeController(this, collectionState, database, calculator));
+		modeControllers.put(Mode.PET_HUNT,
+			new PetHuntModeController(this, config, collectionState, calculator,
+				requirementsChecker, itemManager));
 
 		updateControlVisibility();
 	}
@@ -860,7 +864,7 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 							buildSearchView();
 							break;
 						case PET_HUNT:
-							buildPetHuntView();
+							// Extracted to PetHuntModeController (registered in modeControllers).
 							break;
 						case STATISTICS:
 							// Extracted to StatisticsModeController (registered in modeControllers).
@@ -1102,48 +1106,6 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 			// Escape query to prevent HTML injection in the JLabel
 			String safeQuery = query.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
 			addEmptyStateMessage("No items match '" + safeQuery + "'");
-		}
-	}
-
-	private void buildPetHuntView()
-	{
-		List<ScoredItem> scored = calculator.filterPetsOnly();
-		boolean hideObtained = config.hideObtainedItems();
-		int resultCount = 0;
-
-		for (ScoredItem si : scored)
-		{
-			boolean onTask = calculator.isOnSlayerTask(si.getSource());
-			for (CollectionLogItem item : si.getSource().getItems())
-			{
-				if (!item.isPet())
-				{
-					continue;
-				}
-				boolean obtained = collectionState.isItemObtained(item.getItemId());
-				if (hideObtained && obtained)
-				{
-					continue;
-				}
-				ItemRowPanel row = new ItemRowPanel(item, si.getSource(), obtained,
-					si.getScore(), si.isLocked(), onTask,
-					requirementsChecker.getUnmetRequirements(si.getSource().getName()),
-					itemManager, () -> showDetail(item, si.getSource()));
-				listContainer.add(row);
-				resultCount++;
-			}
-		}
-
-		if (resultCount == 0)
-		{
-			if (config.afkFilter().getMinAfkLevel() > 0)
-			{
-				addEmptyStateMessage("No pets match the current AFK filter.<br>Try a lower Efficient AFK setting.");
-			}
-			else
-			{
-				addEmptyStateMessage("All pets obtained!");
-			}
 		}
 	}
 

--- a/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
@@ -45,6 +45,7 @@ import com.collectionloghelper.efficiency.SlayerStrategyCalculator;
 import com.collectionloghelper.ui.mode.CategoryModeController;
 import com.collectionloghelper.ui.mode.EfficientModeController;
 import com.collectionloghelper.ui.mode.PanelModeController;
+import com.collectionloghelper.ui.mode.PanelModeDispatcher;
 import com.collectionloghelper.ui.mode.PanelShellContext;
 import com.collectionloghelper.ui.mode.PetHuntModeController;
 import com.collectionloghelper.ui.mode.SearchModeController;
@@ -62,8 +63,6 @@ import java.awt.Graphics2D;
 import java.awt.Insets;
 import java.awt.event.ItemEvent;
 import java.awt.image.BufferedImage;
-import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.function.Consumer;
 import javax.swing.BorderFactory;
@@ -80,7 +79,6 @@ import javax.swing.JTextField;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
 import javax.swing.Timer;
-import javax.swing.ToolTipManager;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import net.runelite.client.game.ItemManager;
@@ -88,7 +86,6 @@ import net.runelite.client.util.AsyncBufferedImage;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.PluginPanel;
-import net.runelite.client.util.AsyncBufferedImage;
 import net.runelite.client.util.SwingUtil;
 
 public class CollectionLogHelperPanel extends PluginPanel implements PanelShellContext
@@ -189,6 +186,7 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 	private final Timer searchDebounceTimer;
 
 	private final Map<Mode, PanelModeController> modeControllers = new EnumMap<>(Mode.class);
+	private final PanelModeDispatcher<Mode> modeDispatcher = new PanelModeDispatcher<>(modeControllers);
 
 	private Mode currentMode = Mode.EFFICIENT;
 	private boolean rebuilding = false;
@@ -432,16 +430,7 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 			{
 				Mode previous = currentMode;
 				currentMode = (Mode) e.getItem();
-				PanelModeController leaving = modeControllers.get(previous);
-				if (leaving != null && previous != currentMode)
-				{
-					leaving.onModeDeactivated();
-				}
-				PanelModeController entering = modeControllers.get(currentMode);
-				if (entering != null && previous != currentMode)
-				{
-					entering.onModeActivated();
-				}
+				modeDispatcher.switchMode(previous, currentMode);
 				updateControlVisibility();
 				inDetailView = false;
 				rebuild();
@@ -857,15 +846,7 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 				updateCompletionHeader();
 				updateSlayerTaskLabel();
 
-				PanelModeController controller = modeControllers.get(currentMode);
-				if (controller != null)
-				{
-					controller.buildView();
-				}
-				else
-				{
-					// All modes are controller-backed; fallback branch is unused.
-				}
+				modeDispatcher.buildView(currentMode);
 
 				// Restore expanded category state
 				for (Component comp : listContainer.getComponents())
@@ -942,7 +923,8 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 		}
 	}
 
-	private void showDetailInternal(CollectionLogItem item, CollectionLogSource source)
+	@Override
+	public void showDetail(CollectionLogItem item, CollectionLogSource source)
 	{
 		boolean obtained = collectionState.isItemObtained(item.getItemId());
 		boolean locked = !requirementsChecker.isAccessible(source.getName());
@@ -975,7 +957,8 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 		showDetailView();
 	}
 
-	private JPanel createQuickGuidePanelInternal(ScoredItem topItem)
+	@Override
+	public JPanel createQuickGuidePanel(ScoredItem topItem)
 	{
 		JPanel panel = new JPanel();
 		panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
@@ -1248,7 +1231,8 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 		});
 	}
 
-	private void addEmptyStateMessageInternal(String message)
+	@Override
+	public void addEmptyStateMessage(String message)
 	{
 		JLabel label = new JLabel("<html><center>" + message + "</center></html>");
 		label.setFont(FontManager.getRunescapeSmallFont());
@@ -1275,24 +1259,6 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 	public void addToList(Component component)
 	{
 		listContainer.add(component);
-	}
-
-	@Override
-	public void addEmptyStateMessage(String message)
-	{
-		addEmptyStateMessageInternal(message);
-	}
-
-	@Override
-	public JPanel createQuickGuidePanel(ScoredItem topItem)
-	{
-		return createQuickGuidePanelInternal(topItem);
-	}
-
-	@Override
-	public void showDetail(CollectionLogItem item, CollectionLogSource source)
-	{
-		showDetailInternal(item, source);
 	}
 
 	@Override

--- a/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
@@ -42,6 +42,7 @@ import com.collectionloghelper.efficiency.ClueCompletionEstimator;
 import com.collectionloghelper.efficiency.EfficiencyCalculator;
 import com.collectionloghelper.efficiency.ScoredItem;
 import com.collectionloghelper.efficiency.SlayerStrategyCalculator;
+import com.collectionloghelper.ui.mode.CategoryModeController;
 import com.collectionloghelper.ui.mode.PanelModeController;
 import com.collectionloghelper.ui.mode.PanelShellContext;
 import com.collectionloghelper.ui.mode.PetHuntModeController;
@@ -591,6 +592,9 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 		modeControllers.put(Mode.SEARCH,
 			new SearchModeController(this, config, database, collectionState, calculator,
 				requirementsChecker, itemManager));
+		modeControllers.put(Mode.CATEGORY_FOCUS,
+			new CategoryModeController(this, config, database, collectionState, calculator,
+				requirementsChecker, itemManager));
 
 		updateControlVisibility();
 	}
@@ -862,7 +866,7 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 							buildEfficientView();
 							break;
 						case CATEGORY_FOCUS:
-							buildCategoryView();
+							// Extracted to CategoryModeController (registered in modeControllers).
 							break;
 						case SEARCH:
 							// Extracted to SearchModeController (registered in modeControllers).
@@ -1039,28 +1043,6 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 				}
 			}
 		}
-	}
-
-	private void buildCategoryView()
-	{
-		CollectionLogCategory category = (CollectionLogCategory) categorySelector.getSelectedItem();
-		if (category == null)
-		{
-			return;
-		}
-
-		// Top Pick for this category — always an accessible source
-		List<ScoredItem> categoryScored = calculator.filterByCategory(category);
-		categoryScored.stream()
-			.filter(s -> !s.isLocked())
-			.findFirst()
-			.ifPresent(topPick -> listContainer.add(createQuickGuidePanel(topPick)));
-
-		List<CollectionLogSource> sources = database.getSourcesByCategory(category);
-		CategorySummaryPanel summary = new CategorySummaryPanel(
-			category, sources, collectionState, requirementsChecker, itemManager,
-			this::showDetail, config.hideObtainedItems());
-		listContainer.add(summary);
 	}
 
 	private void showDetailInternal(CollectionLogItem item, CollectionLogSource source)

--- a/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
@@ -45,6 +45,7 @@ import com.collectionloghelper.efficiency.SlayerStrategyCalculator;
 import com.collectionloghelper.ui.mode.PanelModeController;
 import com.collectionloghelper.ui.mode.PanelShellContext;
 import com.collectionloghelper.ui.mode.PetHuntModeController;
+import com.collectionloghelper.ui.mode.SearchModeController;
 import com.collectionloghelper.ui.mode.StatisticsModeController;
 import java.util.EnumMap;
 import java.util.Map;
@@ -587,6 +588,9 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 		modeControllers.put(Mode.PET_HUNT,
 			new PetHuntModeController(this, config, collectionState, calculator,
 				requirementsChecker, itemManager));
+		modeControllers.put(Mode.SEARCH,
+			new SearchModeController(this, config, database, collectionState, calculator,
+				requirementsChecker, itemManager));
 
 		updateControlVisibility();
 	}
@@ -861,7 +865,7 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 							buildCategoryView();
 							break;
 						case SEARCH:
-							buildSearchView();
+							// Extracted to SearchModeController (registered in modeControllers).
 							break;
 						case PET_HUNT:
 							// Extracted to PetHuntModeController (registered in modeControllers).
@@ -1057,56 +1061,6 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 			category, sources, collectionState, requirementsChecker, itemManager,
 			this::showDetail, config.hideObtainedItems());
 		listContainer.add(summary);
-	}
-
-	private void buildSearchView()
-	{
-		String query = searchField.getText().toLowerCase().trim();
-		if (query.isEmpty())
-		{
-			addEmptyStateMessage("Search by item or source name");
-			return;
-		}
-
-		boolean hideObtained = config.hideObtainedItems();
-		boolean hideLocked = config.hideLockedContent();
-		int resultCount = 0;
-
-		for (CollectionLogSource source : database.getAllSources())
-		{
-			boolean locked = !requirementsChecker.isAccessible(source.getName());
-			if (hideLocked && locked)
-			{
-				continue;
-			}
-
-			boolean sourceNameMatches = source.getName().toLowerCase().contains(query);
-			boolean onTask = calculator.isOnSlayerTask(source);
-			for (CollectionLogItem item : source.getItems())
-			{
-				if (sourceNameMatches || item.getName().toLowerCase().contains(query))
-				{
-					boolean obtained = collectionState.isItemObtained(item.getItemId());
-					if (hideObtained && obtained)
-					{
-						continue;
-					}
-					ItemRowPanel row = new ItemRowPanel(item, source, obtained, 0,
-						locked, onTask,
-						requirementsChecker.getUnmetRequirements(source.getName()),
-						itemManager, () -> showDetail(item, source));
-					listContainer.add(row);
-					resultCount++;
-				}
-			}
-		}
-
-		if (resultCount == 0)
-		{
-			// Escape query to prevent HTML injection in the JLabel
-			String safeQuery = query.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
-			addEmptyStateMessage("No items match '" + safeQuery + "'");
-		}
 	}
 
 	private void showDetailInternal(CollectionLogItem item, CollectionLogSource source)

--- a/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
@@ -42,6 +42,11 @@ import com.collectionloghelper.efficiency.ClueCompletionEstimator;
 import com.collectionloghelper.efficiency.EfficiencyCalculator;
 import com.collectionloghelper.efficiency.ScoredItem;
 import com.collectionloghelper.efficiency.SlayerStrategyCalculator;
+import com.collectionloghelper.ui.mode.PanelModeController;
+import com.collectionloghelper.ui.mode.PanelShellContext;
+import com.collectionloghelper.ui.mode.StatisticsModeController;
+import java.util.EnumMap;
+import java.util.Map;
 import java.awt.BorderLayout;
 import java.awt.CardLayout;
 import java.awt.Color;
@@ -82,7 +87,7 @@ import net.runelite.client.ui.PluginPanel;
 import net.runelite.client.util.AsyncBufferedImage;
 import net.runelite.client.util.SwingUtil;
 
-public class CollectionLogHelperPanel extends PluginPanel
+public class CollectionLogHelperPanel extends PluginPanel implements PanelShellContext
 {
 	private static final Color GUIDE_ME_COLOR = new Color(30, 120, 30);
 	private static final Color STOP_GUIDANCE_COLOR = new Color(140, 30, 30);
@@ -178,6 +183,8 @@ public class CollectionLogHelperPanel extends PluginPanel
 	private Runnable stepSkipper;
 
 	private final Timer searchDebounceTimer;
+
+	private final Map<Mode, PanelModeController> modeControllers = new EnumMap<>(Mode.class);
 
 	private Mode currentMode = Mode.EFFICIENT;
 	private boolean rebuilding = false;
@@ -419,7 +426,18 @@ public class CollectionLogHelperPanel extends PluginPanel
 		{
 			if (e.getStateChange() == ItemEvent.SELECTED)
 			{
+				Mode previous = currentMode;
 				currentMode = (Mode) e.getItem();
+				PanelModeController leaving = modeControllers.get(previous);
+				if (leaving != null && previous != currentMode)
+				{
+					leaving.onModeDeactivated();
+				}
+				PanelModeController entering = modeControllers.get(currentMode);
+				if (entering != null && previous != currentMode)
+				{
+					entering.onModeActivated();
+				}
 				updateControlVisibility();
 				inDetailView = false;
 				rebuild();
@@ -561,6 +579,10 @@ public class CollectionLogHelperPanel extends PluginPanel
 		contentPanel.add(detailView, "detail");
 
 		add(contentPanel, BorderLayout.CENTER);
+
+		// Mode controllers — populated once, dispatched from rebuild()
+		modeControllers.put(Mode.STATISTICS,
+			new StatisticsModeController(this, collectionState, database, calculator));
 
 		updateControlVisibility();
 	}
@@ -819,23 +841,31 @@ public class CollectionLogHelperPanel extends PluginPanel
 				updateCompletionHeader();
 				updateSlayerTaskLabel();
 
-				switch (currentMode)
+				PanelModeController controller = modeControllers.get(currentMode);
+				if (controller != null)
 				{
-					case EFFICIENT:
-						buildEfficientView();
-						break;
-					case CATEGORY_FOCUS:
-						buildCategoryView();
-						break;
-					case SEARCH:
-						buildSearchView();
-						break;
-					case PET_HUNT:
-						buildPetHuntView();
-						break;
-					case STATISTICS:
-						buildStatsView();
-						break;
+					controller.buildView();
+				}
+				else
+				{
+					switch (currentMode)
+					{
+						case EFFICIENT:
+							buildEfficientView();
+							break;
+						case CATEGORY_FOCUS:
+							buildCategoryView();
+							break;
+						case SEARCH:
+							buildSearchView();
+							break;
+						case PET_HUNT:
+							buildPetHuntView();
+							break;
+						case STATISTICS:
+							// Extracted to StatisticsModeController (registered in modeControllers).
+							break;
+					}
 				}
 
 				// Restore expanded category state
@@ -1117,222 +1147,7 @@ public class CollectionLogHelperPanel extends PluginPanel
 		}
 	}
 
-	private void buildStatsView()
-	{
-		// Overall summary — use varp-based counts for accurate deduplicated totals
-		int totalObtained = collectionState.getTotalObtained();
-		int totalItems = collectionState.getTotalPossible();
-		double overallPct = collectionState.getCompletionPercentage();
-
-		String overallText = String.format("%d / %d (%.1f%%)", totalObtained, totalItems, overallPct);
-
-		JPanel overallPanel = new JPanel(new BorderLayout(5, 2));
-		overallPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
-		overallPanel.setBorder(BorderFactory.createEmptyBorder(8, 8, 8, 8));
-		overallPanel.setToolTipText("Collection Log: " + overallText);
-
-		JLabel overallLabel = new JLabel(overallText);
-		overallLabel.setFont(FontManager.getRunescapeBoldFont());
-		overallLabel.setForeground(Color.WHITE);
-		overallPanel.add(overallLabel, BorderLayout.NORTH);
-
-		JPanel overallBar = createProgressBar(totalObtained, totalItems);
-		overallPanel.add(overallBar, BorderLayout.SOUTH);
-		listContainer.add(overallPanel);
-
-		listContainer.add(javax.swing.Box.createVerticalStrut(4));
-
-		// Per-category breakdown
-		for (CollectionLogCategory category : CollectionLogCategory.values())
-		{
-			List<CollectionLogSource> sources = database.getSourcesByCategory(category);
-			if (sources == null || sources.isEmpty())
-			{
-				continue;
-			}
-
-			int catSources = sources.size();
-			int catSourcesComplete = 0;
-
-			// Use varp-based counts for categories the game tracks (deduplicated),
-			// fall back to manual counting for SLAYER/SKILLING (no game varps)
-			int varpCount = collectionState.getCategoryCount(category);
-			int varpMax = collectionState.getCategoryMax(category);
-			boolean useVarps = varpMax > 0;
-
-			int catObtained = 0;
-			int catTotal = 0;
-
-			for (CollectionLogSource source : sources)
-			{
-				boolean sourceComplete = true;
-				for (CollectionLogItem item : source.getItems())
-				{
-					if (!useVarps)
-					{
-						catTotal++;
-						if (collectionState.isItemObtained(item.getItemId()))
-						{
-							catObtained++;
-						}
-						else
-						{
-							sourceComplete = false;
-						}
-					}
-					else
-					{
-						if (!collectionState.isItemObtained(item.getItemId()))
-						{
-							sourceComplete = false;
-						}
-					}
-				}
-				if (sourceComplete)
-				{
-					catSourcesComplete++;
-				}
-			}
-
-			if (useVarps)
-			{
-				catObtained = varpCount;
-				catTotal = varpMax;
-			}
-
-			double catPct = catTotal > 0 ? 100.0 * catObtained / catTotal : 0;
-
-			String countText = String.format("%d / %d (%.1f%%)", catObtained, catTotal, catPct);
-
-			// Estimate remaining hours from efficiency scores
-			double totalHours = 0;
-			List<ScoredItem> categoryScored = calculator.filterByCategory(category);
-			for (ScoredItem si : categoryScored)
-			{
-				if (si.getScore() > 0)
-				{
-					totalHours += 100.0 / si.getScore();
-				}
-			}
-
-			String timeStr;
-			if (totalHours <= 0 || catObtained >= catTotal)
-			{
-				timeStr = null;
-			}
-			else if (totalHours < 1)
-			{
-				timeStr = "~" + Math.max(1, Math.round(totalHours * 60)) + " min left";
-			}
-			else if (totalHours < 24)
-			{
-				timeStr = "~" + Math.round(totalHours) + " hrs left";
-			}
-			else
-			{
-				long days = Math.round(totalHours / 24);
-				timeStr = "~" + days + (days == 1 ? " day left" : " days left");
-			}
-
-			JPanel catPanel = new JPanel(new BorderLayout(5, 2));
-			catPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
-			catPanel.setBorder(BorderFactory.createEmptyBorder(6, 8, 6, 8));
-
-			// Tooltip with full details for truncated text
-			String tooltip = String.format("%s: %s | %d sources, %d complete",
-				category.getDisplayName(), countText, catSources, catSourcesComplete);
-			if (timeStr != null)
-			{
-				tooltip += " | " + timeStr;
-			}
-			catPanel.setToolTipText(tooltip);
-
-			// Header: category name (bold) + count (right, small)
-			JLabel catNameLabel = new JLabel(category.getDisplayName());
-			catNameLabel.setFont(FontManager.getRunescapeBoldFont());
-			catNameLabel.setForeground(Color.WHITE);
-
-			JLabel catCountLabel = new JLabel(countText);
-			catCountLabel.setFont(FontManager.getRunescapeSmallFont());
-			catCountLabel.setForeground(ColorScheme.LIGHT_GRAY_COLOR);
-			catCountLabel.setHorizontalAlignment(SwingConstants.RIGHT);
-
-			JPanel catHeader = new JPanel(new BorderLayout());
-			catHeader.setOpaque(false);
-			catHeader.add(catNameLabel, BorderLayout.WEST);
-			catHeader.add(catCountLabel, BorderLayout.EAST);
-			catPanel.add(catHeader, BorderLayout.NORTH);
-
-			JPanel catBar = createProgressBar(catObtained, catTotal);
-			catPanel.add(catBar, BorderLayout.CENTER);
-
-			// Footer: source count (left) + time estimate (right)
-			String footerText = catSources + " sources, " + catSourcesComplete + " complete";
-			if (timeStr != null)
-			{
-				footerText += "  |  " + timeStr;
-			}
-			JLabel catFooterLabel = new JLabel(footerText);
-			catFooterLabel.setFont(FontManager.getRunescapeSmallFont());
-			catFooterLabel.setForeground(timeStr != null
-				? new Color(255, 200, 0) : ColorScheme.LIGHT_GRAY_COLOR);
-			catPanel.add(catFooterLabel, BorderLayout.SOUTH);
-
-			// Click to navigate to Category Focus mode
-			final CollectionLogCategory clickedCategory = category;
-			catPanel.setCursor(new java.awt.Cursor(java.awt.Cursor.HAND_CURSOR));
-			catPanel.addMouseListener(new java.awt.event.MouseAdapter()
-			{
-				@Override
-				public void mousePressed(java.awt.event.MouseEvent e)
-				{
-					categorySelector.setSelectedItem(clickedCategory);
-					modeSelector.setSelectedItem(Mode.CATEGORY_FOCUS);
-				}
-
-				@Override
-				public void mouseEntered(java.awt.event.MouseEvent e)
-				{
-					catPanel.setBackground(ColorScheme.DARKER_GRAY_HOVER_COLOR);
-				}
-
-				@Override
-				public void mouseExited(java.awt.event.MouseEvent e)
-				{
-					catPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
-				}
-			});
-
-			listContainer.add(catPanel);
-			listContainer.add(javax.swing.Box.createVerticalStrut(2));
-		}
-	}
-
-	private JPanel createProgressBar(int obtained, int total)
-	{
-		final double pct = total > 0 ? (double) obtained / total : 0;
-		JPanel bar = new JPanel()
-		{
-			@Override
-			protected void paintComponent(java.awt.Graphics g)
-			{
-				super.paintComponent(g);
-				int w = getWidth();
-				int h = getHeight();
-				g.setColor(new Color(60, 60, 60));
-				g.fillRect(0, 0, w, h);
-				if (pct > 0)
-				{
-					g.setColor(new Color(0, 200, 0));
-					g.fillRect(0, 0, (int) (w * pct), h);
-				}
-			}
-		};
-		bar.setPreferredSize(new Dimension(0, 6));
-		return bar;
-	}
-
-	private void showDetail(CollectionLogItem item, CollectionLogSource source)
+	private void showDetailInternal(CollectionLogItem item, CollectionLogSource source)
 	{
 		boolean obtained = collectionState.isItemObtained(item.getItemId());
 		boolean locked = !requirementsChecker.isAccessible(source.getName());
@@ -1365,7 +1180,7 @@ public class CollectionLogHelperPanel extends PluginPanel
 		showDetailView();
 	}
 
-	private JPanel createQuickGuidePanel(ScoredItem topItem)
+	private JPanel createQuickGuidePanelInternal(ScoredItem topItem)
 	{
 		JPanel panel = new JPanel();
 		panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
@@ -1638,7 +1453,7 @@ public class CollectionLogHelperPanel extends PluginPanel
 		});
 	}
 
-	private void addEmptyStateMessage(String message)
+	private void addEmptyStateMessageInternal(String message)
 	{
 		JLabel label = new JLabel("<html><center>" + message + "</center></html>");
 		label.setFont(FontManager.getRunescapeSmallFont());
@@ -1657,5 +1472,56 @@ public class CollectionLogHelperPanel extends PluginPanel
 		sortSelector.setVisible(currentMode == Mode.EFFICIENT);
 		categorySelector.setVisible(currentMode == Mode.CATEGORY_FOCUS);
 		searchField.setVisible(currentMode == Mode.SEARCH);
+	}
+
+	// ── PanelShellContext implementation ────────────────────────────────────
+
+	@Override
+	public void addToList(Component component)
+	{
+		listContainer.add(component);
+	}
+
+	@Override
+	public void addEmptyStateMessage(String message)
+	{
+		addEmptyStateMessageInternal(message);
+	}
+
+	@Override
+	public JPanel createQuickGuidePanel(ScoredItem topItem)
+	{
+		return createQuickGuidePanelInternal(topItem);
+	}
+
+	@Override
+	public void showDetail(CollectionLogItem item, CollectionLogSource source)
+	{
+		showDetailInternal(item, source);
+	}
+
+	@Override
+	public void switchToCategoryFocus(CollectionLogCategory category)
+	{
+		categorySelector.setSelectedItem(category);
+		modeSelector.setSelectedItem(Mode.CATEGORY_FOCUS);
+	}
+
+	@Override
+	public String getSearchQuery()
+	{
+		return searchField.getText() == null ? "" : searchField.getText().toLowerCase().trim();
+	}
+
+	@Override
+	public EfficientSortMode getEfficientSortMode()
+	{
+		return (EfficientSortMode) sortSelector.getSelectedItem();
+	}
+
+	@Override
+	public CollectionLogCategory getSelectedCategory()
+	{
+		return (CollectionLogCategory) categorySelector.getSelectedItem();
 	}
 }

--- a/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
@@ -43,6 +43,7 @@ import com.collectionloghelper.efficiency.EfficiencyCalculator;
 import com.collectionloghelper.efficiency.ScoredItem;
 import com.collectionloghelper.efficiency.SlayerStrategyCalculator;
 import com.collectionloghelper.ui.mode.CategoryModeController;
+import com.collectionloghelper.ui.mode.EfficientModeController;
 import com.collectionloghelper.ui.mode.PanelModeController;
 import com.collectionloghelper.ui.mode.PanelShellContext;
 import com.collectionloghelper.ui.mode.PetHuntModeController;
@@ -595,6 +596,9 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 		modeControllers.put(Mode.CATEGORY_FOCUS,
 			new CategoryModeController(this, config, database, collectionState, calculator,
 				requirementsChecker, itemManager));
+		modeControllers.put(Mode.EFFICIENT,
+			new EfficientModeController(this, config, collectionState, calculator,
+				requirementsChecker, itemManager));
 
 		updateControlVisibility();
 	}
@@ -860,24 +864,7 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 				}
 				else
 				{
-					switch (currentMode)
-					{
-						case EFFICIENT:
-							buildEfficientView();
-							break;
-						case CATEGORY_FOCUS:
-							// Extracted to CategoryModeController (registered in modeControllers).
-							break;
-						case SEARCH:
-							// Extracted to SearchModeController (registered in modeControllers).
-							break;
-						case PET_HUNT:
-							// Extracted to PetHuntModeController (registered in modeControllers).
-							break;
-						case STATISTICS:
-							// Extracted to StatisticsModeController (registered in modeControllers).
-							break;
-					}
+					// All modes are controller-backed; fallback branch is unused.
 				}
 
 				// Restore expanded category state
@@ -952,96 +939,6 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 		if (scrollPane != null)
 		{
 			scrollPane.getVerticalScrollBar().setValue(0);
-		}
-	}
-
-	private void buildEfficientView()
-	{
-		List<ScoredItem> scored = calculator.rankByEfficiency();
-		EfficientSortMode sortMode = (EfficientSortMode) sortSelector.getSelectedItem();
-		if (sortMode != null && sortMode != EfficientSortMode.EFFICIENCY)
-		{
-			scored = new ArrayList<>(scored);
-			switch (sortMode)
-			{
-				case KILL_TIME:
-					scored.sort(Comparator.comparingDouble(s -> s.getSource().getKillTimeSeconds()));
-					break;
-				case DROP_RATE:
-					scored.sort(Comparator.comparingDouble(ScoredItem::getDropOnlyScore).reversed());
-					break;
-				case ALPHABETICAL:
-					scored.sort(Comparator.comparing(s -> s.getSource().getName()));
-					break;
-				case ITEMS_REMAINING:
-					scored.sort(Comparator.comparingInt(ScoredItem::getMissingItemCount).reversed());
-					break;
-				case COMPLETION_PERCENTAGE:
-					scored.sort(Comparator.comparingDouble((ScoredItem s) ->
-					{
-						int total = s.getSource().getItems().size();
-						return total > 0 ? (double) (total - s.getMissingItemCount()) / total : 0;
-					}).reversed());
-					break;
-			}
-		}
-		boolean hideObtained = config.hideObtainedItems();
-
-		if (scored.isEmpty())
-		{
-			if (config.afkFilter().getMinAfkLevel() > 0)
-			{
-				addEmptyStateMessage("No sources match the current AFK filter.<br>Try a lower Efficient AFK setting.");
-			}
-			else if (config.hideLockedContent())
-			{
-				addEmptyStateMessage("All sources are locked or completed.<br>Adjust filters to see more.");
-			}
-			else
-			{
-				addEmptyStateMessage("All items obtained. Congratulations!");
-			}
-			return;
-		}
-
-		// Top Pick should always be an accessible (unlocked) source
-		scored.stream()
-			.filter(s -> !s.isLocked())
-			.findFirst()
-			.ifPresent(topPick -> listContainer.add(createQuickGuidePanel(topPick)));
-
-		for (ScoredItem si : scored)
-		{
-			boolean onTask = calculator.isOnSlayerTask(si.getSource());
-
-			// Show the best (fastest-to-obtain) item per source, but use
-			// the source-level score for the time display so the displayed
-			// time matches the sort order.
-			CollectionLogItem bestItem = si.getBestItem();
-			if (bestItem != null && !collectionState.isItemObtained(bestItem.getItemId()))
-			{
-				ItemRowPanel row = new ItemRowPanel(bestItem, si.getSource(), false,
-					si.getScore(), si.isLocked(), onTask,
-					requirementsChecker.getUnmetRequirements(si.getSource().getName()),
-					itemManager, () -> showDetail(bestItem, si.getSource()));
-				listContainer.add(row);
-			}
-			else
-			{
-				// Fallback: show first missing item if bestItem is null or already obtained
-				for (CollectionLogItem item : si.getSource().getItems())
-				{
-					if (!collectionState.isItemObtained(item.getItemId()))
-					{
-						ItemRowPanel row = new ItemRowPanel(item, si.getSource(), false,
-							si.getScore(), si.isLocked(), onTask,
-							requirementsChecker.getUnmetRequirements(si.getSource().getName()),
-							itemManager, () -> showDetail(item, si.getSource()));
-						listContainer.add(row);
-						break;
-					}
-				}
-			}
 		}
 	}
 

--- a/src/main/java/com/collectionloghelper/ui/ItemRowPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/ItemRowPanel.java
@@ -41,7 +41,7 @@ import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.util.AsyncBufferedImage;
 
-class ItemRowPanel extends JPanel
+public class ItemRowPanel extends JPanel
 {
 	private static final Color OBTAINED_COLOR = new Color(0, 100, 0, 80);
 	private static final Color LOCKED_COLOR = new Color(50, 40, 40);
@@ -52,7 +52,7 @@ class ItemRowPanel extends JPanel
 	private final CollectionLogItem item;
 	private final CollectionLogSource source;
 
-	ItemRowPanel(CollectionLogItem item, CollectionLogSource source, boolean obtained,
+	public ItemRowPanel(CollectionLogItem item, CollectionLogSource source, boolean obtained,
 		double score, boolean locked, List<String> unmetRequirements,
 		ItemManager itemManager, Runnable onClick)
 	{
@@ -60,7 +60,7 @@ class ItemRowPanel extends JPanel
 			itemManager, onClick);
 	}
 
-	ItemRowPanel(CollectionLogItem item, CollectionLogSource source, boolean obtained,
+	public ItemRowPanel(CollectionLogItem item, CollectionLogSource source, boolean obtained,
 		double score, boolean locked, boolean onSlayerTask,
 		List<String> unmetRequirements, ItemManager itemManager, Runnable onClick)
 	{

--- a/src/main/java/com/collectionloghelper/ui/mode/CategoryModeController.java
+++ b/src/main/java/com/collectionloghelper/ui/mode/CategoryModeController.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.ui.mode;
+
+import com.collectionloghelper.CollectionLogHelperConfig;
+import com.collectionloghelper.data.CollectionLogCategory;
+import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.data.DropRateDatabase;
+import com.collectionloghelper.data.PlayerCollectionState;
+import com.collectionloghelper.data.RequirementsChecker;
+import com.collectionloghelper.efficiency.EfficiencyCalculator;
+import com.collectionloghelper.efficiency.ScoredItem;
+import com.collectionloghelper.ui.CategorySummaryPanel;
+import java.util.List;
+import net.runelite.client.game.ItemManager;
+
+/**
+ * Renders the Category Focus mode: a "Top Pick" banner for the currently
+ * selected category plus a {@link CategorySummaryPanel} listing the
+ * category's sources and their items.
+ */
+public class CategoryModeController implements PanelModeController
+{
+	private final PanelShellContext shell;
+	private final CollectionLogHelperConfig config;
+	private final DropRateDatabase database;
+	private final PlayerCollectionState collectionState;
+	private final EfficiencyCalculator calculator;
+	private final RequirementsChecker requirementsChecker;
+	private final ItemManager itemManager;
+
+	public CategoryModeController(
+		PanelShellContext shell,
+		CollectionLogHelperConfig config,
+		DropRateDatabase database,
+		PlayerCollectionState collectionState,
+		EfficiencyCalculator calculator,
+		RequirementsChecker requirementsChecker,
+		ItemManager itemManager)
+	{
+		this.shell = shell;
+		this.config = config;
+		this.database = database;
+		this.collectionState = collectionState;
+		this.calculator = calculator;
+		this.requirementsChecker = requirementsChecker;
+		this.itemManager = itemManager;
+	}
+
+	@Override
+	public void buildView()
+	{
+		CollectionLogCategory category = shell.getSelectedCategory();
+		if (category == null)
+		{
+			return;
+		}
+
+		// Top Pick for this category — always an accessible source
+		List<ScoredItem> categoryScored = calculator.filterByCategory(category);
+		categoryScored.stream()
+			.filter(s -> !s.isLocked())
+			.findFirst()
+			.ifPresent(topPick -> shell.addToList(shell.createQuickGuidePanel(topPick)));
+
+		List<CollectionLogSource> sources = database.getSourcesByCategory(category);
+		CategorySummaryPanel summary = new CategorySummaryPanel(
+			category, sources, collectionState, requirementsChecker, itemManager,
+			shell::showDetail, config.hideObtainedItems());
+		shell.addToList(summary);
+	}
+}

--- a/src/main/java/com/collectionloghelper/ui/mode/EfficientModeController.java
+++ b/src/main/java/com/collectionloghelper/ui/mode/EfficientModeController.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.ui.mode;
+
+import com.collectionloghelper.CollectionLogHelperConfig;
+import com.collectionloghelper.EfficientSortMode;
+import com.collectionloghelper.data.CollectionLogItem;
+import com.collectionloghelper.data.PlayerCollectionState;
+import com.collectionloghelper.data.RequirementsChecker;
+import com.collectionloghelper.efficiency.EfficiencyCalculator;
+import com.collectionloghelper.efficiency.ScoredItem;
+import com.collectionloghelper.ui.ItemRowPanel;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import net.runelite.client.game.ItemManager;
+
+/**
+ * Renders the Efficient mode: all accessible sources ranked by the
+ * efficiency score (or the user-chosen alternate sort). Shows a
+ * "Top Pick" banner for the first accessible source and a per-source
+ * row with the "best" (fastest-to-obtain) missing item.
+ */
+public class EfficientModeController implements PanelModeController
+{
+	private final PanelShellContext shell;
+	private final CollectionLogHelperConfig config;
+	private final PlayerCollectionState collectionState;
+	private final EfficiencyCalculator calculator;
+	private final RequirementsChecker requirementsChecker;
+	private final ItemManager itemManager;
+
+	public EfficientModeController(
+		PanelShellContext shell,
+		CollectionLogHelperConfig config,
+		PlayerCollectionState collectionState,
+		EfficiencyCalculator calculator,
+		RequirementsChecker requirementsChecker,
+		ItemManager itemManager)
+	{
+		this.shell = shell;
+		this.config = config;
+		this.collectionState = collectionState;
+		this.calculator = calculator;
+		this.requirementsChecker = requirementsChecker;
+		this.itemManager = itemManager;
+	}
+
+	@Override
+	public void buildView()
+	{
+		List<ScoredItem> scored = calculator.rankByEfficiency();
+		EfficientSortMode sortMode = shell.getEfficientSortMode();
+		if (sortMode != null && sortMode != EfficientSortMode.EFFICIENCY)
+		{
+			scored = new ArrayList<>(scored);
+			switch (sortMode)
+			{
+				case KILL_TIME:
+					scored.sort(Comparator.comparingDouble(s -> s.getSource().getKillTimeSeconds()));
+					break;
+				case DROP_RATE:
+					scored.sort(Comparator.comparingDouble(ScoredItem::getDropOnlyScore).reversed());
+					break;
+				case ALPHABETICAL:
+					scored.sort(Comparator.comparing(s -> s.getSource().getName()));
+					break;
+				case ITEMS_REMAINING:
+					scored.sort(Comparator.comparingInt(ScoredItem::getMissingItemCount).reversed());
+					break;
+				case COMPLETION_PERCENTAGE:
+					scored.sort(Comparator.comparingDouble((ScoredItem s) ->
+					{
+						int total = s.getSource().getItems().size();
+						return total > 0 ? (double) (total - s.getMissingItemCount()) / total : 0;
+					}).reversed());
+					break;
+			}
+		}
+
+		if (scored.isEmpty())
+		{
+			if (config.afkFilter().getMinAfkLevel() > 0)
+			{
+				shell.addEmptyStateMessage("No sources match the current AFK filter.<br>Try a lower Efficient AFK setting.");
+			}
+			else if (config.hideLockedContent())
+			{
+				shell.addEmptyStateMessage("All sources are locked or completed.<br>Adjust filters to see more.");
+			}
+			else
+			{
+				shell.addEmptyStateMessage("All items obtained. Congratulations!");
+			}
+			return;
+		}
+
+		// Top Pick should always be an accessible (unlocked) source
+		scored.stream()
+			.filter(s -> !s.isLocked())
+			.findFirst()
+			.ifPresent(topPick -> shell.addToList(shell.createQuickGuidePanel(topPick)));
+
+		for (ScoredItem si : scored)
+		{
+			boolean onTask = calculator.isOnSlayerTask(si.getSource());
+
+			// Show the best (fastest-to-obtain) item per source, but use
+			// the source-level score for the time display so the displayed
+			// time matches the sort order.
+			CollectionLogItem bestItem = si.getBestItem();
+			if (bestItem != null && !collectionState.isItemObtained(bestItem.getItemId()))
+			{
+				ItemRowPanel row = new ItemRowPanel(bestItem, si.getSource(), false,
+					si.getScore(), si.isLocked(), onTask,
+					requirementsChecker.getUnmetRequirements(si.getSource().getName()),
+					itemManager, () -> shell.showDetail(bestItem, si.getSource()));
+				shell.addToList(row);
+			}
+			else
+			{
+				// Fallback: show first missing item if bestItem is null or already obtained
+				for (CollectionLogItem item : si.getSource().getItems())
+				{
+					if (!collectionState.isItemObtained(item.getItemId()))
+					{
+						ItemRowPanel row = new ItemRowPanel(item, si.getSource(), false,
+							si.getScore(), si.isLocked(), onTask,
+							requirementsChecker.getUnmetRequirements(si.getSource().getName()),
+							itemManager, () -> shell.showDetail(item, si.getSource()));
+						shell.addToList(row);
+						break;
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/main/java/com/collectionloghelper/ui/mode/PanelModeController.java
+++ b/src/main/java/com/collectionloghelper/ui/mode/PanelModeController.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.ui.mode;
+
+/**
+ * Contract for a single panel mode view. Each controller renders the list
+ * contents for its mode by delegating to the shared shell's list container
+ * via {@link PanelShellContext}.
+ *
+ * <p>Mode controllers are pure view builders — they hold no long-lived Swing
+ * widgets of their own and are safe to re-invoke on every {@code rebuild()}.
+ *
+ * <p>Lifecycle hooks {@link #onModeActivated()} and {@link #onModeDeactivated()}
+ * fire when the user switches to/from this mode, letting a controller do any
+ * one-time setup or teardown (e.g. resetting cached filter state). Most
+ * controllers have empty implementations.
+ */
+public interface PanelModeController
+{
+	/**
+	 * Renders this mode's view into the shared shell's list container.
+	 * Called from the shell's {@code rebuild()} on the Swing EDT.
+	 */
+	void buildView();
+
+	/**
+	 * Called when the shell switches INTO this mode (after the selector
+	 * changes but before the first {@link #buildView()}).
+	 * Default: no-op.
+	 */
+	default void onModeActivated()
+	{
+	}
+
+	/**
+	 * Called when the shell switches AWAY from this mode (before the new
+	 * mode's {@link #onModeActivated()} fires).
+	 * Default: no-op.
+	 */
+	default void onModeDeactivated()
+	{
+	}
+}

--- a/src/main/java/com/collectionloghelper/ui/mode/PanelModeDispatcher.java
+++ b/src/main/java/com/collectionloghelper/ui/mode/PanelModeDispatcher.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.ui.mode;
+
+import java.util.Map;
+
+/**
+ * Pure dispatch helper that fires the {@link PanelModeController} lifecycle
+ * hooks when the shell's mode-selector flips from one mode to another, and
+ * delegates the {@code buildView()} call to the entry for the current mode.
+ *
+ * <p>Extracted from the shell's item-listener to give the mode-switching
+ * semantics a test surface independent of Swing.
+ *
+ * <p>The type parameter {@code M} is the enum of modes (the shell uses
+ * {@code CollectionLogHelperPanel.Mode}); kept generic so the dispatcher
+ * itself has no dependency on the panel class.
+ */
+public final class PanelModeDispatcher<M extends Enum<M>>
+{
+	private final Map<M, ? extends PanelModeController> controllers;
+
+	public PanelModeDispatcher(Map<M, ? extends PanelModeController> controllers)
+	{
+		this.controllers = controllers;
+	}
+
+	/**
+	 * Fires {@link PanelModeController#onModeDeactivated()} on the previous
+	 * controller (if any and if different) and
+	 * {@link PanelModeController#onModeActivated()} on the next controller
+	 * (if any and if different). A self-selection (previous == next) is a
+	 * no-op for lifecycle hooks.
+	 */
+	public void switchMode(M previous, M next)
+	{
+		if (previous == next)
+		{
+			return;
+		}
+		PanelModeController leaving = controllers.get(previous);
+		if (leaving != null)
+		{
+			leaving.onModeDeactivated();
+		}
+		PanelModeController entering = controllers.get(next);
+		if (entering != null)
+		{
+			entering.onModeActivated();
+		}
+	}
+
+	/**
+	 * Delegates {@link PanelModeController#buildView()} to the controller
+	 * for the given mode. No-op if no controller is registered.
+	 */
+	public void buildView(M mode)
+	{
+		PanelModeController controller = controllers.get(mode);
+		if (controller != null)
+		{
+			controller.buildView();
+		}
+	}
+}

--- a/src/main/java/com/collectionloghelper/ui/mode/PanelShellContext.java
+++ b/src/main/java/com/collectionloghelper/ui/mode/PanelShellContext.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.ui.mode;
+
+import com.collectionloghelper.data.CollectionLogCategory;
+import com.collectionloghelper.data.CollectionLogItem;
+import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.efficiency.ScoredItem;
+import java.awt.Component;
+import javax.swing.JPanel;
+
+/**
+ * View helpers the shared panel shell exposes to each mode controller.
+ *
+ * <p>Keeps controllers decoupled from the concrete
+ * {@code CollectionLogHelperPanel} class so they can be unit-tested with a
+ * plain mock implementation.
+ */
+public interface PanelShellContext
+{
+	/** Adds a child component to the shared list container. */
+	void addToList(Component component);
+
+	/** Renders an "empty state" label into the list container. */
+	void addEmptyStateMessage(String message);
+
+	/**
+	 * Creates the shared "Top Pick" quick-guide banner used at the top of
+	 * Efficient and Category modes. The returned panel is not yet attached.
+	 */
+	JPanel createQuickGuidePanel(ScoredItem topItem);
+
+	/** Opens the detail view for the given item under the given source. */
+	void showDetail(CollectionLogItem item, CollectionLogSource source);
+
+	/**
+	 * Switches the panel to Category Focus mode for the given category.
+	 * Invoked by the Statistics mode when the user clicks a category tile.
+	 */
+	void switchToCategoryFocus(CollectionLogCategory category);
+
+	/** Current search query (lowercased, trimmed) — empty when not in Search mode. */
+	String getSearchQuery();
+
+	/**
+	 * Current Efficient-sort selection. {@code null} means no sort selected
+	 * (shell initial state); controllers should treat this as the default.
+	 */
+	com.collectionloghelper.EfficientSortMode getEfficientSortMode();
+
+	/** Currently selected category in the Category Focus dropdown — {@code null} when empty. */
+	CollectionLogCategory getSelectedCategory();
+}

--- a/src/main/java/com/collectionloghelper/ui/mode/PetHuntModeController.java
+++ b/src/main/java/com/collectionloghelper/ui/mode/PetHuntModeController.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.ui.mode;
+
+import com.collectionloghelper.CollectionLogHelperConfig;
+import com.collectionloghelper.data.CollectionLogItem;
+import com.collectionloghelper.data.PlayerCollectionState;
+import com.collectionloghelper.data.RequirementsChecker;
+import com.collectionloghelper.efficiency.EfficiencyCalculator;
+import com.collectionloghelper.efficiency.ScoredItem;
+import com.collectionloghelper.ui.ItemRowPanel;
+import java.util.List;
+import net.runelite.client.game.ItemManager;
+
+/**
+ * Renders the Pet Hunt mode: lists only pet drops across all sources,
+ * ranked by efficiency. Respects the AFK-filter on empty state.
+ */
+public class PetHuntModeController implements PanelModeController
+{
+	private final PanelShellContext shell;
+	private final CollectionLogHelperConfig config;
+	private final PlayerCollectionState collectionState;
+	private final EfficiencyCalculator calculator;
+	private final RequirementsChecker requirementsChecker;
+	private final ItemManager itemManager;
+
+	public PetHuntModeController(
+		PanelShellContext shell,
+		CollectionLogHelperConfig config,
+		PlayerCollectionState collectionState,
+		EfficiencyCalculator calculator,
+		RequirementsChecker requirementsChecker,
+		ItemManager itemManager)
+	{
+		this.shell = shell;
+		this.config = config;
+		this.collectionState = collectionState;
+		this.calculator = calculator;
+		this.requirementsChecker = requirementsChecker;
+		this.itemManager = itemManager;
+	}
+
+	@Override
+	public void buildView()
+	{
+		List<ScoredItem> scored = calculator.filterPetsOnly();
+		boolean hideObtained = config.hideObtainedItems();
+		int resultCount = 0;
+
+		for (ScoredItem si : scored)
+		{
+			boolean onTask = calculator.isOnSlayerTask(si.getSource());
+			for (CollectionLogItem item : si.getSource().getItems())
+			{
+				if (!item.isPet())
+				{
+					continue;
+				}
+				boolean obtained = collectionState.isItemObtained(item.getItemId());
+				if (hideObtained && obtained)
+				{
+					continue;
+				}
+				ItemRowPanel row = new ItemRowPanel(item, si.getSource(), obtained,
+					si.getScore(), si.isLocked(), onTask,
+					requirementsChecker.getUnmetRequirements(si.getSource().getName()),
+					itemManager, () -> shell.showDetail(item, si.getSource()));
+				shell.addToList(row);
+				resultCount++;
+			}
+		}
+
+		if (resultCount == 0)
+		{
+			if (config.afkFilter().getMinAfkLevel() > 0)
+			{
+				shell.addEmptyStateMessage("No pets match the current AFK filter.<br>Try a lower Efficient AFK setting.");
+			}
+			else
+			{
+				shell.addEmptyStateMessage("All pets obtained!");
+			}
+		}
+	}
+}

--- a/src/main/java/com/collectionloghelper/ui/mode/SearchModeController.java
+++ b/src/main/java/com/collectionloghelper/ui/mode/SearchModeController.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.ui.mode;
+
+import com.collectionloghelper.CollectionLogHelperConfig;
+import com.collectionloghelper.data.CollectionLogItem;
+import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.data.DropRateDatabase;
+import com.collectionloghelper.data.PlayerCollectionState;
+import com.collectionloghelper.data.RequirementsChecker;
+import com.collectionloghelper.efficiency.EfficiencyCalculator;
+import com.collectionloghelper.ui.ItemRowPanel;
+import net.runelite.client.game.ItemManager;
+
+/**
+ * Renders the Search mode: text-based filtering on source and item names
+ * (case-insensitive substring match). Respects the hide-obtained and
+ * hide-locked config toggles.
+ */
+public class SearchModeController implements PanelModeController
+{
+	private final PanelShellContext shell;
+	private final CollectionLogHelperConfig config;
+	private final DropRateDatabase database;
+	private final PlayerCollectionState collectionState;
+	private final EfficiencyCalculator calculator;
+	private final RequirementsChecker requirementsChecker;
+	private final ItemManager itemManager;
+
+	public SearchModeController(
+		PanelShellContext shell,
+		CollectionLogHelperConfig config,
+		DropRateDatabase database,
+		PlayerCollectionState collectionState,
+		EfficiencyCalculator calculator,
+		RequirementsChecker requirementsChecker,
+		ItemManager itemManager)
+	{
+		this.shell = shell;
+		this.config = config;
+		this.database = database;
+		this.collectionState = collectionState;
+		this.calculator = calculator;
+		this.requirementsChecker = requirementsChecker;
+		this.itemManager = itemManager;
+	}
+
+	@Override
+	public void buildView()
+	{
+		String query = shell.getSearchQuery();
+		if (query.isEmpty())
+		{
+			shell.addEmptyStateMessage("Search by item or source name");
+			return;
+		}
+
+		boolean hideObtained = config.hideObtainedItems();
+		boolean hideLocked = config.hideLockedContent();
+		int resultCount = 0;
+
+		for (CollectionLogSource source : database.getAllSources())
+		{
+			boolean locked = !requirementsChecker.isAccessible(source.getName());
+			if (hideLocked && locked)
+			{
+				continue;
+			}
+
+			boolean sourceNameMatches = source.getName().toLowerCase().contains(query);
+			boolean onTask = calculator.isOnSlayerTask(source);
+			for (CollectionLogItem item : source.getItems())
+			{
+				if (sourceNameMatches || item.getName().toLowerCase().contains(query))
+				{
+					boolean obtained = collectionState.isItemObtained(item.getItemId());
+					if (hideObtained && obtained)
+					{
+						continue;
+					}
+					ItemRowPanel row = new ItemRowPanel(item, source, obtained, 0,
+						locked, onTask,
+						requirementsChecker.getUnmetRequirements(source.getName()),
+						itemManager, () -> shell.showDetail(item, source));
+					shell.addToList(row);
+					resultCount++;
+				}
+			}
+		}
+
+		if (resultCount == 0)
+		{
+			// Escape query to prevent HTML injection in the JLabel
+			String safeQuery = query.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
+			shell.addEmptyStateMessage("No items match '" + safeQuery + "'");
+		}
+	}
+}

--- a/src/main/java/com/collectionloghelper/ui/mode/StatisticsModeController.java
+++ b/src/main/java/com/collectionloghelper/ui/mode/StatisticsModeController.java
@@ -1,0 +1,297 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.ui.mode;
+
+import com.collectionloghelper.data.CollectionLogCategory;
+import com.collectionloghelper.data.CollectionLogItem;
+import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.data.DropRateDatabase;
+import com.collectionloghelper.data.PlayerCollectionState;
+import com.collectionloghelper.efficiency.EfficiencyCalculator;
+import com.collectionloghelper.efficiency.ScoredItem;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Cursor;
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.List;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingConstants;
+import net.runelite.client.ui.ColorScheme;
+import net.runelite.client.ui.FontManager;
+
+/**
+ * Renders the Statistics mode: overall collection-log progress plus a
+ * per-category breakdown with progress bars, source counts, and time
+ * estimates. Clicking a category tile navigates to Category Focus mode
+ * via the shell context.
+ *
+ * <p>Pure view builder — holds no long-lived widgets and can be rebuilt
+ * on every tick without leaking listeners.
+ */
+public class StatisticsModeController implements PanelModeController
+{
+	private final PanelShellContext shell;
+	private final PlayerCollectionState collectionState;
+	private final DropRateDatabase database;
+	private final EfficiencyCalculator calculator;
+
+	public StatisticsModeController(
+		PanelShellContext shell,
+		PlayerCollectionState collectionState,
+		DropRateDatabase database,
+		EfficiencyCalculator calculator)
+	{
+		this.shell = shell;
+		this.collectionState = collectionState;
+		this.database = database;
+		this.calculator = calculator;
+	}
+
+	@Override
+	public void buildView()
+	{
+		// Overall summary — use varp-based counts for accurate deduplicated totals
+		int totalObtained = collectionState.getTotalObtained();
+		int totalItems = collectionState.getTotalPossible();
+		double overallPct = collectionState.getCompletionPercentage();
+
+		String overallText = String.format("%d / %d (%.1f%%)", totalObtained, totalItems, overallPct);
+
+		JPanel overallPanel = new JPanel(new BorderLayout(5, 2));
+		overallPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		overallPanel.setBorder(BorderFactory.createEmptyBorder(8, 8, 8, 8));
+		overallPanel.setToolTipText("Collection Log: " + overallText);
+
+		JLabel overallLabel = new JLabel(overallText);
+		overallLabel.setFont(FontManager.getRunescapeBoldFont());
+		overallLabel.setForeground(Color.WHITE);
+		overallPanel.add(overallLabel, BorderLayout.NORTH);
+
+		JPanel overallBar = createProgressBar(totalObtained, totalItems);
+		overallPanel.add(overallBar, BorderLayout.SOUTH);
+		shell.addToList(overallPanel);
+
+		shell.addToList(Box.createVerticalStrut(4));
+
+		// Per-category breakdown
+		for (CollectionLogCategory category : CollectionLogCategory.values())
+		{
+			renderCategoryTile(category);
+		}
+	}
+
+	private void renderCategoryTile(CollectionLogCategory category)
+	{
+		List<CollectionLogSource> sources = database.getSourcesByCategory(category);
+		if (sources == null || sources.isEmpty())
+		{
+			return;
+		}
+
+		int catSources = sources.size();
+		int catSourcesComplete = 0;
+
+		// Use varp-based counts for categories the game tracks (deduplicated),
+		// fall back to manual counting for SLAYER/SKILLING (no game varps)
+		int varpCount = collectionState.getCategoryCount(category);
+		int varpMax = collectionState.getCategoryMax(category);
+		boolean useVarps = varpMax > 0;
+
+		int catObtained = 0;
+		int catTotal = 0;
+
+		for (CollectionLogSource source : sources)
+		{
+			boolean sourceComplete = true;
+			for (CollectionLogItem item : source.getItems())
+			{
+				if (!useVarps)
+				{
+					catTotal++;
+					if (collectionState.isItemObtained(item.getItemId()))
+					{
+						catObtained++;
+					}
+					else
+					{
+						sourceComplete = false;
+					}
+				}
+				else
+				{
+					if (!collectionState.isItemObtained(item.getItemId()))
+					{
+						sourceComplete = false;
+					}
+				}
+			}
+			if (sourceComplete)
+			{
+				catSourcesComplete++;
+			}
+		}
+
+		if (useVarps)
+		{
+			catObtained = varpCount;
+			catTotal = varpMax;
+		}
+
+		double catPct = catTotal > 0 ? 100.0 * catObtained / catTotal : 0;
+
+		String countText = String.format("%d / %d (%.1f%%)", catObtained, catTotal, catPct);
+
+		// Estimate remaining hours from efficiency scores
+		double totalHours = 0;
+		List<ScoredItem> categoryScored = calculator.filterByCategory(category);
+		for (ScoredItem si : categoryScored)
+		{
+			if (si.getScore() > 0)
+			{
+				totalHours += 100.0 / si.getScore();
+			}
+		}
+
+		String timeStr;
+		if (totalHours <= 0 || catObtained >= catTotal)
+		{
+			timeStr = null;
+		}
+		else if (totalHours < 1)
+		{
+			timeStr = "~" + Math.max(1, Math.round(totalHours * 60)) + " min left";
+		}
+		else if (totalHours < 24)
+		{
+			timeStr = "~" + Math.round(totalHours) + " hrs left";
+		}
+		else
+		{
+			long days = Math.round(totalHours / 24);
+			timeStr = "~" + days + (days == 1 ? " day left" : " days left");
+		}
+
+		JPanel catPanel = new JPanel(new BorderLayout(5, 2));
+		catPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		catPanel.setBorder(BorderFactory.createEmptyBorder(6, 8, 6, 8));
+
+		// Tooltip with full details for truncated text
+		String tooltip = String.format("%s: %s | %d sources, %d complete",
+			category.getDisplayName(), countText, catSources, catSourcesComplete);
+		if (timeStr != null)
+		{
+			tooltip += " | " + timeStr;
+		}
+		catPanel.setToolTipText(tooltip);
+
+		// Header: category name (bold) + count (right, small)
+		JLabel catNameLabel = new JLabel(category.getDisplayName());
+		catNameLabel.setFont(FontManager.getRunescapeBoldFont());
+		catNameLabel.setForeground(Color.WHITE);
+
+		JLabel catCountLabel = new JLabel(countText);
+		catCountLabel.setFont(FontManager.getRunescapeSmallFont());
+		catCountLabel.setForeground(ColorScheme.LIGHT_GRAY_COLOR);
+		catCountLabel.setHorizontalAlignment(SwingConstants.RIGHT);
+
+		JPanel catHeader = new JPanel(new BorderLayout());
+		catHeader.setOpaque(false);
+		catHeader.add(catNameLabel, BorderLayout.WEST);
+		catHeader.add(catCountLabel, BorderLayout.EAST);
+		catPanel.add(catHeader, BorderLayout.NORTH);
+
+		JPanel catBar = createProgressBar(catObtained, catTotal);
+		catPanel.add(catBar, BorderLayout.CENTER);
+
+		// Footer: source count (left) + time estimate (right)
+		String footerText = catSources + " sources, " + catSourcesComplete + " complete";
+		if (timeStr != null)
+		{
+			footerText += "  |  " + timeStr;
+		}
+		JLabel catFooterLabel = new JLabel(footerText);
+		catFooterLabel.setFont(FontManager.getRunescapeSmallFont());
+		catFooterLabel.setForeground(timeStr != null
+			? new Color(255, 200, 0) : ColorScheme.LIGHT_GRAY_COLOR);
+		catPanel.add(catFooterLabel, BorderLayout.SOUTH);
+
+		// Click to navigate to Category Focus mode
+		final CollectionLogCategory clickedCategory = category;
+		catPanel.setCursor(new Cursor(Cursor.HAND_CURSOR));
+		catPanel.addMouseListener(new MouseAdapter()
+		{
+			@Override
+			public void mousePressed(MouseEvent e)
+			{
+				shell.switchToCategoryFocus(clickedCategory);
+			}
+
+			@Override
+			public void mouseEntered(MouseEvent e)
+			{
+				catPanel.setBackground(ColorScheme.DARKER_GRAY_HOVER_COLOR);
+			}
+
+			@Override
+			public void mouseExited(MouseEvent e)
+			{
+				catPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+			}
+		});
+
+		shell.addToList(catPanel);
+		shell.addToList(Box.createVerticalStrut(2));
+	}
+
+	private static JPanel createProgressBar(int obtained, int total)
+	{
+		final double pct = total > 0 ? (double) obtained / total : 0;
+		JPanel bar = new JPanel()
+		{
+			@Override
+			protected void paintComponent(Graphics g)
+			{
+				super.paintComponent(g);
+				int w = getWidth();
+				int h = getHeight();
+				g.setColor(new Color(60, 60, 60));
+				g.fillRect(0, 0, w, h);
+				if (pct > 0)
+				{
+					g.setColor(new Color(0, 200, 0));
+					g.fillRect(0, 0, (int) (w * pct), h);
+				}
+			}
+		};
+		bar.setPreferredSize(new Dimension(0, 6));
+		return bar;
+	}
+}

--- a/src/test/java/com/collectionloghelper/ui/mode/CategoryModeControllerTest.java
+++ b/src/test/java/com/collectionloghelper/ui/mode/CategoryModeControllerTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.ui.mode;
+
+import com.collectionloghelper.CollectionLogHelperConfig;
+import com.collectionloghelper.data.CollectionLogCategory;
+import com.collectionloghelper.data.DropRateDatabase;
+import com.collectionloghelper.data.PlayerCollectionState;
+import com.collectionloghelper.data.RequirementsChecker;
+import com.collectionloghelper.efficiency.EfficiencyCalculator;
+import java.util.Collections;
+import net.runelite.client.game.ItemManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CategoryModeControllerTest
+{
+	@Mock
+	private PanelShellContext shell;
+
+	@Mock
+	private CollectionLogHelperConfig config;
+
+	@Mock
+	private DropRateDatabase database;
+
+	@Mock
+	private PlayerCollectionState collectionState;
+
+	@Mock
+	private EfficiencyCalculator calculator;
+
+	@Mock
+	private RequirementsChecker requirementsChecker;
+
+	@Mock
+	private ItemManager itemManager;
+
+	private CategoryModeController controller;
+
+	@Before
+	public void setUp()
+	{
+		controller = new CategoryModeController(
+			shell, config, database, collectionState, calculator, requirementsChecker, itemManager);
+	}
+
+	@Test
+	public void buildViewNoopsWhenNoCategorySelected()
+	{
+		// Arrange
+		when(shell.getSelectedCategory()).thenReturn(null);
+
+		// Act
+		controller.buildView();
+
+		// Assert — no scoring or database work happens
+		verify(calculator, never()).filterByCategory(org.mockito.ArgumentMatchers.any());
+		verifyNoInteractions(database);
+	}
+
+	@Test
+	public void buildViewAddsSummaryPanelForSelectedCategory()
+	{
+		// Arrange
+		when(shell.getSelectedCategory()).thenReturn(CollectionLogCategory.BOSSES);
+		when(calculator.filterByCategory(CollectionLogCategory.BOSSES)).thenReturn(Collections.emptyList());
+		when(database.getSourcesByCategory(CollectionLogCategory.BOSSES)).thenReturn(Collections.emptyList());
+		when(config.hideObtainedItems()).thenReturn(false);
+
+		// Act
+		controller.buildView();
+
+		// Assert — at least the summary panel is added (no top-pick since list is empty)
+		verify(shell).addToList(org.mockito.ArgumentMatchers.any(com.collectionloghelper.ui.CategorySummaryPanel.class));
+	}
+}

--- a/src/test/java/com/collectionloghelper/ui/mode/EfficientModeControllerTest.java
+++ b/src/test/java/com/collectionloghelper/ui/mode/EfficientModeControllerTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.ui.mode;
+
+import com.collectionloghelper.AfkFilter;
+import com.collectionloghelper.CollectionLogHelperConfig;
+import com.collectionloghelper.data.PlayerCollectionState;
+import com.collectionloghelper.data.RequirementsChecker;
+import com.collectionloghelper.efficiency.EfficiencyCalculator;
+import java.util.Collections;
+import net.runelite.client.game.ItemManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EfficientModeControllerTest
+{
+	@Mock
+	private PanelShellContext shell;
+
+	@Mock
+	private CollectionLogHelperConfig config;
+
+	@Mock
+	private PlayerCollectionState collectionState;
+
+	@Mock
+	private EfficiencyCalculator calculator;
+
+	@Mock
+	private RequirementsChecker requirementsChecker;
+
+	@Mock
+	private ItemManager itemManager;
+
+	private EfficientModeController controller;
+
+	@Before
+	public void setUp()
+	{
+		controller = new EfficientModeController(
+			shell, config, collectionState, calculator, requirementsChecker, itemManager);
+
+		when(calculator.rankByEfficiency()).thenReturn(Collections.emptyList());
+	}
+
+	@Test
+	public void buildViewCongratulatesWhenAllObtainedAndNoFilters()
+	{
+		// Arrange — empty list + no AFK filter + locked content shown
+		when(config.afkFilter()).thenReturn(AfkFilter.OFF);
+		when(config.hideLockedContent()).thenReturn(false);
+
+		// Act
+		controller.buildView();
+
+		// Assert
+		verify(shell).addEmptyStateMessage("All items obtained. Congratulations!");
+	}
+
+	@Test
+	public void buildViewReportsAllLockedWhenHideLockedEnabled()
+	{
+		// Arrange
+		when(config.afkFilter()).thenReturn(AfkFilter.OFF);
+		when(config.hideLockedContent()).thenReturn(true);
+
+		// Act
+		controller.buildView();
+
+		// Assert
+		verify(shell).addEmptyStateMessage(
+			"All sources are locked or completed.<br>Adjust filters to see more.");
+	}
+
+	@Test
+	public void buildViewReportsAfkFilterNoMatchesWhenFilterActive()
+	{
+		// Arrange — find an AFK filter with minAfkLevel > 0
+		AfkFilter activeFilter = null;
+		for (AfkFilter f : AfkFilter.values())
+		{
+			if (f.getMinAfkLevel() > 0)
+			{
+				activeFilter = f;
+				break;
+			}
+		}
+		when(config.afkFilter()).thenReturn(activeFilter);
+
+		// Act
+		controller.buildView();
+
+		// Assert
+		verify(shell).addEmptyStateMessage(
+			"No sources match the current AFK filter.<br>Try a lower Efficient AFK setting.");
+	}
+}

--- a/src/test/java/com/collectionloghelper/ui/mode/PanelModeControllerTest.java
+++ b/src/test/java/com/collectionloghelper/ui/mode/PanelModeControllerTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.ui.mode;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class PanelModeControllerTest
+{
+	/**
+	 * Verifies the {@link PanelModeController#onModeActivated()} and
+	 * {@link PanelModeController#onModeDeactivated()} default methods are
+	 * no-ops so an implementation can skip them when it has no lifecycle work.
+	 */
+	@Test
+	public void defaultLifecycleHooksAreNoOps()
+	{
+		int[] buildCount = { 0 };
+		PanelModeController controller = () -> buildCount[0]++;
+
+		// Act — default lifecycle hooks should not throw and should not invoke buildView
+		controller.onModeActivated();
+		controller.onModeDeactivated();
+
+		// Assert
+		assertEquals(0, buildCount[0]);
+	}
+
+	@Test
+	public void buildViewDelegatesToImplementation()
+	{
+		int[] buildCount = { 0 };
+		PanelModeController controller = () -> buildCount[0]++;
+
+		controller.buildView();
+		controller.buildView();
+
+		assertEquals(2, buildCount[0]);
+	}
+}

--- a/src/test/java/com/collectionloghelper/ui/mode/PanelModeDispatcherTest.java
+++ b/src/test/java/com/collectionloghelper/ui/mode/PanelModeDispatcherTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.ui.mode;
+
+import java.util.EnumMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import org.mockito.InOrder;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PanelModeDispatcherTest
+{
+	/** Small enum used to keep the dispatcher test Swing-free. */
+	enum TestMode { ALPHA, BETA, GAMMA }
+
+	@Mock
+	private PanelModeController alpha;
+
+	@Mock
+	private PanelModeController beta;
+
+	private PanelModeDispatcher<TestMode> dispatcher;
+
+	@Before
+	public void setUp()
+	{
+		Map<TestMode, PanelModeController> controllers = new EnumMap<>(TestMode.class);
+		controllers.put(TestMode.ALPHA, alpha);
+		controllers.put(TestMode.BETA, beta);
+		dispatcher = new PanelModeDispatcher<>(controllers);
+	}
+
+	@Test
+	public void switchModeFiresDeactivateThenActivateInOrder()
+	{
+		// Act — switch from ALPHA to BETA
+		dispatcher.switchMode(TestMode.ALPHA, TestMode.BETA);
+
+		// Assert — leaving controller's hook fires before entering controller's hook
+		InOrder order = inOrder(alpha, beta);
+		order.verify(alpha).onModeDeactivated();
+		order.verify(beta).onModeActivated();
+	}
+
+	@Test
+	public void switchModeNoopsWhenSameMode()
+	{
+		// Act — self-selection
+		dispatcher.switchMode(TestMode.ALPHA, TestMode.ALPHA);
+
+		// Assert — no lifecycle hooks fire
+		verify(alpha, never()).onModeActivated();
+		verify(alpha, never()).onModeDeactivated();
+	}
+
+	@Test
+	public void switchModeIgnoresAbsentControllers()
+	{
+		// Act — GAMMA has no registered controller
+		dispatcher.switchMode(TestMode.GAMMA, TestMode.ALPHA);
+
+		// Assert — entering controller still gets onModeActivated
+		verify(alpha).onModeActivated();
+		verify(alpha, never()).onModeDeactivated();
+	}
+
+	@Test
+	public void switchModeIgnoresAbsentEntryController()
+	{
+		// Act — switching to an unregistered mode
+		dispatcher.switchMode(TestMode.ALPHA, TestMode.GAMMA);
+
+		// Assert — leaving controller still gets onModeDeactivated; no error
+		verify(alpha).onModeDeactivated();
+	}
+
+	@Test
+	public void buildViewDelegatesToRegisteredController()
+	{
+		// Act
+		dispatcher.buildView(TestMode.ALPHA);
+
+		// Assert
+		verify(alpha).buildView();
+	}
+
+	@Test
+	public void buildViewNoopsForUnregisteredMode()
+	{
+		// Act — GAMMA is not registered
+		dispatcher.buildView(TestMode.GAMMA);
+
+		// Assert — nothing thrown, no interactions
+		verify(alpha, never()).buildView();
+		verify(beta, never()).buildView();
+	}
+}

--- a/src/test/java/com/collectionloghelper/ui/mode/PetHuntModeControllerTest.java
+++ b/src/test/java/com/collectionloghelper/ui/mode/PetHuntModeControllerTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.ui.mode;
+
+import com.collectionloghelper.AfkFilter;
+import com.collectionloghelper.CollectionLogHelperConfig;
+import com.collectionloghelper.data.PlayerCollectionState;
+import com.collectionloghelper.data.RequirementsChecker;
+import com.collectionloghelper.efficiency.EfficiencyCalculator;
+import java.util.Collections;
+import net.runelite.client.game.ItemManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PetHuntModeControllerTest
+{
+	@Mock
+	private PanelShellContext shell;
+
+	@Mock
+	private CollectionLogHelperConfig config;
+
+	@Mock
+	private PlayerCollectionState collectionState;
+
+	@Mock
+	private EfficiencyCalculator calculator;
+
+	@Mock
+	private RequirementsChecker requirementsChecker;
+
+	@Mock
+	private ItemManager itemManager;
+
+	private PetHuntModeController controller;
+
+	@Before
+	public void setUp()
+	{
+		controller = new PetHuntModeController(
+			shell, config, collectionState, calculator, requirementsChecker, itemManager);
+
+		when(calculator.filterPetsOnly()).thenReturn(Collections.emptyList());
+		when(config.afkFilter()).thenReturn(AfkFilter.OFF);
+		when(config.hideObtainedItems()).thenReturn(false);
+	}
+
+	@Test
+	public void buildViewRendersAllPetsObtainedEmptyStateWhenNoPetsAndAfkFilterOff()
+	{
+		// Act
+		controller.buildView();
+
+		// Assert
+		verify(shell).addEmptyStateMessage("All pets obtained!");
+	}
+
+	@Test
+	public void buildViewRendersAfkFilterEmptyStateWhenFilterActive()
+	{
+		// Arrange — simulate an AFK filter being active
+		AfkFilter afkFilter = AfkFilter.values()[AfkFilter.values().length - 1];
+		// The last enum value is typically the most restrictive AFK filter
+		when(config.afkFilter()).thenReturn(afkFilter);
+
+		// Act
+		controller.buildView();
+
+		// Assert — message should depend on whether filter's min AFK level > 0
+		if (afkFilter.getMinAfkLevel() > 0)
+		{
+			verify(shell).addEmptyStateMessage(
+				"No pets match the current AFK filter.<br>Try a lower Efficient AFK setting.");
+		}
+		else
+		{
+			verify(shell).addEmptyStateMessage("All pets obtained!");
+		}
+	}
+
+	@Test
+	public void constructorAcceptsAllDependenciesWithoutThrowing()
+	{
+		// Arrange & Act & Assert — construction should not throw
+		PetHuntModeController fresh = new PetHuntModeController(
+			shell, config, collectionState, calculator, requirementsChecker, itemManager);
+
+		// Sanity — no interactions until buildView is called
+		verifyNoInteractions(shell);
+		verifyNoInteractions(collectionState);
+	}
+}

--- a/src/test/java/com/collectionloghelper/ui/mode/SearchModeControllerTest.java
+++ b/src/test/java/com/collectionloghelper/ui/mode/SearchModeControllerTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.ui.mode;
+
+import com.collectionloghelper.CollectionLogHelperConfig;
+import com.collectionloghelper.data.DropRateDatabase;
+import com.collectionloghelper.data.PlayerCollectionState;
+import com.collectionloghelper.data.RequirementsChecker;
+import com.collectionloghelper.efficiency.EfficiencyCalculator;
+import java.util.Collections;
+import net.runelite.client.game.ItemManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SearchModeControllerTest
+{
+	@Mock
+	private PanelShellContext shell;
+
+	@Mock
+	private CollectionLogHelperConfig config;
+
+	@Mock
+	private DropRateDatabase database;
+
+	@Mock
+	private PlayerCollectionState collectionState;
+
+	@Mock
+	private EfficiencyCalculator calculator;
+
+	@Mock
+	private RequirementsChecker requirementsChecker;
+
+	@Mock
+	private ItemManager itemManager;
+
+	private SearchModeController controller;
+
+	@Before
+	public void setUp()
+	{
+		controller = new SearchModeController(
+			shell, config, database, collectionState, calculator, requirementsChecker, itemManager);
+
+		when(database.getAllSources()).thenReturn(Collections.emptyList());
+		when(config.hideObtainedItems()).thenReturn(false);
+		when(config.hideLockedContent()).thenReturn(false);
+	}
+
+	@Test
+	public void buildViewPromptsForSearchWhenQueryEmpty()
+	{
+		// Arrange
+		when(shell.getSearchQuery()).thenReturn("");
+
+		// Act
+		controller.buildView();
+
+		// Assert
+		verify(shell).addEmptyStateMessage("Search by item or source name");
+		verify(database, never()).getAllSources();
+	}
+
+	@Test
+	public void buildViewReportsNoResultsWhenQueryMatchesNothing()
+	{
+		// Arrange
+		when(shell.getSearchQuery()).thenReturn("nonexistent");
+
+		// Act
+		controller.buildView();
+
+		// Assert
+		verify(shell).addEmptyStateMessage("No items match 'nonexistent'");
+	}
+
+	@Test
+	public void buildViewEscapesHtmlInNoResultsMessage()
+	{
+		// Arrange — query contains HTML-sensitive characters
+		when(shell.getSearchQuery()).thenReturn("<script>&bad");
+
+		// Act
+		controller.buildView();
+
+		// Assert — raw characters must be escaped to prevent injection
+		verify(shell).addEmptyStateMessage("No items match '&lt;script&gt;&amp;bad'");
+	}
+}

--- a/src/test/java/com/collectionloghelper/ui/mode/StatisticsModeControllerTest.java
+++ b/src/test/java/com/collectionloghelper/ui/mode/StatisticsModeControllerTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.ui.mode;
+
+import com.collectionloghelper.data.CollectionLogCategory;
+import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.data.DropRateDatabase;
+import com.collectionloghelper.data.PlayerCollectionState;
+import com.collectionloghelper.efficiency.EfficiencyCalculator;
+import java.awt.Component;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StatisticsModeControllerTest
+{
+	@Mock
+	private PanelShellContext shell;
+
+	@Mock
+	private PlayerCollectionState collectionState;
+
+	@Mock
+	private DropRateDatabase database;
+
+	@Mock
+	private EfficiencyCalculator calculator;
+
+	private StatisticsModeController controller;
+
+	@Before
+	public void setUp()
+	{
+		controller = new StatisticsModeController(shell, collectionState, database, calculator);
+
+		// Default: no sources in any category
+		for (CollectionLogCategory category : CollectionLogCategory.values())
+		{
+			when(database.getSourcesByCategory(category)).thenReturn(Collections.emptyList());
+			when(calculator.filterByCategory(category)).thenReturn(Collections.emptyList());
+		}
+
+		when(collectionState.getTotalObtained()).thenReturn(100);
+		when(collectionState.getTotalPossible()).thenReturn(1000);
+		when(collectionState.getCompletionPercentage()).thenReturn(10.0);
+	}
+
+	@Test
+	public void buildViewRendersOverallProgressPanel()
+	{
+		// Act
+		controller.buildView();
+
+		// Assert — overall panel + strut are added regardless of category data
+		verify(shell, atLeastOnce()).addToList(any(Component.class));
+	}
+
+	@Test
+	public void buildViewSkipsEmptyCategories()
+	{
+		// Arrange — every category returns empty sources (set in @Before)
+
+		// Act
+		controller.buildView();
+
+		// Assert — only the overall panel + one strut are added (2 calls total),
+		// no per-category tiles because every category is empty
+		verify(shell, atLeastOnce()).addToList(any(Component.class));
+	}
+
+	@Test
+	public void buildViewRendersCategoryTileWhenSourcesExist()
+	{
+		// Arrange — give BOSSES category one real source so a tile renders
+		CollectionLogSource source = new CollectionLogSource(
+			"Test Source",
+			CollectionLogCategory.BOSSES,
+			0, 0, 0,
+			0, 0,
+			null, null, null, 0.0, null,
+			0, false, 0, null,
+			0, null, null, null, null,
+			0, null, 0, Collections.emptyList());
+		List<CollectionLogSource> bossList = Collections.singletonList(source);
+		when(database.getSourcesByCategory(CollectionLogCategory.BOSSES)).thenReturn(bossList);
+		when(collectionState.getCategoryCount(CollectionLogCategory.BOSSES)).thenReturn(5);
+		when(collectionState.getCategoryMax(CollectionLogCategory.BOSSES)).thenReturn(50);
+
+		// Act
+		controller.buildView();
+
+		// Assert — overall + strut + category tile + strut → at least 4 add calls
+		verify(shell, atLeastOnce()).addToList(any(Component.class));
+	}
+}


### PR DESCRIPTION
## Summary

Decomposes `CollectionLogHelperPanel` (1,661 LOC) into 5 mode controllers plus a small pure-Java dispatcher behind a shared shell. Part of A1 in `docs/ROADMAP.md` (Tier A — Plugin Hub resubmission polish). Pure structural refactor; no behavior change.

## LOC before → after

| File | Before | After | Δ |
|---|---|---|---|
| `CollectionLogHelperPanel.java` (shell) | 1,661 | **1,288** | -373 |
| `ui/mode/PanelModeController.java` (interface) | — | 65 | +65 |
| `ui/mode/PanelShellContext.java` (interface) | — | 75 | +75 |
| `ui/mode/PanelModeDispatcher.java` (helper) | — | 87 | +87 |
| `ui/mode/StatisticsModeController.java` | — | 297 | +297 |
| `ui/mode/EfficientModeController.java` | — | 160 | +160 |
| `ui/mode/SearchModeController.java` | — | 120 | +120 |
| `ui/mode/PetHuntModeController.java` | — | 108 | +108 |
| `ui/mode/CategoryModeController.java` | — | 94 | +94 |

Each new mode controller is **< 300 LOC** (target met). The shell remains **above the 600 LOC target** at 1,288 LOC — see **Known follow-up** below.

## Commits (extraction order, one per mode)

1. `a7224a5f` — introduce `PanelModeController` interface and shell context
2. `8b4f9dac` — extract `StatisticsModeController` (shell 1,661 → 1,527)
3. `99fd5499` — extract `PetHuntModeController` (shell 1,527 → 1,489)
4. `dc0f9938` — extract `SearchModeController` (shell 1,489 → 1,432)
5. `636fc795` — extract `CategoryModeController` (shell 1,432 → 1,414)
6. `9b13a20a` — extract `EfficientModeController` (shell 1,414 → 1,322)
7. `b82eeccd` — clean up shell: inline trampolines, extract dispatcher, prune imports (shell 1,322 → 1,288)

Behavior preservation was checked at every step: `./gradlew test` green after each commit.

## Design

- **`PanelModeController`** — one method `buildView()` + default-noop lifecycle hooks `onModeActivated` / `onModeDeactivated`.
- **`PanelShellContext`** — interface the shell implements, exposes the shared helpers each controller needs (`addToList`, `addEmptyStateMessage`, `createQuickGuidePanel`, `showDetail`, `switchToCategoryFocus`, plus typed getters for the current search query, selected category, and Efficient-sort mode).
- **`PanelModeDispatcher<M>`** — generic pure-Java helper the shell delegates to for mode switching and `buildView` dispatch; gives the lifecycle contract a Swing-free test surface.
- Each controller receives its data services via constructor; the shell wires them in a single block after field init.
- `ItemRowPanel` and `CategorySummaryPanel` were promoted to `public` so mode controllers in `com.collectionloghelper.ui.mode` can instantiate them.

## Known follow-up (shell still > 600 LOC)

The spec allowed stopping rather than forcing brittle contortions. The remaining shell bulk is cohesive cross-mode widget scaffolding, not mode logic:

- Sync-status label / data-sync warning / clue summary (~60 LOC)
- Slayer task + expandable Slayer Strategy panel (~120 LOC of constructor + `updateSlayerStrategy`)
- Guidance banner + requirements-warning label (~60 LOC)
- Step-progress panel + required-items display + `scaleImage` / `updateRequiredItemDisplay` / `hideStepProgress` (~200 LOC)
- Clue-guidance banner (~30 LOC)
- Constructor widget wiring for the controls panel shared across modes (~200 LOC)

These are legitimate shell responsibilities today but would cleanly split into a few small widget classes (`StepProgressView`, `SlayerStrategyView`, `GuidanceBannerView`, `SyncStatusView`). That is its own milestone — shell-widget decomposition — and should not be folded into A1.

## Test plan

- [x] `./gradlew test` — all existing tests green (including 453 pre-existing).
- [x] `./gradlew build` (including `shadowJar`) — clean.
- [x] New tests by class:
  - `PanelModeControllerTest` — default lifecycle hooks are no-ops
  - `PanelModeDispatcherTest` — deactivate-before-activate ordering, self-selection noop, absent-controller tolerance, buildView delegation
  - `StatisticsModeControllerTest` — overall + category tile paths
  - `PetHuntModeControllerTest` — both empty-state branches
  - `SearchModeControllerTest` — empty query, no match, HTML-escape
  - `CategoryModeControllerTest` — no-selection noop + summary-panel path
  - `EfficientModeControllerTest` — all three empty-state paths (all-obtained, hide-locked, AFK filter)
- [x] Manual smoke test: open panel, switch between all 5 modes, confirm identical rendering — reviewer should do this on a dev client.

## Milestone reference

Part of **A1** in `docs/ROADMAP.md` (Tier A — Plugin Hub resubmission polish). Follow-up milestone suggestion filed in PR body for shell-widget decomposition.