### PR TITLE
fix(data): add missing rewardType MILESTONE to 3 sources (#323 close)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -12834,6 +12834,7 @@
       }
     ],
     "afkLevel": 1,
+    "rewardType": "MILESTONE",
     "travelTip": "Obtain from various activities, open for random tier clue"
   },
   {
@@ -16096,6 +16097,7 @@
         "completionCondition": "MANUAL"
       }
     ],
+    "rewardType": "MILESTONE",
     "requirements": {
       "skills": [
         {
@@ -18167,7 +18169,8 @@
         "worldPlane": 0,
         "completionCondition": "MANUAL"
       }
-    ]
+    ],
+    "rewardType": "MILESTONE"
   },
   {
     "name": "Motherlode Mine",


### PR DESCRIPTION
Closes part of cha-ndler/collection-log-helper#323

## Summary

Full audit of all 14 sources from cha-ndler/collection-log-helper#323 confirmed that the `dropRate: 1.0` smell was already addressed in prior commits (`3bf6dd4` fix pointsPerHour/pointCost for 19 SHOP/MIXED sources, `5ffb9045` Fix Ocean Encounters, `d35ec7a3` Fix rewardType for Vale Totems/Boat Paints). One remaining gap: three sources had correct `milestoneKills` modeling on their items but were missing the top-level `rewardType` annotation.

### Sources fixed

| Source | Previous state | New state | Notes |
|---|---|---|---|
| Scroll Cases | `milestoneKills` per item, `rewardType` absent | `rewardType: "MILESTONE"` added | 13 items, milestone thresholds 25–250 clues |
| Ocean Encounters | `milestoneKills: 1` per item, `rewardType` absent | `rewardType: "MILESTONE"` added | 11 pearl items, each unlocks on first clam encounter |
| Shayzien Armour | `milestoneKills` per item, `rewardType` absent | `rewardType: "MILESTONE"` added | 25 items across tiers 1–5 (40/80/120/160/200 kills) |

### Sources confirmed already correct (no change needed)

| Source | Model |
|---|---|
| Pest Control | `rewardType: SHOP`, `pointsPerHour: 270`, `pointCost` per item |
| Mage Training Arena | `rewardType: SHOP`, `pointsPerHour: 10`, `pointCost` per item |
| Mahogany Homes | `rewardType: SHOP`, `pointsPerHour: 285`, `pointCost` per item |
| Mastering Mixology | `rewardType: SHOP`, `pointsPerHour: 12000`, `pointCost` per item |
| Volcanic Mine | `rewardType: SHOP`, `pointsPerHour: 10000`, `pointCost` per item |
| Tithe Farm | `rewardType: SHOP`, `pointsPerHour: 95`, `pointCost` per item |
| Castle Wars | `rewardType: SHOP`, `pointsPerHour: 12.7`, `pointCost` per item |
| Trouble Brewing | `rewardType: SHOP`, `pointsPerHour: 1200`, `pointCost` per item |
| Lost Schematics | `rewardType: SHOP`, `pointsPerHour: 2`, `pointCost: 1` per item |
| Monkey Backpacks | `rewardType: MILESTONE`, `milestoneKills` per lap tier |
| Motherlode Mine | `rewardType: SHOP`, `pointsPerHour: 8`, `pointCost` per item |
| Boat Paints | Drops use `dropRate`, unlocks use `milestoneKills` |

### Impact

Missing `rewardType` did not affect scoring (the `scoreIndividualItem` formula checks `milestoneKills > 0` and `pointCost > 0` directly, without branching on `rewardType`). The annotation is used only in the debug audit log (`RewardType:` line). Still correct to fix for consistency and future-proofing.

## Test plan

- [x] `validate_drop_rates` passes for all 3 fixed sources and globally
- [x] `./gradlew test` — 514/514 tests passed, BUILD SUCCESSFUL