### PR TITLE
A1b follow-up: address LOW notes from PR #351 review

### DIFF
--- a/src/main/java/com/collectionloghelper/ui/widget/QuickGuidePanelView.java
+++ b/src/main/java/com/collectionloghelper/ui/widget/QuickGuidePanelView.java
@@ -119,6 +119,11 @@ public class QuickGuidePanelView
 		guideButton.setMaximumSize(new Dimension(Integer.MAX_VALUE, 28));
 		guideButton.addActionListener(e ->
 		{
+			// Note: This action listener updates the button locally (immediate),
+			// and the guidanceActivator/guidanceDeactivator callbacks route through
+			// GuidanceOverlayCoordinator → syncGuidanceState(), which updates the
+			// same button again on the next invokeLater. This double-update is
+			// expected and harmless (idempotent button state changes).
 			if (guideButton.getText().equals("Stop Guidance"))
 			{
 				guidanceDeactivator.run();

--- a/src/test/java/com/collectionloghelper/ui/widget/SlayerStrategyViewTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/SlayerStrategyViewTest.java
@@ -26,12 +26,17 @@ package com.collectionloghelper.ui.widget;
 
 import com.collectionloghelper.data.SlayerTaskState;
 import com.collectionloghelper.efficiency.SlayerStrategyCalculator;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 import java.util.Collections;
+import javax.swing.JButton;
+import javax.swing.SwingUtilities;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Unit tests for {@link SlayerStrategyView}.
@@ -95,5 +100,63 @@ public class SlayerStrategyViewTest
 			.thenReturn(Collections.emptyList());
 		Mockito.when(calculator.getMissingItemsForCreature(null)).thenReturn(0);
 		view.refresh();
+	}
+
+	@Test
+	public void refresh_activeTask_expandedState_doesNotThrow() throws Exception
+	{
+		Mockito.when(slayerTaskState.isTaskActive()).thenReturn(true);
+		Mockito.when(slayerTaskState.getCreatureName()).thenReturn("Abyssal Demons");
+		Mockito.when(slayerTaskState.getRemaining()).thenReturn(120);
+		Mockito.when(calculator.getRecommendedMaster()).thenReturn("Duradel");
+		Mockito.when(calculator.getUsefulSourcesForCreature("Abyssal Demons"))
+			.thenReturn(Collections.singletonList("Abyssal Lord"));
+		Mockito.when(calculator.getMissingItemsForCreature("Abyssal Demons")).thenReturn(2);
+		Mockito.when(calculator.getRecommendedBlockList("Duradel"))
+			.thenReturn(Collections.emptyList());
+
+		view.refresh();
+
+		// Drive the toggle button's ActionListener on the EDT to expand
+		SwingUtilities.invokeAndWait(() ->
+		{
+			ActionListener[] listeners = view.getComponents()[1].getListeners(ActionListener.class);
+			for (ActionListener listener : listeners)
+			{
+				listener.actionPerformed(new ActionEvent(this, ActionEvent.ACTION_PERFORMED, ""));
+			}
+		});
+
+		// No exception should occur; expanded content should render without error
+	}
+
+	@Test
+	public void toggleExpanded_multipleToggles_doesNotThrow() throws Exception
+	{
+		Mockito.when(slayerTaskState.isTaskActive()).thenReturn(true);
+		Mockito.when(slayerTaskState.getCreatureName()).thenReturn("Slayer Master");
+		Mockito.when(slayerTaskState.getRemaining()).thenReturn(50);
+		Mockito.when(calculator.getRecommendedMaster()).thenReturn("Konar");
+		Mockito.when(calculator.getUsefulSourcesForCreature("Slayer Master"))
+			.thenReturn(Collections.singletonList("Boss"));
+		Mockito.when(calculator.getMissingItemsForCreature("Slayer Master")).thenReturn(1);
+		Mockito.when(calculator.getRecommendedBlockList("Konar"))
+			.thenReturn(Collections.singletonList("Easy Task"));
+
+		view.refresh();
+
+		// Toggle expanded and collapsed states repeatedly
+		SwingUtilities.invokeAndWait(() ->
+		{
+			ActionListener[] listeners = view.getComponents()[1].getListeners(ActionListener.class);
+			if (listeners.length > 0)
+			{
+				ActionListener listener = listeners[0];
+				// Toggle to expanded
+				listener.actionPerformed(new ActionEvent(this, ActionEvent.ACTION_PERFORMED, ""));
+				// Toggle back to collapsed
+				listener.actionPerformed(new ActionEvent(this, ActionEvent.ACTION_PERFORMED, ""));
+			}
+		});
 	}
 }

--- a/src/test/java/com/collectionloghelper/ui/widget/SlayerStrategyViewTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/SlayerStrategyViewTest.java
@@ -26,10 +26,9 @@ package com.collectionloghelper.ui.widget;
 
 import com.collectionloghelper.data.SlayerTaskState;
 import com.collectionloghelper.efficiency.SlayerStrategyCalculator;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.util.Collections;
 import javax.swing.JButton;
+import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
 import org.junit.Before;
 import org.junit.Test;
@@ -117,17 +116,17 @@ public class SlayerStrategyViewTest
 
 		view.refresh();
 
-		// Drive the toggle button's ActionListener on the EDT to expand
-		SwingUtilities.invokeAndWait(() ->
-		{
-			ActionListener[] listeners = view.getComponents()[1].getListeners(ActionListener.class);
-			for (ActionListener listener : listeners)
-			{
-				listener.actionPerformed(new ActionEvent(this, ActionEvent.ACTION_PERFORMED, ""));
-			}
-		});
+		// Drill down to the toggle button: view → slayerStrategyPanel (JPanel) → strategyToggle (JButton).
+		// view.getComponents()[1] is the JPanel, not the button; the button sits one level deeper.
+		JPanel strategyPanel = (JPanel) view.getComponents()[1];
+		JButton toggle = (JButton) strategyPanel.getComponents()[0];
+		assertTrue("toggle should have an expand/collapse listener", toggle.getActionListeners().length > 0);
 
-		// No exception should occur; expanded content should render without error
+		SwingUtilities.invokeAndWait(toggle::doClick);
+
+		// After one click, toggle text should flip to the expanded glyph (▼).
+		assertTrue("toggle text should indicate expanded state after click",
+			toggle.getText().startsWith("\u25BC"));
 	}
 
 	@Test
@@ -145,18 +144,18 @@ public class SlayerStrategyViewTest
 
 		view.refresh();
 
-		// Toggle expanded and collapsed states repeatedly
-		SwingUtilities.invokeAndWait(() ->
-		{
-			ActionListener[] listeners = view.getComponents()[1].getListeners(ActionListener.class);
-			if (listeners.length > 0)
-			{
-				ActionListener listener = listeners[0];
-				// Toggle to expanded
-				listener.actionPerformed(new ActionEvent(this, ActionEvent.ACTION_PERFORMED, ""));
-				// Toggle back to collapsed
-				listener.actionPerformed(new ActionEvent(this, ActionEvent.ACTION_PERFORMED, ""));
-			}
-		});
+		JPanel strategyPanel = (JPanel) view.getComponents()[1];
+		JButton toggle = (JButton) strategyPanel.getComponents()[0];
+		String collapsedGlyph = "\u25B6";
+		String expandedGlyph = "\u25BC";
+		assertTrue("toggle should start collapsed", toggle.getText().startsWith(collapsedGlyph));
+
+		SwingUtilities.invokeAndWait(toggle::doClick);
+		assertTrue("toggle should be expanded after first click",
+			toggle.getText().startsWith(expandedGlyph));
+
+		SwingUtilities.invokeAndWait(toggle::doClick);
+		assertTrue("toggle should be collapsed after second click",
+			toggle.getText().startsWith(collapsedGlyph));
 	}
 }


### PR DESCRIPTION
## Summary
Addresses the two trailing LOW notes from the clh-pr-reviewer review of PR #351 (merged at commit 9b62bd7b):

1. **SlayerStrategyView expanded-state test coverage**: Added two new unit tests (`refresh_activeTask_expandedState_doesNotThrow` and `toggleExpanded_multipleToggles_doesNotThrow`) that drive the toggle into the expanded state and verify the strategy content renders without error. Tests use `SwingUtilities.invokeAndWait` to drive the ActionListener on the EDT (mirrors pattern in GuidanceBannerViewTest).

2. **QuickGuidePanelView double-update interaction comment**: Added a 3-line comment explaining that the guide button's action listener updates the button twice (once locally/immediate, once via the coordinator deferred via invokeLater). This double-update is expected and harmless.

## Details
Follow-up to cha-ndler/collection-log-helper#351 (A1b). Addresses the two LOW notes from the clh-pr-reviewer review: https://github.com/cha-ndler/collection-log-helper/pull/351

## Test Plan
- [x] All 515+ existing tests pass
- [x] New SlayerStrategyView expanded-state tests pass (2 new tests added)
- [x] No behavioral changes, only docs and test coverage additions
- [x] Verify QuickGuidePanelView compiles without errors