### PR TITLE
fix(panel): StepProgressView tooltip lookup no longer aborts the strip

### DIFF
--- a/docs/in-game-validation-log.md
+++ b/docs/in-game-validation-log.md
@@ -86,7 +86,7 @@ Documentation only. No in-game validation required. **Skip.**
 
 ---
 
-## PR fix/373-overlay-toggle-preserves-guidance — Show Overlays toggle no longer kills the guidance session *(pending merge)*
+## PR #390 (fix/373-overlay-toggle-preserves-guidance) — Show Overlays toggle no longer kills the guidance session *(merged 2026-05-11)*
 
 Closes cha-ndler/collection-log-helper#373. Removes the early-return at the top of `GuidanceOverlayCoordinator.activateGuidance` that aborted the whole call when `config.showOverlays()` was false. Since cha-ndler/collection-log-helper#386 added per-overlay self-gating, the early-return is now redundant *and* wrong: toggling Show Overlays off should hide overlays (which #386 already does), not refuse to start guidance.
 
@@ -98,6 +98,23 @@ Closes cha-ndler/collection-log-helper#373. Removes the early-return at the top 
 | 4 | Repeat toggle cycle 3 times rapidly → state stays consistent each cycle; no stuck buttons; no console errors | `[ ]` | |
 | 5 | Stop Guidance manually with Show Overlays OFF → button returns to "Guide Me", banner clears | `[ ]` | |
 | 6 | Regression: Show Overlays ON + Guide Me on Shades of Mort'ton → still works as in cha-ndler/collection-log-helper#389 (panel + overlay both populate) | `[ ]` | |
+
+---
+
+## PR fix/step-progress-view-client-thread — StepProgressView tooltip lookup no longer crashes *(pending merge)*
+
+Closes the same class of bug as cha-ndler/collection-log-helper#389 but on the side-panel widget. `StepProgressView.updateRequiredItemDisplay` calls `itemManager.getItemComposition(itemId).getName()` to build tooltips for each required-item icon — but that runs on the EDT (the widget is a Swing panel), and `getItemComposition` asserts caller-is-client-thread. The `AssertionError` aborted the loop mid-iteration, leaving the required-items strip hidden in the panel and dumping stack traces to `client.log`.
+
+Minimal fix: wrap the `getItemComposition` call in `try / catch (Throwable)`, falling back to `"Item #N"` for the tooltip. Loop completes, panel renders icons + colored borders correctly; only tooltips degrade to IDs when on EDT.
+
+A proper architectural fix (pre-resolved `List<RequiredItemDisplay>` passed from coordinator on client thread) is queued as a follow-up; out of scope here to keep the PR minimal.
+
+| # | Test | Status | Notes |
+|---|---|---|---|
+| 1 | Activate guidance on a source with `requiredItemIds` (e.g. Shades of Mort'ton step 1) → side-panel required-items strip shows item icons with colored borders | `[ ]` | |
+| 2 | Hover over an item icon → tooltip shows either the item name (if cache loaded on EDT) OR "Item #N (in inventory / bank / MISSING)" — both acceptable, no crash | `[ ]` | |
+| 3 | Open `client.log` after a Guide Me click → ZERO `Uncaught exception` lines pointing at `StepProgressView.updateRequiredItemDisplay` | `[ ]` | |
+| 4 | Cycle Guide Me → Stop Guidance → Guide Me 5 times → required-items strip renders each time, no degradation | `[ ]` | |
 
 ---
 

--- a/src/main/java/com/collectionloghelper/ui/widget/StepProgressView.java
+++ b/src/main/java/com/collectionloghelper/ui/widget/StepProgressView.java
@@ -42,6 +42,7 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
+import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.util.AsyncBufferedImage;
@@ -61,6 +62,7 @@ import net.runelite.client.util.AsyncBufferedImage;
  * an override with the same signature breaks {@code setVisible(false)} for this
  * widget and leaves it visible in pre-guidance states (see issue #353).
  */
+@Slf4j
 public class StepProgressView extends JPanel
 {
 	private static final Color ITEM_STATUS_GREEN = new Color(40, 180, 40);
@@ -276,7 +278,27 @@ public class StepProgressView extends JPanel
 			BufferedImage scaled = scaleImage(asyncImage, 28, 28);
 			itemLabel.setIcon(new ImageIcon(scaled));
 
-			itemLabel.setToolTipText(itemManager.getItemComposition(itemId).getName() + statusText);
+			// ItemManager.getItemComposition() asserts client-thread, but this
+			// runs on the EDT (the panel is a Swing widget updated via
+			// SwingUtilities.invokeLater in showStep). The assertion is an Error
+			// (not RuntimeException) so it would otherwise propagate up,
+			// abort the loop mid-iteration, and leave the required-items strip
+			// hidden. See cha-ndler/collection-log-helper#388 for the trace.
+			// Falling back to "Item #N" keeps the row visible; a proper fix
+			// (pre-resolved items via RequiredItemResolver on client thread) is
+			// tracked as a follow-up — see PR description.
+			String tooltipName;
+			try
+			{
+				tooltipName = itemManager.getItemComposition(itemId).getName();
+			}
+			catch (Throwable t)
+			{
+				log.warn("Item composition lookup failed for required-item id {}: {}",
+					itemId, t.toString());
+				tooltipName = "Item #" + itemId;
+			}
+			itemLabel.setToolTipText(tooltipName + statusText);
 			requiredItemsPanel.add(itemLabel);
 		}
 


### PR DESCRIPTION
## Summary

Same class of bug as cha-ndler/collection-log-helper#389, fixed on the side-panel widget this time. Eliminates the `Uncaught exception` stack traces the user surfaced in `client.log` after merging cha-ndler/collection-log-helper#390.

## Root cause (from `client.log`)

```
java.lang.AssertionError: must be called on client thread
    at client.getItemDefinition(client.java:11676)
    at net.runelite.client.game.ItemManager.getItemComposition(ItemManager.java:461)
    at com.collectionloghelper.ui.widget.StepProgressView.updateRequiredItemDisplay(StepProgressView.java:279)
    at com.collectionloghelper.ui.widget.StepProgressView.lambda$showStep$2(StepProgressView.java:181)
    at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:318)
```

`StepProgressView.updateRequiredItemDisplay` iterates required items on the EDT (the widget is a Swing panel; `showStep` wraps the work in `SwingUtilities.invokeLater`). The tooltip lookup at line 279 calls `getItemComposition(itemId).getName()` — but that asserts caller-is-client-thread. `AssertionError` extends `Error`, not `RuntimeException`, so it propagated up, aborted the loop mid-iteration, and the `setVisible(true)` at the end of `updateRequiredItemDisplay` never ran. The required-items strip stayed hidden in the side panel.

User-visible symptom: side-panel required-items icons sometimes failed to appear (state-dependent on EDT cache warmth). Backend symptom: `Uncaught exception` stack traces in `client.log` on every Guide Me click.

## Fix (minimal)

Wrap the `getItemComposition` call in `try / catch (Throwable)` and fall back to `"Item #N"` for the tooltip. The loop continues, `setVisible(true)` runs, the strip renders correctly. Also adds `@Slf4j` to the widget so the warn lands in `client.log` for visibility instead of silently disappearing.

```diff
- itemLabel.setToolTipText(itemManager.getItemComposition(itemId).getName() + statusText);
+ String tooltipName;
+ try
+ {
+     tooltipName = itemManager.getItemComposition(itemId).getName();
+ }
+ catch (Throwable t)
+ {
+     log.warn("Item composition lookup failed for required-item id {}: {}", itemId, t.toString());
+     tooltipName = "Item #" + itemId;
+ }
+ itemLabel.setToolTipText(tooltipName + statusText);
```

## Tradeoff

Tooltips degrade to `"Item #590 (in inventory)"` when the assertion fires (EDT call) and to `"Tinderbox (in inventory)"` when the cache happens to be warm on the EDT (rare but possible). Acceptable degradation; the icon + colored border still convey the actual state.

## Follow-up (out of scope)

A proper architectural fix would mirror cha-ndler/collection-log-helper#389's approach: pre-resolve names via `RequiredItemResolver` on the client thread and pass `List<RequiredItemDisplay>` to the panel widget. This requires:

- Changing `StepProgressView` constructor (drop `PlayerInventoryState` / `PlayerBankState`, take resolved items via `showStep`)
- Changing `CollectionLogHelperPanel.updateStepProgress` signature
- Coordinator: dispatch `panel.updateStepProgress(...)` inside the existing `clientThread.invokeLater` block from cha-ndler/collection-log-helper#389

Deliberately deferred — that's a 4-file refactor with API changes, while this PR is a 2-file 24-line minimal patch that eliminates the user-reported error log.

## Tests

542/542 pass on RuneLite 1.12.26.3 (unchanged from master).

Tried adding a unit test asserting `AssertionError` doesn't escape, but the rendering path constructs `Graphics2D` from `AsyncBufferedImage` which can't be cleanly mocked (`BufferedImage` carries native state). Coverage instead via:

- The existing `RequiredItemResolverTest.itemCompositionAssertionErrorFallsBackToIdLabel` test from cha-ndler/collection-log-helper#389 proves the `catch (Throwable)` pattern works.
- 4 in-game validation log rows under `fix/step-progress-view-client-thread` cover: rendering, tooltip fallback, log cleanliness, cycle stability.

## Test plan

- [ ] CI build green
- [ ] Pull, `./gradlew run`
- [ ] Click Guide Me on Shades of Mort'ton → side-panel required-items strip shows item icons with colored borders
- [ ] Hover an icon → tooltip shows either item name or "Item #N (status)" — both acceptable, no crash
- [ ] Open `client.log` → ZERO `Uncaught exception` lines pointing at `StepProgressView.updateRequiredItemDisplay` (was multiple per Guide Me click before this PR)
- [ ] Cycle Guide Me/Stop Guidance 5 times → strip renders each cycle, no degradation