### PR TITLE
fix(guidance): Show Overlays toggle no longer aborts activation

### DIFF
--- a/docs/in-game-validation-log.md
+++ b/docs/in-game-validation-log.md
@@ -86,6 +86,21 @@ Documentation only. No in-game validation required. **Skip.**
 
 ---
 
+## PR fix/373-overlay-toggle-preserves-guidance — Show Overlays toggle no longer kills the guidance session *(pending merge)*
+
+Closes cha-ndler/collection-log-helper#373. Removes the early-return at the top of `GuidanceOverlayCoordinator.activateGuidance` that aborted the whole call when `config.showOverlays()` was false. Since cha-ndler/collection-log-helper#386 added per-overlay self-gating, the early-return is now redundant *and* wrong: toggling Show Overlays off should hide overlays (which #386 already does), not refuse to start guidance.
+
+| # | Test | Status | Notes |
+|---|---|---|---|
+| 1 | With Show Overlays OFF, click Guide Me on any source → panel button changes to "Stop Guidance", banner shows "Guiding: X", step progress widget appears in panel, but NO 3D world overlays render | `[ ]` | |
+| 2 | While guidance is active with Show Overlays OFF, toggle Show Overlays ON → overlays appear immediately at the current step's target (without re-clicking Guide Me) | `[ ]` | |
+| 3 | While guidance is active with Show Overlays ON, toggle Show Overlays OFF → overlays disappear immediately but guidance stays active (panel button stays "Stop Guidance") | `[ ]` | |
+| 4 | Repeat toggle cycle 3 times rapidly → state stays consistent each cycle; no stuck buttons; no console errors | `[ ]` | |
+| 5 | Stop Guidance manually with Show Overlays OFF → button returns to "Guide Me", banner clears | `[ ]` | |
+| 6 | Regression: Show Overlays ON + Guide Me on Shades of Mort'ton → still works as in cha-ndler/collection-log-helper#389 (panel + overlay both populate) | `[ ]` | |
+
+---
+
 ## PR fix/required-items-client-thread — Guide Me activation regression *(pending merge)*
 
 Closes the regression surfaced by trace from PR #388: Guide Me on any source with `requiredItemIds` (e.g. Shades of Mort'ton) silently failed because `RequiredItemResolver.lookupName` called `ItemManager.getItemComposition()` from the EDT, which throws `AssertionError("must be called on client thread")`. The original catch only caught `RuntimeException`, so the assertion propagated up and aborted `activateGuidance` mid-flight — leaving the overlay state set but the panel state stale ("Guide Me" instead of "Stop Guidance").
@@ -156,7 +171,7 @@ These need fresh validation when a follow-up PR ships the real fix. The "still b
 | #363 | Activate guidance -> toggle Show Overlays OFF -> overlay should clear immediately (not require Stop/Start) | `[!]` | fix/363 | `[ ]` |
 | #363 | Activate guidance -> toggle Show Hint Arrow OFF -> minimap arrow + in-game tile arrow clear immediately | `[!]` | fix/363 | `[ ]` |
 | #364 | Toggle Hide Locked Content ON -> items with unmet quest/skill requirements disappear from list | `[!]` | fix/364 | `[ ]` |
-| #373 | Toggle Show Overlays OFF mid-guidance -> guidance session CONTINUES; only overlay rendering stops | `[ ]` | — | `[ ]` |
+| #373 | Toggle Show Overlays OFF mid-guidance -> guidance session CONTINUES; only overlay rendering stops | `[!]` | fix/373 | `[ ]` |
 | #374 | Efficient mode with locked items -> locked items appear at their natural efficiency position (e.g., a ~17-min locked item sits near other ~17-min items), not segregated to the bottom | `[ ]` | — | `[ ]` |
 | #378 | Walk away from the active step's tile mid-sequence -> step does NOT regress to a prior step | `[ ]` | — | `[ ]` |
 | #381 | Mid-guidance: teleport far away and back -> hint arrow re-renders without a Stop/Start cycle | `[ ]` | — | `[ ]` |

--- a/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
@@ -198,10 +198,13 @@ public class GuidanceOverlayCoordinator
 	 */
 	public void activateGuidance(CollectionLogSource source, WorldPoint cachedPlayerLocation)
 	{
-		if (!config.showOverlays())
-		{
-			return;
-		}
+		// Note: deliberately NO early-return on config.showOverlays() here.
+		// Show Overlays controls whether *overlays render*, not whether
+		// guidance is active. Each overlay's render() method self-gates
+		// on config.showOverlays() (added in cha-ndler/collection-log-helper#386),
+		// so toggling the option off hides them on the next paint without
+		// stopping the sequencer or the panel banner. Closes
+		// cha-ndler/collection-log-helper#373.
 
 		// Warn if the source has unmet requirements (don't block, just warn)
 		List<String> unmetReqs = requirementsChecker.getUnmetRequirements(source.getName());


### PR DESCRIPTION
## Summary

Closes cha-ndler/collection-log-helper#373. Single-line deletion that completes the work cha-ndler/collection-log-helper#386 started.

## Root cause

`GuidanceOverlayCoordinator.activateGuidance` had a guard at its top:

```java
if (!config.showOverlays())
{
    return;
}
```

With Show Overlays OFF, clicking Guide Me returned silently — sequencer never started, panel banner never appeared, button stayed "Guide Me". From the player's perspective, "toggling Show Overlays kills the entire guidance session."

That guard was load-bearing **before** cha-ndler/collection-log-helper#386 because nothing else suppressed overlay rendering — without it, overlay state would have been set and painted regardless of the toggle. After cha-ndler/collection-log-helper#386 added per-overlay self-gating on `config.showOverlays()`, the guard became **redundant AND wrong**: each overlay's `render()` now returns null when the toggle is off, so guidance can safely activate while the rendering layer suppresses visuals.

## Fix

Delete the early-return.

Behavior after the fix:
- Show Overlays OFF + click Guide Me → sequencer starts, panel banner shows, step progress widget appears, button changes to "Stop Guidance", BUT no 3D world overlays render.
- Toggle Show Overlays ON mid-guidance → overlays appear at the current step's target without re-clicking Guide Me.
- Toggle Show Overlays OFF mid-guidance → overlays disappear; guidance session continues.

## Why no new unit tests

The change is a pure deletion of an early-return that fights cha-ndler/collection-log-helper#386's intended behavior. Standing up a `GuidanceOverlayCoordinator` unit test for one removed line would require mocking ~19 dependencies — bad value-to-effort.

Coverage instead via in-game validation log: 6 reproducer rows added under `fix/373-overlay-toggle-preserves-guidance` covering off-state activation, mid-session toggle on/off cycles, and regression check against cha-ndler/collection-log-helper#389's required-items path.

## Tests

542 / 542 pass on RuneLite 1.12.26.3 (unchanged from master).

## Test plan

- [ ] CI build green
- [ ] Pull, `./gradlew run`
- [ ] Toggle Show Overlays OFF, click Guide Me on any source → panel button changes to "Stop Guidance", banner shows "Guiding: X", NO 3D world overlays
- [ ] Toggle Show Overlays ON while guidance active → overlays appear at current step
- [ ] Toggle Show Overlays OFF again → overlays disappear, guidance stays active
- [ ] Stop Guidance manually with Show Overlays OFF → button reverts to "Guide Me", banner clears
- [ ] Regression: Show Overlays ON + Guide Me on Shades of Mort'ton → still works as in cha-ndler/collection-log-helper#389

## Pipeline state

After this lands, still-open #371-orphaned bugs are:

- cha-ndler/collection-log-helper#362 SLAYER/SKILLING category counts 0/0 (varp/data root cause, different class)
- cha-ndler/collection-log-helper#374 Locked items at bottom instead of natural efficiency position (ranking comparator)
- cha-ndler/collection-log-helper#378 Bi-directional step regression on leaving step location
- cha-ndler/collection-log-helper#381 Hint arrow stale after long-distance teleport