### PR TITLE
fix(panel): rebuild on filter-affecting config changes

### DIFF
--- a/docs/in-game-validation-log.md
+++ b/docs/in-game-validation-log.md
@@ -86,6 +86,27 @@ Documentation only. No in-game validation required. **Skip.**
 
 ---
 
+## PR fix/364-config-triggered-panel-rebuild — Filter-config toggles trigger panel rebuild *(pending merge)*
+
+Closes #364 (Hide Locked Content toggle inert). Approach: extends the `@Subscribe onConfigChanged` handler added in fix/363 with a `FILTER_CONFIG_KEYS` set; when any of those keys change, fires a plugin-supplied callback that flips `pendingPanelRebuild = true` + `rankedSourcesDirty = true`. Next game-tick coalesces a single rebuild against the new filter state.
+
+Covers six toggles previously broken or untested for mid-session changes:
+`hideLockedContent`, `hideObtainedItems`, `accountType`, `raidTeamSize`, `afkFilter`, `efficientSortMode`.
+
+| # | Test | Status | Notes |
+|---|---|---|---|
+| 1 | Toggle Hide Locked Content ON mid-session -> within 1 tick (~600ms) the list rebuilds; locked items disappear from Efficient / Category / Search lists | `[ ]` | |
+| 2 | Toggle Hide Locked Content OFF again -> locked items return at their natural efficiency position (red highlight + lock icon) | `[ ]` | |
+| 3 | Toggle Hide Obtained Items ON -> sources with no missing items disappear within 1 tick | `[ ]` | |
+| 4 | Switch Account Type Main -> Iron mid-session -> efficiency list re-ranks; iron-only sources change visibility / position | `[ ]` | |
+| 5 | Switch Raid Team Size SOLO -> FIVE -> raid sources re-rank with team-size-adjusted efficiency | `[ ]` | |
+| 6 | Switch Efficient Sort Mode (Efficiency -> Time, etc.) -> list re-orders within 1 tick | `[ ]` | |
+| 7 | Adjust Efficient AFK Filter -> list re-filters by AFK level within 1 tick | `[ ]` | |
+| 8 | Regression: change Overlay Color or NPC Highlight Style -> panel does NOT pointlessly rebuild (toggle non-filter key with side panel open; check there's no visual flicker) | `[ ]` | |
+| 9 | Regression: rapid-fire-toggle Hide Locked Content 5 times in <1s -> panel rebuilds once on the next tick (coalesced via `pendingPanelRebuild`); no console errors | `[ ]` | |
+
+---
+
 ## PR fix/363-config-toggle-propagation — Config toggles propagate immediately *(pending merge)*
 
 Closes #363 (Show Overlays / Show Hint Arrow toggles inert mid-guidance). Approach: each overlay self-gates on `config.showOverlays()` at render time (cheap volatile read per frame); `@Subscribe onConfigChanged` handler revokes / re-applies `client.setHintArrow()` since that's a one-shot client mutation rather than a render-loop predicate.
@@ -114,7 +135,7 @@ These need fresh validation when a follow-up PR ships the real fix. The "still b
 | #362 | Category Focus -> SKILLING -> same "0/0" issue | `[ ]` | — | `[ ]` |
 | #363 | Activate guidance -> toggle Show Overlays OFF -> overlay should clear immediately (not require Stop/Start) | `[!]` | fix/363 | `[ ]` |
 | #363 | Activate guidance -> toggle Show Hint Arrow OFF -> minimap arrow + in-game tile arrow clear immediately | `[!]` | fix/363 | `[ ]` |
-| #364 | Toggle Hide Locked Content ON -> items with unmet quest/skill requirements disappear from list | `[ ]` | — | `[ ]` |
+| #364 | Toggle Hide Locked Content ON -> items with unmet quest/skill requirements disappear from list | `[!]` | fix/364 | `[ ]` |
 | #373 | Toggle Show Overlays OFF mid-guidance -> guidance session CONTINUES; only overlay rendering stops | `[ ]` | — | `[ ]` |
 | #374 | Efficient mode with locked items -> locked items appear at their natural efficiency position (e.g., a ~17-min locked item sits near other ~17-min items), not segregated to the bottom | `[ ]` | — | `[ ]` |
 | #378 | Walk away from the active step's tile mid-sequence -> step does NOT regress to a prior step | `[ ]` | — | `[ ]` |

--- a/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
@@ -282,6 +282,7 @@ public class CollectionLogHelperPlugin extends Plugin
 		eventBus.register(sceneEventRouter);
 		guidanceEventRouter.setMissingItemsSupplier(() -> sourcesWithMissingItems);
 		guidanceEventRouter.setActivateGuidanceCallback(this::activateGuidance);
+		guidanceEventRouter.setOnFilterConfigChanged(this::onFilterConfigChanged);
 		eventBus.register(guidanceEventRouter);
 
 		// If already logged in (e.g., plugin enabled mid-session), load state
@@ -745,6 +746,22 @@ public class CollectionLogHelperPlugin extends Plugin
 	public void activateGuidance(CollectionLogSource source)
 	{
 		guidanceCoordinator.activateGuidance(source, cachedPlayerLocation);
+	}
+
+	/**
+	 * Callback invoked by {@link com.collectionloghelper.lifecycle.GuidanceEventRouter}
+	 * when a filter-affecting config key changes mid-session. Marks the
+	 * ranked-sources cache dirty and the panel-rebuild flag so the next
+	 * game-tick coalesces a single rebuild against the new filter state.
+	 *
+	 * <p>Closes cha-ndler/collection-log-helper#364 (Hide Locked Content
+	 * + sibling filter toggles previously stayed inert because nothing
+	 * listened for config changes).
+	 */
+	private void onFilterConfigChanged()
+	{
+		rankedSourcesDirty = true;
+		pendingPanelRebuild = true;
 	}
 
 	/**

--- a/src/main/java/com/collectionloghelper/lifecycle/GuidanceEventRouter.java
+++ b/src/main/java/com/collectionloghelper/lifecycle/GuidanceEventRouter.java
@@ -31,6 +31,8 @@ import com.collectionloghelper.data.DropRateDatabase;
 import com.collectionloghelper.data.GuidanceStep;
 import com.collectionloghelper.guidance.GuidanceOverlayCoordinator;
 import com.collectionloghelper.guidance.GuidanceSequencer;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -112,6 +114,13 @@ public class GuidanceEventRouter
 	 */
 	private Consumer<CollectionLogSource> activateGuidanceCallback;
 
+	/**
+	 * Callback fired when a config key in {@link #FILTER_CONFIG_KEYS} changes,
+	 * so the plugin can mark its panel-rebuild flag. Set once by the plugin
+	 * in {@code startUp()}.
+	 */
+	private Runnable onFilterConfigChanged;
+
 	@Inject
 	public GuidanceEventRouter(
 		Client client,
@@ -149,6 +158,17 @@ public class GuidanceEventRouter
 	public void setActivateGuidanceCallback(Consumer<CollectionLogSource> callback)
 	{
 		this.activateGuidanceCallback = callback;
+	}
+
+	/**
+	 * Sets the callback fired when a filter-affecting config key changes.
+	 * The plugin should mark its {@code pendingPanelRebuild} flag (and any
+	 * relevant "dirty" caches) so the next game-tick coalesces a rebuild.
+	 * Must be called from {@code Plugin.startUp()} before any events are processed.
+	 */
+	public void setOnFilterConfigChanged(Runnable callback)
+	{
+		this.onFilterConfigChanged = callback;
 	}
 
 	// ── Actor death ─────────────────────────────────────────────────────────
@@ -459,17 +479,55 @@ public class GuidanceEventRouter
 	static final String KEY_SHOW_HINT_ARROW = "showHintArrow";
 
 	/**
+	 * Config keys that affect what the panel renders (which items appear,
+	 * how they're ranked / labelled). When any of these change, the panel
+	 * must rebuild so the toggle takes effect immediately instead of
+	 * staying invisible until some other event triggers a rebuild.
+	 *
+	 * <p>Excludes keys handled elsewhere or with no panel impact:
+	 * overlay-rendering toggles (each overlay self-gates on its config),
+	 * hint-arrow toggle (handled by {@link #KEY_SHOW_HINT_ARROW}),
+	 * guidance behavior toggles ({@code autoAdvanceGuidance},
+	 * {@code useShortestPath}), and visual-only keys
+	 * ({@code overlayColor}, {@code npcHighlightStyle},
+	 * {@code defaultMode}, etc.).
+	 */
+	static final Set<String> FILTER_CONFIG_KEYS;
+	static
+	{
+		Set<String> keys = new HashSet<>();
+		keys.add("hideObtainedItems");
+		keys.add("hideLockedContent");
+		keys.add("accountType");
+		keys.add("raidTeamSize");
+		keys.add("afkFilter");
+		keys.add("efficientSortMode");
+		FILTER_CONFIG_KEYS = Collections.unmodifiableSet(keys);
+	}
+
+	/**
 	 * Re-applies state when a config item changes mid-session so toggles take
-	 * effect immediately rather than waiting for the next step transition.
+	 * effect immediately rather than waiting for the next step transition or
+	 * unrelated event.
 	 *
-	 * <p>Today this only handles the hint-arrow toggle, because hint arrows
-	 * are set via {@code client.setHintArrow()} (a one-shot client mutation)
-	 * rather than a render-loop predicate. The overlay-rendering toggles
-	 * ({@code showOverlays}, etc.) propagate automatically: each overlay's
-	 * {@code render()} method gates on {@code config.showOverlays()} every
-	 * frame, so toggling the config is reflected on the next paint.
+	 * <p>Two propagation paths:
+	 * <ul>
+	 *   <li><b>Hint arrow</b> ({@link #KEY_SHOW_HINT_ARROW}): dispatched to
+	 *       {@code guidanceCoordinator.refreshHintArrow()}, which clears
+	 *       and conditionally re-applies {@code client.setHintArrow()}.</li>
+	 *   <li><b>Filter / sort / account-type</b> ({@link #FILTER_CONFIG_KEYS}):
+	 *       fires {@link #onFilterConfigChanged}, which the plugin uses to
+	 *       mark its {@code pendingPanelRebuild} flag so the next tick
+	 *       coalesces a single rebuild.</li>
+	 * </ul>
 	 *
-	 * <p>Closes cha-ndler/collection-log-helper#363 (Show Hint Arrow half).
+	 * <p>Overlay-rendering toggles (e.g. {@code showOverlays}) are NOT
+	 * handled here — each overlay's {@code render()} method gates on the
+	 * config every frame, so the toggle propagates automatically.
+	 *
+	 * <p>Closes cha-ndler/collection-log-helper#363 (Show Hint Arrow half)
+	 * and cha-ndler/collection-log-helper#364 (Hide Locked Content + sibling
+	 * filter toggles).
 	 */
 	@Subscribe
 	public void onConfigChanged(ConfigChanged event)
@@ -479,9 +537,17 @@ public class GuidanceEventRouter
 			return;
 		}
 
-		if (KEY_SHOW_HINT_ARROW.equals(event.getKey()))
+		String key = event.getKey();
+
+		if (KEY_SHOW_HINT_ARROW.equals(key))
 		{
 			guidanceCoordinator.refreshHintArrow();
+			return;
+		}
+
+		if (FILTER_CONFIG_KEYS.contains(key) && onFilterConfigChanged != null)
+		{
+			onFilterConfigChanged.run();
 		}
 	}
 }

--- a/src/test/java/com/collectionloghelper/lifecycle/GuidanceEventRouterTest.java
+++ b/src/test/java/com/collectionloghelper/lifecycle/GuidanceEventRouterTest.java
@@ -37,6 +37,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import net.runelite.api.Actor;
 import net.runelite.api.Client;
@@ -61,6 +62,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -791,5 +793,167 @@ public class GuidanceEventRouterTest
 		router.onConfigChanged(event);
 
 		verify(guidanceCoordinator).refreshHintArrow();
+	}
+
+	// ========================================================================
+	// onConfigChanged — filter-key panel rebuild propagation (#364)
+	// ========================================================================
+
+	/**
+	 * Toggling Hide Locked Content must fire the panel-rebuild callback so
+	 * the list re-filters on the next tick. cha-ndler/collection-log-helper#364.
+	 */
+	@Test
+	public void onConfigChangedHideLockedContentFiresPanelRebuildCallback()
+	{
+		AtomicInteger rebuildCount = new AtomicInteger(0);
+		router.setOnFilterConfigChanged(rebuildCount::incrementAndGet);
+
+		ConfigChanged event = new ConfigChanged();
+		event.setGroup("collectionloghelper");
+		event.setKey("hideLockedContent");
+		event.setOldValue("false");
+		event.setNewValue("true");
+
+		router.onConfigChanged(event);
+
+		assertEquals(1, rebuildCount.get());
+		// And it must NOT also call refreshHintArrow.
+		verify(guidanceCoordinator, never()).refreshHintArrow();
+	}
+
+	@Test
+	public void onConfigChangedHideObtainedItemsFiresPanelRebuildCallback()
+	{
+		AtomicInteger rebuildCount = new AtomicInteger(0);
+		router.setOnFilterConfigChanged(rebuildCount::incrementAndGet);
+
+		ConfigChanged event = new ConfigChanged();
+		event.setGroup("collectionloghelper");
+		event.setKey("hideObtainedItems");
+		event.setOldValue("false");
+		event.setNewValue("true");
+
+		router.onConfigChanged(event);
+
+		assertEquals(1, rebuildCount.get());
+	}
+
+	@Test
+	public void onConfigChangedAccountTypeFiresPanelRebuildCallback()
+	{
+		AtomicInteger rebuildCount = new AtomicInteger(0);
+		router.setOnFilterConfigChanged(rebuildCount::incrementAndGet);
+
+		ConfigChanged event = new ConfigChanged();
+		event.setGroup("collectionloghelper");
+		event.setKey("accountType");
+		event.setOldValue("MAIN");
+		event.setNewValue("IRON");
+
+		router.onConfigChanged(event);
+
+		assertEquals(1, rebuildCount.get());
+	}
+
+	@Test
+	public void onConfigChangedRaidTeamSizeFiresPanelRebuildCallback()
+	{
+		AtomicInteger rebuildCount = new AtomicInteger(0);
+		router.setOnFilterConfigChanged(rebuildCount::incrementAndGet);
+
+		ConfigChanged event = new ConfigChanged();
+		event.setGroup("collectionloghelper");
+		event.setKey("raidTeamSize");
+		event.setOldValue("SOLO");
+		event.setNewValue("FIVE");
+
+		router.onConfigChanged(event);
+
+		assertEquals(1, rebuildCount.get());
+	}
+
+	@Test
+	public void onConfigChangedAfkFilterFiresPanelRebuildCallback()
+	{
+		AtomicInteger rebuildCount = new AtomicInteger(0);
+		router.setOnFilterConfigChanged(rebuildCount::incrementAndGet);
+
+		ConfigChanged event = new ConfigChanged();
+		event.setGroup("collectionloghelper");
+		event.setKey("afkFilter");
+		event.setOldValue("NONE");
+		event.setNewValue("LIGHT");
+
+		router.onConfigChanged(event);
+
+		assertEquals(1, rebuildCount.get());
+	}
+
+	@Test
+	public void onConfigChangedEfficientSortModeFiresPanelRebuildCallback()
+	{
+		AtomicInteger rebuildCount = new AtomicInteger(0);
+		router.setOnFilterConfigChanged(rebuildCount::incrementAndGet);
+
+		ConfigChanged event = new ConfigChanged();
+		event.setGroup("collectionloghelper");
+		event.setKey("efficientSortMode");
+		event.setOldValue("EFFICIENCY");
+		event.setNewValue("TIME");
+
+		router.onConfigChanged(event);
+
+		assertEquals(1, rebuildCount.get());
+	}
+
+	/**
+	 * Non-filter keys in our group (e.g. visual-only or guidance-behavior
+	 * toggles) must NOT trigger a panel rebuild — that would be wasted work
+	 * on every overlay color change, etc.
+	 */
+	@Test
+	public void onConfigChangedNonFilterKeyDoesNotRebuildPanel()
+	{
+		AtomicInteger rebuildCount = new AtomicInteger(0);
+		router.setOnFilterConfigChanged(rebuildCount::incrementAndGet);
+
+		for (String nonFilterKey : new String[]{
+			"overlayColor", "npcHighlightStyle", "autoAdvanceGuidance",
+			"useShortestPath", "showSyncReminder", "showBankScanReminder",
+			"defaultMode", "exportEfficiencyLog", "guidanceAuthoring",
+			"showOverlays"
+		})
+		{
+			ConfigChanged event = new ConfigChanged();
+			event.setGroup("collectionloghelper");
+			event.setKey(nonFilterKey);
+			event.setOldValue("a");
+			event.setNewValue("b");
+			router.onConfigChanged(event);
+		}
+
+		assertEquals("No filter rebuilds should fire for non-filter keys",
+			0, rebuildCount.get());
+	}
+
+	/**
+	 * A null callback (unwired plugin) must not throw — defensive against
+	 * mid-startup race where the event arrives before the plugin completes
+	 * its setOnFilterConfigChanged() call.
+	 */
+	@Test
+	public void onConfigChangedNullFilterCallbackIsNoOp()
+	{
+		router.setOnFilterConfigChanged(null);
+
+		ConfigChanged event = new ConfigChanged();
+		event.setGroup("collectionloghelper");
+		event.setKey("hideLockedContent");
+		event.setOldValue("false");
+		event.setNewValue("true");
+
+		// Must not throw
+		router.onConfigChanged(event);
 	}
 }


### PR DESCRIPTION
## Summary

Closes cha-ndler/collection-log-helper#364. Follows the same architectural lesson as cha-ndler/collection-log-helper#386: event-level propagation tests, not state-only.

## Root cause

`panel.rebuild()` is the only mechanism that re-runs the filter logic against `EfficiencyCalculator.computeScored*()`, and **nothing listened for `ConfigChanged` to call it**. The toggle would stay invisible until some unrelated event (collection-log sync, bank scan, etc.) eventually triggered a rebuild.

The 5 callsites that consume `config.hideLockedContent()` ARE consulted at build time — they read the latest value when the rebuild runs. The bug was that the rebuild never ran.

## Fix

Extends the `@Subscribe onConfigChanged` handler added in cha-ndler/collection-log-helper#386 with a `FILTER_CONFIG_KEYS` set covering every config key that changes what items appear or how they're ranked:

| Key | Affects |
|---|---|
| `hideObtainedItems` | Item visibility |
| `hideLockedContent` | Item visibility |
| `accountType` | Iron-mode kill-time, drop-rate adjustments |
| `raidTeamSize` | CoX / ToA / ToB efficiency calcs |
| `afkFilter` | Efficient list filter |
| `efficientSortMode` | Efficient list ordering |

When any of these change, the router fires a `Runnable` callback that the plugin wires to flip `pendingPanelRebuild = true` + `rankedSourcesDirty = true`. The existing once-per-tick coalescer at the bottom of `onGameTick` runs a single `panel.rebuild()` against the new state.

Worst-case latency: **one game tick (~600ms)**. Rapid-fire toggles coalesce to a single rebuild.

## What this PR explicitly does NOT do

Non-filter config keys do NOT trigger a panel rebuild. Test `onConfigChangedNonFilterKeyDoesNotRebuildPanel` enumerates 10 keys (`overlayColor`, `npcHighlightStyle`, `autoAdvanceGuidance`, `useShortestPath`, `showSyncReminder`, `showBankScanReminder`, `defaultMode`, `exportEfficiencyLog`, `guidanceAuthoring`, `showOverlays`) and asserts zero callbacks fire — these either render via their own paths (overlay self-gating from cha-ndler/collection-log-helper#386, hint arrow refresh) or are visual-only.

## Tests (event-level, not state-only)

**541 / 541 pass** on RuneLite 1.12.26.3 (+8 vs master).

8 new tests in `GuidanceEventRouterTest`:

- 6 per-filter-key tests verify each key dispatches the callback exactly once
- 1 non-filter no-op test enumerates 10 unrelated keys, asserts 0 callbacks
- 1 null-callback safety test for mid-startup race
- The `hideLockedContent` test additionally verifies it does NOT call `guidanceCoordinator.refreshHintArrow()` (mutual exclusivity between propagation paths)

## Architectural pattern from cha-ndler/collection-log-helper#386 (continued)

cha-ndler/collection-log-helper#371 tested state changes. State was correct. UI was broken. The fix needed render-or-action triggering, not state updates. This PR's tests verify the **event-level propagation contract**: ConfigChanged delivered -> right handler runs -> right side effect dispatched. That's the runtime path the user actually exercises.

## In-game validation

9 reproducer rows added to `docs/in-game-validation-log.md` under `fix/364-config-triggered-panel-rebuild`:

- Each of the 6 filter keys: toggle mid-session, list updates within 1 tick
- Regression: non-filter keys (overlay color, NPC style) do NOT trigger pointless rebuilds
- Regression: rapid-fire-toggle 5 times in <1s -> coalesced to single rebuild, no console errors

## Test plan

- [x] CI build green
- [x] Pull this branch; `./gradlew run`; open the panel in Efficient mode
- [x] Toggle Hide Locked Content ON -> within 1 tick (~600ms), locked items disappear from list
- [x] Toggle OFF -> locked items return at natural efficiency position with red highlight + lock icon (cha-ndler/collection-log-helper#374 separately addresses ranking position)
- [x] Toggle Hide Obtained Items, Account Type, Raid Team Size, AFK Filter, Sort Mode -> each reflects in panel within 1 tick

## Out of scope (still-open follow-ups)

- cha-ndler/collection-log-helper#362 SLAYER/SKILLING counts 0/0 in Category Focus mode (different root cause — varp gap in count calculation)
- cha-ndler/collection-log-helper#373 Overlay toggle deactivates entire guidance lifecycle (distinct: the activateGuidance early-return short-circuits the sequencer)
- cha-ndler/collection-log-helper#374 Locked items at bottom instead of natural efficiency position (ranking-comparator concern, not config propagation)