### PR TITLE
fix(panel-widget): rename StepProgressView.hide() to hideStep() (#353)

### DIFF
--- a/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
@@ -627,7 +627,7 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 	/** Hides the step progress banner. */
 	public void hideStepProgress()
 	{
-		stepProgressView.hide();
+		stepProgressView.hideStep();
 	}
 
 	/** Sets callbacks for step advance/skip buttons. */

--- a/src/main/java/com/collectionloghelper/ui/widget/StepProgressView.java
+++ b/src/main/java/com/collectionloghelper/ui/widget/StepProgressView.java
@@ -52,8 +52,14 @@ import net.runelite.client.util.AsyncBufferedImage;
  * and the Next Step / Skip buttons.
  *
  * <p>Constructed once by the shell; updated via {@link #showStep} and
- * hidden via {@link #hide}. Step-advance and skip callbacks are wired
+ * hidden via {@link #hideStep}. Step-advance and skip callbacks are wired
  * via {@link #setCallbacks}.
+ *
+ * <p><b>Note:</b> the hide method is named {@code hideStep} rather than
+ * {@code hide} to avoid shadowing the deprecated {@link java.awt.Component#hide()}.
+ * {@code Component.setVisible(false)} internally dispatches to {@code hide()};
+ * an override with the same signature breaks {@code setVisible(false)} for this
+ * widget and leaves it visible in pre-guidance states (see issue #353).
  */
 public class StepProgressView extends JPanel
 {
@@ -185,8 +191,12 @@ public class StepProgressView extends JPanel
 	/**
 	 * Hides the step progress panel and clears required items.
 	 * Safe to call from any thread.
+	 *
+	 * <p>Intentionally named {@code hideStep} (not {@code hide}) — see class
+	 * Javadoc and issue #353 for why overriding {@link java.awt.Component#hide()}
+	 * would break {@link #setVisible}.
 	 */
-	public void hide()
+	public void hideStep()
 	{
 		SwingUtilities.invokeLater(() ->
 		{

--- a/src/test/java/com/collectionloghelper/ui/widget/StepProgressViewTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/StepProgressViewTest.java
@@ -28,11 +28,14 @@ import com.collectionloghelper.data.PlayerBankState;
 import com.collectionloghelper.data.PlayerInventoryState;
 import net.runelite.client.game.ItemManager;
 import java.util.Collections;
+import javax.swing.SwingUtilities;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Unit tests for {@link StepProgressView}.
@@ -78,9 +81,9 @@ public class StepProgressViewTest
 	}
 
 	@Test
-	public void hide_doesNotThrow()
+	public void hideStep_doesNotThrow()
 	{
-		view.hide();
+		view.hideStep();
 	}
 
 	@Test
@@ -97,9 +100,49 @@ public class StepProgressViewTest
 	}
 
 	@Test
-	public void hide_afterShowStep_doesNotThrow()
+	public void hideStep_afterShowStep_doesNotThrow()
 	{
 		view.showStep(1, 3, "Do the thing", false, Collections.emptyList());
-		view.hide();
+		view.hideStep();
+	}
+
+	// ── Visibility regression tests for issue #353 ──────────────────────────
+	//
+	// The widget previously defined public void hide(), which shadowed the
+	// deprecated-but-still-wired java.awt.Component#hide(). Component#setVisible
+	// dispatches to hide()/show() internally, so the override silently turned
+	// setVisible(false) into a no-op and left the Skip-button panel visible in
+	// every state where guidance wasn't running. These tests pin the contract.
+
+	@Test
+	public void afterConstruction_isNotVisible()
+	{
+		assertFalse("StepProgressView must start hidden", view.isVisible());
+	}
+
+	@Test
+	public void hideStep_afterShowStep_actuallyHides() throws Exception
+	{
+		view.showStep(1, 3, "Do the thing", false, Collections.emptyList());
+		flushEdt();
+		assertTrue("showStep should make widget visible", view.isVisible());
+
+		view.hideStep();
+		flushEdt();
+		assertFalse("hideStep must make widget invisible", view.isVisible());
+	}
+
+	@Test
+	public void showStep_makesVisible() throws Exception
+	{
+		view.showStep(2, 4, "Pick up reward", true, Collections.emptyList());
+		flushEdt();
+		assertTrue("showStep must make widget visible", view.isVisible());
+	}
+
+	/** Flush the Swing event queue so invokeLater-scheduled work completes. */
+	private static void flushEdt() throws Exception
+	{
+		SwingUtilities.invokeAndWait(() -> { });
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #353. The step-details widget (blue-bordered panel with the **Skip** button) was visible in every state where guidance wasn't running — logged out, logged in idle, and after Stop Guidance still showing stale step text.

**Root cause** (not what the issue body guessed): `StepProgressView` was extracted in #351 with a `public void hide()` method. That signature shadows the deprecated-but-still-wired `java.awt.Component#hide()`. `Component.setVisible(boolean)` is implemented as `show(b)` which calls `hide()` when `b == false`, so Java's virtual dispatch routed it to the widget's override — which only schedules an `invokeLater` and never flips the `visible` field. Every call to `setVisible(false)` on this widget — including the one in its own constructor — was a silent no-op.

Why it worked pre-A1b: the old `stepProgressPanel` was a raw `JPanel`, not a subclass, so nothing shadowed `Component.hide()`.

Why existing tests missed it: `StepProgressViewTest` only asserted `doesNotThrow`, never `isVisible()`.

**Fix:** rename `hide()` → `hideStep()`, update the one caller (`CollectionLogHelperPanel.hideStepProgress`), and add three visibility regression tests that flush the EDT and assert `isVisible()`.

## Test plan

- [x] `./gradlew test` — full suite green
- [x] New test `afterConstruction_isNotVisible` — widget starts hidden
- [x] New test `hideStep_afterShowStep_actuallyHides` — `isVisible() == false` after `hideStep()`
- [x] New test `showStep_makesVisible` — `isVisible() == true` after `showStep(...)`
- [x] Manual smoke: pre-login, logged-in idle, after Stop Guidance — Skip panel gone in all three states
- [x] Manual smoke: Guide Me → panel populates → Next Step / Skip buttons still wired and functional

## Notes for reviewer

The method is renamed rather than refactoring the widget to follow the outer-transparent / inner-panel pattern used by `GuidanceBannerView` et al. That refactor would also fix it but touches more surface area; the rename addresses the actual root cause with minimal diff. Class-level Javadoc calls out the shadowing pitfall so it doesn't recur.