### PR TITLE
fix(guidance): step ordering, teleport arrival detection, skip overlay refresh

### DIFF
--- a/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
@@ -240,9 +240,12 @@ public class CollectionLogHelperPlugin extends Plugin
 			filter -> configManager.setConfiguration("collectionloghelper", "afkFilter", filter.name()),
 			sort -> configManager.setConfiguration("collectionloghelper", "efficientSortMode", sort.name()));
 		panel.setMode(config.defaultMode());
+		// Route step-advance and skip through the client thread so overlay
+		// rescans (e.g. ObjectHighlightOverlay.rescanScene) fire in the same
+		// game-frame as auto-completion events rather than the next tick.
 		panel.setStepCallbacks(
-			() -> guidanceSequencer.advanceStep(),
-			() -> guidanceSequencer.skipStep()
+			() -> clientThread.invokeLater(guidanceSequencer::advanceStep),
+			() -> clientThread.invokeLater(guidanceSequencer::skipStep)
 		);
 
 		// Wire coordinator with references it needs from the plugin

--- a/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
@@ -215,14 +215,28 @@ public class GuidanceOverlayCoordinator
 		if (source.getGuidanceSteps() != null && !source.getGuidanceSteps().isEmpty())
 		{
 			guidanceSequencer.setPlayerLocation(cachedPlayerLocation);
-			// startSequence triggers onStepChanged callback which handles
-			// applyStepToOverlays and scanForTrackedNpc for the initial step
+			// startSequence runs the initial skip-chain synchronously. If all steps
+			// are already satisfied, onSequenceComplete fires inside startSequence,
+			// which calls deactivateGuidance() — leave panel cleared and return.
 			guidanceSequencer.startSequence(source, this::onStepChanged, this::onSequenceComplete);
+
+			if (!guidanceSequencer.isActive())
+			{
+				// All steps were already satisfied — sequence completed immediately.
+				// onSequenceComplete already called deactivateGuidance(); nothing more to do.
+				log.debug("Multi-step guidance for {} completed immediately (all steps already satisfied)",
+					source.getName());
+				return;
+			}
+
+			// Sequence is active: landed on a mid-sequence step after skip-chain.
+			// Explicitly push the landed step to the panel to ensure the blue box is
+			// rendered even when the skip-chain bypassed the normal step-transition path.
 			GuidanceStep step = guidanceSequencer.getCurrentStep();
+			GuidanceStep rawStep = guidanceSequencer.getRawCurrentStep();
 			if (panel != null)
 			{
 				panel.setGuidanceState(true, source);
-				GuidanceStep rawStep = guidanceSequencer.getRawCurrentStep();
 				panel.updateStepProgress(
 					guidanceSequencer.getCurrentIndex() + 1,
 					guidanceSequencer.getTotalSteps(),
@@ -230,18 +244,20 @@ public class GuidanceOverlayCoordinator
 					step != null && step.getCompletionCondition() == CompletionCondition.MANUAL,
 					rawStep != null ? rawStep.getRequiredItemIds() : null);
 			}
-			// Add InfoBox showing step progress
+			// Add InfoBox showing the correct landed step (not always "1/N")
 			if (!source.getItems().isEmpty() && pluginInstance != null)
 			{
 				BufferedImage icon = itemManager.getImage(source.getItems().get(0).getItemId());
 				activeInfoBox = new GuidanceInfoBox(icon, pluginInstance);
-				activeInfoBox.setStepText("1/" + guidanceSequencer.getTotalSteps());
+				int landedStep = guidanceSequencer.getCurrentIndex() + 1;
+				activeInfoBox.setStepText(landedStep + "/" + guidanceSequencer.getTotalSteps());
 				activeInfoBox.setTooltipText(source.getName() + ": "
 					+ (step != null ? step.getDescription() : ""));
 				infoBoxManager.addInfoBox(activeInfoBox);
 			}
-			log.debug("Multi-step guidance activated for {} ({} steps)",
-				source.getName(), source.getGuidanceSteps().size());
+			log.debug("Multi-step guidance activated for {} ({} steps, starting at step {})",
+				source.getName(), source.getGuidanceSteps().size(),
+				guidanceSequencer.getCurrentIndex() + 1);
 			return;
 		}
 

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -11640,13 +11640,14 @@
     "travelTip": "Minigame teleport -> Shades of Mort'ton, or Mort'ton teleport scroll",
     "guidanceSteps": [
       {
-        "description": "Travel to Mort'ton via Barrows teleport or fairy ring BKR. Bring pyre logs and shade remains",
-        "worldX": 3506,
-        "worldY": 3310,
+        "description": "Bank: bring pyre logs, shade remains, and a tinderbox to Mort'ton",
+        "worldX": 3488,
+        "worldY": 3283,
         "worldPlane": 0,
-        "travelTip": "Minigame teleport -> Shades of Mort'ton | Barrows teleport + run south | Mort'ton teleport scroll",
+        "travelTip": "Minigame teleport -> Shades of Mort'ton | Barrows teleport + run south | Mort'ton teleport scroll | Fairy ring BKR",
+        "requiredItemIds": [590],
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 8
+        "completionDistance": 25
       },
       {
         "description": "Burn shade remains on the funeral pyres, then use shade keys on the underground chests",

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -11690,9 +11690,9 @@
         "completionChatPattern": "You attempt to light the funeral pyre"
       },
       {
-        "description": "Pick up your shade key from the reward pillar",
-        "worldX": 3505,
-        "worldY": 3279,
+        "description": "Pick up your shade key from the reward pillar inside the temple.",
+        "worldX": 3495,
+        "worldY": 3298,
         "worldPlane": 0,
         "groundItemIds": [
           3450,

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
@@ -1500,4 +1500,106 @@ public class GuidanceSequencerTest
 		GuidanceStep resolved = base.resolveAlternative(mockChecker);
 		assertSame(base, resolved);
 	}
+
+	// ---- Skip-chain on activation tests (#375) ----
+
+	/**
+	 * When the initial skip-chain skips N steps and lands on step N+1,
+	 * onStepChanged must be called with that landed step and the sequencer
+	 * index must reflect the skipped position.
+	 * This guards the bug where the panel blue box was not rendered after
+	 * mid-sequence activation.
+	 */
+	@Test
+	public void testStepChangedCallbackFiredWithLandedStepAfterSkipChain()
+	{
+		int item1 = 100;
+		// Step 1: already satisfied (player has item)
+		when(inventoryState.hasItemCount(item1, 1)).thenReturn(true);
+
+		List<GuidanceStep> steps = Arrays.asList(
+			makeInventoryHasItemStep(item1, 1),  // step 0: will be skipped
+			makeManualStep("Landed step"),        // step 1: should be landed on
+			makeManualStep("Final step")          // step 2: not yet reached
+		);
+
+		AtomicReference<GuidanceStep> landedStep = new AtomicReference<>();
+		AtomicReference<Integer> landedIndex = new AtomicReference<>();
+
+		startSequence(steps, s -> {
+			landedStep.set(s);
+			landedIndex.set(sequencer.getCurrentIndex());
+		}, () -> {});
+
+		// Skip-chain should have advanced past step 0 and landed on step 1
+		assertTrue("Sequencer should still be active", sequencer.isActive());
+		assertEquals("Should be at index 1 (step 2/3)", 1, sequencer.getCurrentIndex());
+
+		// onStepChanged must have been called with the landed step
+		assertNotNull("onStepChanged must be called after skip-chain", landedStep.get());
+		assertEquals("Landed step description must match", "Landed step", landedStep.get().getDescription());
+		assertEquals("Landed index must match current index", 1, landedIndex.get().intValue());
+	}
+
+	/**
+	 * When all steps are already satisfied at activation, onStepChanged must NOT be
+	 * called (there is no valid step to display), but onSequenceComplete must fire,
+	 * and the sequencer must be inactive when startSequence returns.
+	 * This guards the edge-case where the panel showed an empty blue box ("Step 1/0:").
+	 */
+	@Test
+	public void testAllStepsSatisfiedNoStepChangedCallbackFired()
+	{
+		int item1 = 100, item2 = 200;
+		when(inventoryState.hasItemCount(item1, 1)).thenReturn(true);
+		when(inventoryState.hasItemCount(item2, 1)).thenReturn(true);
+
+		List<GuidanceStep> steps = Arrays.asList(
+			makeInventoryHasItemStep(item1, 1),
+			makeInventoryHasItemStep(item2, 1)
+		);
+
+		AtomicReference<GuidanceStep> receivedStep = new AtomicReference<>();
+		AtomicBoolean completed = new AtomicBoolean(false);
+
+		startSequence(steps, s -> receivedStep.set(s), () -> completed.set(true));
+
+		// Sequence should be complete and inactive
+		assertTrue("onSequenceComplete must fire", completed.get());
+		assertFalse("Sequencer must be inactive after all-satisfied sequence", sequencer.isActive());
+
+		// onStepChanged must NOT have been called — there is no valid step to land on
+		assertNull("onStepChanged must not be called when all steps are already satisfied",
+			receivedStep.get());
+	}
+
+	/**
+	 * When the skip-chain skips the first two steps out of five and lands on step 3,
+	 * the callback receives step 3 and the index is 2.
+	 * Mirrors the Shades of Mort'ton scenario from issue #375.
+	 */
+	@Test
+	public void testMidSequenceActivationLandsOnCorrectStep()
+	{
+		// Steps 1 and 2: ARRIVE_AT_TILE already satisfied (player is at location)
+		sequencer.setPlayerLocation(new WorldPoint(3507, 3275, 0));
+
+		List<GuidanceStep> steps = Arrays.asList(
+			makeArriveStep(3488, 3283, 0, 25),   // step 0: bank/arrive — satisfied
+			makeArriveStep(3507, 3275, 0, 10),   // step 1: at pyre — satisfied
+			makeManualStep("Pick up shade key"), // step 2: not satisfied, should land here
+			makeManualStep("Enter catacombs"),   // step 3
+			makeManualStep("Open chests")        // step 4
+		);
+
+		AtomicReference<GuidanceStep> landedStep = new AtomicReference<>();
+		startSequence(steps, s -> landedStep.set(s), () -> {});
+
+		assertTrue("Sequencer should be active", sequencer.isActive());
+		assertEquals("Should land on index 2", 2, sequencer.getCurrentIndex());
+		assertEquals("Total steps should be 5", 5, sequencer.getTotalSteps());
+		assertNotNull("onStepChanged must have fired", landedStep.get());
+		assertEquals("Landed step should be 'Pick up shade key'",
+			"Pick up shade key", landedStep.get().getDescription());
+	}
 }


### PR DESCRIPTION
## Summary

- **#366 Problem A (data)**: Shades of Mort'ton travel step was step 1, but the player needs a tinderbox (and pyre logs/shade remains) before travelling. Added `requiredItemIds:[590]` to the travel step so the existing bank-routing mechanism in `GuidanceSequencer.getCurrentStep()` automatically prompts the player to bank before setting off.
- **#366 Problem B (data)**: Mort'ton teleport scroll lands ~30 tiles from the old ARRIVE_AT_TILE target `(3506,3310)`, well outside the 8-tile threshold. Re-anchored the completion point to the centre of Mort'ton town `(3488,3283)` and widened `completionDistance` from `8` → `25`, covering all common arrival methods (teleport scroll ~4 tiles, minigame teleport, fairy ring BKR, Barrows + run south).
- **#367 (code)**: Skip and Next Step button callbacks fired on the Swing EDT, causing `ObjectHighlightOverlay.rescanScene()` (queued via `clientThread.invokeLater`) to execute on the next game tick instead of the current frame's event queue. Wrapped both callbacks in `clientThread.invokeLater` at the wiring site in `CollectionLogHelperPlugin`, making EDT-triggered advances consistent with auto-completion events.
- **#375 (code)**: When activation skip-chain bypassed already-satisfied steps and landed mid-sequence, the panel blue box (StepProgressView) was not reliably rendered. Fixed two sub-bugs: (a) if all steps were already satisfied, `deactivateGuidance()` was called inside `startSequence` but `activateGuidance` continued and re-showed an empty "Step 1/0:" box; (b) InfoBox step text was hardcoded to "1/N" regardless of landed step. Now returns early if sequencer is inactive post-startSequence, and InfoBox uses the correct landed index.
- **#376 (data)**: Shades of Mort'ton step 3/5 shade-key pickup tile was at `(3505,3279)` on the surface near the funeral pyres — between the pyre and the temple reward pillar, causing visual confusion. Moved tile to `(3495,3298)` inside the Mort'ton temple where the reward pillar and shade key ground items actually appear. Updated description for clarity. All 5 steps reviewed; no other changes needed.

## Problem A.5 — Audit of other sources

Audited all 227 sources with an `ARRIVE_AT_TILE` first step for `requiredItemIds` in subsequent steps. **Only Shades of Mort'ton** had the bank-before-travel ordering issue. No other sources require items from a bank before the first travel step.

## Root cause summary

| Bug | Root cause |
|-----|------------|
| #366-A step order | Travel was step 1; no `requiredItemIds` on travel step meant bank routing never triggered for the items needed at the destination |
| #366-B teleport scroll | `completionDistance: 8` from `(3506,3310)` is ~30 tiles from the Mort'ton teleport scroll landing spot |
| #367 skip overlays | Step callbacks wired to EDT; `invokeLater(rescanScene)` queued for next tick instead of current frame |
| #375 blue box | Skip-chain on activation did not update panel in all-satisfied edge case; InfoBox hardcoded "1/N" |
| #376 tile marker | Step 3 tile at `(3505,3279)` (surface, near pyre) should be `(3495,3298)` (inside temple, reward pillar) |

## Test plan

- [ ] Start guidance on Shades of Mort'ton without tinderbox in inventory → bank step appears first
- [ ] Start guidance on Shades of Mort'ton with tinderbox → travel step appears first, auto-completes when arriving within 25 tiles via any teleport method
- [ ] Teleport to Mort'ton via teleport scroll → travel step auto-completes
- [ ] Click Skip on any step → next step's overlays render on the same game frame (no visible gap)
- [ ] Start guidance on Shades of Mort'ton already at Mort'ton with shade keys in inventory → blue box shows step 3/5 (shade key pickup) immediately
- [ ] Start guidance on Shades of Mort'ton with all steps already complete → guidance deactivates cleanly, no empty blue box
- [ ] Step 3/5 tile marker appears inside the Mort'ton temple near the reward pillar
- [ ] Full test suite: `./gradlew clean test` — all tests pass

Closes cha-ndler/collection-log-helper#366
Closes cha-ndler/collection-log-helper#367
Closes cha-ndler/collection-log-helper#375
Closes cha-ndler/collection-log-helper#376