### PR TITLE
debug: add [guide-me-trace] diagnostic logging for Guide-Me state divergence

### DIFF
--- a/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
@@ -198,8 +198,15 @@ public class GuidanceOverlayCoordinator
 	 */
 	public void activateGuidance(CollectionLogSource source, WorldPoint cachedPlayerLocation)
 	{
+		log.info("[guide-me-trace] activateGuidance ENTRY source={} showOverlays={} panel={} cachedLoc={}",
+			source != null ? source.getName() : "null",
+			config.showOverlays(),
+			panel != null ? "set" : "NULL",
+			cachedPlayerLocation);
+
 		if (!config.showOverlays())
 		{
+			log.info("[guide-me-trace] activateGuidance EARLY-RETURN: showOverlays=false");
 			return;
 		}
 
@@ -213,23 +220,30 @@ public class GuidanceOverlayCoordinator
 		}
 
 		// Clear any existing guidance first, including InfoBox and sequencer
+		log.info("[guide-me-trace] activateGuidance calling deactivateGuidance() to clear prior state");
 		deactivateGuidance();
 
 		// If source has multi-step guidance, start the sequencer
 		if (source.getGuidanceSteps() != null && !source.getGuidanceSteps().isEmpty())
 		{
+			log.info("[guide-me-trace] activateGuidance: source has {} guidance steps, calling startSequence",
+				source.getGuidanceSteps().size());
 			guidanceSequencer.setPlayerLocation(cachedPlayerLocation);
 			// startSequence runs the initial skip-chain synchronously. If all steps
 			// are already satisfied, onSequenceComplete fires inside startSequence,
 			// which calls deactivateGuidance() — leave panel cleared and return.
 			guidanceSequencer.startSequence(source, this::onStepChanged, this::onSequenceComplete);
 
+			log.info("[guide-me-trace] activateGuidance: after startSequence isActive={} currentIndex={} totalSteps={}",
+				guidanceSequencer.isActive(),
+				guidanceSequencer.getCurrentIndex(),
+				guidanceSequencer.getTotalSteps());
+
 			if (!guidanceSequencer.isActive())
 			{
 				// All steps were already satisfied — sequence completed immediately.
 				// onSequenceComplete already called deactivateGuidance(); nothing more to do.
-				log.debug("Multi-step guidance for {} completed immediately (all steps already satisfied)",
-					source.getName());
+				log.info("[guide-me-trace] activateGuidance EARLY-RETURN: all steps already satisfied (panel state NOT activated)");
 				return;
 			}
 
@@ -240,13 +254,28 @@ public class GuidanceOverlayCoordinator
 			GuidanceStep rawStep = guidanceSequencer.getRawCurrentStep();
 			if (panel != null)
 			{
-				panel.setGuidanceState(true, source);
+				log.info("[guide-me-trace] activateGuidance: about to call panel.setGuidanceState(true, {})",
+					source.getName());
+				try
+				{
+					panel.setGuidanceState(true, source);
+					log.info("[guide-me-trace] activateGuidance: panel.setGuidanceState COMPLETED");
+				}
+				catch (RuntimeException ex)
+				{
+					log.error("[guide-me-trace] activateGuidance: panel.setGuidanceState THREW", ex);
+					throw ex;
+				}
 				panel.updateStepProgress(
 					guidanceSequencer.getCurrentIndex() + 1,
 					guidanceSequencer.getTotalSteps(),
 					step != null ? step.getDescription() : "",
 					step != null && step.getCompletionCondition() == CompletionCondition.MANUAL,
 					rawStep != null ? rawStep.getRequiredItemIds() : null);
+			}
+			else
+			{
+				log.warn("[guide-me-trace] activateGuidance: panel reference is NULL, cannot setGuidanceState");
 			}
 			// Add InfoBox showing the correct landed step (not always "1/N")
 			if (!source.getItems().isEmpty() && pluginInstance != null)
@@ -259,9 +288,10 @@ public class GuidanceOverlayCoordinator
 					+ (step != null ? step.getDescription() : ""));
 				infoBoxManager.addInfoBox(activeInfoBox);
 			}
-			log.debug("Multi-step guidance activated for {} ({} steps, starting at step {})",
-				source.getName(), source.getGuidanceSteps().size(),
-				guidanceSequencer.getCurrentIndex() + 1);
+			log.info("[guide-me-trace] activateGuidance EXIT (multi-step path) for {} at step {}/{}",
+				source.getName(),
+				guidanceSequencer.getCurrentIndex() + 1,
+				guidanceSequencer.getTotalSteps());
 			return;
 		}
 
@@ -308,6 +338,11 @@ public class GuidanceOverlayCoordinator
 	 */
 	public void deactivateGuidance()
 	{
+		log.info("[guide-me-trace] deactivateGuidance ENTRY sequencerActive={} caller-stack-top={}",
+			guidanceSequencer.isActive(),
+			Thread.currentThread().getStackTrace().length > 2
+				? Thread.currentThread().getStackTrace()[2].toString()
+				: "?");
 		lastMessagedStepIndex = -1;
 		trackedGuidanceNpc = null;
 		if (activeInfoBox != null)
@@ -760,6 +795,9 @@ public class GuidanceOverlayCoordinator
 	 */
 	private void onStepChanged(GuidanceStep step)
 	{
+		log.info("[guide-me-trace] onStepChanged ENTRY step.desc={} stepIndex={}",
+			step != null ? step.getDescription() : "null",
+			guidanceSequencer.getCurrentIndex());
 		clearGuidanceOverlays();
 		CollectionLogSource activeSource = guidanceSequencer.getActiveSource();
 		String sourceName = activeSource != null ? activeSource.getName() : "";
@@ -807,6 +845,7 @@ public class GuidanceOverlayCoordinator
 	{
 		String sourceName = guidanceSequencer.getActiveSource() != null
 			? guidanceSequencer.getActiveSource().getName() : "unknown";
+		log.info("[guide-me-trace] onSequenceComplete ENTRY sourceName={}", sourceName);
 		deactivateGuidance();
 		log.debug("Guidance sequence complete for {}", sourceName);
 		if (onSequenceCompleteCallback != null)

--- a/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
@@ -82,12 +82,14 @@ import javax.swing.SwingUtilities;
 import javax.swing.Timer;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
+import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.PluginPanel;
 import net.runelite.client.util.SwingUtil;
 
+@Slf4j
 public class CollectionLogHelperPanel extends PluginPanel implements PanelShellContext
 {
 
@@ -592,11 +594,20 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 	@Override
 	public JPanel createQuickGuidePanel(ScoredItem topItem)
 	{
+		log.info("[guide-me-trace] createQuickGuidePanel topItem.source={} guidanceActive={} guidedSource={}",
+			topItem != null && topItem.getSource() != null ? topItem.getSource().getName() : "null",
+			guidanceActive,
+			guidedSource != null ? guidedSource.getName() : "null");
 		return quickGuidePanelView.create(topItem, guidanceActive, guidedSource);
 	}
 
 	public void setGuidanceState(boolean active, CollectionLogSource source)
 	{
+		log.info("[guide-me-trace] panel.setGuidanceState ENTRY active={} source={} prevActive={} prevSource={}",
+			active,
+			source != null ? source.getName() : "null",
+			guidanceActive,
+			guidedSource != null ? guidedSource.getName() : "null");
 		guidanceActive = active;
 		guidedSource = source;
 		if (active && source != null)
@@ -608,6 +619,9 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 			guidanceBannerView.hideGuidance();
 		}
 		quickGuidePanelView.syncGuidanceState(active, source);
+		log.info("[guide-me-trace] panel.setGuidanceState EXIT guidanceActive={} guidedSource={}",
+			guidanceActive,
+			guidedSource != null ? guidedSource.getName() : "null");
 	}
 
 	public void showClueGuidance(CollectionLogSource source)


### PR DESCRIPTION
## Summary

**Diagnostic-only PR** — captures the exact failure path for the Guide-Me regression observed during in-game testing on 2026-05-11.

## Symptom (from in-game test session)

- Clicking Guide Me on Top Pick (Bronze lock → Shades of Mort'ton) leaves the panel button as "Guide Me" — never flickers to "Stop Guidance"
- BUT the in-game overlay shows guidance content (title "Shades of Mort'ton", step description "Bank: bring pyre logs…", "Item requirements: Tinderbox (bank)")
- Other sources (e.g. Dagon'hai robe bottom → Larran's Big Chest) work normally

**Diagnosis**: state-divergence between overlay coordinator (says active) and panel (says inactive). Two possible causes that the logs will distinguish:

1. `panel.setGuidanceState(true, source)` never ran — silent exception or null panel reference
2. It ran successfully, but a subsequent unexpected `deactivateGuidance()` call flipped the panel state back

## What this PR adds

`log.info` traces with the `[guide-me-trace]` prefix at every state transition in the activation flow:

- `GuidanceOverlayCoordinator.activateGuidance` — entry, every early-return path, before/after `panel.setGuidanceState`, exit
- `GuidanceOverlayCoordinator.deactivateGuidance` — entry + caller stack frame (catches surprise callers)
- `GuidanceOverlayCoordinator.onStepChanged` — entry with step desc + index
- `GuidanceOverlayCoordinator.onSequenceComplete` — entry with source name
- `CollectionLogHelperPanel.setGuidanceState` — entry+exit with `prev -> new` state transition
- `CollectionLogHelperPanel.createQuickGuidePanel` — rebuild-time snapshot showing what state the new button will be created with

Plus a `try/catch` around `panel.setGuidanceState` that re-throws but logs first, so any silent `RuntimeException` surfaces.

## How to capture the data

1. Pull this branch, `./gradlew run`
2. Reproduce the bug: click Guide Me on Top Pick for Shades of Mort'ton, observe panel button stays "Guide Me"
3. `Help` → `Open logs folder` → `client.log`
4. Grep `[guide-me-trace]` from the time of the click — share the output

The traces will show exactly which path executed and where state diverged.

## Important: this is reversible

Once the root cause is identified and the fix lands, these traces should be removed (or downgraded to `log.debug`). Auto-merge **not recommended** — review the trace output first, then ship the real fix and revert this debug PR.

## Tests

541 / 541 pass — no behavior change, only added logging + a defensive try/catch around `panel.setGuidanceState`.

## Out of scope

- The actual fix — will be a follow-up PR once the trace output identifies the failure path
- Removing the diagnostic logs — should happen in the fix PR or a follow-up cleanup commit