### PR TITLE
docs: add in-game validation log

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,15 @@ Ranks every collection log source by efficiency and guides you there step-by-ste
 
 Requires Java 11+. Uses RuneLite client API, Lombok, and JUnit 4.
 
+## Testing
+
+```bash
+./gradlew test    # unit tests
+./gradlew run     # dev-mode RuneLite with the plugin sideloaded
+```
+
+Unit tests cover pure logic. Anything touching overlay rendering, player state, or live game events also needs in-game verification — track that work in [`docs/in-game-validation-log.md`](docs/in-game-validation-log.md), the running ledger of per-PR test reproducers and pass/fail status.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the JSON schema reference, data sourcing tiers, and PR process.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -128,6 +128,7 @@ This costs two weeks. It saves the much larger cost of another closure.
 2. **Use `code-reviewer` agent before requesting review**. Fix CRITICAL and HIGH issues. Document any intentional deviations.
 3. **Run `./gradlew build` locally before push**. CI is not a linter.
 4. **Superset detection**: before opening, check whether an already-open PR supersedes yours.
+5. **In-game validation for player-facing changes**. Anything touching overlays, panel rendering, hint arrows, or live game events adds reproducer rows to [`docs/in-game-validation-log.md`](in-game-validation-log.md) in the same PR. A merged PR with unticked validation rows is "code-merged, not user-verified" — track the gap explicitly. The closed cha-ndler/collection-log-helper#371 cycle is the cautionary example: 521/521 unit tests passed but every claimed fix was still broken in-game.
 
 ---
 

--- a/docs/in-game-validation-log.md
+++ b/docs/in-game-validation-log.md
@@ -1,0 +1,134 @@
+# In-Game Validation Log
+
+> **Purpose**: Track manual in-game testing for merged PRs. Unit tests, type checks, and CI only prove correctness of pure logic — anything touching player state, overlay rendering, or live game events needs human verification against the OSRS client. This file is the source of truth for "did the fix actually work for real users?"
+
+> **Status legend**:
+> - `[ ]` — Not tested yet
+> - `[~]` — Testing in progress
+> - `[x]` — Verified pass
+> - `[!]` — Regression / failed (file a new issue and cross-link)
+> - `[?]` — Inconclusive (couldn't reproduce / state-dependent)
+
+> **Last updated**: 2026-05-11
+
+---
+
+## How to use this file
+
+1. Pull / `git checkout master` and `git pull` so you're on the merged state.
+2. `./gradlew run` launches dev-mode RuneLite with the plugin sideloaded.
+3. Work through the checklist sections in any order; mark each item with the status above.
+4. Add a short note (or screenshot path) whenever something is off.
+5. If a regression is found, file a GitHub issue and link it from the note column.
+6. When every row in a PR section is `[x]`, append the validation date to the section header and consider the work closed.
+
+---
+
+## PR #379 — RuneLite client bump 1.12.24 -> 1.12.26.3 *(merged 2026-05-10)*
+
+Critical because `error_game_js5connect_outofdate` blocked all prior in-game testing.
+
+| # | Test | Status | Notes |
+|---|---|---|---|
+| 1 | `./gradlew run` launches without build/run errors | `[ ]` | |
+| 2 | Login screen reaches OSRS (no `error_game_js5connect_outofdate`) | `[ ]` | |
+| 3 | Plugin loads; "Collection Log Helper" sidebar icon appears | `[ ]` | |
+| 4 | No new console stack traces during 5 minutes of normal play | `[ ]` | |
+
+---
+
+## PR #372 — Shades of Mort'ton guidance fixes *(merged 2026-05-11)*
+
+Closes #366 (step ordering + arrival distance), #367 (skip overlay refresh), #375 (mid-sequence panel render), #376 (shade-key tile).
+
+> NOTE: PR #372 set Mort'ton step 1's description to "Bank: bring pyre logs, shade remains, and a tinderbox to Mort'ton". After PR #384 merged, the description is technically misleading (there's no bank step anymore). If item-requirements UX is confusing in testing, the description can be edited in a small follow-up to "Travel to Mort'ton (bring pyre logs, shade remains, and a tinderbox)" without touching code.
+
+| # | Issue | Test | Status | Notes |
+|---|---|---|---|---|
+| 1 | #366-B | Mort'ton teleport scroll -> step 1 (travel) auto-completes within ~1 second of landing | `[ ]` | |
+| 2 | #366-B | Minigame teleport -> Shades of Mort'ton -> step 1 auto-completes on landing | `[ ]` | |
+| 3 | #366-B | Fairy ring BKR -> step 1 auto-completes on landing | `[ ]` | |
+| 4 | #366-B | Barrows teleport, run south to Mort'ton -> step 1 auto-completes near town centre, NOT at the river | `[ ]` | |
+| 5 | #367 | Mid-sequence click **Skip** -> object highlight, tile marker, and panel all update in the same tick (no visible 1-tick gap) | `[ ]` | |
+| 6 | #367 | Mid-sequence click **Next Step** -> same behavior as Skip | `[ ]` | |
+| 7 | #367 | Skip rapidly across 3 steps -> no orphaned overlays from prior steps | `[ ]` | |
+| 8 | #375 | Mid-sequence landing: stand at funeral pyres with a shade key + pyre logs + remains, activate guidance -> blue box shows landed step 3/5, InfoBox reads **3/5** not **1/5** | `[ ]` | |
+| 9 | #375 | All-satisfied: pre-meet every condition for the source, activate guidance -> deactivates cleanly, NO empty "Step 1/0:" box | `[ ]` | |
+| 10 | #375 | Plain start: fresh inv at Lumbridge, activate Shades of Mort'ton -> blue box shows step 1/N (regression check for the common path) | `[ ]` | |
+| 11 | #376 | While on step 3/5 -> tile marker is INSIDE Mort'ton temple at ~(3495, 3298) near reward pillar, not on surface near the pyre | `[ ]` | |
+
+---
+
+## PR #384 — Surface required-item availability; remove bank-step routing *(merged 2026-05-11)*
+
+Closes #380. Major behavior change: `requiredItemIds` now surface as colored entries in the panel + in-game overlay instead of substituting a synthetic GE bank step.
+
+| # | Test | Status | Notes |
+|---|---|---|---|
+| 1 | Activate Shades of Mort'ton with no tinderbox -> active step is **step 1 (travel)**, NOT a synthetic "Get required items from bank" step | `[ ]` | |
+| 2 | Side panel: required-items section shows **Tinderbox** with RED border + "(MISSING)" tooltip | `[ ]` | |
+| 3 | In-game overlay (top-left): "Item requirements:" header + "Tinderbox" line rendered in red | `[ ]` | |
+| 4 | Withdraw tinderbox -> panel row turns GREEN with "(in inventory)" tooltip; overlay line turns green | `[ ]` | |
+| 5 | With tinderbox in BANK only -> panel row YELLOW with "(in bank)" tooltip; overlay shows "Tinderbox (bank)" yellow | `[ ]` | |
+| 6 | Equip a `requiredItemIds` item -> panel shows GREEN with "(equipped)" tooltip | `[ ]` | |
+| 7 | Walk onto the active step's tile -> minimal overlay panel renders WITH only the requirements list when items are required; NO panel when no items are required | `[ ]` | |
+| 8 | Activate a source whose current step has no `requiredItemIds` -> no "Item requirements:" section appears | `[ ]` | |
+| 9 | World map view -> route overlay still draws correctly (regression check) | `[ ]` | |
+| 10 | Trigger Skip on a step with required items -> next step's requirements render in same tick | `[ ]` | |
+| 11 | Stop guidance -> requirements section disappears from both panel and overlay | `[ ]` | |
+| 12 | Switch sources without stopping (panel-driven mode change) -> stale items from previous source don't leak | `[ ]` | |
+
+---
+
+## PR #383 — ROADMAP Tier B.5 *(merged 2026-05-11)*
+
+Documentation only. No in-game validation required. **Skip.**
+
+---
+
+## Still-open bugs that closed PR #371 left unfixed
+
+These need fresh validation when a follow-up PR ships the real fix. The "still broken on master" column captures the regression baseline observed on 2026-05-10.
+
+| Issue | Reproducer | Still broken on master? | Fix PR | Verified after fix? |
+|---|---|---|---|---|
+| #362 | Category Focus -> SLAYER -> count reads "0/0", no progress bar | `[ ]` | — | `[ ]` |
+| #362 | Category Focus -> SKILLING -> same "0/0" issue | `[ ]` | — | `[ ]` |
+| #363 | Activate guidance -> toggle Show Overlays OFF -> overlay should clear immediately (not require Stop/Start) | `[ ]` | — | `[ ]` |
+| #363 | Activate guidance -> toggle Show Hint Arrow OFF -> minimap arrow + in-game tile arrow clear immediately | `[ ]` | — | `[ ]` |
+| #364 | Toggle Hide Locked Content ON -> items with unmet quest/skill requirements disappear from list | `[ ]` | — | `[ ]` |
+| #373 | Toggle Show Overlays OFF mid-guidance -> guidance session CONTINUES; only overlay rendering stops | `[ ]` | — | `[ ]` |
+| #374 | Efficient mode with locked items -> locked items appear at their natural efficiency position (e.g., a ~17-min locked item sits near other ~17-min items), not segregated to the bottom | `[ ]` | — | `[ ]` |
+| #378 | Walk away from the active step's tile mid-sequence -> step does NOT regress to a prior step | `[ ]` | — | `[ ]` |
+| #381 | Mid-guidance: teleport far away and back -> hint arrow re-renders without a Stop/Start cycle | `[ ]` | — | `[ ]` |
+
+---
+
+## Regression smoke test (run after ANY batch of in-game testing)
+
+Quick check that core features still work end-to-end:
+
+- `[ ]` Sync collection log: open the in-game collection log widget once -> "Synced N items" reminder clears
+- `[ ]` Bank scan: open bank once -> "Open Bank to scan items" reminder clears
+- `[ ]` Switch between modes (Efficient / Category / Search / Pet Hunt / Statistics) -> no errors, panel renders for each
+- `[ ]` Activate guidance on a non-Mort'ton source (Vorkath, Cerberus, Wintertodt, a clue tier) -> panel + overlay render
+- `[ ]` Stop guidance, restart guidance on the same source -> clean cycle, no orphaned overlays or InfoBoxes
+- `[ ]` Close client, reopen -> bank scan cache restores correctly per RS profile (verify by re-opening Helper panel without re-banking)
+
+---
+
+## Reporting findings
+
+When a regression / failure is observed:
+
+1. Screenshot the in-game state (full RuneLite window, including the panel).
+2. Capture the relevant log output (RuneLite `Help` → `Open logs folder` -> `client.log`).
+3. File a GitHub issue with: the screenshot, the master commit SHA at testing time (`git rev-parse HEAD`), and the reproducer steps from this file.
+4. Cross-link the new issue in the Notes column above.
+5. Update this file's status from `[ ]` to `[!]` so the next pass picks it up.
+
+When all items in a PR section are `[x]`:
+
+- Add the validation date to the section header: e.g. `## PR #372 — ... *(merged 2026-05-11, validated 2026-05-15)*`.
+- Consider the PR's in-game obligations closed.
+- Older sections can be archived to a `validation-archive/` subdirectory if this file grows long.


### PR DESCRIPTION
## Summary

Adds `docs/in-game-validation-log.md` — a running ledger of manual in-game testing for merged PRs. Distinct from GitHub issue state: GitHub tracks "is there a code-side claim of resolution?", this file tracks "did the fix actually work for real users in-game?"

The 2026-05-10 testing session that surfaced cha-ndler/collection-log-helper#380, cha-ndler/collection-log-helper#381, and the cha-ndler/collection-log-helper#371 closure showed the gap: 521/521 unit tests passed, GitHub said "closes #362/#363/#364/#373/#374", and every one of those was still broken when actually played.

## What the file covers

- **PR #379** (RuneLite client bump): launch + login + plugin-load smoke tests
- **PR #372** (Mort'ton fixes): 11 reproducers for #366 / #367 / #375 / #376 (teleport arrival, skip refresh, mid-sequence panel, shade-key tile)
- **PR #384** (required-items): 12 reproducers for the panel + overlay bank-scan-aware availability rendering
- **Reopened bugs from PR #371** (#362 / #363 / #364 / #373 / #374): baseline "still broken" status, plus a slot for the eventual fix PR and post-fix verification
- A **regression smoke test** to run after each batch of in-game testing

## Status legend

- `[ ]` not tested
- `[~]` testing in progress
- `[x]` verified pass
- `[!]` regression / failed (file an issue, cross-link)
- `[?]` inconclusive

## Lifecycle

- Sections gain a `validated YYYY-MM-DD` suffix once every row is `[x]`.
- Older sections archive to a `validation-archive/` subdirectory as the file grows.

## Test plan

- [ ] File renders cleanly on GitHub (tables intact, status legend visible)
- [ ] Linked issues use the fully-qualified `cha-ndler/collection-log-helper#NNN` form

## Why now

Per the user's request after merging #372/#379/#383/#384: the merges happened without in-game validation, and we need a structured place to record what still needs verifying so nothing slips. This file is meant to be edited in place as testing happens.