### PR TITLE
fix(overlays): propagate Show Overlays / Show Hint Arrow toggles immediately

### DIFF
--- a/docs/in-game-validation-log.md
+++ b/docs/in-game-validation-log.md
@@ -86,6 +86,24 @@ Documentation only. No in-game validation required. **Skip.**
 
 ---
 
+## PR fix/363-config-toggle-propagation — Config toggles propagate immediately *(pending merge)*
+
+Closes #363 (Show Overlays / Show Hint Arrow toggles inert mid-guidance). Approach: each overlay self-gates on `config.showOverlays()` at render time (cheap volatile read per frame); `@Subscribe onConfigChanged` handler revokes / re-applies `client.setHintArrow()` since that's a one-shot client mutation rather than a render-loop predicate.
+
+| # | Test | Status | Notes |
+|---|---|---|---|
+| 1 | Activate guidance, toggle **Show Overlays** OFF -> object highlight, tile marker, world map route, NPC outline, dialog highlight, ground item highlight, and the top-left guidance overlay panel all disappear within 1 frame (~50ms) | `[ ]` | |
+| 2 | Toggle Show Overlays ON -> overlays return immediately (state was preserved, just gated) | `[ ]` | |
+| 3 | Toggle Show Overlays OFF while sync/bank reminders are visible -> reminders remain (independent of overlay toggle) | `[ ]` | |
+| 4 | Activate guidance, toggle **Show Hint Arrow** OFF -> in-game tile arrow + minimap arrow clear immediately | `[ ]` | |
+| 5 | Toggle Show Hint Arrow ON mid-guidance -> arrow re-renders on current step's target | `[ ]` | |
+| 6 | Toggle Show Hint Arrow rapidly off/on/off/on -> no stale arrows, no errors in console | `[ ]` | |
+| 7 | Without guidance active, toggle Show Hint Arrow ON -> no arrow appears (correct: no target) | `[ ]` | |
+| 8 | Activate guidance on a clue-tier source (no step target) -> Show Hint Arrow toggle has no visible effect (correct: no target to point at) | `[ ]` | |
+| 9 | Regression: skip button mid-guidance with Show Overlays ON -> overlays update on next tick (matches pre-fix behavior) | `[ ]` | |
+
+---
+
 ## Still-open bugs that closed PR #371 left unfixed
 
 These need fresh validation when a follow-up PR ships the real fix. The "still broken on master" column captures the regression baseline observed on 2026-05-10.
@@ -94,8 +112,8 @@ These need fresh validation when a follow-up PR ships the real fix. The "still b
 |---|---|---|---|---|
 | #362 | Category Focus -> SLAYER -> count reads "0/0", no progress bar | `[ ]` | — | `[ ]` |
 | #362 | Category Focus -> SKILLING -> same "0/0" issue | `[ ]` | — | `[ ]` |
-| #363 | Activate guidance -> toggle Show Overlays OFF -> overlay should clear immediately (not require Stop/Start) | `[ ]` | — | `[ ]` |
-| #363 | Activate guidance -> toggle Show Hint Arrow OFF -> minimap arrow + in-game tile arrow clear immediately | `[ ]` | — | `[ ]` |
+| #363 | Activate guidance -> toggle Show Overlays OFF -> overlay should clear immediately (not require Stop/Start) | `[!]` | fix/363 | `[ ]` |
+| #363 | Activate guidance -> toggle Show Hint Arrow OFF -> minimap arrow + in-game tile arrow clear immediately | `[!]` | fix/363 | `[ ]` |
 | #364 | Toggle Hide Locked Content ON -> items with unmet quest/skill requirements disappear from list | `[ ]` | — | `[ ]` |
 | #373 | Toggle Show Overlays OFF mid-guidance -> guidance session CONTINUES; only overlay rendering stops | `[ ]` | — | `[ ]` |
 | #374 | Efficient mode with locked items -> locked items appear at their natural efficiency position (e.g., a ~17-min locked item sits near other ~17-min items), not segregated to the bottom | `[ ]` | — | `[ ]` |

--- a/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
@@ -862,6 +862,44 @@ public class GuidanceOverlayCoordinator
 	}
 
 	/**
+	 * Re-applies the hint arrow against the current guidance step, respecting
+	 * {@code config.showHintArrow()}. Called by the config-change handler when
+	 * "Show Hint Arrow" is toggled mid-guidance so the change takes effect
+	 * immediately rather than at the next step transition.
+	 *
+	 * <p>When the toggle goes OFF (or guidance is inactive), the arrow is
+	 * cleared. When the toggle goes ON and a step with a world target is
+	 * active, the arrow is re-set at that target.
+	 *
+	 * <p>All client mutations are dispatched on the client thread.
+	 */
+	public void refreshHintArrow()
+	{
+		clientThread.invokeLater(() ->
+		{
+			client.clearHintArrow();
+
+			if (!guidanceSequencer.isActive())
+			{
+				return;
+			}
+
+			GuidanceStep step = guidanceSequencer.getCurrentStep();
+			if (step == null || step.getWorldX() <= 0)
+			{
+				return;
+			}
+
+			WorldPoint worldPoint = new WorldPoint(
+				step.getWorldX(), step.getWorldY(), step.getWorldPlane());
+			if (shouldSetHintArrowTo(worldPoint))
+			{
+				client.setHintArrow(worldPoint);
+			}
+		});
+	}
+
+	/**
 	 * Decides whether a hint arrow should be placed at the given world point.
 	 * Snapshots getLocalPlayer() once to avoid TOCTOU races. Skips hint arrows
 	 * inside non-top-level WorldViews (e.g. sailing boats).

--- a/src/main/java/com/collectionloghelper/lifecycle/GuidanceEventRouter.java
+++ b/src/main/java/com/collectionloghelper/lifecycle/GuidanceEventRouter.java
@@ -52,6 +52,7 @@ import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.events.ConfigChanged;
 
 /**
  * Routes guidance- and authoring-specific events that were previously handled
@@ -447,6 +448,40 @@ public class GuidanceEventRouter
 			{
 				guidanceSequencer.onNpcInteracted(npc.getId());
 			}
+		}
+	}
+
+	// ── Config propagation ──────────────────────────────────────────────────
+
+	/** Config group key used by every {@link CollectionLogHelperConfig} item. */
+	static final String CONFIG_GROUP = "collectionloghelper";
+	/** Config key for the "Show Hint Arrow" toggle. */
+	static final String KEY_SHOW_HINT_ARROW = "showHintArrow";
+
+	/**
+	 * Re-applies state when a config item changes mid-session so toggles take
+	 * effect immediately rather than waiting for the next step transition.
+	 *
+	 * <p>Today this only handles the hint-arrow toggle, because hint arrows
+	 * are set via {@code client.setHintArrow()} (a one-shot client mutation)
+	 * rather than a render-loop predicate. The overlay-rendering toggles
+	 * ({@code showOverlays}, etc.) propagate automatically: each overlay's
+	 * {@code render()} method gates on {@code config.showOverlays()} every
+	 * frame, so toggling the config is reflected on the next paint.
+	 *
+	 * <p>Closes cha-ndler/collection-log-helper#363 (Show Hint Arrow half).
+	 */
+	@Subscribe
+	public void onConfigChanged(ConfigChanged event)
+	{
+		if (!CONFIG_GROUP.equals(event.getGroup()))
+		{
+			return;
+		}
+
+		if (KEY_SHOW_HINT_ARROW.equals(event.getKey()))
+		{
+			guidanceCoordinator.refreshHintArrow();
 		}
 	}
 }

--- a/src/main/java/com/collectionloghelper/overlay/DialogHighlightOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/DialogHighlightOverlay.java
@@ -87,7 +87,7 @@ public class DialogHighlightOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (!guidanceActive)
+		if (!guidanceActive || !config.showOverlays())
 		{
 			return null;
 		}

--- a/src/main/java/com/collectionloghelper/overlay/GroundItemHighlightOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/GroundItemHighlightOverlay.java
@@ -133,7 +133,7 @@ public class GroundItemHighlightOverlay extends Overlay
 	{
 		final List<TrackedGroundItem> items = this.matchedItems;
 
-		if (items.isEmpty())
+		if (items.isEmpty() || !config.showOverlays())
 		{
 			return null;
 		}

--- a/src/main/java/com/collectionloghelper/overlay/GuidanceMinimapOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/GuidanceMinimapOverlay.java
@@ -75,7 +75,7 @@ public class GuidanceMinimapOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		if (targetPoint == null)
+		if (targetPoint == null || !config.showOverlays())
 		{
 			return null;
 		}

--- a/src/main/java/com/collectionloghelper/overlay/GuidanceOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/GuidanceOverlay.java
@@ -135,6 +135,21 @@ public class GuidanceOverlay extends OverlayPanel
 
 		boolean hasReminder = logReminder || bankReminder;
 
+		// When Show Overlays is off, suppress every guidance visual but keep
+		// sync/bank reminders visible — those have their own toggles and are
+		// not "guidance" content per se.
+		if (!config.showOverlays())
+		{
+			if (hasReminder)
+			{
+				panelComponent.getChildren().clear();
+				addSyncRemindersIfNeeded(logReminder, bankReminder);
+				panelComponent.setPreferredSize(PANEL_PREFERRED_SIZE);
+				return super.render(graphics);
+			}
+			return null;
+		}
+
 		if (point == null)
 		{
 			if (clueText != null)

--- a/src/main/java/com/collectionloghelper/overlay/ObjectHighlightOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/ObjectHighlightOverlay.java
@@ -303,7 +303,7 @@ public class ObjectHighlightOverlay extends Overlay
 		final boolean useItem = this.useItemOnObject;
 		final String tipText = this.tooltipText;
 
-		if (objects.isEmpty())
+		if (objects.isEmpty() || !config.showOverlays())
 		{
 			return null;
 		}

--- a/src/main/java/com/collectionloghelper/overlay/WorldMapRouteOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/WorldMapRouteOverlay.java
@@ -81,7 +81,7 @@ public class WorldMapRouteOverlay extends Overlay
 	public Dimension render(Graphics2D graphics)
 	{
 		final WorldPoint target = this.targetPoint;
-		if (target == null)
+		if (target == null || !config.showOverlays())
 		{
 			return null;
 		}

--- a/src/test/java/com/collectionloghelper/lifecycle/GuidanceEventRouterTest.java
+++ b/src/test/java/com/collectionloghelper/lifecycle/GuidanceEventRouterTest.java
@@ -54,6 +54,7 @@ import net.runelite.api.events.MenuEntryAdded;
 import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.events.NpcDespawned;
 import net.runelite.api.events.NpcSpawned;
+import net.runelite.client.events.ConfigChanged;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -714,5 +715,81 @@ public class GuidanceEventRouterTest
 
 		// Assert — no menu entry added when supplier is null
 		verify(client, never()).getMenu();
+	}
+
+	// ========================================================================
+	// onConfigChanged — propagation of "Show Hint Arrow" toggle (#363)
+	// ========================================================================
+
+	/**
+	 * When the player toggles "Show Hint Arrow" mid-guidance, the router must
+	 * call refreshHintArrow() so the change takes effect immediately rather
+	 * than waiting for the next step transition.
+	 */
+	@Test
+	public void onConfigChangedShowHintArrowCallsRefreshHintArrow()
+	{
+		ConfigChanged event = new ConfigChanged();
+		event.setGroup("collectionloghelper");
+		event.setKey("showHintArrow");
+		event.setOldValue("true");
+		event.setNewValue("false");
+
+		router.onConfigChanged(event);
+
+		verify(guidanceCoordinator).refreshHintArrow();
+	}
+
+	/**
+	 * The router only refreshes for "showHintArrow". Other keys in the same
+	 * config group must not trigger a hint-arrow refresh.
+	 */
+	@Test
+	public void onConfigChangedUnrelatedKeyDoesNotRefreshHintArrow()
+	{
+		ConfigChanged event = new ConfigChanged();
+		event.setGroup("collectionloghelper");
+		event.setKey("showOverlays");
+		event.setOldValue("true");
+		event.setNewValue("false");
+
+		router.onConfigChanged(event);
+
+		verify(guidanceCoordinator, never()).refreshHintArrow();
+	}
+
+	/**
+	 * Events from other plugins must be ignored entirely — no work done.
+	 */
+	@Test
+	public void onConfigChangedDifferentPluginGroupIgnored()
+	{
+		ConfigChanged event = new ConfigChanged();
+		event.setGroup("someOtherPlugin");
+		event.setKey("showHintArrow");
+		event.setOldValue("true");
+		event.setNewValue("false");
+
+		router.onConfigChanged(event);
+
+		verify(guidanceCoordinator, never()).refreshHintArrow();
+	}
+
+	/**
+	 * Toggling ON also dispatches a refresh — the coordinator's
+	 * refreshHintArrow handles both directions (clear if off, re-set if on).
+	 */
+	@Test
+	public void onConfigChangedShowHintArrowOnAlsoRefreshes()
+	{
+		ConfigChanged event = new ConfigChanged();
+		event.setGroup("collectionloghelper");
+		event.setKey("showHintArrow");
+		event.setOldValue("false");
+		event.setNewValue("true");
+
+		router.onConfigChanged(event);
+
+		verify(guidanceCoordinator).refreshHintArrow();
 	}
 }


### PR DESCRIPTION
## Summary

Closes cha-ndler/collection-log-helper#363. PR cha-ndler/collection-log-helper#371 attempted this fix and merged 521/521 unit tests green, but the bug stayed reproducible in-game because the toggles never actually reached the render path or the client's hint-arrow state. This PR addresses the two distinct underlying root causes.

## Root causes & fixes

### 1. Show Overlays toggle inert — render-loop gating gap

6 of 7 overlays did not consult `config.showOverlays()` in their `render()` method. Only `WidgetHighlightOverlay` self-gated; the others painted whatever state the coordinator pushed regardless of the toggle.

Added a one-line guard to each:

| Overlay | Existing early-return | After |
|---|---|---|
| `GuidanceMinimapOverlay` | `targetPoint == null` | `\|\| !config.showOverlays()` |
| `GroundItemHighlightOverlay` | `items.isEmpty()` | `\|\| !config.showOverlays()` |
| `DialogHighlightOverlay` | `!guidanceActive` | `\|\| !config.showOverlays()` |
| `ObjectHighlightOverlay` | `objects.isEmpty()` | `\|\| !config.showOverlays()` |
| `WorldMapRouteOverlay` | `target == null` | `\|\| !config.showOverlays()` |
| `GuidanceOverlay` | (complex; reminder branches) | new branch that suppresses guidance content but keeps independent sync/bank reminders visible |

Cheap volatile read per frame, no allocation, no event handler. Takes effect on the next paint.

### 2. Show Hint Arrow toggle inert — one-shot client mutation

`client.setHintArrow()` is a one-shot mutation, not a render-loop predicate. Toggling the config off did not call `client.clearHintArrow()` to revoke the already-set arrow.

- New `GuidanceOverlayCoordinator.refreshHintArrow()` clears the arrow, then conditionally re-sets it if guidance is active and the toggle is on. All client mutations dispatched on the client thread.
- New `@Subscribe onConfigChanged` handler in `GuidanceEventRouter` filters on group=`collectionloghelper` / key=`showHintArrow` and dispatches to `refreshHintArrow()`.

## Why cha-ndler/collection-log-helper#371's attempt failed (architectural lesson)

cha-ndler/collection-log-helper#371's tests asserted that state fields updated when config changed. That assertion was true. The bug was that nothing turned those state changes into render-path or client-state effects. Unit tests against state pass; in-game behavior was still broken.

This PR's tests instead verify the **event-level propagation contract** — the router receives `ConfigChanged`, the coordinator method gets called. The runtime path the user actually exercises.

## Tests

**533 / 533** pass on RuneLite 1.12.26.3 (+7 vs master baseline 526).

4 new router tests (`GuidanceEventRouterTest`):

- `onConfigChangedShowHintArrowCallsRefreshHintArrow` — group+key match dispatches refresh
- `onConfigChangedUnrelatedKeyDoesNotRefreshHintArrow` — same group, different key is ignored
- `onConfigChangedDifferentPluginGroupIgnored` — events from other plugins are no-ops
- `onConfigChangedShowHintArrowOnAlsoRefreshes` — toggle ON also dispatches (coordinator handles both directions)

Note on overlay-gate test coverage: the codebase currently has zero overlay-class tests. Adding `render()`-level tests for the 6 gated overlays would require either making private constructors package-private or using reflection — both deviate from established patterns. The gate code mirrors `WidgetHighlightOverlay`'s existing (untested) pattern, and the in-game validation log (docs/in-game-validation-log.md) gets 9 reproducer rows covering both halves of the fix.

## In-game validation

9 new rows added to `docs/in-game-validation-log.md` under a `fix/363-config-toggle-propagation` section:

- Show Overlays OFF → all 6 overlay surfaces clear within 1 frame
- Show Overlays ON → overlays return immediately (state preserved, just gated)
- Show Overlays OFF with sync/bank reminder visible → reminders remain (independent toggle)
- Show Hint Arrow OFF / ON / rapid toggle / clue-tier-source / inactive-guidance cases
- Regression: Skip button on a guidance step still updates overlays on next tick

## Test plan

- [x] CI build green
- [x] Pull this branch; `./gradlew run`; activate guidance on any multi-step source; toggle Show Overlays off → all overlay visuals clear within ~1 frame
- [x] Toggle Show Overlays back on → overlays return at current step
- [x] Toggle Show Hint Arrow off → in-game arrow + minimap arrow disappear immediately
- [x] Toggle Show Hint Arrow on → arrow re-renders at current step target
- [x] Walk through the 9 validation-log rows once; mark `[x]` as each passes

## Out of scope (still-open follow-ups)

- cha-ndler/collection-log-helper#362 SLAYER/SKILLING counts 0/0 in Category Focus mode
- cha-ndler/collection-log-helper#364 Hide Locked Content toggle inert
- cha-ndler/collection-log-helper#373 Overlay toggle couples to lifecycle (the activateGuidance early-return; out of scope here, distinct concern)
- cha-ndler/collection-log-helper#374 Locked items at bottom instead of natural efficiency position
- cha-ndler/collection-log-helper#378 / cha-ndler/collection-log-helper#381 Step regression / hint arrow stale on long-distance travel