### PR TITLE
chore(release): refresh CHANGELOG and resubmission doc for v1.0.0-hub re-cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,9 @@
 
 ## Unreleased
 
-### Changed
+_(none — all queued changes folded into 1.0.0-hub below.)_
 
-- **Clue per-casket time labeled "Per Clue:"** — for clue sources the secondary time row
-  (player-progression bucket) was previously also labeled "Est. Time:", making the two
-  values ("total" vs "per casket") visually indistinguishable.
-  ([#368](../../issues/368))
-
-## 1.0.0-hub — 2026-04-17
+## 1.0.0-hub — 2026-05-12
 
 ### Changed
 
@@ -23,6 +18,14 @@
   (-59%) by extracting seven dedicated service classes: `OverlayRegistry`, `SceneEventRouter`,
   `AuthoringLogger`, `SyncStateCoordinator`, `GuidanceUIState`, `GuidanceOverlayCoordinator`,
   `GuidanceEventRouter`.  PRs [#331](../../pull/331)–[#339](../../pull/339), [#347](../../pull/347).
+- **RuneLite client bumped to 1.12.26.3** (from 1.12.24).  PR [#379](../../pull/379).
+- **Required-item availability surfaced inline** — the guidance panel now shows whether each
+  `requiredItemIds` entry is held in inventory / equipment / bank, replacing the older
+  bank-step routing.  PR [#384](../../pull/384).
+- **Clue per-casket time labeled "Per Clue:"** — for clue sources the secondary time row
+  (player-progression bucket) was previously also labeled "Est. Time:", making the two
+  values ("total" vs "per casket") visually indistinguishable.  PR [#394](../../pull/394)
+  ([#368](../../issues/368)).
 
 ### Added
 
@@ -33,12 +36,55 @@
 - **Plugin Hub self-review doc** — `docs/plugin-hub-review.md` audits all submission criteria
   (27 green / 3 yellow / 2 red), with fix milestones for each open item.
   PR [#346](../../pull/346).
+- **Deep-guidance authoring bar (D1)** — `CONTRIBUTING.md` documents the 10-element
+  checklist required for any new guidance source.  PR [#358](../../pull/358).
+- **GitHub Actions CI** — `build` and `test` jobs run on every PR against `master`.
+  PR [#361](../../pull/361).
+- **In-game validation log** — `docs/in-game-validation-2026-05-10.md` captures the manual
+  test pass that surfaced the v1-blocker bugs closed by PRs #384, #386–#394.
+  PR [#385](../../pull/385).
 
 ### Fixed
 
 - **`StepProgressView.hide()` shadowed deprecated `Component.hide()`** — renamed to `hideStep()`
   so Swing's internal visibility dispatch routes correctly.  PR [#353](../../pull/353) /
   [#354](../../pull/354).
+- **Shades of Mort'ton guidance** — bank-before-travel step ordering, wider
+  `ARRIVE_AT_TILE` completion distance for teleport-scroll landings, shade-key pickup tile
+  re-anchored inside the temple, and the InfoBox/blue-box render correctly when activation
+  skips into a mid-sequence step.  PR [#372](../../pull/372)
+  ([#366](../../issues/366), [#367](../../issues/367), [#375](../../issues/375), [#376](../../issues/376)).
+- **Step-advance and skip callbacks routed through the client thread** — overlays now
+  refresh on the same game frame instead of one tick later.  Part of PR [#372](../../pull/372)
+  ([#367](../../issues/367)).
+- **`Show Overlays` / `Show Hint Arrow` toggles propagate immediately** — flipping either
+  setting while guidance is active updates overlay visibility on the next tick instead of
+  requiring a restart.  PR [#386](../../pull/386) ([#363](../../issues/363)).
+- **Filter-affecting config changes rebuild the panel** — `Hide Obtained`, `Hide Locked`,
+  `Account Type`, `Raid Team Size`, `AFK Filter`, `Efficient Sort`, sync/bank-scan reminders,
+  and `Default Mode` toggles take effect immediately.  PR [#387](../../pull/387)
+  ([#364](../../issues/364), [#365](../../issues/365)).
+- **Required-item name resolution happens on the client thread** — eliminates rare
+  cross-thread access exceptions during guidance-step item lookup.  PR [#389](../../pull/389).
+- **`Show Overlays` toggle no longer aborts the active guidance session** — disabling
+  overlays clears their visuals without tearing down sequencer state, InfoBox, or panel
+  step display.  PR [#390](../../pull/390) ([#373](../../issues/373)).
+- **StepProgressView tooltip lookup safe against missing entries** — a single bad tooltip
+  no longer aborts the entire step strip.  PR [#391](../../pull/391).
+- **Locked items rank by efficiency score** — locked content is no longer segregated to the
+  bottom of the Efficient list; the lock indicator remains visual-only.  PR [#392](../../pull/392)
+  ([#374](../../issues/374)).
+- **Hint arrow refreshes after long-distance teleport mid-guidance** — `client.setHintArrow`
+  and similar one-shot APIs are re-applied when a per-tick Chebyshev delta > 10 tiles is
+  detected, so the arrow no longer points at the prior scene origin.  PR [#393](../../pull/393)
+  ([#381](../../issues/381)).
+
+### Notes
+
+- The `v1.0.0-hub` git tag is being re-cut on the post-fix `master` HEAD.  The
+  locally-drafted tag from 2026-04-17 (commit b9518653) is stale and will be replaced
+  before the Plugin Hub PR is opened.  See `docs/plugin-hub-resubmission.md` for the
+  quiet-week schedule and push procedure.
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -528,7 +528,7 @@ Focus: god-object decomposition, build hardening, test expansion. Resulted in th
 - [x] A3 — Issue triage & labels                         status: done          owner: cha-ndler  updated: 2026-04-17  note: GitHub-only — summary in #345; 10 labels created, #319 closed, #323/#314/#306/#134 labeled
 - [x] A4 — Plugin Hub self-review doc                    status: done          owner: cha-ndler  updated: 2026-04-17  pr: #346  note: 27 green / 3 yellow / 2 red — docs/plugin-hub-review.md
 - [x] A5 — Screenshots refresh                           status: done          owner: cha-ndler  updated: 2026-04-16  note: docs/screenshots/ populated
-- [/] A6 — Tag v1.0.0-hub, wait a week, resubmit         status: in-progress   owner: cha-ndler  updated: 2026-04-17  pr: #355  note: CHANGELOG promoted to 1.0.0-hub, resubmission checklist drafted (docs/plugin-hub-resubmission.md), tag v1.0.0-hub drafted locally — awaiting quiet-week validation before `git push origin v1.0.0-hub`.
+- [/] A6 — Tag v1.0.0-hub, wait a week, resubmit         status: in-progress   owner: cha-ndler  updated: 2026-05-12  pr: #355, refresh pending  note: original locally-drafted tag from 2026-04-17 (commit b9518653) went stale — 13 PRs landed afterward including the v1-blocker fix burst from in-game testing on 2026-05-10. CHANGELOG and docs/plugin-hub-resubmission.md refreshed; tag will be deleted and re-cut on current master HEAD after the refresh PR merges. Earliest push date 2026-05-19 assuming no further master merges during the quiet week.
 
 **Tier A.5 — Data sourcing infrastructure**
 

--- a/docs/plugin-hub-resubmission.md
+++ b/docs/plugin-hub-resubmission.md
@@ -9,7 +9,7 @@ Readiness gate for the `v1.0.0-hub` resubmission to `runelite/plugin-hub`.
 All Tier-A milestones must be `[x] done` in [docs/ROADMAP.md — Status log](ROADMAP.md#9-status-log)
 before the tag is pushed.
 
-Current state (as of 2026-04-17):
+Current state (as of 2026-05-12):
 
 | Milestone | Status |
 |-----------|--------|
@@ -20,7 +20,13 @@ Current state (as of 2026-04-17):
 | A4 — Plugin Hub self-review doc | [x] done — PR #346 |
 | A5 — Screenshots refresh | [x] done |
 | A5.1–A5.6 — Data sourcing infrastructure | [x] done |
-| A6 — Tag v1.0.0-hub (this milestone) | [/] in-progress |
+| A6 — Tag v1.0.0-hub (this milestone) | [/] in-progress — tag re-cut pending |
+
+The originally-drafted tag from 2026-04-17 (commit `b9518653`, mapping to PR #357) is stale.
+Between that commit and the current `master` HEAD, 13 PRs landed — RuneLite client bump,
+Tier B.5 roadmap addition, in-game validation log, and the v1-blocker fix burst from manual
+testing on 2026-05-10 (PRs #372, #384, #386–#394).  The tag will be re-cut on the current
+`master` HEAD before the Plugin Hub PR is opened.
 
 ---
 
@@ -40,12 +46,12 @@ Expected result: empty list.  If any P1 bugs are open, resolve them before pushi
 
 `docs/plugin-hub-review.md` must have no un-triaged **Red** items.
 
-Current open reds (as of 2026-04-17):
+Current open reds (as of 2026-05-12):
 
 | Item | Mitigation |
 |------|-----------|
 | `runelite-plugin` Gradle plugin missing | Investigate whether Hub CI requires `com.openosrs.externalplugin`; add if needed. Low-risk: the build passes without it and no reviewer comment cited it explicitly in #11156. |
-| Files > 800 LOC | Resolved by A1/A1b: `CollectionLogHelperPanel` shell is now 698 LOC; `CollectionLogHelperPlugin` is 904 LOC (borderline, not over). Residuals: `GuidanceOverlayCoordinator` (859), `EfficiencyCalculator` (754), `GuidanceSequencer` (719) — all functional, acceptable at submission. |
+| Files > 800 LOC | Resolved by A1/A1b: `CollectionLogHelperPanel` shell is now 698 LOC; `CollectionLogHelperPlugin` is 904 LOC (borderline, not over). Residuals: `GuidanceOverlayCoordinator` (859), `EfficiencyCalculator` (754), `GuidanceSequencer` (719) — all functional, acceptable at submission. Re-measure residuals after the 2026-05-10 fix burst before submission. |
 
 Re-run `mcp__plugin_runelite-dev-toolkit_runelite-dev__plugin_hub_validate` on the tag commit to
 confirm no new findings before opening the PR.
@@ -54,18 +60,42 @@ confirm no new findings before opening the PR.
 
 ## 4. Quiet-week criteria
 
-- No merges to `master` for **7 calendar days** after the tag is pushed.
-- Exception: critical bug-fix commits may land; update the `Unreleased` CHANGELOG section if so.
+- No merges to `master` for **7 calendar days** *before* the tag is pushed and the Plugin
+  Hub PR is opened. (Reviewer-facing signal: this codebase has stabilized.)
+- Exception: post-tag critical bug-fix commits may land; update the `Unreleased` CHANGELOG
+  section if so. Avoid this if at all possible.
 - Do **not** amend or re-push the tag once it is live.
 
-The tag was drafted locally on 2026-04-17 as `v1.0.0-hub`.  The earliest push date is
-**2026-04-24**.
+The tag was originally drafted locally on 2026-04-17 (commit `b9518653`).  That tag is
+**stale** — 13 PRs landed afterward, including the v1-blocker fix burst from in-game testing
+on 2026-05-10 (PRs #372, #384, #386–#394).  The tag will be deleted locally and re-cut on
+the current `master` HEAD once this CHANGELOG/doc refresh PR merges.
+
+**New earliest-push date**: 7 calendar days after the CHANGELOG/doc refresh PR merges to
+`master` (final merge in the v1.0.0-hub content set).  Assuming that merge lands on
+2026-05-12, the earliest push date is **2026-05-19**.  If any additional merges land
+during the window — for any reason — the clock resets to 7 days from the latest merge.
 
 ---
 
-## 5. Push the tag
+## 5. Re-cut and push the tag
 
-When quiet-week criteria are met:
+The locally-drafted tag from 2026-04-17 must be deleted before re-cutting so the name is
+free to point at the current `master` HEAD:
+
+```bash
+# Delete the stale local tag (it was never pushed)
+git tag -d v1.0.0-hub
+
+# Confirm not on remote (must return empty)
+git ls-remote --tags origin | grep v1.0.0-hub
+
+# Re-cut on current master HEAD
+git fetch origin master
+git tag -a v1.0.0-hub origin/master -m "v1.0.0-hub: Plugin Hub submission"
+```
+
+When quiet-week criteria are met, push:
 
 ```bash
 git push origin v1.0.0-hub
@@ -116,4 +146,19 @@ For context during review responses:
 | #349, #351 | Panel decomposition (1,661 → 698 LOC shell) |
 | #346 | Plugin Hub self-review doc |
 | #342, #341 | Data-sourcing infrastructure |
-| #353, #354 | Fix StepProgressView.hide() Component shadow |
+| #353, #354 | Fix `StepProgressView.hide()` Component shadow |
+| #358 | Deep-guidance authoring bar (D1) |
+| #361 | GitHub Actions CI |
+| #379 | RuneLite client 1.12.24 → 1.12.26.3 |
+| #383 | ROADMAP: Tier B.5 (UI parity) added |
+| #384 | Surface required-item availability inline |
+| #385 | In-game validation log (2026-05-10) |
+| #372 | Mort'ton step ordering, teleport arrival, skip overlay refresh |
+| #386 | Show Overlays / Show Hint Arrow toggle propagation |
+| #387 | Filter-affecting config rebuild |
+| #389 | Required-item name resolution on client thread |
+| #390 | Show Overlays toggle no longer aborts guidance |
+| #391 | StepProgressView tooltip lookup safety |
+| #392 | Locked items rank by score |
+| #393 | Hint arrow refresh after teleport |
+| #394 | "Per Clue:" labeling fix |


### PR DESCRIPTION
## Summary

The originally-drafted `v1.0.0-hub` tag from 2026-04-17 (commit `b9518653`, mapping to PR #357) went stale — 13 PRs landed on `master` afterward:

- **Pre-validation burst (≤ 2026-05-09)**: #358 (deep-guidance D1), #361 (CI), #379 (RuneLite client 1.12.26.3).
- **Tier B.5 roadmap**: #383.
- **In-game validation 2026-05-10** (#385 log + #382 meta tracker) surfaced 10 v1-blocker bugs closed by: #372, #384, #386, #387, #389, #390, #391, #392, #393, #394.

This PR folds those into the `1.0.0-hub` CHANGELOG block (dated 2026-05-12), updates the resubmission doc to walk through the tag delete + re-cut on the new master HEAD, and bumps the A6 status-log entry.

## Changes

- **`CHANGELOG.md`** — collapses `Unreleased` into `1.0.0-hub` (2026-05-12). Adds 13 entries across `Changed`, `Added`, `Fixed`. Adds a `Notes` block explaining the stale-tag situation.
- **`docs/plugin-hub-resubmission.md`** — refreshes \"as of\" dates, rewrites section 4 (quiet-week criteria) with the new push-date arithmetic, rewrites section 5 (now \"Re-cut and push the tag\") to document the local delete + re-tag procedure, expands section 7 with the 13 new PRs.
- **`docs/ROADMAP.md`** — updates the A6 status-log entry: stale tag, refresh pending, earliest push 2026-05-19.

## What this PR does NOT do

- Does not push or re-cut the `v1.0.0-hub` tag — that happens locally after this merges.
- Does not open the Plugin Hub PR — that's gated on the 7-day quiet window from the merge of this PR.
- Does not touch any plugin code — pure documentation.

## Test plan

- [ ] CHANGELOG renders cleanly on GitHub (markdown sanity).
- [ ] All linked issue/PR numbers in the CHANGELOG resolve correctly.
- [ ] `docs/plugin-hub-resubmission.md` section-5 commands run as a dry-read (no execution needed in CI).
- [ ] No new build failures (CI build job runs on this PR automatically).

## Post-merge

1. Delete and re-cut the tag locally:
   \`\`\`
   git tag -d v1.0.0-hub
   git fetch origin master
   git tag -a v1.0.0-hub origin/master -m \"v1.0.0-hub: Plugin Hub submission\"
   \`\`\`
2. Start the 7-day quiet window from this PR's merge timestamp.
3. After the window, push the tag and submit a fresh PR to \`runelite/plugin-hub\`.