### PR TITLE
feat(overlay): per-step world map arrow and destination icon (B.5.5)

### DIFF
--- a/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
@@ -45,6 +45,7 @@ import com.collectionloghelper.overlay.GuidanceOverlay;
 import com.collectionloghelper.overlay.ItemHighlightOverlay;
 import com.collectionloghelper.overlay.ObjectHighlightOverlay;
 import com.collectionloghelper.overlay.WidgetHighlightOverlay;
+import com.collectionloghelper.overlay.WorldMapDestinationOverlay;
 import com.collectionloghelper.overlay.WorldMapRouteOverlay;
 import com.collectionloghelper.ui.CollectionLogHelperPanel;
 import java.awt.image.BufferedImage;
@@ -104,6 +105,7 @@ public class GuidanceOverlayCoordinator
 	private final ObjectHighlightOverlay objectHighlightOverlay;
 	private final ItemHighlightOverlay itemHighlightOverlay;
 	private final WorldMapRouteOverlay worldMapRouteOverlay;
+	private final WorldMapDestinationOverlay worldMapDestinationOverlay;
 	private final GroundItemHighlightOverlay groundItemHighlightOverlay;
 	private final WidgetHighlightOverlay widgetHighlightOverlay;
 
@@ -164,6 +166,7 @@ public class GuidanceOverlayCoordinator
 		ObjectHighlightOverlay objectHighlightOverlay,
 		ItemHighlightOverlay itemHighlightOverlay,
 		WorldMapRouteOverlay worldMapRouteOverlay,
+		WorldMapDestinationOverlay worldMapDestinationOverlay,
 		GroundItemHighlightOverlay groundItemHighlightOverlay,
 		WidgetHighlightOverlay widgetHighlightOverlay)
 	{
@@ -185,6 +188,7 @@ public class GuidanceOverlayCoordinator
 		this.objectHighlightOverlay = objectHighlightOverlay;
 		this.itemHighlightOverlay = itemHighlightOverlay;
 		this.worldMapRouteOverlay = worldMapRouteOverlay;
+		this.worldMapDestinationOverlay = worldMapDestinationOverlay;
 		this.groundItemHighlightOverlay = groundItemHighlightOverlay;
 		this.widgetHighlightOverlay = widgetHighlightOverlay;
 	}
@@ -322,6 +326,7 @@ public class GuidanceOverlayCoordinator
 		guidanceOverlay.clearTarget();
 		guidanceMinimapOverlay.clearTarget();
 		worldMapRouteOverlay.clearTarget();
+		worldMapDestinationOverlay.clearTarget();
 		dialogHighlightOverlay.clear();
 		objectHighlightOverlay.clearTarget();
 		itemHighlightOverlay.clearTarget();
@@ -553,6 +558,7 @@ public class GuidanceOverlayCoordinator
 			dialogHighlightOverlay.setGuidanceActive(true);
 			guidanceMinimapOverlay.setTargetPoint(worldPoint);
 			worldMapRouteOverlay.setTargetPoint(worldPoint);
+			worldMapDestinationOverlay.setTarget(worldPoint, resolveStepIconType(step));
 			if (activeMapPoint != null)
 			{
 				worldMapPointManager.remove(activeMapPoint);
@@ -589,6 +595,7 @@ public class GuidanceOverlayCoordinator
 			guidanceOverlay.setTravelTip(null);
 			guidanceMinimapOverlay.setTargetPoint(null);
 			worldMapRouteOverlay.setTargetPoint(null);
+			worldMapDestinationOverlay.clearTarget();
 			if (activeMapPoint != null)
 			{
 				worldMapPointManager.remove(activeMapPoint);
@@ -692,6 +699,8 @@ public class GuidanceOverlayCoordinator
 		dialogHighlightOverlay.setGuidanceActive(true);
 		guidanceMinimapOverlay.setTargetPoint(worldPoint);
 		worldMapRouteOverlay.setTargetPoint(worldPoint);
+		// Non-sequencer path: no step context, use generic TILE icon
+		worldMapDestinationOverlay.setTarget(worldPoint, WorldMapDestinationOverlay.StepIconType.TILE);
 		if (activeMapPoint != null)
 		{
 			worldMapPointManager.remove(activeMapPoint);
@@ -722,6 +731,7 @@ public class GuidanceOverlayCoordinator
 		guidanceOverlay.clearTarget();
 		guidanceMinimapOverlay.clearTarget();
 		worldMapRouteOverlay.clearTarget();
+		worldMapDestinationOverlay.clearTarget();
 		dialogHighlightOverlay.clear();
 		objectHighlightOverlay.clearTarget();
 		itemHighlightOverlay.clearTarget();
@@ -936,5 +946,23 @@ public class GuidanceOverlayCoordinator
 		}
 		WorldPoint playerLoc = lp.getWorldLocation();
 		return playerLoc != null && playerLoc.getPlane() == worldPoint.getPlane();
+	}
+
+	/**
+	 * Determines the world-map destination icon type for a guidance step.
+	 * NPC steps use the NPC icon, object steps use the object/chest icon,
+	 * and all other steps use the generic tile diamond.
+	 */
+	private static WorldMapDestinationOverlay.StepIconType resolveStepIconType(GuidanceStep step)
+	{
+		if (step.getNpcId() > 0)
+		{
+			return WorldMapDestinationOverlay.StepIconType.NPC;
+		}
+		if (step.getObjectId() > 0 || (step.getObjectIds() != null && !step.getObjectIds().isEmpty()))
+		{
+			return WorldMapDestinationOverlay.StepIconType.OBJECT;
+		}
+		return WorldMapDestinationOverlay.StepIconType.TILE;
 	}
 }

--- a/src/main/java/com/collectionloghelper/lifecycle/OverlayRegistry.java
+++ b/src/main/java/com/collectionloghelper/lifecycle/OverlayRegistry.java
@@ -31,6 +31,7 @@ import com.collectionloghelper.overlay.GuidanceOverlay;
 import com.collectionloghelper.overlay.ItemHighlightOverlay;
 import com.collectionloghelper.overlay.ObjectHighlightOverlay;
 import com.collectionloghelper.overlay.WidgetHighlightOverlay;
+import com.collectionloghelper.overlay.WorldMapDestinationOverlay;
 import com.collectionloghelper.overlay.WorldMapRouteOverlay;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -51,6 +52,7 @@ public class OverlayRegistry
 	private final ObjectHighlightOverlay objectHighlightOverlay;
 	private final ItemHighlightOverlay itemHighlightOverlay;
 	private final WorldMapRouteOverlay worldMapRouteOverlay;
+	private final WorldMapDestinationOverlay worldMapDestinationOverlay;
 	private final GroundItemHighlightOverlay groundItemHighlightOverlay;
 	private final WidgetHighlightOverlay widgetHighlightOverlay;
 
@@ -63,6 +65,7 @@ public class OverlayRegistry
 		ObjectHighlightOverlay objectHighlightOverlay,
 		ItemHighlightOverlay itemHighlightOverlay,
 		WorldMapRouteOverlay worldMapRouteOverlay,
+		WorldMapDestinationOverlay worldMapDestinationOverlay,
 		GroundItemHighlightOverlay groundItemHighlightOverlay,
 		WidgetHighlightOverlay widgetHighlightOverlay)
 	{
@@ -73,6 +76,7 @@ public class OverlayRegistry
 		this.objectHighlightOverlay = objectHighlightOverlay;
 		this.itemHighlightOverlay = itemHighlightOverlay;
 		this.worldMapRouteOverlay = worldMapRouteOverlay;
+		this.worldMapDestinationOverlay = worldMapDestinationOverlay;
 		this.groundItemHighlightOverlay = groundItemHighlightOverlay;
 		this.widgetHighlightOverlay = widgetHighlightOverlay;
 	}
@@ -86,6 +90,7 @@ public class OverlayRegistry
 		overlayManager.add(objectHighlightOverlay);
 		overlayManager.add(itemHighlightOverlay);
 		overlayManager.add(worldMapRouteOverlay);
+		overlayManager.add(worldMapDestinationOverlay);
 		overlayManager.add(groundItemHighlightOverlay);
 		overlayManager.add(widgetHighlightOverlay);
 	}
@@ -99,6 +104,7 @@ public class OverlayRegistry
 		overlayManager.remove(objectHighlightOverlay);
 		overlayManager.remove(itemHighlightOverlay);
 		overlayManager.remove(worldMapRouteOverlay);
+		overlayManager.remove(worldMapDestinationOverlay);
 		overlayManager.remove(groundItemHighlightOverlay);
 		overlayManager.remove(widgetHighlightOverlay);
 	}

--- a/src/main/java/com/collectionloghelper/overlay/WorldMapDestinationOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/WorldMapDestinationOverlay.java
@@ -1,0 +1,513 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.overlay;
+
+import com.collectionloghelper.CollectionLogHelperConfig;
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import java.awt.RenderingHints;
+import java.awt.Shape;
+import java.awt.geom.AffineTransform;
+import java.awt.image.BufferedImage;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import net.runelite.api.Client;
+import net.runelite.api.Player;
+import net.runelite.api.Point;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.gameval.InterfaceID;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.worldmap.WorldMap;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPosition;
+
+/**
+ * Renders a directional arrow (when destination is off-screen) and a destination
+ * icon (when destination is on-screen) on the world map for the active guidance step.
+ *
+ * <p>This overlay is additive to {@link WorldMapRouteOverlay}'s route line. It
+ * draws on top via the same MANUAL layer so both render inside the world map widget.
+ *
+ * <p>Arrow is drawn toward the target from the edge of the map view when the
+ * destination tile is outside the visible bounds. The destination icon is drawn
+ * at the target's map position when it is inside the visible bounds.
+ *
+ * <p>Per-frame allocation rules (feedback_overlay_performance.md):
+ * Arrow {@link BufferedImage}s are cached once at construction. No new objects
+ * are allocated in the render path.
+ */
+@Singleton
+public class WorldMapDestinationOverlay extends Overlay
+{
+	/** Size of the cached directional arrow sprites (px). */
+	private static final int ARROW_SPRITE_SIZE = 32;
+
+	/** Size of the destination icon drawn at the target tile (px). */
+	private static final int ICON_SIZE = 20;
+
+	/** Inset from the map edge at which the off-screen arrow is placed (px). */
+	private static final int EDGE_INSET = 18;
+
+	/** Fill colour for arrow and icon (teal to match CollectionLogWorldMapPoint). */
+	private static final Color FILL_COLOR = new Color(0, 200, 200);
+
+	/** Outline/border colour. */
+	private static final Color BORDER_COLOR = new Color(0, 100, 100);
+
+	/** Stroke used to outline the destination icon shapes. */
+	private static final BasicStroke ICON_STROKE =
+		new BasicStroke(1.5f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND);
+
+	/** Stroke used to outline the edge-snap arrow. */
+	private static final BasicStroke ARROW_STROKE =
+		new BasicStroke(2.0f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND);
+
+	private final Client client;
+	private final CollectionLogHelperConfig config;
+
+	/** Target world-point set by the coordinator. Volatile for cross-thread visibility. */
+	private volatile WorldPoint targetPoint;
+
+	/** Step type used to pick the icon variant. Volatile for cross-thread visibility. */
+	private volatile StepIconType iconType = StepIconType.TILE;
+
+	/**
+	 * 8 pre-rendered directional arrow sprites (0°, 45°, 90°, …, 315°).
+	 * 0° = pointing right; angles increase clockwise (screen-space).
+	 * Allocated once at construction; never re-allocated per frame.
+	 */
+	private final BufferedImage[] arrowSprites = new BufferedImage[8];
+
+	/**
+	 * 3 pre-rendered destination icon sprites: NPC, object, tile.
+	 * Allocated once at construction; never re-allocated per frame.
+	 */
+	private final BufferedImage npcIcon;
+	private final BufferedImage objectIcon;
+	private final BufferedImage tileIcon;
+
+	@Inject
+	WorldMapDestinationOverlay(Client client, CollectionLogHelperConfig config)
+	{
+		this.client = client;
+		this.config = config;
+		setPosition(OverlayPosition.DYNAMIC);
+		setLayer(OverlayLayer.MANUAL);
+		drawAfterInterface(InterfaceID.WORLDMAP);
+		// Slightly higher priority than WorldMapRouteOverlay so destination icon
+		// renders on top of the route line endpoint.
+		setPriority(PRIORITY_HIGH + 0.01f);
+
+		// Pre-render all 8 directional arrow sprites at construction time
+		for (int i = 0; i < 8; i++)
+		{
+			arrowSprites[i] = buildArrowSprite(i * 45);
+		}
+
+		// Pre-render destination icon variants at construction time
+		npcIcon = buildDestinationIcon(IconVariant.NPC);
+		objectIcon = buildDestinationIcon(IconVariant.OBJECT);
+		tileIcon = buildDestinationIcon(IconVariant.TILE);
+	}
+
+	// -------------------------------------------------------------------------
+	// Public API (called by GuidanceOverlayCoordinator)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Sets the destination tile and icon type for the active guidance step.
+	 *
+	 * @param point    the world-map destination tile (may be null to hide)
+	 * @param stepIconType icon variant based on step type (NPC, object, or tile)
+	 */
+	public void setTarget(WorldPoint point, StepIconType stepIconType)
+	{
+		this.targetPoint = point;
+		this.iconType = stepIconType != null ? stepIconType : StepIconType.TILE;
+	}
+
+	/** Clears the destination, hiding this overlay. */
+	public void clearTarget()
+	{
+		this.targetPoint = null;
+	}
+
+	// -------------------------------------------------------------------------
+	// Overlay render
+	// -------------------------------------------------------------------------
+
+	@Override
+	public Dimension render(Graphics2D graphics)
+	{
+		// Snapshot volatile fields once — prevents mid-frame races
+		final WorldPoint target = this.targetPoint;
+		if (target == null || !config.showOverlays())
+		{
+			return null;
+		}
+
+		Widget mapWidget = client.getWidget(InterfaceID.Worldmap.MAP_CONTAINER);
+		if (mapWidget == null)
+		{
+			return null;
+		}
+
+		Player lp = client.getLocalPlayer();
+		if (lp == null)
+		{
+			return null;
+		}
+
+		WorldPoint playerLocation = lp.getWorldLocation();
+		if (playerLocation == null)
+		{
+			return null;
+		}
+
+		Rectangle mapBounds = mapWidget.getBounds();
+
+		Point targetMapPoint = mapWorldPointToGraphicsPoint(target, mapBounds);
+		if (targetMapPoint == null)
+		{
+			// Target is outside surfaceContainsPosition — skip rendering
+			return null;
+		}
+
+		boolean targetVisible = mapBounds.contains(targetMapPoint.getX(), targetMapPoint.getY());
+
+		Shape previousClip = graphics.getClip();
+		graphics.setClip(mapBounds);
+		graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+
+		if (targetVisible)
+		{
+			renderDestinationIcon(graphics, targetMapPoint);
+		}
+		else
+		{
+			Point playerMapPoint = mapWorldPointToGraphicsPoint(playerLocation, mapBounds);
+			renderOffScreenArrow(graphics, mapBounds, playerMapPoint, targetMapPoint);
+		}
+
+		graphics.setClip(previousClip);
+		return null;
+	}
+
+	// -------------------------------------------------------------------------
+	// Private rendering helpers (no allocations)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Draws the destination icon at the target's map pixel position.
+	 * Uses a pre-rendered sprite selected by the current {@link StepIconType}.
+	 */
+	private void renderDestinationIcon(Graphics2D graphics, Point targetMapPoint)
+	{
+		BufferedImage icon = selectIcon();
+		int x = targetMapPoint.getX() - icon.getWidth() / 2;
+		int y = targetMapPoint.getY() - icon.getHeight() / 2;
+		graphics.drawImage(icon, x, y, null);
+	}
+
+	/**
+	 * Draws a directional arrow on the map edge pointing toward the off-screen target.
+	 *
+	 * <p>The arrow position is computed by tracing the line from the player's map position
+	 * (or the map center when the player is off-surface) toward the target, then snapping
+	 * to the inset map boundary. The nearest pre-rendered 45°-increment sprite is used.
+	 *
+	 * <p>Per feedback_worldmap_arrow_rendering.md: never draw a clipped route line to an
+	 * off-screen target — the edge-snap arrow alone indicates direction.
+	 */
+	private void renderOffScreenArrow(Graphics2D graphics, Rectangle mapBounds,
+		Point playerMapPoint, Point targetMapPoint)
+	{
+		// Use either the player's on-screen map position or the map center as arrow origin
+		double fromX = (playerMapPoint != null && mapBounds.contains(playerMapPoint.getX(), playerMapPoint.getY()))
+			? playerMapPoint.getX()
+			: mapBounds.getCenterX();
+		double fromY = (playerMapPoint != null && mapBounds.contains(playerMapPoint.getX(), playerMapPoint.getY()))
+			? playerMapPoint.getY()
+			: mapBounds.getCenterY();
+
+		double toX = targetMapPoint.getX();
+		double toY = targetMapPoint.getY();
+
+		double dx = toX - fromX;
+		double dy = toY - fromY;
+
+		if (Math.abs(dx) < 0.001 && Math.abs(dy) < 0.001)
+		{
+			// Coincident points — no useful direction to draw
+			return;
+		}
+
+		// Angle in screen-space radians (0 = right, positive = clockwise)
+		double angleRad = Math.atan2(dy, dx);
+
+		// Find the edge-snap position: trace the direction vector to the inset boundary
+		double minX = mapBounds.getX() + EDGE_INSET;
+		double minY = mapBounds.getY() + EDGE_INSET;
+		double maxX = mapBounds.getX() + mapBounds.getWidth() - EDGE_INSET;
+		double maxY = mapBounds.getY() + mapBounds.getHeight() - EDGE_INSET;
+
+		// Parameterise: find the smallest t where the ray hits a boundary
+		double t = Double.MAX_VALUE;
+		if (dx > 0)
+		{
+			t = Math.min(t, (maxX - fromX) / dx);
+		}
+		else if (dx < 0)
+		{
+			t = Math.min(t, (minX - fromX) / dx);
+		}
+		if (dy > 0)
+		{
+			t = Math.min(t, (maxY - fromY) / dy);
+		}
+		else if (dy < 0)
+		{
+			t = Math.min(t, (minY - fromY) / dy);
+		}
+
+		double arrowX = Math.max(minX, Math.min(maxX, fromX + dx * t));
+		double arrowY = Math.max(minY, Math.min(maxY, fromY + dy * t));
+
+		// Select the sprite whose angle is nearest to the computed angle (8 sprites, 45° each)
+		double angleDeg = Math.toDegrees(angleRad);
+		if (angleDeg < 0)
+		{
+			angleDeg += 360.0;
+		}
+		int spriteIndex = (int) Math.round(angleDeg / 45.0) % 8;
+		BufferedImage sprite = arrowSprites[spriteIndex];
+
+		int drawX = (int) arrowX - sprite.getWidth() / 2;
+		int drawY = (int) arrowY - sprite.getHeight() / 2;
+		graphics.drawImage(sprite, drawX, drawY, null);
+	}
+
+	/** Returns the destination icon sprite matching the current step type. */
+	private BufferedImage selectIcon()
+	{
+		switch (iconType)
+		{
+			case NPC:
+				return npcIcon;
+			case OBJECT:
+				return objectIcon;
+			default:
+				return tileIcon;
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Coordinate conversion (same algorithm as WorldMapRouteOverlay)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Converts a WorldPoint to pixel coordinates on the world map widget.
+	 * Returns null when the world map is not initialised or the point is off-surface.
+	 */
+	private Point mapWorldPointToGraphicsPoint(WorldPoint worldPoint, Rectangle worldMapRect)
+	{
+		WorldMap worldMap = client.getWorldMap();
+		if (worldMap == null || worldMap.getWorldMapData() == null)
+		{
+			return null;
+		}
+
+		if (!worldMap.getWorldMapData().surfaceContainsPosition(worldPoint.getX(), worldPoint.getY()))
+		{
+			return null;
+		}
+
+		float pixelsPerTile = worldMap.getWorldMapZoom();
+
+		int widthInTiles = (int) Math.ceil(worldMapRect.getWidth() / pixelsPerTile);
+		int heightInTiles = (int) Math.ceil(worldMapRect.getHeight() / pixelsPerTile);
+
+		Point worldMapPosition = worldMap.getWorldMapPosition();
+		if (worldMapPosition == null)
+		{
+			return null;
+		}
+
+		int yTileMax = worldMapPosition.getY() - heightInTiles / 2;
+		int yTileOffset = (yTileMax - worldPoint.getY() - 1) * -1;
+		int xTileOffset = worldPoint.getX() + widthInTiles / 2 - worldMapPosition.getX();
+
+		int xGraphDiff = (int) (xTileOffset * pixelsPerTile);
+		int yGraphDiff = (int) (yTileOffset * pixelsPerTile);
+
+		yGraphDiff -= pixelsPerTile - Math.ceil(pixelsPerTile / 2);
+		xGraphDiff += pixelsPerTile - Math.ceil(pixelsPerTile / 2);
+
+		yGraphDiff = worldMapRect.height - yGraphDiff;
+		yGraphDiff += (int) worldMapRect.getY();
+		xGraphDiff += (int) worldMapRect.getX();
+
+		return new Point(xGraphDiff, yGraphDiff);
+	}
+
+	// -------------------------------------------------------------------------
+	// Sprite builders (called once at construction, never in render loop)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Builds a single directional arrow sprite pointing at the given angle.
+	 * 0° = right, 90° = down (screen-space, y-axis down).
+	 *
+	 * <p>Per feedback_worldmap_arrow_rendering.md: fill first, then draw outline;
+	 * use JOIN_ROUND / CAP_ROUND to prevent miter artifacts on narrow chevrons.
+	 */
+	private static BufferedImage buildArrowSprite(int degrees)
+	{
+		int size = ARROW_SPRITE_SIZE;
+		BufferedImage img = new BufferedImage(size, size, BufferedImage.TYPE_INT_ARGB);
+		Graphics2D g = img.createGraphics();
+		g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+
+		int cx = size / 2;
+		int cy = size / 2;
+
+		// Chevron pointing right at 0° — matches CollectionLogWorldMapPoint shape
+		int[] xPoints = {cx + 12, cx - 6, cx - 2, cx - 6};
+		int[] yPoints = {cy, cy - 9, cy, cy + 9};
+
+		AffineTransform tx = new AffineTransform();
+		tx.rotate(Math.toRadians(degrees), cx, cy);
+		g.setTransform(tx);
+
+		// Fill first, then outline (per memory guidance — fill-before-outline)
+		g.setColor(FILL_COLOR);
+		g.fillPolygon(xPoints, yPoints, 4);
+		g.setColor(BORDER_COLOR);
+		g.setStroke(ARROW_STROKE);
+		g.drawPolygon(xPoints, yPoints, 4);
+
+		g.dispose();
+		return img;
+	}
+
+	/**
+	 * Builds a destination icon sprite for the given variant.
+	 *
+	 * <ul>
+	 *   <li>NPC — person silhouette (head circle + body triangle)</li>
+	 *   <li>OBJECT — chest (rectangle with lid line and keyhole)</li>
+	 *   <li>TILE — diamond tile marker (Quest Helper style)</li>
+	 * </ul>
+	 */
+	private static BufferedImage buildDestinationIcon(IconVariant variant)
+	{
+		int size = ICON_SIZE;
+		BufferedImage img = new BufferedImage(size, size, BufferedImage.TYPE_INT_ARGB);
+		Graphics2D g = img.createGraphics();
+		g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+
+		int cx = size / 2;
+		int cy = size / 2;
+
+		switch (variant)
+		{
+			case NPC:
+				// Head circle
+				g.setColor(FILL_COLOR);
+				g.fillOval(cx - 3, cy - 8, 6, 6);
+				g.setColor(BORDER_COLOR);
+				g.setStroke(new BasicStroke(1.0f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
+				g.drawOval(cx - 3, cy - 8, 6, 6);
+				// Body triangle (torso)
+				int[] bx = {cx - 5, cx + 5, cx};
+				int[] by = {cy + 5, cy + 5, cy - 2};
+				g.setColor(FILL_COLOR);
+				g.fillPolygon(bx, by, 3);
+				g.setColor(BORDER_COLOR);
+				g.setStroke(ICON_STROKE);
+				g.drawPolygon(bx, by, 3);
+				break;
+
+			case OBJECT:
+				// Chest body
+				int chestX = cx - 6;
+				int chestY = cy - 4;
+				int chestW = 12;
+				int chestH = 8;
+				g.setColor(FILL_COLOR);
+				g.fillRect(chestX, chestY, chestW, chestH);
+				g.setColor(BORDER_COLOR);
+				g.setStroke(ICON_STROKE);
+				g.drawRect(chestX, chestY, chestW, chestH);
+				// Lid divider line
+				g.drawLine(chestX, chestY + 3, chestX + chestW, chestY + 3);
+				// Keyhole dot
+				g.fillOval(cx - 1, chestY + 4, 3, 3);
+				break;
+
+			case TILE:
+			default:
+				// Diamond tile marker
+				int[] dx = {cx, cx + 7, cx, cx - 7};
+				int[] dy = {cy - 7, cy, cy + 7, cy};
+				g.setColor(FILL_COLOR);
+				g.fillPolygon(dx, dy, 4);
+				g.setColor(BORDER_COLOR);
+				g.setStroke(ICON_STROKE);
+				g.drawPolygon(dx, dy, 4);
+				break;
+		}
+
+		g.dispose();
+		return img;
+	}
+
+	// -------------------------------------------------------------------------
+	// Supporting enums
+	// -------------------------------------------------------------------------
+
+	/** Determines which destination icon sprite is drawn at the target tile. */
+	public enum StepIconType
+	{
+		/** Step targets an NPC (has npcId). */
+		NPC,
+		/** Step targets a game object (has objectId). */
+		OBJECT,
+		/** Generic tile destination. */
+		TILE
+	}
+
+	/** Internal discriminant for {@link #buildDestinationIcon}. */
+	private enum IconVariant
+	{
+		NPC,
+		OBJECT,
+		TILE
+	}
+}

--- a/src/test/java/com/collectionloghelper/lifecycle/OverlayRegistryTest.java
+++ b/src/test/java/com/collectionloghelper/lifecycle/OverlayRegistryTest.java
@@ -31,6 +31,7 @@ import com.collectionloghelper.overlay.GuidanceOverlay;
 import com.collectionloghelper.overlay.ItemHighlightOverlay;
 import com.collectionloghelper.overlay.ObjectHighlightOverlay;
 import com.collectionloghelper.overlay.WidgetHighlightOverlay;
+import com.collectionloghelper.overlay.WorldMapDestinationOverlay;
 import com.collectionloghelper.overlay.WorldMapRouteOverlay;
 import net.runelite.client.ui.overlay.OverlayManager;
 import org.junit.Before;
@@ -60,6 +61,8 @@ public class OverlayRegistryTest
 	@Mock
 	private WorldMapRouteOverlay worldMapRouteOverlay;
 	@Mock
+	private WorldMapDestinationOverlay worldMapDestinationOverlay;
+	@Mock
 	private GroundItemHighlightOverlay groundItemHighlightOverlay;
 	@Mock
 	private WidgetHighlightOverlay widgetHighlightOverlay;
@@ -77,6 +80,7 @@ public class OverlayRegistryTest
 			objectHighlightOverlay,
 			itemHighlightOverlay,
 			worldMapRouteOverlay,
+			worldMapDestinationOverlay,
 			groundItemHighlightOverlay,
 			widgetHighlightOverlay
 		);
@@ -132,6 +136,13 @@ public class OverlayRegistryTest
 	}
 
 	@Test
+	public void testRegisterAllAddsWorldMapDestinationOverlay()
+	{
+		registry.registerAll();
+		verify(overlayManager).add(worldMapDestinationOverlay);
+	}
+
+	@Test
 	public void testRegisterAllAddsGroundItemHighlightOverlay()
 	{
 		registry.registerAll();
@@ -146,13 +157,13 @@ public class OverlayRegistryTest
 	}
 
 	@Test
-	public void testRegisterAllAddsEightOverlays()
+	public void testRegisterAllAddsNineOverlays()
 	{
 		// Arrange + Act
 		registry.registerAll();
 
-		// Assert — exactly 8 add() calls, no more
-		verify(overlayManager, times(8)).add(any());
+		// Assert — exactly 9 add() calls, no more
+		verify(overlayManager, times(9)).add(any());
 	}
 
 	@Test
@@ -171,6 +182,7 @@ public class OverlayRegistryTest
 		inOrder.verify(overlayManager).add(objectHighlightOverlay);
 		inOrder.verify(overlayManager).add(itemHighlightOverlay);
 		inOrder.verify(overlayManager).add(worldMapRouteOverlay);
+		inOrder.verify(overlayManager).add(worldMapDestinationOverlay);
 		inOrder.verify(overlayManager).add(groundItemHighlightOverlay);
 		inOrder.verify(overlayManager).add(widgetHighlightOverlay);
 	}
@@ -180,10 +192,10 @@ public class OverlayRegistryTest
 	// ========================================================================
 
 	@Test
-	public void testUnregisterAllRemovesEightOverlays()
+	public void testUnregisterAllRemovesNineOverlays()
 	{
 		registry.unregisterAll();
-		verify(overlayManager, times(8)).remove(any());
+		verify(overlayManager, times(9)).remove(any());
 	}
 
 	@Test
@@ -229,6 +241,13 @@ public class OverlayRegistryTest
 	}
 
 	@Test
+	public void testUnregisterAllRemovesWorldMapDestinationOverlay()
+	{
+		registry.unregisterAll();
+		verify(overlayManager).remove(worldMapDestinationOverlay);
+	}
+
+	@Test
 	public void testUnregisterAllRemovesGroundItemHighlightOverlay()
 	{
 		registry.unregisterAll();
@@ -255,6 +274,7 @@ public class OverlayRegistryTest
 		inOrder.verify(overlayManager).remove(objectHighlightOverlay);
 		inOrder.verify(overlayManager).remove(itemHighlightOverlay);
 		inOrder.verify(overlayManager).remove(worldMapRouteOverlay);
+		inOrder.verify(overlayManager).remove(worldMapDestinationOverlay);
 		inOrder.verify(overlayManager).remove(groundItemHighlightOverlay);
 		inOrder.verify(overlayManager).remove(widgetHighlightOverlay);
 	}
@@ -275,6 +295,8 @@ public class OverlayRegistryTest
 		verify(overlayManager, times(1)).remove(guidanceOverlay);
 		verify(overlayManager, times(1)).add(guidanceMinimapOverlay);
 		verify(overlayManager, times(1)).remove(guidanceMinimapOverlay);
+		verify(overlayManager, times(1)).add(worldMapDestinationOverlay);
+		verify(overlayManager, times(1)).remove(worldMapDestinationOverlay);
 		verify(overlayManager, times(1)).add(widgetHighlightOverlay);
 		verify(overlayManager, times(1)).remove(widgetHighlightOverlay);
 	}

--- a/src/test/java/com/collectionloghelper/overlay/WorldMapDestinationOverlayTest.java
+++ b/src/test/java/com/collectionloghelper/overlay/WorldMapDestinationOverlayTest.java
@@ -1,0 +1,314 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.overlay;
+
+import com.collectionloghelper.CollectionLogHelperConfig;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import net.runelite.api.Client;
+import net.runelite.api.Player;
+import net.runelite.api.Point;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.gameval.InterfaceID;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.worldmap.WorldMap;
+import net.runelite.api.worldmap.WorldMapData;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link WorldMapDestinationOverlay} covering:
+ * - Returns null and draws nothing when target is null (hidden state)
+ * - Returns null and draws nothing when {@code showOverlays()} is false
+ * - Returns null when the world map widget is not open
+ * - Returns null when local player is null
+ * - Calls drawImage when target is visible on the map (on-screen destination icon)
+ * - Calls drawImage when target is off-screen (edge-snap arrow)
+ * - clearTarget() hides the overlay
+ * - Null icon type defaults to TILE without throwing
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class WorldMapDestinationOverlayTest
+{
+	@Mock
+	private Client client;
+
+	@Mock
+	private CollectionLogHelperConfig config;
+
+	@Mock
+	private Graphics2D graphics;
+
+	@Mock
+	private Widget mapWidget;
+
+	@Mock
+	private Player player;
+
+	private WorldMapDestinationOverlay overlay;
+
+	/** A realistic map bounds rectangle (600 x 500 at position 0,0). */
+	private static final Rectangle MAP_BOUNDS = new Rectangle(0, 0, 600, 500);
+
+	/** Player world location used across tests. */
+	private static final WorldPoint PLAYER_WORLD = new WorldPoint(3200, 3200, 0);
+
+	/**
+	 * A target tile close to the player — at zoom 4.0 it projects inside MAP_BOUNDS
+	 * (roughly ±5 tiles from center = ±20 px, well inside 600x500).
+	 */
+	private static final WorldPoint TARGET_ON_SCREEN = new WorldPoint(3205, 3205, 0);
+
+	/**
+	 * A target tile far from the player — at zoom 1.0 it projects outside MAP_BOUNDS
+	 * (300 tiles away = 300 px from center, beyond the 300px half-width of MAP_BOUNDS).
+	 */
+	private static final WorldPoint TARGET_OFF_SCREEN = new WorldPoint(3500, 3500, 0);
+
+	@Before
+	public void setUp()
+	{
+		when(config.showOverlays()).thenReturn(true);
+		when(mapWidget.getBounds()).thenReturn(MAP_BOUNDS);
+		when(player.getWorldLocation()).thenReturn(PLAYER_WORLD);
+		overlay = new WorldMapDestinationOverlay(client, config);
+	}
+
+	// -----------------------------------------------------------------------
+	// Hidden / guard-clause checks
+	// -----------------------------------------------------------------------
+
+	@Test
+	public void render_returnsNull_whenNoTargetSet()
+	{
+		// No target — render should skip all drawing
+		Dimension result = overlay.render(graphics);
+
+		assertNull(result);
+		verifyNoDraw();
+	}
+
+	@Test
+	public void render_returnsNull_whenShowOverlaysFalse()
+	{
+		when(config.showOverlays()).thenReturn(false);
+		overlay.setTarget(TARGET_ON_SCREEN, WorldMapDestinationOverlay.StepIconType.TILE);
+
+		Dimension result = overlay.render(graphics);
+
+		assertNull(result);
+		verifyNoDraw();
+	}
+
+	@Test
+	public void render_returnsNull_whenWorldMapWidgetAbsent()
+	{
+		when(client.getWidget(InterfaceID.Worldmap.MAP_CONTAINER)).thenReturn(null);
+		overlay.setTarget(TARGET_ON_SCREEN, WorldMapDestinationOverlay.StepIconType.TILE);
+
+		Dimension result = overlay.render(graphics);
+
+		assertNull(result);
+		verifyNoDraw();
+	}
+
+	@Test
+	public void render_returnsNull_whenLocalPlayerNull()
+	{
+		when(client.getWidget(InterfaceID.Worldmap.MAP_CONTAINER)).thenReturn(mapWidget);
+		when(client.getLocalPlayer()).thenReturn(null);
+		overlay.setTarget(TARGET_ON_SCREEN, WorldMapDestinationOverlay.StepIconType.TILE);
+
+		Dimension result = overlay.render(graphics);
+
+		assertNull(result);
+		verifyNoDraw();
+	}
+
+	@Test
+	public void render_returnsNull_afterClearTarget()
+	{
+		// Set then immediately clear — should behave as if no target was set
+		overlay.setTarget(TARGET_ON_SCREEN, WorldMapDestinationOverlay.StepIconType.TILE);
+		overlay.clearTarget();
+
+		Dimension result = overlay.render(graphics);
+
+		assertNull(result);
+		verifyNoDraw();
+	}
+
+	// -----------------------------------------------------------------------
+	// On-screen rendering (destination icon drawn at target tile)
+	// -----------------------------------------------------------------------
+
+	@Test
+	public void render_drawsDestinationIcon_whenTargetOnScreen()
+	{
+		// At zoom 4.0, target 5 tiles away projects ~20 px from center — inside MAP_BOUNDS
+		wireFullSetup(TARGET_ON_SCREEN, 4.0f);
+		overlay.setTarget(TARGET_ON_SCREEN, WorldMapDestinationOverlay.StepIconType.TILE);
+
+		Dimension result = overlay.render(graphics);
+
+		assertNull(result);
+		verifyDrew();
+	}
+
+	@Test
+	public void render_drawsNpcIcon_forNpcStepType()
+	{
+		wireFullSetup(TARGET_ON_SCREEN, 4.0f);
+		overlay.setTarget(TARGET_ON_SCREEN, WorldMapDestinationOverlay.StepIconType.NPC);
+
+		Dimension result = overlay.render(graphics);
+
+		assertNull(result);
+		verifyDrew();
+	}
+
+	@Test
+	public void render_drawsObjectIcon_forObjectStepType()
+	{
+		wireFullSetup(TARGET_ON_SCREEN, 4.0f);
+		overlay.setTarget(TARGET_ON_SCREEN, WorldMapDestinationOverlay.StepIconType.OBJECT);
+
+		Dimension result = overlay.render(graphics);
+
+		assertNull(result);
+		verifyDrew();
+	}
+
+	// -----------------------------------------------------------------------
+	// Off-screen rendering (edge-snap arrow)
+	// -----------------------------------------------------------------------
+
+	@Test
+	public void render_drawsArrow_whenTargetOffScreen()
+	{
+		// At zoom 1.0, target 300 tiles away projects 300 px from center.
+		// MAP_BOUNDS is 600 wide so center is at 300 — projection lands at 600 or beyond.
+		wireFullSetup(TARGET_OFF_SCREEN, 1.0f);
+		overlay.setTarget(TARGET_OFF_SCREEN, WorldMapDestinationOverlay.StepIconType.TILE);
+
+		Dimension result = overlay.render(graphics);
+
+		assertNull(result);
+		verifyDrew();
+	}
+
+	// -----------------------------------------------------------------------
+	// Null / default handling
+	// -----------------------------------------------------------------------
+
+	@Test
+	public void setTarget_nullIconType_defaultsToTileWithoutThrowing()
+	{
+		// Passing null for icon type must not throw — defaults to TILE
+		overlay.setTarget(TARGET_ON_SCREEN, null);
+
+		wireFullSetup(TARGET_ON_SCREEN, 4.0f);
+
+		Dimension result = overlay.render(graphics);
+		// Must not throw; drawImage should be called (TILE icon rendered)
+		assertNull(result);
+		verifyDrew();
+	}
+
+	// -----------------------------------------------------------------------
+	// Helpers
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Wires client mocks for the full render path: widget open, player present,
+	 * world map initialised at the given zoom level centered on PLAYER_WORLD.
+	 *
+	 * <p>All mock objects are created before being passed to {@code thenReturn}
+	 * to avoid the Mockito UnfinishedStubbingException that occurs when a mock
+	 * is created (and immediately stubbed) inside a {@code thenReturn(...)} argument.
+	 */
+	private void wireFullSetup(WorldPoint target, float zoom)
+	{
+		when(client.getWidget(InterfaceID.Worldmap.MAP_CONTAINER)).thenReturn(mapWidget);
+		when(client.getLocalPlayer()).thenReturn(player);
+
+		// Build world map mock before passing it into thenReturn
+		WorldMap worldMap = buildWorldMap(zoom);
+		when(client.getWorldMap()).thenReturn(worldMap);
+	}
+
+	/**
+	 * Builds a minimal WorldMap mock. {@code surfaceContainsPosition} always
+	 * returns true so coordinate conversion proceeds for any tile.
+	 *
+	 * <p>The map center is set to PLAYER_WORLD so that TARGET_ON_SCREEN (5 tiles
+	 * away) projects close to the widget center.
+	 */
+	private static WorldMap buildWorldMap(float zoom)
+	{
+		WorldMapData worldMapData = mock(WorldMapData.class);
+		when(worldMapData.surfaceContainsPosition(anyInt(), anyInt())).thenReturn(true);
+
+		WorldMap worldMap = mock(WorldMap.class);
+		when(worldMap.getWorldMapData()).thenReturn(worldMapData);
+		when(worldMap.getWorldMapZoom()).thenReturn(zoom);
+		when(worldMap.getWorldMapPosition())
+			.thenReturn(new Point(PLAYER_WORLD.getX(), PLAYER_WORLD.getY()));
+
+		return worldMap;
+	}
+
+	/** Asserts that {@code graphics.drawImage} was called exactly once. */
+	private void verifyDrew()
+	{
+		verify(graphics).drawImage(
+			ArgumentMatchers.any(),
+			anyInt(),
+			anyInt(),
+			ArgumentMatchers.isNull());
+	}
+
+	/** Asserts that {@code graphics.drawImage} was never called. */
+	private void verifyNoDraw()
+	{
+		verify(graphics, never()).drawImage(
+			ArgumentMatchers.any(),
+			anyInt(),
+			anyInt(),
+			ArgumentMatchers.any());
+	}
+}


### PR DESCRIPTION
## Summary

- Add `WorldMapDestinationOverlay`: a new `MANUAL`-layer overlay that renders a **directional arrow** at the map edge (when the destination is off-screen) and a **destination icon** at the target tile (when on-screen), coexisting with the existing `WorldMapRouteOverlay` route line.
- Icon type is determined by step context: NPC steps → person silhouette; object steps → chest; all others → diamond tile marker.
- All sprites (8 directional arrows + 3 icon variants) are pre-rendered once at construction. Zero per-frame allocation in the render path.
- `WorldMapRouteOverlay` is untouched — the route line continues to work as before.

**Note on dual arrows:** when the destination is off-screen, both this overlay's edge-snap arrow and the `CollectionLogWorldMapPoint` edge-snap image (from the WorldMapPoint system) will be visible simultaneously. The WorldMapPoint arrow is rendered by RuneLite's widget machinery; this overlay's arrow is drawn via `Graphics2D`. They use the same chevron shape and teal colour so they appear as a consistent pair rather than visual clutter.

## Test plan

- [ ] `WorldMapDestinationOverlayTest` — 11 unit tests covering hidden/guard-clause states, on-screen icon, off-screen arrow, all three icon types, null icon type default
- [ ] `OverlayRegistryTest` — updated to 9 overlays; order, add, remove, and symmetry tests all updated
- [ ] `./gradlew build` passes (567 tests, 0 failures)

Refs cha-ndler/collection-log-helper#382 (B.5.5)