### PR TITLE
fix(guidance): surface required-item availability; remove bank-step routing

### DIFF
--- a/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
@@ -33,10 +33,7 @@ import com.collectionloghelper.data.DropRateDatabase;
 import com.collectionloghelper.data.GuidanceStep;
 import com.collectionloghelper.data.ItemObjectTier;
 import com.collectionloghelper.data.PlayerCollectionState;
-import com.collectionloghelper.data.PlayerBankState;
 import com.collectionloghelper.data.PlayerInventoryState;
-import com.collectionloghelper.overlay.GuidanceOverlay.RequiredItemDisplay;
-import com.collectionloghelper.overlay.GuidanceOverlay.RequiredItemDisplay.Status;
 import com.collectionloghelper.data.PlayerTravelCapabilities;
 import com.collectionloghelper.data.RequirementsChecker;
 import com.collectionloghelper.overlay.CollectionLogWorldMapPoint;
@@ -52,6 +49,7 @@ import com.collectionloghelper.overlay.WorldMapRouteOverlay;
 import com.collectionloghelper.ui.CollectionLogHelperPanel;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -96,8 +94,8 @@ public class GuidanceOverlayCoordinator
 	private final RequirementsChecker requirementsChecker;
 	private final PlayerTravelCapabilities travelCapabilities;
 	private final PlayerInventoryState playerInventoryState;
-	private final PlayerBankState playerBankState;
 	private final ItemManager itemManager;
+	private final RequiredItemResolver requiredItemResolver;
 	private final WorldMapPointManager worldMapPointManager;
 	private final InfoBoxManager infoBoxManager;
 	private final GuidanceOverlay guidanceOverlay;
@@ -156,8 +154,8 @@ public class GuidanceOverlayCoordinator
 		RequirementsChecker requirementsChecker,
 		PlayerTravelCapabilities travelCapabilities,
 		PlayerInventoryState playerInventoryState,
-		PlayerBankState playerBankState,
 		ItemManager itemManager,
+		RequiredItemResolver requiredItemResolver,
 		WorldMapPointManager worldMapPointManager,
 		InfoBoxManager infoBoxManager,
 		GuidanceOverlay guidanceOverlay,
@@ -177,8 +175,8 @@ public class GuidanceOverlayCoordinator
 		this.requirementsChecker = requirementsChecker;
 		this.travelCapabilities = travelCapabilities;
 		this.playerInventoryState = playerInventoryState;
-		this.playerBankState = playerBankState;
 		this.itemManager = itemManager;
+		this.requiredItemResolver = requiredItemResolver;
 		this.worldMapPointManager = worldMapPointManager;
 		this.infoBoxManager = infoBoxManager;
 		this.guidanceOverlay = guidanceOverlay;
@@ -256,7 +254,7 @@ public class GuidanceOverlayCoordinator
 			// Clue sources: text overlay + panel banner instead of map markers
 			guidanceOverlay.setClueGuidanceText("Do " + source.getName());
 			// Clue-only sources never carry per-step required items.
-			guidanceOverlay.setRequiredItems(java.util.Collections.emptyList());
+			guidanceOverlay.setRequiredItems(Collections.emptyList());
 			if (panel != null)
 			{
 				panel.showClueGuidance(source);
@@ -428,59 +426,6 @@ public class GuidanceOverlayCoordinator
 		return missing;
 	}
 
-	/**
-	 * Resolves each required item ID into a display row (name + availability).
-	 * Held-in-inventory and equipped both count as {@link Status#HELD}; bank
-	 * scan hits count as {@link Status#IN_BANK}; nothing-found is
-	 * {@link Status#MISSING}. Item names are looked up via {@link ItemManager}.
-	 *
-	 * <p>Returns an empty list when the step has no required items.
-	 */
-	private List<RequiredItemDisplay> resolveRequiredItems(GuidanceStep step)
-	{
-		if (step == null
-			|| step.getRequiredItemIds() == null
-			|| step.getRequiredItemIds().isEmpty())
-		{
-			return java.util.Collections.emptyList();
-		}
-
-		List<RequiredItemDisplay> out = new java.util.ArrayList<>(step.getRequiredItemIds().size());
-		for (Integer itemId : step.getRequiredItemIds())
-		{
-			if (itemId == null || itemId <= 0)
-			{
-				continue;
-			}
-
-			Status status;
-			if (playerInventoryState.hasItem(itemId) || playerInventoryState.hasEquippedItem(itemId))
-			{
-				status = Status.HELD;
-			}
-			else if (playerBankState.hasItem(itemId))
-			{
-				status = Status.IN_BANK;
-			}
-			else
-			{
-				status = Status.MISSING;
-			}
-
-			String name;
-			try
-			{
-				name = itemManager.getItemComposition(itemId).getName();
-			}
-			catch (Exception ex)
-			{
-				name = "Item #" + itemId;
-			}
-			out.add(new RequiredItemDisplay(name, status));
-		}
-		return out;
-	}
-
 	// -- Private methods --
 
 	/**
@@ -555,7 +500,7 @@ public class GuidanceOverlayCoordinator
 
 		// Resolve required-item availability for this step once and push to the
 		// overlay; the render loop must never touch inventory/bank state.
-		guidanceOverlay.setRequiredItems(resolveRequiredItems(step));
+		guidanceOverlay.setRequiredItems(requiredItemResolver.resolve(step));
 
 		if (step.getWorldX() > 0)
 		{
@@ -708,7 +653,7 @@ public class GuidanceOverlayCoordinator
 		guidanceOverlay.setTargetName(source.getName());
 		guidanceOverlay.setLocationDescription(displayName);
 		// Non-sequencer path: no step context, so no per-step item requirements.
-		guidanceOverlay.setRequiredItems(java.util.Collections.emptyList());
+		guidanceOverlay.setRequiredItems(Collections.emptyList());
 		guidanceOverlay.setTravelTip(source.getTravelTip());
 		guidanceOverlay.setTargetNpcId(source.getNpcId());
 		guidanceOverlay.setInteractAction(source.getInteractAction());

--- a/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
@@ -33,7 +33,10 @@ import com.collectionloghelper.data.DropRateDatabase;
 import com.collectionloghelper.data.GuidanceStep;
 import com.collectionloghelper.data.ItemObjectTier;
 import com.collectionloghelper.data.PlayerCollectionState;
+import com.collectionloghelper.data.PlayerBankState;
 import com.collectionloghelper.data.PlayerInventoryState;
+import com.collectionloghelper.overlay.GuidanceOverlay.RequiredItemDisplay;
+import com.collectionloghelper.overlay.GuidanceOverlay.RequiredItemDisplay.Status;
 import com.collectionloghelper.data.PlayerTravelCapabilities;
 import com.collectionloghelper.data.RequirementsChecker;
 import com.collectionloghelper.overlay.CollectionLogWorldMapPoint;
@@ -93,6 +96,7 @@ public class GuidanceOverlayCoordinator
 	private final RequirementsChecker requirementsChecker;
 	private final PlayerTravelCapabilities travelCapabilities;
 	private final PlayerInventoryState playerInventoryState;
+	private final PlayerBankState playerBankState;
 	private final ItemManager itemManager;
 	private final WorldMapPointManager worldMapPointManager;
 	private final InfoBoxManager infoBoxManager;
@@ -152,6 +156,7 @@ public class GuidanceOverlayCoordinator
 		RequirementsChecker requirementsChecker,
 		PlayerTravelCapabilities travelCapabilities,
 		PlayerInventoryState playerInventoryState,
+		PlayerBankState playerBankState,
 		ItemManager itemManager,
 		WorldMapPointManager worldMapPointManager,
 		InfoBoxManager infoBoxManager,
@@ -172,6 +177,7 @@ public class GuidanceOverlayCoordinator
 		this.requirementsChecker = requirementsChecker;
 		this.travelCapabilities = travelCapabilities;
 		this.playerInventoryState = playerInventoryState;
+		this.playerBankState = playerBankState;
 		this.itemManager = itemManager;
 		this.worldMapPointManager = worldMapPointManager;
 		this.infoBoxManager = infoBoxManager;
@@ -249,6 +255,8 @@ public class GuidanceOverlayCoordinator
 		{
 			// Clue sources: text overlay + panel banner instead of map markers
 			guidanceOverlay.setClueGuidanceText("Do " + source.getName());
+			// Clue-only sources never carry per-step required items.
+			guidanceOverlay.setRequiredItems(java.util.Collections.emptyList());
 			if (panel != null)
 			{
 				panel.showClueGuidance(source);
@@ -420,6 +428,59 @@ public class GuidanceOverlayCoordinator
 		return missing;
 	}
 
+	/**
+	 * Resolves each required item ID into a display row (name + availability).
+	 * Held-in-inventory and equipped both count as {@link Status#HELD}; bank
+	 * scan hits count as {@link Status#IN_BANK}; nothing-found is
+	 * {@link Status#MISSING}. Item names are looked up via {@link ItemManager}.
+	 *
+	 * <p>Returns an empty list when the step has no required items.
+	 */
+	private List<RequiredItemDisplay> resolveRequiredItems(GuidanceStep step)
+	{
+		if (step == null
+			|| step.getRequiredItemIds() == null
+			|| step.getRequiredItemIds().isEmpty())
+		{
+			return java.util.Collections.emptyList();
+		}
+
+		List<RequiredItemDisplay> out = new java.util.ArrayList<>(step.getRequiredItemIds().size());
+		for (Integer itemId : step.getRequiredItemIds())
+		{
+			if (itemId == null || itemId <= 0)
+			{
+				continue;
+			}
+
+			Status status;
+			if (playerInventoryState.hasItem(itemId) || playerInventoryState.hasEquippedItem(itemId))
+			{
+				status = Status.HELD;
+			}
+			else if (playerBankState.hasItem(itemId))
+			{
+				status = Status.IN_BANK;
+			}
+			else
+			{
+				status = Status.MISSING;
+			}
+
+			String name;
+			try
+			{
+				name = itemManager.getItemComposition(itemId).getName();
+			}
+			catch (Exception ex)
+			{
+				name = "Item #" + itemId;
+			}
+			out.add(new RequiredItemDisplay(name, status));
+		}
+		return out;
+	}
+
 	// -- Private methods --
 
 	/**
@@ -491,6 +552,10 @@ public class GuidanceOverlayCoordinator
 
 		// Suppress tile highlight when ObjectHighlightOverlay handles the visual
 		guidanceOverlay.setSuppressTileHighlight(!step.getAllObjectIds().isEmpty());
+
+		// Resolve required-item availability for this step once and push to the
+		// overlay; the render loop must never touch inventory/bank state.
+		guidanceOverlay.setRequiredItems(resolveRequiredItems(step));
 
 		if (step.getWorldX() > 0)
 		{
@@ -642,6 +707,8 @@ public class GuidanceOverlayCoordinator
 		guidanceOverlay.setTargetPoint(worldPoint);
 		guidanceOverlay.setTargetName(source.getName());
 		guidanceOverlay.setLocationDescription(displayName);
+		// Non-sequencer path: no step context, so no per-step item requirements.
+		guidanceOverlay.setRequiredItems(java.util.Collections.emptyList());
 		guidanceOverlay.setTravelTip(source.getTravelTip());
 		guidanceOverlay.setTargetNpcId(source.getNpcId());
 		guidanceOverlay.setInteractAction(source.getInteractAction());

--- a/src/main/java/com/collectionloghelper/guidance/GuidanceSequencer.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceSequencer.java
@@ -49,11 +49,6 @@ import net.runelite.api.coords.WorldPoint;
 @Singleton
 public class GuidanceSequencer
 {
-	/** Grand Exchange bank location for synthetic "go to bank" steps. */
-	private static final int GE_BANK_X = 3164;
-	private static final int GE_BANK_Y = 3489;
-	private static final int GE_BANK_PLANE = 0;
-
 	private final PlayerInventoryState inventoryState;
 	private final PlayerCollectionState collectionState;
 	private final RequirementsChecker requirementsChecker;
@@ -147,8 +142,11 @@ public class GuidanceSequencer
 	/**
 	 * Returns the current guidance step, or null if no sequence is active.
 	 * If the step has conditional alternatives, returns the resolved version.
-	 * If the current step requires items not in inventory, returns a synthetic
-	 * "go to bank" step instead.
+	 *
+	 * <p>Missing {@code requiredItemIds} no longer trigger a synthetic bank
+	 * routing step. Required items are surfaced informationally via the panel
+	 * and in-game overlay (with green / yellow / red availability borders);
+	 * the player chooses when and where to bank.
 	 */
 	public GuidanceStep getCurrentStep()
 	{
@@ -156,17 +154,7 @@ public class GuidanceSequencer
 		{
 			return null;
 		}
-
-		GuidanceStep step = resolveStep(currentIndex);
-
-		// Check if the step requires items not currently in inventory
-		if (step.getRequiredItemIds() != null && !step.getRequiredItemIds().isEmpty()
-			&& !inventoryState.hasAllItems(step.getRequiredItemIds()))
-		{
-			return createBankStep(step);
-		}
-
-		return step;
+		return resolveStep(currentIndex);
 	}
 
 	/**
@@ -678,35 +666,6 @@ public class GuidanceSequencer
 			default:
 				return false;
 		}
-	}
-
-	private GuidanceStep createBankStep(GuidanceStep originalStep)
-	{
-		return new GuidanceStep(
-			"Get required items from bank",
-			GE_BANK_X, GE_BANK_Y, GE_BANK_PLANE,
-			0, null, null,
-			"Grand Exchange bank",
-			null,
-			CompletionCondition.MANUAL,
-			0, 0, 0, 0,
-			null,  // completionNpcIds
-			null,  // worldMessage
-			0, null, null,  // objectId, objectIds, objectInteractAction
-			null,  // highlightItemIds
-			null,  // groundItemIds
-			null,  // completionChatPattern
-			0, 0,  // completionVarbitId, completionVarbitValue
-			false,  // useItemOnObject
-			0,     // objectMaxDistance
-			null,  // objectFilterTiles
-			null,  // highlightWidgetIds
-			0, 0,  // loopBackToStep, loopCount
-			null,  // skipIfHasAnyItemIds
-			null,  // dynamicItemObjectTiers
-			null,  // completionZone
-			null   // conditionalAlternatives
-		);
 	}
 
 	private void notifyStepChanged(GuidanceStep step)

--- a/src/main/java/com/collectionloghelper/guidance/RequiredItemDisplay.java
+++ b/src/main/java/com/collectionloghelper/guidance/RequiredItemDisplay.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.guidance;
+
+import java.awt.Color;
+import java.util.Objects;
+
+/**
+ * Immutable display row describing a single required item's availability
+ * for the active guidance step.
+ *
+ * <p>Resolved by {@link RequiredItemResolver} at step-transition time and
+ * pushed to both the side panel (StepProgressView) and the in-game overlay
+ * (GuidanceOverlay) so the render path never touches inventory or bank state.
+ *
+ * <p>Color constants are shared by both render targets so a "missing" badge
+ * looks the same in the panel and the in-game overlay.
+ */
+public final class RequiredItemDisplay
+{
+	/** Item is in inventory or equipped on the player. */
+	public static final Color COLOR_HELD = new Color(40, 180, 40);
+	/** Item is not on the player but was seen in the last bank scan. */
+	public static final Color COLOR_IN_BANK = new Color(200, 180, 40);
+	/** Item is not held anywhere known to the plugin. */
+	public static final Color COLOR_MISSING = new Color(200, 40, 40);
+
+	public enum Status
+	{
+		HELD,
+		IN_BANK,
+		MISSING
+	}
+
+	private final String name;
+	private final Status status;
+
+	public RequiredItemDisplay(String name, Status status)
+	{
+		this.name = Objects.requireNonNull(name, "name");
+		this.status = Objects.requireNonNull(status, "status");
+	}
+
+	public String getName()
+	{
+		return name;
+	}
+
+	public Status getStatus()
+	{
+		return status;
+	}
+
+	/** Returns the color associated with this row's status. */
+	public Color getStatusColor()
+	{
+		switch (status)
+		{
+			case HELD:
+				return COLOR_HELD;
+			case IN_BANK:
+				return COLOR_IN_BANK;
+			case MISSING:
+			default:
+				return COLOR_MISSING;
+		}
+	}
+
+	@Override
+	public boolean equals(Object o)
+	{
+		if (this == o)
+		{
+			return true;
+		}
+		if (!(o instanceof RequiredItemDisplay))
+		{
+			return false;
+		}
+		RequiredItemDisplay other = (RequiredItemDisplay) o;
+		return status == other.status && name.equals(other.name);
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return Objects.hash(name, status);
+	}
+
+	@Override
+	public String toString()
+	{
+		return "RequiredItemDisplay{name='" + name + "', status=" + status + '}';
+	}
+}

--- a/src/main/java/com/collectionloghelper/guidance/RequiredItemResolver.java
+++ b/src/main/java/com/collectionloghelper/guidance/RequiredItemResolver.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.guidance;
+
+import com.collectionloghelper.data.GuidanceStep;
+import com.collectionloghelper.data.PlayerBankState;
+import com.collectionloghelper.data.PlayerInventoryState;
+import com.collectionloghelper.guidance.RequiredItemDisplay.Status;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.game.ItemManager;
+
+/**
+ * Resolves a {@link GuidanceStep}'s required item IDs into display rows
+ * (name + availability) by consulting inventory and bank state.
+ *
+ * <p>This runs at step-transition time (not in any render loop), so the
+ * cost of {@link ItemManager#getItemComposition(int)} is paid once per
+ * step change rather than every frame.
+ */
+@Slf4j
+@Singleton
+public class RequiredItemResolver
+{
+	private final PlayerInventoryState inventoryState;
+	private final PlayerBankState bankState;
+	private final ItemManager itemManager;
+
+	@Inject
+	RequiredItemResolver(
+		PlayerInventoryState inventoryState,
+		PlayerBankState bankState,
+		ItemManager itemManager)
+	{
+		this.inventoryState = inventoryState;
+		this.bankState = bankState;
+		this.itemManager = itemManager;
+	}
+
+	/**
+	 * Resolves a step's required item IDs into display rows.
+	 * Returns an empty list when the step is null, has no required items,
+	 * or the list contains only invalid IDs.
+	 */
+	public List<RequiredItemDisplay> resolve(GuidanceStep step)
+	{
+		if (step == null
+			|| step.getRequiredItemIds() == null
+			|| step.getRequiredItemIds().isEmpty())
+		{
+			return Collections.emptyList();
+		}
+
+		List<Integer> ids = step.getRequiredItemIds();
+		List<RequiredItemDisplay> out = new ArrayList<>(ids.size());
+		for (Integer itemId : ids)
+		{
+			if (itemId == null || itemId <= 0)
+			{
+				continue;
+			}
+			out.add(resolveSingle(itemId));
+		}
+		return out;
+	}
+
+	private RequiredItemDisplay resolveSingle(int itemId)
+	{
+		Status status = resolveStatus(itemId);
+		return new RequiredItemDisplay(lookupName(itemId), status);
+	}
+
+	private Status resolveStatus(int itemId)
+	{
+		if (inventoryState.hasItem(itemId) || inventoryState.hasEquippedItem(itemId))
+		{
+			return Status.HELD;
+		}
+		if (bankState.hasItem(itemId))
+		{
+			return Status.IN_BANK;
+		}
+		return Status.MISSING;
+	}
+
+	private String lookupName(int itemId)
+	{
+		try
+		{
+			return itemManager.getItemComposition(itemId).getName();
+		}
+		catch (RuntimeException ex)
+		{
+			// Defensive: getItemComposition can throw for invalid IDs in some
+			// client states (e.g. cache not yet loaded). Surface the ID so the
+			// player still sees a row instead of silently dropping it.
+			log.debug("Item composition lookup failed for id {}: {}", itemId, ex.getMessage());
+			return "Item #" + itemId;
+		}
+	}
+}

--- a/src/main/java/com/collectionloghelper/overlay/GuidanceOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/GuidanceOverlay.java
@@ -26,6 +26,7 @@ package com.collectionloghelper.overlay;
 
 import com.collectionloghelper.CollectionLogHelperConfig;
 import com.collectionloghelper.NpcHighlightStyle;
+import com.collectionloghelper.guidance.RequiredItemDisplay;
 import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Dimension;
@@ -72,9 +73,6 @@ public class GuidanceOverlay extends OverlayPanel
 	private static final Color ACTION_COLOR = new Color(100, 255, 100);
 	private static final Color REMINDER_COLOR = new Color(255, 170, 0);
 	private static final Color ITEM_REQUIREMENTS_HEADER_COLOR = new Color(220, 220, 220);
-	static final Color ITEM_HELD_COLOR = new Color(40, 180, 40);
-	static final Color ITEM_IN_BANK_COLOR = new Color(200, 180, 40);
-	static final Color ITEM_MISSING_COLOR = new Color(220, 70, 70);
 	private static final int MAX_RENDER_DISTANCE = 2400;
 
 	private final Client client;
@@ -520,13 +518,11 @@ public class GuidanceOverlay extends OverlayPanel
 
 	/**
 	 * Appends "Item requirements:" header followed by one line per required
-	 * item, colored by availability:
-	 * <ul>
-	 *   <li>{@link Status#HELD}    -> green   (in inventory or equipped)</li>
-	 *   <li>{@link Status#IN_BANK} -> yellow  (found in last bank scan)</li>
-	 *   <li>{@link Status#MISSING} -> red     (not held anywhere known)</li>
-	 * </ul>
-	 * No-op when {@link #requiredItems} is empty.
+	 * item, colored by availability via
+	 * {@link RequiredItemDisplay#getStatusColor()}. Items found in the bank
+	 * get a " (bank)" suffix so the row reads as a hint to withdraw.
+	 *
+	 * <p>No-op when {@code items} is null or empty.
 	 */
 	private void addRequiredItemsIfPresent(List<RequiredItemDisplay> items)
 	{
@@ -542,57 +538,12 @@ public class GuidanceOverlay extends OverlayPanel
 
 		for (RequiredItemDisplay item : items)
 		{
-			Color color;
-			String suffix;
-			switch (item.getStatus())
-			{
-				case HELD:
-					color = ITEM_HELD_COLOR;
-					suffix = "";
-					break;
-				case IN_BANK:
-					color = ITEM_IN_BANK_COLOR;
-					suffix = " (bank)";
-					break;
-				case MISSING:
-				default:
-					color = ITEM_MISSING_COLOR;
-					suffix = "";
-					break;
-			}
+			String suffix = item.getStatus() == RequiredItemDisplay.Status.IN_BANK
+				? " (bank)" : "";
 			panelComponent.getChildren().add(LineComponent.builder()
 				.left(item.getName() + suffix)
-				.leftColor(color)
+				.leftColor(item.getStatusColor())
 				.build());
-		}
-	}
-
-	/**
-	 * Immutable display row for the required-items section.
-	 * Pre-resolved by {@code GuidanceOverlayCoordinator} so the render path
-	 * never touches inventory or bank state.
-	 */
-	public static final class RequiredItemDisplay
-	{
-		public enum Status { HELD, IN_BANK, MISSING }
-
-		private final String name;
-		private final Status status;
-
-		public RequiredItemDisplay(String name, Status status)
-		{
-			this.name = name;
-			this.status = status;
-		}
-
-		public String getName()
-		{
-			return name;
-		}
-
-		public Status getStatus()
-		{
-			return status;
 		}
 	}
 }

--- a/src/main/java/com/collectionloghelper/overlay/GuidanceOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/GuidanceOverlay.java
@@ -36,6 +36,8 @@ import java.awt.Polygon;
 import java.awt.Rectangle;
 import java.awt.RenderingHints;
 import java.awt.Shape;
+import java.util.Collections;
+import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import net.runelite.api.Client;
@@ -69,6 +71,10 @@ public class GuidanceOverlay extends OverlayPanel
 	private static final Color TRAVEL_COLOR = new Color(100, 200, 255);
 	private static final Color ACTION_COLOR = new Color(100, 255, 100);
 	private static final Color REMINDER_COLOR = new Color(255, 170, 0);
+	private static final Color ITEM_REQUIREMENTS_HEADER_COLOR = new Color(220, 220, 220);
+	static final Color ITEM_HELD_COLOR = new Color(40, 180, 40);
+	static final Color ITEM_IN_BANK_COLOR = new Color(200, 180, 40);
+	static final Color ITEM_MISSING_COLOR = new Color(220, 70, 70);
 	private static final int MAX_RENDER_DISTANCE = 2400;
 
 	private final Client client;
@@ -91,6 +97,7 @@ public class GuidanceOverlay extends OverlayPanel
 	private volatile boolean showBankReminder;
 	private volatile boolean suppressTileHighlight;
 	private volatile NPC trackedNpc;
+	private volatile List<RequiredItemDisplay> requiredItems = Collections.emptyList();
 	private final Polygon arrowPolygon = new Polygon();
 	private Color cachedOverlayColor;
 	private Color cachedFillColor50;
@@ -123,6 +130,7 @@ public class GuidanceOverlay extends OverlayPanel
 		final String action = this.interactAction;
 		final boolean logReminder = this.showCollectionLogReminder;
 		final boolean bankReminder = this.showBankReminder;
+		final List<RequiredItemDisplay> items = this.requiredItems;
 
 		Color overlayColor = config.overlayColor();
 		updateCachedColors(overlayColor);
@@ -138,6 +146,7 @@ public class GuidanceOverlay extends OverlayPanel
 					.text(clueText)
 					.color(Color.WHITE)
 					.build());
+				addRequiredItemsIfPresent(items);
 				addSyncRemindersIfNeeded(logReminder, bankReminder);
 				panelComponent.setPreferredSize(PANEL_PREFERRED_SIZE);
 				return super.render(graphics);
@@ -193,6 +202,7 @@ public class GuidanceOverlay extends OverlayPanel
 						.leftColor(ACTION_COLOR)
 						.build());
 				}
+				addRequiredItemsIfPresent(items);
 				addSyncRemindersIfNeeded(logReminder, bankReminder);
 				panelComponent.setPreferredSize(PANEL_PREFERRED_SIZE);
 				return super.render(graphics);
@@ -217,22 +227,32 @@ public class GuidanceOverlay extends OverlayPanel
 		if (!npcHighlighted && !suppressTileHighlight)
 		{
 			Polygon poly = Perspective.getCanvasTilePoly(client, localPoint);
-			if (poly == null)
+			if (poly != null)
 			{
-				return null;
-			}
+				OverlayUtil.renderPolygon(graphics, poly, overlayColor, cachedFillColor50,
+					STROKE_2);
 
-			OverlayUtil.renderPolygon(graphics, poly, overlayColor, cachedFillColor50,
-				STROKE_2);
-
-			if (name != null)
-			{
-				Point tileTextPoint = Perspective.getCanvasTextLocation(client, graphics, localPoint, name, 150);
-				if (tileTextPoint != null)
+				if (name != null)
 				{
-					OverlayUtil.renderTextLocation(graphics, tileTextPoint, name, overlayColor);
+					Point tileTextPoint = Perspective.getCanvasTextLocation(client, graphics, localPoint, name, 150);
+					if (tileTextPoint != null)
+					{
+						OverlayUtil.renderTextLocation(graphics, tileTextPoint, name, overlayColor);
+					}
 				}
 			}
+		}
+
+		// When the target is on-screen we normally skip the side panel, but a
+		// required-items list still needs to be visible so the player can
+		// confirm they have what the step needs (or notice what's missing).
+		if (items != null && !items.isEmpty())
+		{
+			panelComponent.getChildren().clear();
+			addRequiredItemsIfPresent(items);
+			addSyncRemindersIfNeeded(logReminder, bankReminder);
+			panelComponent.setPreferredSize(PANEL_PREFERRED_SIZE);
+			return super.render(graphics);
 		}
 
 		return null;
@@ -437,6 +457,18 @@ public class GuidanceOverlay extends OverlayPanel
 		rebuildNpcLabel(this.interactAction, npc);
 	}
 
+	/**
+	 * Sets the required-item availability list rendered beneath the step
+	 * description. Each entry is a pre-resolved (name + availability) pair so
+	 * the render loop never touches inventory or bank state directly.
+	 *
+	 * <p>Pass an empty list (or {@code null}) to hide the section.
+	 */
+	public void setRequiredItems(List<RequiredItemDisplay> items)
+	{
+		this.requiredItems = items == null ? Collections.emptyList() : List.copyOf(items);
+	}
+
 	public void clearTarget()
 	{
 		targetPoint = null;
@@ -450,6 +482,7 @@ public class GuidanceOverlay extends OverlayPanel
 		trackedNpc = null;
 		cachedTravelLabel = null;
 		cachedNpcLabel = null;
+		requiredItems = Collections.emptyList();
 	}
 
 	private void rebuildNpcLabel(String action, NPC npc)
@@ -482,6 +515,84 @@ public class GuidanceOverlay extends OverlayPanel
 				.text("Open Bank to scan items")
 				.color(REMINDER_COLOR)
 				.build());
+		}
+	}
+
+	/**
+	 * Appends "Item requirements:" header followed by one line per required
+	 * item, colored by availability:
+	 * <ul>
+	 *   <li>{@link Status#HELD}    -> green   (in inventory or equipped)</li>
+	 *   <li>{@link Status#IN_BANK} -> yellow  (found in last bank scan)</li>
+	 *   <li>{@link Status#MISSING} -> red     (not held anywhere known)</li>
+	 * </ul>
+	 * No-op when {@link #requiredItems} is empty.
+	 */
+	private void addRequiredItemsIfPresent(List<RequiredItemDisplay> items)
+	{
+		if (items == null || items.isEmpty())
+		{
+			return;
+		}
+
+		panelComponent.getChildren().add(LineComponent.builder()
+			.left("Item requirements:")
+			.leftColor(ITEM_REQUIREMENTS_HEADER_COLOR)
+			.build());
+
+		for (RequiredItemDisplay item : items)
+		{
+			Color color;
+			String suffix;
+			switch (item.getStatus())
+			{
+				case HELD:
+					color = ITEM_HELD_COLOR;
+					suffix = "";
+					break;
+				case IN_BANK:
+					color = ITEM_IN_BANK_COLOR;
+					suffix = " (bank)";
+					break;
+				case MISSING:
+				default:
+					color = ITEM_MISSING_COLOR;
+					suffix = "";
+					break;
+			}
+			panelComponent.getChildren().add(LineComponent.builder()
+				.left(item.getName() + suffix)
+				.leftColor(color)
+				.build());
+		}
+	}
+
+	/**
+	 * Immutable display row for the required-items section.
+	 * Pre-resolved by {@code GuidanceOverlayCoordinator} so the render path
+	 * never touches inventory or bank state.
+	 */
+	public static final class RequiredItemDisplay
+	{
+		public enum Status { HELD, IN_BANK, MISSING }
+
+		private final String name;
+		private final Status status;
+
+		public RequiredItemDisplay(String name, Status status)
+		{
+			this.name = name;
+			this.status = status;
+		}
+
+		public String getName()
+		{
+			return name;
+		}
+
+		public Status getStatus()
+		{
+			return status;
 		}
 	}
 }

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
@@ -54,6 +54,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -990,11 +992,16 @@ public class GuidanceSequencerTest
 		assertFalse(sequencer.isActive());
 	}
 
+	/**
+	 * Missing required items must no longer trigger a synthetic bank step.
+	 * The sequencer returns the real step regardless of held-item state;
+	 * required-item availability is surfaced via the panel + in-game overlay
+	 * (cha-ndler/collection-log-helper#380).
+	 */
 	@Test
-	public void testBankRoutingWhenMissingRequiredItems()
+	public void testMissingRequiredItemsStillReturnsRealStep()
 	{
 		List<Integer> required = Arrays.asList(100, 200);
-		when(inventoryState.hasAllItems(required)).thenReturn(false);
 
 		List<GuidanceStep> steps = Arrays.asList(
 			makeStepWithRequiredItems(required),
@@ -1003,20 +1010,24 @@ public class GuidanceSequencerTest
 
 		startSequence(steps);
 		GuidanceStep current = sequencer.getCurrentStep();
-		// Should return a bank routing step instead
-		assertEquals("Get required items from bank", current.getDescription());
-		assertEquals(CompletionCondition.MANUAL, current.getCompletionCondition());
+		assertEquals("Step needing items", current.getDescription());
+		// requiredItemIds must remain on the returned step so the panel/overlay
+		// can render availability borders.
+		assertEquals(required, current.getRequiredItemIds());
 
-		// Raw step should still be the original
+		// Raw step accessor returns the same step (no substitution path remains).
 		GuidanceStep raw = sequencer.getRawCurrentStep();
 		assertEquals("Step needing items", raw.getDescription());
+
+		// The sequencer must not consult inventory state in getCurrentStep
+		// any more; the previous bank-routing path was the only consumer.
+		verify(inventoryState, never()).hasAllItems(required);
 	}
 
 	@Test
-	public void testBankRoutingNotAppliedWhenItemsPresent()
+	public void testRequiredItemsPresentReturnsRealStep()
 	{
 		List<Integer> required = Arrays.asList(100, 200);
-		when(inventoryState.hasAllItems(required)).thenReturn(true);
 
 		List<GuidanceStep> steps = Arrays.asList(
 			makeStepWithRequiredItems(required),

--- a/src/test/java/com/collectionloghelper/guidance/RequiredItemResolverTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/RequiredItemResolverTest.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.guidance;
+
+import com.collectionloghelper.data.CompletionCondition;
+import com.collectionloghelper.data.GuidanceStep;
+import com.collectionloghelper.data.PlayerBankState;
+import com.collectionloghelper.data.PlayerInventoryState;
+import com.collectionloghelper.guidance.RequiredItemDisplay.Status;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import net.runelite.api.ItemComposition;
+import net.runelite.client.game.ItemManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RequiredItemResolverTest
+{
+	@Mock
+	private PlayerInventoryState inventoryState;
+
+	@Mock
+	private PlayerBankState bankState;
+
+	@Mock
+	private ItemManager itemManager;
+
+	@Mock
+	private ItemComposition tinderboxComp;
+	@Mock
+	private ItemComposition pyreLogsComp;
+	@Mock
+	private ItemComposition remainsComp;
+
+	private RequiredItemResolver resolver;
+
+	private static final int TINDERBOX = 590;
+	private static final int PYRE_LOGS = 3438;
+	private static final int SHADE_REMAINS = 3392;
+
+	@Before
+	public void setUp()
+	{
+		resolver = new RequiredItemResolver(inventoryState, bankState, itemManager);
+
+		// Default: nothing held, nothing in bank — keeps each test focused on
+		// the one signal it stubs.
+		lenient().when(inventoryState.hasItem(anyInt())).thenReturn(false);
+		lenient().when(inventoryState.hasEquippedItem(anyInt())).thenReturn(false);
+		lenient().when(bankState.hasItem(anyInt())).thenReturn(false);
+
+		lenient().when(tinderboxComp.getName()).thenReturn("Tinderbox");
+		lenient().when(pyreLogsComp.getName()).thenReturn("Pyre logs");
+		lenient().when(remainsComp.getName()).thenReturn("Loar remains");
+		lenient().when(itemManager.getItemComposition(TINDERBOX)).thenReturn(tinderboxComp);
+		lenient().when(itemManager.getItemComposition(PYRE_LOGS)).thenReturn(pyreLogsComp);
+		lenient().when(itemManager.getItemComposition(SHADE_REMAINS)).thenReturn(remainsComp);
+	}
+
+	@Test
+	public void resolveReturnsEmptyForNullStep()
+	{
+		List<RequiredItemDisplay> result = resolver.resolve(null);
+		assertTrue("Null step must yield an empty result", result.isEmpty());
+	}
+
+	@Test
+	public void resolveReturnsEmptyForStepWithNoRequiredItems()
+	{
+		GuidanceStep step = stepWithRequiredItems(null);
+		assertTrue(resolver.resolve(step).isEmpty());
+
+		step = stepWithRequiredItems(Collections.emptyList());
+		assertTrue(resolver.resolve(step).isEmpty());
+	}
+
+	@Test
+	public void heldInInventoryResolvesToHeld()
+	{
+		when(inventoryState.hasItem(TINDERBOX)).thenReturn(true);
+
+		List<RequiredItemDisplay> rows = resolver.resolve(
+			stepWithRequiredItems(Collections.singletonList(TINDERBOX)));
+
+		assertEquals(1, rows.size());
+		assertEquals("Tinderbox", rows.get(0).getName());
+		assertEquals(Status.HELD, rows.get(0).getStatus());
+	}
+
+	@Test
+	public void heldEquippedResolvesToHeldEvenWhenNotInInventory()
+	{
+		when(inventoryState.hasItem(TINDERBOX)).thenReturn(false);
+		when(inventoryState.hasEquippedItem(TINDERBOX)).thenReturn(true);
+
+		List<RequiredItemDisplay> rows = resolver.resolve(
+			stepWithRequiredItems(Collections.singletonList(TINDERBOX)));
+
+		assertEquals(Status.HELD, rows.get(0).getStatus());
+	}
+
+	@Test
+	public void itemFoundOnlyInBankResolvesToInBank()
+	{
+		when(bankState.hasItem(PYRE_LOGS)).thenReturn(true);
+
+		List<RequiredItemDisplay> rows = resolver.resolve(
+			stepWithRequiredItems(Collections.singletonList(PYRE_LOGS)));
+
+		assertEquals(Status.IN_BANK, rows.get(0).getStatus());
+		assertEquals("Pyre logs", rows.get(0).getName());
+	}
+
+	@Test
+	public void itemNotFoundAnywhereResolvesToMissing()
+	{
+		List<RequiredItemDisplay> rows = resolver.resolve(
+			stepWithRequiredItems(Collections.singletonList(SHADE_REMAINS)));
+
+		assertEquals(Status.MISSING, rows.get(0).getStatus());
+	}
+
+	/**
+	 * Held-in-inventory must short-circuit before the bank check so we don't
+	 * pay a cache lookup on every required item the player is already carrying.
+	 */
+	@Test
+	public void inventoryShortCircuitsBeforeBankCheck()
+	{
+		when(inventoryState.hasItem(TINDERBOX)).thenReturn(true);
+
+		List<RequiredItemDisplay> rows = resolver.resolve(
+			stepWithRequiredItems(Collections.singletonList(TINDERBOX)));
+
+		assertEquals(Status.HELD, rows.get(0).getStatus());
+		verify(bankState, never()).hasItem(TINDERBOX);
+	}
+
+	@Test
+	public void multipleItemsResolveIndependently()
+	{
+		when(inventoryState.hasItem(TINDERBOX)).thenReturn(true);
+		when(bankState.hasItem(PYRE_LOGS)).thenReturn(true);
+		// SHADE_REMAINS is neither held nor in bank — MISSING by default
+
+		List<RequiredItemDisplay> rows = resolver.resolve(
+			stepWithRequiredItems(Arrays.asList(TINDERBOX, PYRE_LOGS, SHADE_REMAINS)));
+
+		assertEquals(3, rows.size());
+		assertEquals(Status.HELD, rows.get(0).getStatus());
+		assertEquals(Status.IN_BANK, rows.get(1).getStatus());
+		assertEquals(Status.MISSING, rows.get(2).getStatus());
+	}
+
+	@Test
+	public void invalidItemIdsAreSkipped()
+	{
+		when(inventoryState.hasItem(TINDERBOX)).thenReturn(true);
+
+		List<RequiredItemDisplay> rows = resolver.resolve(
+			stepWithRequiredItems(Arrays.asList(0, -1, TINDERBOX, null)));
+
+		assertEquals("Only the one valid id must produce a row", 1, rows.size());
+		assertEquals(Status.HELD, rows.get(0).getStatus());
+	}
+
+	@Test
+	public void itemCompositionFailureFallsBackToIdLabel()
+	{
+		final int unknownId = 99999;
+		when(itemManager.getItemComposition(unknownId))
+			.thenThrow(new RuntimeException("Cache miss"));
+
+		List<RequiredItemDisplay> rows = resolver.resolve(
+			stepWithRequiredItems(Collections.singletonList(unknownId)));
+
+		assertEquals(1, rows.size());
+		assertEquals("Item #" + unknownId, rows.get(0).getName());
+		assertEquals(Status.MISSING, rows.get(0).getStatus());
+	}
+
+	// --- Helpers ---
+
+	private static GuidanceStep stepWithRequiredItems(List<Integer> requiredItemIds)
+	{
+		return new GuidanceStep(
+			"Test step",
+			0, 0, 0,
+			0, null, null,
+			null,
+			requiredItemIds,
+			CompletionCondition.MANUAL,
+			0, 0, 0, 0,
+			null,
+			null,
+			0, null, null,
+			null,
+			null,
+			null,
+			0, 0,
+			false,
+			0,
+			null,
+			null,
+			0, 0,
+			null,
+			null,
+			null,
+			null
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Replaces the synthetic "go to bank" step that `GuidanceSequencer` substituted whenever a step's `requiredItemIds` weren't all in inventory. The bank step was hardcoded to Grand Exchange (3164, 3489) for every source in the game — routing players 400+ tiles away from sources like Shades of Mort'ton instead of letting them choose a nearby bank.

The new model surfaces item availability informationally and lets the player handle banking on their own, matching Quest Helper's approach.

Closes cha-ndler/collection-log-helper#380

## Behavior

- `GuidanceSequencer.getCurrentStep()` returns the real authored step regardless of held-item state. No more bank substitution, no more hardcoded GE destination.
- The existing `StepProgressView` side panel widget (which already had bank-scan-aware colored borders) now renders the right items for every step that declares `requiredItemIds` — previously hidden behind the bank-step swap.
- `GuidanceOverlay` (in-game) renders a new **Item requirements:** section beneath the step description with one colored line per item:
  - **Green** — held in inventory or equipped
  - **Yellow** — found in last bank scan; suffix " (bank)" tells the player to withdraw
  - **Red** — not held anywhere known to the plugin
- When the target tile is on-screen and items are required, a minimal overlay panel still renders so missing items remain visible — previously the on-screen branch returned no panel.
- Player progression is **never gated** on missing items. A `ARRIVE_AT_TILE` step still auto-completes when the player arrives — they just see red entries until they bank what's missing.

## Best-practices refactor (commit `fd3d49ad`)

The initial commit added ~50 LOC of resolution logic and a 25-LOC nested value type to `GuidanceOverlayCoordinator` and `GuidanceOverlay` respectively. That moved both files in the wrong direction relative to the anti-monolith goal, so the follow-up commit extracts:

- **`RequiredItemDisplay`** (`com.collectionloghelper.guidance`) — immutable value type with shared color constants. Pulls the three status colors out of `GuidanceOverlay` so the panel and overlay paint a "missing" item the same shade.
- **`RequiredItemResolver`** (`com.collectionloghelper.guidance`) — `@Singleton` service that owns the resolution logic. Takes `PlayerInventoryState` + `PlayerBankState` + `ItemManager`. Short-circuits inventory → bank → missing, defensively handles invalid IDs and `ItemManager.getItemComposition` cache-miss exceptions.

After refactor: `GuidanceOverlayCoordinator` loses 69 LOC, `GuidanceOverlay` loses 67 LOC.

## RuneLite best-practices checklist

- [x] No new `@Subscribe` handlers (event-handler perf rule honored).
- [x] Render loop touches zero inventory/bank/client state — resolution happens once per step transition, not per frame.
- [x] `ItemManager.getItemComposition()` called from step-transition path, not render.
- [x] `volatile` fields on overlay, snapshot at top of `render()` (matches existing pattern).
- [x] Defensive immutable copy in setter (`List.copyOf`).
- [x] No new `Color`/`Polygon`/`Stroke` allocations in hot paths (status colors are `static final`).

## Tests

- **526/526 pass** against RuneLite 1.12.26.3 (+10 vs master's 516).
- New `RequiredItemResolverTest` (10 cases): null/empty inputs, HELD via inventory, HELD via equipped, IN_BANK, MISSING, inventory-short-circuit-before-bank (`verify(bankState, never()).hasItem()`), multi-item independent resolution, invalid-id skipping, `ItemManager` cache-miss fallback.
- Updated `GuidanceSequencerTest`: `testBankRoutingWhenMissingRequiredItems` -> `testMissingRequiredItemsStillReturnsRealStep`; verifies `inventoryState.hasAllItems` is never called from `getCurrentStep`.

## Test plan

- [ ] CI build green
- [ ] In-game: activate Shades of Mort'ton guidance without a tinderbox -> step 1 (travel to Mort'ton) is the active step (not a synthetic GE bank step), with **Tinderbox** shown red in the panel and "Item requirements: Tinderbox" red in the in-game overlay
- [ ] Withdraw a tinderbox -> the row turns green; teleport to Mort'ton -> step auto-completes on arrival
- [ ] Put a required item in the bank only -> row renders yellow with " (bank)" suffix
- [ ] Non-Mort'ton multi-step source with no `requiredItemIds` -> no requirements section appears

## Follow-up notes (out of scope)

- cha-ndler/collection-log-helper#372 (open) sets the Mort'ton step 1 description to "Bank: bring pyre logs, shade remains, and a tinderbox to Mort'ton". After this PR merges, that description becomes misleading (no bank step). When #372 rebases on top of this, the description should change to something like "Travel to Mort'ton (bring pyre logs, shade remains, and a tinderbox)".
- Future work tracked under cha-ndler/collection-log-helper#382 (Quest Helper UI parity meta): per-step inventory glow, recommended-items section, general requirements panel, collapsible step sections.