### PR TITLE
fix(rank): locked items rank by score, not segregated to the bottom

### DIFF
--- a/docs/in-game-validation-log.md
+++ b/docs/in-game-validation-log.md
@@ -118,6 +118,21 @@ A proper architectural fix (pre-resolved `List<RequiredItemDisplay>` passed from
 
 ---
 
+## PR fix/374-locked-items-natural-position — Locked items rank by score, not segregated *(pending merge)*
+
+Closes cha-ndler/collection-log-helper#374. Three identical `Comparator.comparing(ScoredItem::isLocked).thenComparing(...)` chains in `EfficiencyCalculator` (`rankByEfficiency`, `filterByCategory`, `filterPetsOnly`) sorted by `isLocked` first — pushing every locked item to the bottom of the list regardless of its score. Removed the segregation key: score-only sort. Locked items keep their `isLocked` flag for the renderer (red highlight + lock icon + tooltip), they just appear in their natural efficiency position now.
+
+| # | Test | Status | Notes |
+|---|---|---|---|
+| 1 | Efficient mode with a locked source whose score sits between two unlocked ones → locked source appears INTERLEAVED, not at the bottom | `[ ]` | |
+| 2 | Locked source still renders with red highlight + lock icon (renderer unchanged) | `[ ]` | |
+| 3 | Hover the locked source → tooltip names the unmet requirement (quest / skill / diary) | `[ ]` | |
+| 4 | Toggle Hide Locked Content ON → locked sources still disappear entirely (no regression from cha-ndler/collection-log-helper#387) | `[ ]` | |
+| 5 | Category Focus mode with mixed locked/unlocked sources → same interleaving behavior | `[ ]` | |
+| 6 | Top Pick still picks the highest-score UNLOCKED source (locked sources can't be Top Pick — `findFirst().filter(!isLocked)` semantics intact) | `[ ]` | |
+
+---
+
 ## PR fix/required-items-client-thread — Guide Me activation regression *(pending merge)*
 
 Closes the regression surfaced by trace from PR #388: Guide Me on any source with `requiredItemIds` (e.g. Shades of Mort'ton) silently failed because `RequiredItemResolver.lookupName` called `ItemManager.getItemComposition()` from the EDT, which throws `AssertionError("must be called on client thread")`. The original catch only caught `RuntimeException`, so the assertion propagated up and aborted `activateGuidance` mid-flight — leaving the overlay state set but the panel state stale ("Guide Me" instead of "Stop Guidance").
@@ -189,7 +204,7 @@ These need fresh validation when a follow-up PR ships the real fix. The "still b
 | #363 | Activate guidance -> toggle Show Hint Arrow OFF -> minimap arrow + in-game tile arrow clear immediately | `[!]` | fix/363 | `[ ]` |
 | #364 | Toggle Hide Locked Content ON -> items with unmet quest/skill requirements disappear from list | `[!]` | fix/364 | `[ ]` |
 | #373 | Toggle Show Overlays OFF mid-guidance -> guidance session CONTINUES; only overlay rendering stops | `[!]` | fix/373 | `[ ]` |
-| #374 | Efficient mode with locked items -> locked items appear at their natural efficiency position (e.g., a ~17-min locked item sits near other ~17-min items), not segregated to the bottom | `[ ]` | — | `[ ]` |
+| #374 | Efficient mode with locked items -> locked items appear at their natural efficiency position (e.g., a ~17-min locked item sits near other ~17-min items), not segregated to the bottom | `[!]` | fix/374 | `[ ]` |
 | #378 | Walk away from the active step's tile mid-sequence -> step does NOT regress to a prior step | `[ ]` | — | `[ ]` |
 | #381 | Mid-guidance: teleport far away and back -> hint arrow re-renders without a Stop/Start cycle | `[ ]` | — | `[ ]` |
 

--- a/src/main/java/com/collectionloghelper/efficiency/EfficiencyCalculator.java
+++ b/src/main/java/com/collectionloghelper/efficiency/EfficiencyCalculator.java
@@ -111,10 +111,11 @@ public class EfficiencyCalculator
 			}
 		}
 
-		// Unlocked first (by score desc), then locked (by score desc)
-		results.sort(Comparator
-			.comparing(ScoredItem::isLocked)
-			.thenComparing(Comparator.comparingDouble(ScoredItem::getScore).reversed()));
+		// Sort by score descending only. Locked items stay at their natural
+		// efficiency position; the renderer visually distinguishes them via a
+		// red highlight + lock icon + tooltip naming the unmet requirement.
+		// Closes cha-ndler/collection-log-helper#374.
+		results.sort(Comparator.comparingDouble(ScoredItem::getScore).reversed());
 		return results;
 	}
 
@@ -147,9 +148,7 @@ public class EfficiencyCalculator
 			}
 		}
 
-		results.sort(Comparator
-			.comparing(ScoredItem::isLocked)
-			.thenComparing(Comparator.comparingDouble(ScoredItem::getScore).reversed()));
+		results.sort(Comparator.comparingDouble(ScoredItem::getScore).reversed());
 		return results;
 	}
 
@@ -178,9 +177,7 @@ public class EfficiencyCalculator
 			}
 		}
 
-		results.sort(Comparator
-			.comparing(ScoredItem::isLocked)
-			.thenComparing(Comparator.comparingDouble(ScoredItem::getScore).reversed()));
+		results.sort(Comparator.comparingDouble(ScoredItem::getScore).reversed());
 		return results;
 	}
 

--- a/src/test/java/com/collectionloghelper/efficiency/EfficiencyCalculatorTest.java
+++ b/src/test/java/com/collectionloghelper/efficiency/EfficiencyCalculatorTest.java
@@ -1112,6 +1112,81 @@ public class EfficiencyCalculatorTest
 		assertEquals(fullRate * fullKph * 100, full.getScore(), 0.01);
 	}
 
+	// --- Locked-item ranking position (cha-ndler/collection-log-helper#374) ---
+
+	/**
+	 * Closes cha-ndler/collection-log-helper#374. Locked items must rank by
+	 * score alone — same as unlocked items — and NOT get segregated to the
+	 * bottom of the list. The renderer visually distinguishes locked items
+	 * (red highlight + lock icon) but their position should reflect their
+	 * efficiency.
+	 */
+	@Test
+	public void testRankByEfficiency_lockedItemRanksAtNaturalScorePosition()
+	{
+		// Three sources, deliberately staggered scores. The middle one is locked.
+		CollectionLogSource fast = makeSource("Fast Unlocked", CollectionLogCategory.BOSSES,
+			30, Collections.singletonList(makeItem(1, "Fast drop", 0.05)));
+		CollectionLogSource mediumLocked = makeSource("Medium Locked", CollectionLogCategory.BOSSES,
+			60, Collections.singletonList(makeItem(2, "Medium drop", 0.05)));
+		CollectionLogSource slow = makeSource("Slow Unlocked", CollectionLogCategory.BOSSES,
+			120, Collections.singletonList(makeItem(3, "Slow drop", 0.05)));
+
+		when(database.getAllSources()).thenReturn(Arrays.asList(fast, mediumLocked, slow));
+		// Mark only the middle one as locked.
+		when(requirementsChecker.isAccessible("Fast Unlocked")).thenReturn(true);
+		when(requirementsChecker.isAccessible("Medium Locked")).thenReturn(false);
+		when(requirementsChecker.isAccessible("Slow Unlocked")).thenReturn(true);
+		// All drops are unobtained so the items count toward score.
+		when(collectionState.isItemObtained(1)).thenReturn(false);
+		when(collectionState.isItemObtained(2)).thenReturn(false);
+		when(collectionState.isItemObtained(3)).thenReturn(false);
+		// Hide-locked OFF so the locked source isn't filtered out.
+		when(config.hideLockedContent()).thenReturn(false);
+
+		List<ScoredItem> ranked = calculator.rankByEfficiency();
+
+		assertEquals(3, ranked.size());
+		assertEquals("Fast Unlocked", ranked.get(0).getSource().getName());
+		assertEquals("Medium Locked", ranked.get(1).getSource().getName());
+		assertEquals("Slow Unlocked", ranked.get(2).getSource().getName());
+
+		// Sanity: locked-flag is preserved (renderer needs it for the red border).
+		assertFalse(ranked.get(0).isLocked());
+		assertTrue("Middle source must still be flagged as locked for the renderer",
+			ranked.get(1).isLocked());
+		assertFalse(ranked.get(2).isLocked());
+	}
+
+	/**
+	 * Same rule applies inside Category Focus mode.
+	 */
+	@Test
+	public void testFilterByCategory_lockedItemRanksAtNaturalScorePosition()
+	{
+		CollectionLogSource fast = makeSource("Fast Unlocked", CollectionLogCategory.BOSSES,
+			30, Collections.singletonList(makeItem(1, "Fast drop", 0.05)));
+		CollectionLogSource mediumLocked = makeSource("Medium Locked", CollectionLogCategory.BOSSES,
+			60, Collections.singletonList(makeItem(2, "Medium drop", 0.05)));
+		CollectionLogSource slow = makeSource("Slow Unlocked", CollectionLogCategory.BOSSES,
+			120, Collections.singletonList(makeItem(3, "Slow drop", 0.05)));
+
+		when(database.getAllSources()).thenReturn(Arrays.asList(fast, mediumLocked, slow));
+		when(requirementsChecker.isAccessible("Fast Unlocked")).thenReturn(true);
+		when(requirementsChecker.isAccessible("Medium Locked")).thenReturn(false);
+		when(requirementsChecker.isAccessible("Slow Unlocked")).thenReturn(true);
+		when(collectionState.isItemObtained(1)).thenReturn(false);
+		when(collectionState.isItemObtained(2)).thenReturn(false);
+		when(collectionState.isItemObtained(3)).thenReturn(false);
+		when(config.hideLockedContent()).thenReturn(false);
+
+		List<ScoredItem> ranked = calculator.filterByCategory(CollectionLogCategory.BOSSES);
+
+		assertEquals(3, ranked.size());
+		assertEquals("Medium Locked", ranked.get(1).getSource().getName());
+		assertTrue(ranked.get(1).isLocked());
+	}
+
 	// --- Iron kill time with raid source ---
 
 	@Test


### PR DESCRIPTION
## Summary

Closes cha-ndler/collection-log-helper#374. Re-implements the fix that cha-ndler/collection-log-helper#371 attempted (commit `ae001bc5` "rank locked items at natural efficiency position in Efficient mode") but was lost when #371 was closed unmerged.

## Root cause

`EfficiencyCalculator` had three identical comparator chains in `rankByEfficiency`, `filterByCategory`, and `filterPetsOnly`:

```java
Comparator
    .comparing(ScoredItem::isLocked)              // <- segregation key
    .thenComparing(comparingDouble(getScore).reversed())
```

Sorting by `isLocked` first meant **all unlocked items came first, then all locked items — regardless of score**. A locked source with an ~17-minute expected time got pushed past unlocked sources taking ~30+ minutes.

User's complaint (verbatim from in-game testing):

> "hide locked content: toggling this feature seems to continue to show the item although it shows up at the very bottom of the list... I was expecting the item show up in my list... in the respective location based on how long it takes to obtain (i.e., screenshot says ~17 mins, so around items that take about the same amount of time with the same red highlight/lock icon)"

## Fix

Drop the `isLocked` segregation key. Score-only sort. Locked items appear at their natural efficiency position.

```diff
- Comparator
-     .comparing(ScoredItem::isLocked)
-     .thenComparing(Comparator.comparingDouble(ScoredItem::getScore).reversed())
+ Comparator.comparingDouble(ScoredItem::getScore).reversed()
```

Three identical changes in `EfficiencyCalculator.java` (lines 115, 150, 181 on pre-fix master). The renderer preserves visual distinction (red highlight + lock icon + tooltip naming the unmet requirement) via the still-present `isLocked()` flag on each `ScoredItem` — only the **sort order** changed, not the data.

## What this PR explicitly does NOT change

- **Top Pick logic** (`CollectionLogHelperPlugin`, `CategoryModeController`, `EfficientModeController`): uses `.filter(s -> !s.isLocked()).findFirst()` independent of comparator order. The highest-score **unlocked** source still wins Top Pick.
- **Hide Locked Content toggle** (cha-ndler/collection-log-helper#387's infrastructure): still correctly filters locked items OUT entirely when enabled. This PR only affects their POSITION when shown.
- **User-selected sort modes** (KILL_TIME, DROP_RATE, ALPHABETICAL, etc.) in `EfficientModeController`: never segregated; no change needed.

## Tests

**544/544 pass** on RuneLite 1.12.26.3 (+2 vs master).

Two new tests in `EfficiencyCalculatorTest`:

- `testRankByEfficiency_lockedItemRanksAtNaturalScorePosition`: three staggered-score sources, middle one locked. Asserts the locked source appears at position 1 (middle) rather than position 2 (last). Also verifies the `isLocked()` flag remains set for the renderer.
- `testFilterByCategory_lockedItemRanksAtNaturalScorePosition`: same contract for Category Focus mode.

## In-game validation

6 reproducer rows added to `docs/in-game-validation-log.md` under `fix/374-locked-items-natural-position`:

- Interleaving in Efficient + Category modes
- Visual distinction preserved (red highlight + lock icon + tooltip)
- Regression: Hide Locked Content toggle still filters locked items
- Regression: Top Pick still picks highest-score unlocked source

## Test plan

- [x] CI build green
- [x] Pull, `./gradlew run`
- [ ] Efficient mode with at least one locked source whose efficiency is between unlocked sources → locked source appears interleaved, not at bottom
- [ ] Locked source still renders with red highlight + lock icon + unmet-requirement tooltip
- [ ] Toggle Hide Locked Content ON → locked sources disappear entirely (no regression)
- [ ] Top Pick still selects the highest-score unlocked source even when a higher-score source is locked

## Pipeline state

After this lands, still-open #371-orphaned bugs are:

- cha-ndler/collection-log-helper#362 SLAYER/SKILLING category counts 0/0 (varp gap, different root cause class)
- cha-ndler/collection-log-helper#378 Bi-directional step regression on leaving step location
- cha-ndler/collection-log-helper#381 Hint arrow stale after long-distance teleport