### PR TITLE
docs: mark A1 done, add A1b for shell widget decomposition

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -492,7 +492,8 @@ Focus: god-object decomposition, build hardening, test expansion. Resulted in th
 
 **Tier A — Production polish for Plugin Hub resubmission**
 
-- [ ] A1 — Panel decomposition                          status: planned       owner: —          updated: 2026-04-16
+- [x] A1 — Panel decomposition                          status: done          owner: cha-ndler  updated: 2026-04-17  pr: #349  note: 5 mode controllers extracted (94–297 LOC each) behind PanelModeDispatcher; 468/468 tests green. Shell still 1,288 LOC (shared widgets) — follow-up A1b.
+- [ ] A1b — Shell widget decomposition                   status: planned       owner: —          updated: 2026-04-17  note: extract StepProgressView / SlayerStrategyView / GuidanceBannerView / SyncStatusView / clue summary from CollectionLogHelperPanel shell; target <600 LOC shell
 - [x] A2 — Plugin class <1,000 LOC                       status: done          owner: cha-ndler  updated: 2026-04-17  pr: #347  note: 1,281 → 904 LOC via GuidanceEventRouter extraction
 - [x] A3 — Issue triage & labels                         status: done          owner: cha-ndler  updated: 2026-04-17  note: GitHub-only — summary in #345; 10 labels created, #319 closed, #323/#314/#306/#134 labeled
 - [x] A4 — Plugin Hub self-review doc                    status: done          owner: cha-ndler  updated: 2026-04-17  pr: #346  note: 27 green / 3 yellow / 2 red — docs/plugin-hub-review.md


### PR DESCRIPTION
## Summary

Post-merge status update for PR #349 (A1 panel decomposition).

- **A1** `[ ]` planned → `[x]` done — PR #349 (5 mode controllers extracted behind `PanelModeDispatcher`; each <300 LOC; 468/468 tests green)
- **A1b** added `[ ]` planned — shell widget decomposition follow-up

## Why A1 is `[x]` not partial

The A1 milestone spec was "decompose CollectionLogHelperPanel into mode controllers + shared shell." Mode controllers landed. The shell still exists at 1,288 LOC (down from 1,661), and the reviewer on #349 recommended tracking the remaining shared-widget extraction as a follow-up rather than blocking A1 on it. The symbol set (`[ ] [/] [x] [-] [?]`) has no "partial" — `[x]` + explicit note is the cleanest fit.

## A1b scope

Extract these cross-mode shared widgets from the shell:
- `StepProgressView`
- `SlayerStrategyView`
- `GuidanceBannerView`
- `SyncStatusView`
- Clue summary block

Target: shell <600 LOC. This blocks A6 (v1.0.0-hub tag) since Plugin Hub reviewers flag files over 800 LOC.

## Test plan

- [x] No code changes — docs only
- [x] `git diff origin/master -- docs/ROADMAP.md` shows exactly 2 line changes (1 flip, 1 addition)