### PR TITLE
fix(panel): label clue per-casket time 'Per Clue:' (#368)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Changed
+
+- **Clue per-casket time labeled "Per Clue:"** — for clue sources the secondary time row
+  (player-progression bucket) was previously also labeled "Est. Time:", making the two
+  values ("total" vs "per casket") visually indistinguishable.
+  ([#368](../../issues/368))
+
 ## 1.0.0-hub — 2026-04-17
 
 ### Changed

--- a/src/main/java/com/collectionloghelper/ui/ItemDetailPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/ItemDetailPanel.java
@@ -146,7 +146,7 @@ class ItemDetailPanel extends JPanel
 			if (estSeconds > 0)
 			{
 				String bucketName = clueEstimator.getBucket().getDisplayName();
-				appendInfoRow(info, "Est. Time:",
+				appendInfoRow(info, "Per Clue:",
 					"~" + ClueCompletionEstimator.formatTime(estSeconds)
 						+ " (" + bucketName.toLowerCase() + ")");
 			}


### PR DESCRIPTION
## Summary

Closes cha-ndler/collection-log-helper#368.

For clue-tier sources the item detail panel renders two time rows that were both labeled `Est. Time:`:

| Row | Quantity | Example |
|-----|----------|---------|
| 1st | Total acquisition time (expected caskets x per-casket kill-time) | `~975 min` |
| 2nd | Per-casket completion time, bucketed to player progression | `~3 min (maxed)` |

Identical labels invited the wrong comparison. Renaming the second row to `Per Clue:` removes the ambiguity at zero render cost.

## Change

One-line label string in `ItemDetailPanel.buildInfoTable` -- `"Est. Time:" -> "Per Clue:"` for the `ProgressionBucket` row only. No behavior, no API, no data.

## Test plan

- [x] `./gradlew test` -- 555/555 green (no test touches that row; no test added -- the rest of the panel renders identically)
- [ ] In-game spot check: open detail for a Hard clue item (e.g. Zamorak full helm). First row reads `Est. Time: ~N min`, second row reads `Per Clue: ~N min (<bucket>)`.