### PR TITLE
ci: add GitHub Actions build and test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-gradle-
+
+      - name: Build and test
+        run: ./gradlew build
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: build/reports/tests/
+          retention-days: 7


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` — runs `./gradlew build` (compile + test) on every PR to master and every push to master
- Caches Gradle packages for faster subsequent runs
- Uploads test results as artifacts (7-day retention) for debugging failures

## What this enables
- PRs show green/red CI status before manual merge
- Build failures caught automatically instead of relying on local verification
- Future: can add as a required status check in branch protection settings

## Test plan
- [x] This PR itself will trigger the workflow — check the Actions tab after opening