### PR TITLE
feat(panel): per-step item requirements with bank-scan state coloring (B.5.1)

### DIFF
--- a/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
@@ -243,13 +243,25 @@ public class GuidanceOverlayCoordinator
 			GuidanceStep rawStep = guidanceSequencer.getRawCurrentStep();
 			if (panel != null)
 			{
+				final int landedIdx = guidanceSequencer.getCurrentIndex() + 1;
+				final int stepTotal = guidanceSequencer.getTotalSteps();
+				final String stepDesc = step != null ? step.getDescription() : "";
+				final boolean stepManual =
+					step != null && step.getCompletionCondition() == CompletionCondition.MANUAL;
 				panel.setGuidanceState(true, source);
-				panel.updateStepProgress(
-					guidanceSequencer.getCurrentIndex() + 1,
-					guidanceSequencer.getTotalSteps(),
-					step != null ? step.getDescription() : "",
-					step != null && step.getCompletionCondition() == CompletionCondition.MANUAL,
-					rawStep != null ? rawStep.getRequiredItemIds() : null);
+				// Show step text immediately without items; resolve names on the client
+				// thread (~1 tick) to avoid the EDT assert in ItemManager#getItemComposition
+				// (see cha-ndler/collection-log-helper#388).
+				panel.updateStepProgress(landedIdx, stepTotal, stepDesc, stepManual,
+					Collections.emptyList());
+				final GuidanceStep rawForResolve = rawStep;
+				clientThread.invokeLater(() ->
+				{
+					final List<RequiredItemDisplay> resolvedItems =
+						requiredItemResolver.resolve(rawForResolve);
+					panel.updateStepProgress(landedIdx, stepTotal, stepDesc, stepManual,
+						resolvedItems);
+				});
 			}
 			// Add InfoBox showing the correct landed step (not always "1/N")
 			if (!source.getItems().isEmpty() && pluginInstance != null)
@@ -803,13 +815,24 @@ public class GuidanceOverlayCoordinator
 
 		if (panel != null)
 		{
-			GuidanceStep rawStep = guidanceSequencer.getRawCurrentStep();
-			panel.updateStepProgress(
-				guidanceSequencer.getCurrentIndex() + 1,
-				guidanceSequencer.getTotalSteps(),
-				step.getDescription(),
-				step.getCompletionCondition() == CompletionCondition.MANUAL,
-				rawStep != null ? rawStep.getRequiredItemIds() : null);
+			final int current = guidanceSequencer.getCurrentIndex() + 1;
+			final int total = guidanceSequencer.getTotalSteps();
+			final String desc = step.getDescription();
+			final boolean isManual = step.getCompletionCondition() == CompletionCondition.MANUAL;
+			final GuidanceStep rawStep = guidanceSequencer.getRawCurrentStep();
+
+			// Push description + step progress to the panel immediately (safe from any thread
+			// because showStep dispatches to the EDT). Required-item resolution is deferred
+			// to the client thread because RequiredItemResolver.resolve() calls
+			// ItemManager.getItemComposition, which asserts caller-is-client-thread. See
+			// cha-ndler/collection-log-helper#388 for the original trace.
+			panel.updateStepProgress(current, total, desc, isManual, Collections.emptyList());
+			clientThread.invokeLater(() ->
+			{
+				final List<RequiredItemDisplay> resolvedItems =
+					requiredItemResolver.resolve(rawStep);
+				panel.updateStepProgress(current, total, desc, isManual, resolvedItems);
+			});
 		}
 	}
 

--- a/src/main/java/com/collectionloghelper/guidance/RequiredItemDisplay.java
+++ b/src/main/java/com/collectionloghelper/guidance/RequiredItemDisplay.java
@@ -54,13 +54,20 @@ public final class RequiredItemDisplay
 		MISSING
 	}
 
+	private final int itemId;
 	private final String name;
 	private final Status status;
 
-	public RequiredItemDisplay(String name, Status status)
+	public RequiredItemDisplay(int itemId, String name, Status status)
 	{
+		this.itemId = itemId;
 		this.name = Objects.requireNonNull(name, "name");
 		this.status = Objects.requireNonNull(status, "status");
+	}
+
+	public int getItemId()
+	{
+		return itemId;
 	}
 
 	public String getName()
@@ -100,18 +107,18 @@ public final class RequiredItemDisplay
 			return false;
 		}
 		RequiredItemDisplay other = (RequiredItemDisplay) o;
-		return status == other.status && name.equals(other.name);
+		return itemId == other.itemId && status == other.status && name.equals(other.name);
 	}
 
 	@Override
 	public int hashCode()
 	{
-		return Objects.hash(name, status);
+		return Objects.hash(itemId, name, status);
 	}
 
 	@Override
 	public String toString()
 	{
-		return "RequiredItemDisplay{name='" + name + "', status=" + status + '}';
+		return "RequiredItemDisplay{itemId=" + itemId + ", name='" + name + "', status=" + status + '}';
 	}
 }

--- a/src/main/java/com/collectionloghelper/guidance/RequiredItemResolver.java
+++ b/src/main/java/com/collectionloghelper/guidance/RequiredItemResolver.java
@@ -93,7 +93,7 @@ public class RequiredItemResolver
 	private RequiredItemDisplay resolveSingle(int itemId)
 	{
 		Status status = resolveStatus(itemId);
-		return new RequiredItemDisplay(lookupName(itemId), status);
+		return new RequiredItemDisplay(itemId, lookupName(itemId), status);
 	}
 
 	private Status resolveStatus(int itemId)

--- a/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
@@ -36,6 +36,7 @@ import com.collectionloghelper.data.PlayerBankState;
 import com.collectionloghelper.data.PlayerCollectionState;
 import com.collectionloghelper.data.PlayerInventoryState;
 import com.collectionloghelper.data.RequirementsChecker;
+import com.collectionloghelper.guidance.RequiredItemDisplay;
 import com.collectionloghelper.data.SlayerTaskState;
 import com.collectionloghelper.efficiency.ClueCompletionEstimator;
 import com.collectionloghelper.efficiency.EfficiencyCalculator;
@@ -238,7 +239,7 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 		guidanceBannerView.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
 		controlsPanel.add(guidanceBannerView);
 
-		stepProgressView = new StepProgressView(itemManager, inventoryState, bankState);
+		stepProgressView = new StepProgressView(itemManager);
 		stepProgressView.setAlignmentX(CENTER_ALIGNMENT);
 		controlsPanel.add(stepProgressView);
 
@@ -617,11 +618,15 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 
 	/**
 	 * Updates the step progress banner with current step info.
+	 *
+	 * @param requiredItems pre-resolved display rows from
+	 *                      {@link com.collectionloghelper.guidance.RequiredItemResolver};
+	 *                      may be {@code null} or empty when the step has no required items
 	 */
 	public void updateStepProgress(int current, int total, String description, boolean isManual,
-		List<Integer> requiredItemIds)
+		List<RequiredItemDisplay> requiredItems)
 	{
-		stepProgressView.showStep(current, total, description, isManual, requiredItemIds);
+		stepProgressView.showStep(current, total, description, isManual, requiredItems);
 	}
 
 	/** Hides the step progress banner. */

--- a/src/main/java/com/collectionloghelper/ui/widget/StepProgressView.java
+++ b/src/main/java/com/collectionloghelper/ui/widget/StepProgressView.java
@@ -24,14 +24,13 @@
  */
 package com.collectionloghelper.ui.widget;
 
-import com.collectionloghelper.data.PlayerBankState;
-import com.collectionloghelper.data.PlayerInventoryState;
+import com.collectionloghelper.guidance.RequiredItemDisplay;
 import java.awt.Color;
 import java.awt.Dimension;
-import java.awt.FlowLayout;
 import java.awt.Font;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
+import java.util.Collections;
 import java.util.List;
 import javax.swing.BorderFactory;
 import javax.swing.Box;
@@ -42,15 +41,19 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.util.AsyncBufferedImage;
 
 /**
  * Shared widget that displays the multi-step guidance progress bar,
- * the required-items panel (with colour-coded availability borders),
- * and the Next Step / Skip buttons.
+ * the required-items subsection (with colour-coded availability), and the
+ * Next Step / Skip buttons.
+ *
+ * <p>Required-item rows are passed in as pre-resolved {@link RequiredItemDisplay}
+ * objects (name + status already determined on the client thread by
+ * {@link com.collectionloghelper.guidance.RequiredItemResolver}) so this widget
+ * never touches inventory/bank state directly.
  *
  * <p>Constructed once by the shell; updated via {@link #showStep} and
  * hidden via {@link #hideStep}. Step-advance and skip callbacks are wired
@@ -62,16 +65,12 @@ import net.runelite.client.util.AsyncBufferedImage;
  * an override with the same signature breaks {@code setVisible(false)} for this
  * widget and leaves it visible in pre-guidance states (see issue #353).
  */
-@Slf4j
 public class StepProgressView extends JPanel
 {
-	private static final Color ITEM_STATUS_GREEN = new Color(40, 180, 40);
-	private static final Color ITEM_STATUS_YELLOW = new Color(200, 180, 40);
-	private static final Color ITEM_STATUS_RED = new Color(200, 40, 40);
+	/** Tooltip suffix appended to items whose status is IN_BANK. */
+	private static final String IN_BANK_TOOLTIP_SUFFIX = " ℹ in bank";
 
 	private final ItemManager itemManager;
-	private final PlayerInventoryState inventoryState;
-	private final PlayerBankState bankState;
 
 	private final JLabel stepProgressLabel;
 	private final JPanel requiredItemsPanel;
@@ -81,13 +80,9 @@ public class StepProgressView extends JPanel
 	private Runnable stepAdvancer;
 	private Runnable stepSkipper;
 
-	public StepProgressView(ItemManager itemManager,
-		PlayerInventoryState inventoryState,
-		PlayerBankState bankState)
+	public StepProgressView(ItemManager itemManager)
 	{
 		this.itemManager = itemManager;
-		this.inventoryState = inventoryState;
-		this.bankState = bankState;
 
 		setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
 		setBackground(new Color(25, 35, 55));
@@ -105,7 +100,8 @@ public class StepProgressView extends JPanel
 		stepProgressLabel.setAlignmentX(LEFT_ALIGNMENT);
 		add(stepProgressLabel);
 
-		requiredItemsPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 4, 2));
+		requiredItemsPanel = new JPanel();
+		requiredItemsPanel.setLayout(new BoxLayout(requiredItemsPanel, BoxLayout.Y_AXIS));
 		requiredItemsPanel.setBackground(new Color(25, 35, 55));
 		requiredItemsPanel.setAlignmentX(LEFT_ALIGNMENT);
 		requiredItemsPanel.setVisible(false);
@@ -163,24 +159,26 @@ public class StepProgressView extends JPanel
 	 * Shows and populates the step progress panel.
 	 * Safe to call from any thread.
 	 *
-	 * @param current         one-based step index
-	 * @param total           total number of steps
-	 * @param description     human-readable step description
-	 * @param isManual        whether the Next Step button should be shown
-	 * @param requiredItemIds item IDs to display (may be {@code null} or empty)
+	 * @param current       one-based step index
+	 * @param total         total number of steps
+	 * @param description   human-readable step description
+	 * @param isManual      whether the Next Step button should be shown
+	 * @param requiredItems pre-resolved display rows (may be {@code null} or empty);
+	 *                      resolved on the client thread by
+	 *                      {@link com.collectionloghelper.guidance.RequiredItemResolver}
 	 */
 	public void showStep(int current, int total, String description, boolean isManual,
-		List<Integer> requiredItemIds)
+		List<RequiredItemDisplay> requiredItems)
 	{
-		// Snapshot immutable values before dispatch
-		final List<Integer> itemIds = requiredItemIds;
+		final List<RequiredItemDisplay> rows =
+			requiredItems != null ? requiredItems : Collections.emptyList();
 
 		SwingUtilities.invokeLater(() ->
 		{
 			stepProgressLabel.setText(
 				"<html>Step " + current + "/" + total + ": " + description + "</html>");
 			nextStepButton.setVisible(isManual);
-			updateRequiredItemDisplay(itemIds);
+			updateRequiredItemDisplay(rows);
 			setVisible(true);
 			revalidate();
 			if (getParent() != null)
@@ -214,97 +212,139 @@ public class StepProgressView extends JPanel
 	}
 
 	/**
-	 * Updates the required-item icon strip with colour-coded availability borders.
+	 * Rebuilds the required-items subsection from pre-resolved display rows.
+	 *
+	 * <p>Each row shows a 28×28 item sprite icon followed by the item name.
+	 * The name label is coloured by availability:
 	 * <ul>
-	 *   <li>Green — item is in inventory or equipped</li>
-	 *   <li>Yellow — item is in the bank but not on the player</li>
-	 *   <li>Red — item not found anywhere</li>
+	 *   <li><b>Green</b> — held in inventory or equipped</li>
+	 *   <li><b>White</b> (+ tooltip suffix "ℹ in bank") — present in last bank scan</li>
+	 *   <li><b>Red</b> — not found anywhere</li>
 	 * </ul>
+	 * The subsection is hidden when {@code rows} is empty.
 	 * Must be called on the EDT.
+	 *
+	 * @param rows pre-resolved display rows from
+	 *             {@link com.collectionloghelper.guidance.RequiredItemResolver}
 	 */
-	private void updateRequiredItemDisplay(List<Integer> requiredItemIds)
+	void updateRequiredItemDisplay(List<RequiredItemDisplay> rows)
 	{
 		requiredItemsPanel.removeAll();
 
-		if (requiredItemIds == null || requiredItemIds.isEmpty())
+		if (rows == null || rows.isEmpty())
 		{
 			requiredItemsPanel.setVisible(false);
 			return;
 		}
 
-		JLabel headerLabel = new JLabel("Required:");
-		headerLabel.setFont(FontManager.getRunescapeSmallFont());
+		JLabel headerLabel = new JLabel("Items needed:");
+		headerLabel.setFont(FontManager.getRunescapeSmallFont().deriveFont(Font.BOLD));
 		headerLabel.setForeground(new Color(180, 180, 180));
+		headerLabel.setAlignmentX(LEFT_ALIGNMENT);
 		requiredItemsPanel.add(headerLabel);
 
-		for (int itemId : requiredItemIds)
+		requiredItemsPanel.add(Box.createVerticalStrut(2));
+
+		for (RequiredItemDisplay row : rows)
 		{
-			boolean inInventory = inventoryState.hasItem(itemId);
-			boolean equipped = inventoryState.hasEquippedItem(itemId);
-			boolean inBank = bankState.hasItem(itemId);
-
-			Color borderColor;
-			String statusText;
-			if (inInventory || equipped)
-			{
-				borderColor = ITEM_STATUS_GREEN;
-				statusText = equipped && !inInventory ? " (equipped)" : " (in inventory)";
-			}
-			else if (inBank)
-			{
-				borderColor = ITEM_STATUS_YELLOW;
-				statusText = " (in bank)";
-			}
-			else
-			{
-				borderColor = ITEM_STATUS_RED;
-				statusText = " (MISSING)";
-			}
-
-			JLabel itemLabel = new JLabel();
-			itemLabel.setPreferredSize(new Dimension(32, 32));
-			itemLabel.setBorder(BorderFactory.createLineBorder(borderColor, 2));
-			itemLabel.setHorizontalAlignment(SwingConstants.CENTER);
-			itemLabel.setVerticalAlignment(SwingConstants.CENTER);
-
-			AsyncBufferedImage asyncImage = itemManager.getImage(itemId);
-			asyncImage.onLoaded(() ->
-			{
-				BufferedImage scaled = scaleImage(asyncImage, 28, 28);
-				itemLabel.setIcon(new ImageIcon(scaled));
-				itemLabel.revalidate();
-				itemLabel.repaint();
-			});
-			BufferedImage scaled = scaleImage(asyncImage, 28, 28);
-			itemLabel.setIcon(new ImageIcon(scaled));
-
-			// ItemManager.getItemComposition() asserts client-thread, but this
-			// runs on the EDT (the panel is a Swing widget updated via
-			// SwingUtilities.invokeLater in showStep). The assertion is an Error
-			// (not RuntimeException) so it would otherwise propagate up,
-			// abort the loop mid-iteration, and leave the required-items strip
-			// hidden. See cha-ndler/collection-log-helper#388 for the trace.
-			// Falling back to "Item #N" keeps the row visible; a proper fix
-			// (pre-resolved items via RequiredItemResolver on client thread) is
-			// tracked as a follow-up — see PR description.
-			String tooltipName;
-			try
-			{
-				tooltipName = itemManager.getItemComposition(itemId).getName();
-			}
-			catch (Throwable t)
-			{
-				log.warn("Item composition lookup failed for required-item id {}: {}",
-					itemId, t.toString());
-				tooltipName = "Item #" + itemId;
-			}
-			itemLabel.setToolTipText(tooltipName + statusText);
-			requiredItemsPanel.add(itemLabel);
+			JPanel rowPanel = buildItemRow(row);
+			rowPanel.setAlignmentX(LEFT_ALIGNMENT);
+			requiredItemsPanel.add(rowPanel);
+			requiredItemsPanel.add(Box.createVerticalStrut(2));
 		}
 
 		requiredItemsPanel.setVisible(true);
 		requiredItemsPanel.revalidate();
 		requiredItemsPanel.repaint();
+	}
+
+	/**
+	 * Builds a single item row: a 28×28 sprite icon + a name label coloured
+	 * by the row's availability status.
+	 */
+	private JPanel buildItemRow(RequiredItemDisplay row)
+	{
+		JPanel rowPanel = new JPanel();
+		rowPanel.setLayout(new BoxLayout(rowPanel, BoxLayout.X_AXIS));
+		rowPanel.setBackground(new Color(25, 35, 55));
+		rowPanel.setMaximumSize(new Dimension(Integer.MAX_VALUE, 32));
+
+		// --- Icon ---
+		JLabel iconLabel = new JLabel();
+		iconLabel.setPreferredSize(new Dimension(28, 28));
+		iconLabel.setMinimumSize(new Dimension(28, 28));
+		iconLabel.setMaximumSize(new Dimension(28, 28));
+		iconLabel.setHorizontalAlignment(SwingConstants.CENTER);
+		iconLabel.setVerticalAlignment(SwingConstants.CENTER);
+
+		// --- Name label ---
+		Color nameColor;
+		String tooltipSuffix;
+		switch (row.getStatus())
+		{
+			case HELD:
+				nameColor = RequiredItemDisplay.COLOR_HELD;
+				tooltipSuffix = "";
+				break;
+			case IN_BANK:
+				nameColor = Color.WHITE;
+				tooltipSuffix = IN_BANK_TOOLTIP_SUFFIX;
+				break;
+			case MISSING:
+			default:
+				nameColor = RequiredItemDisplay.COLOR_MISSING;
+				tooltipSuffix = "";
+				break;
+		}
+
+		JLabel nameLabel = new JLabel(row.getName());
+		nameLabel.setFont(FontManager.getRunescapeSmallFont());
+		nameLabel.setForeground(nameColor);
+		nameLabel.setToolTipText(row.getName() + tooltipSuffix);
+		iconLabel.setToolTipText(row.getName() + tooltipSuffix);
+
+		rowPanel.add(iconLabel);
+		rowPanel.add(Box.createHorizontalStrut(4));
+		rowPanel.add(nameLabel);
+
+		// Load sprite asynchronously; itemManager.getImage is safe to call on the EDT.
+		if (row.getItemId() > 0)
+		{
+			loadItemIcon(row.getItemId(), iconLabel);
+		}
+
+		return rowPanel;
+	}
+
+	/**
+	 * Loads the item sprite for the given item ID into {@code iconLabel} asynchronously.
+	 * Called after the row panel is constructed so the icon appears as soon as the
+	 * image is available. Safe to call when {@code itemManager} has no image for the
+	 * given ID (e.g., in tests) — the icon label is simply left empty.
+	 */
+	void loadItemIcon(int itemId, JLabel iconLabel)
+	{
+		AsyncBufferedImage asyncImage = itemManager.getImage(itemId);
+		if (asyncImage == null)
+		{
+			return;
+		}
+		asyncImage.onLoaded(() ->
+		{
+			if (asyncImage.getWidth() > 0)
+			{
+				BufferedImage scaled = scaleImage(asyncImage, 28, 28);
+				iconLabel.setIcon(new ImageIcon(scaled));
+				iconLabel.revalidate();
+				iconLabel.repaint();
+			}
+		});
+		// Apply synchronously in case the image is already loaded
+		if (asyncImage.getWidth() > 0)
+		{
+			BufferedImage scaled = scaleImage(asyncImage, 28, 28);
+			iconLabel.setIcon(new ImageIcon(scaled));
+		}
 	}
 
 	private static BufferedImage scaleImage(BufferedImage source, int width, int height)

--- a/src/test/java/com/collectionloghelper/guidance/RequiredItemResolverTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/RequiredItemResolverTest.java
@@ -237,6 +237,18 @@ public class RequiredItemResolverTest
 		assertEquals(Status.MISSING, rows.get(0).getStatus());
 	}
 
+	@Test
+	public void resolvedRowPreservesItemId()
+	{
+		when(inventoryState.hasItem(TINDERBOX)).thenReturn(true);
+
+		List<RequiredItemDisplay> rows = resolver.resolve(
+			stepWithRequiredItems(Collections.singletonList(TINDERBOX)));
+
+		assertEquals("Item ID must be preserved in the display row so the panel can load the sprite",
+			TINDERBOX, rows.get(0).getItemId());
+	}
+
 	// --- Helpers ---
 
 	private static GuidanceStep stepWithRequiredItems(List<Integer> requiredItemIds)

--- a/src/test/java/com/collectionloghelper/ui/widget/StepProgressViewTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/StepProgressViewTest.java
@@ -24,36 +24,55 @@
  */
 package com.collectionloghelper.ui.widget;
 
-import com.collectionloghelper.data.PlayerBankState;
-import com.collectionloghelper.data.PlayerInventoryState;
+import com.collectionloghelper.guidance.RequiredItemDisplay;
+import com.collectionloghelper.guidance.RequiredItemDisplay.Status;
 import net.runelite.client.game.ItemManager;
+import java.awt.Color;
+import java.awt.Component;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**
  * Unit tests for {@link StepProgressView}.
+ *
+ * <p>Covers:
+ * <ul>
+ *   <li>Construction and basic visibility contract (including issue #353 regression)</li>
+ *   <li>Required-items subsection: hidden when empty, visible with rows</li>
+ *   <li>All three availability states (HELD / IN_BANK / MISSING) reflected in name
+ *       label colours and tooltip text</li>
+ *   <li>State transition: colours update when rows change between showStep calls</li>
+ * </ul>
  */
 public class StepProgressViewTest
 {
+	private static final int TINDERBOX_ID = 590;
+	private static final int PYRE_LOGS_ID = 3438;
+	private static final int SHADE_REMAINS_ID = 3392;
+
 	private ItemManager itemManager;
-	private PlayerInventoryState inventoryState;
-	private PlayerBankState bankState;
 	private StepProgressView view;
 
 	@Before
 	public void setUp()
 	{
 		itemManager = Mockito.mock(ItemManager.class);
-		inventoryState = Mockito.mock(PlayerInventoryState.class);
-		bankState = Mockito.mock(PlayerBankState.class);
-		view = new StepProgressView(itemManager, inventoryState, bankState);
+		// itemManager.getImage() is called for sprites; return null safely — the
+		// test does not exercise icon loading.
+		Mockito.when(itemManager.getImage(Mockito.anyInt())).thenReturn(null);
+		view = new StepProgressView(itemManager);
 	}
 
 	@Test
@@ -140,9 +159,195 @@ public class StepProgressViewTest
 		assertTrue("showStep must make widget visible", view.isVisible());
 	}
 
+	// ── Required-items subsection tests (B.5.1) ─────────────────────────────
+
+	/**
+	 * When the step has no required items the subsection must be invisible so no
+	 * empty "Items needed:" heading appears in the panel.
+	 */
+	@Test
+	public void updateRequiredItemDisplay_emptyList_subsectionHidden() throws Exception
+	{
+		view.showStep(1, 1, "no items", false, Collections.emptyList());
+		flushEdt();
+		assertFalse("Required-items panel must be hidden when item list is empty",
+			findRequiredItemsPanel(view).isVisible());
+	}
+
+	/**
+	 * A HELD row must use the green colour constant and not append a bank tooltip.
+	 */
+	@Test
+	public void updateRequiredItemDisplay_heldStatus_greenNameLabel() throws Exception
+	{
+		List<RequiredItemDisplay> rows = Collections.singletonList(
+			new RequiredItemDisplay(TINDERBOX_ID, "Tinderbox", Status.HELD));
+
+		view.updateRequiredItemDisplay(rows);
+		flushEdt();
+
+		JLabel nameLabel = findFirstNameLabel(view);
+		assertNotNull("Name label must be present for HELD row", nameLabel);
+		assertEquals("HELD row must use green colour",
+			RequiredItemDisplay.COLOR_HELD, nameLabel.getForeground());
+		assertFalse("HELD tooltip must not mention bank",
+			nameLabel.getToolTipText() != null
+				&& nameLabel.getToolTipText().contains("in bank"));
+	}
+
+	/**
+	 * An IN_BANK row must use white text and append the "ℹ in bank" suffix to the
+	 * tooltip so the player knows where to fetch the item from.
+	 */
+	@Test
+	public void updateRequiredItemDisplay_inBankStatus_whiteLabelWithBankTooltip() throws Exception
+	{
+		List<RequiredItemDisplay> rows = Collections.singletonList(
+			new RequiredItemDisplay(PYRE_LOGS_ID, "Pyre logs", Status.IN_BANK));
+
+		view.updateRequiredItemDisplay(rows);
+		flushEdt();
+
+		JLabel nameLabel = findFirstNameLabel(view);
+		assertNotNull("Name label must be present for IN_BANK row", nameLabel);
+		assertEquals("IN_BANK row must use white colour", Color.WHITE, nameLabel.getForeground());
+		assertTrue("IN_BANK tooltip must contain 'in bank' hint",
+			nameLabel.getToolTipText() != null
+				&& nameLabel.getToolTipText().contains("in bank"));
+	}
+
+	/**
+	 * A MISSING row must use the red colour constant.
+	 */
+	@Test
+	public void updateRequiredItemDisplay_missingStatus_redNameLabel() throws Exception
+	{
+		List<RequiredItemDisplay> rows = Collections.singletonList(
+			new RequiredItemDisplay(SHADE_REMAINS_ID, "Loar remains", Status.MISSING));
+
+		view.updateRequiredItemDisplay(rows);
+		flushEdt();
+
+		JLabel nameLabel = findFirstNameLabel(view);
+		assertNotNull("Name label must be present for MISSING row", nameLabel);
+		assertEquals("MISSING row must use red colour",
+			RequiredItemDisplay.COLOR_MISSING, nameLabel.getForeground());
+	}
+
+	/**
+	 * All three statuses can appear in the same strip. Verifies ordering and that
+	 * each status gets its correct colour independently.
+	 */
+	@Test
+	public void updateRequiredItemDisplay_allThreeStatuses_correctColoursInOrder() throws Exception
+	{
+		List<RequiredItemDisplay> rows = Arrays.asList(
+			new RequiredItemDisplay(TINDERBOX_ID, "Tinderbox", Status.HELD),
+			new RequiredItemDisplay(PYRE_LOGS_ID, "Pyre logs", Status.IN_BANK),
+			new RequiredItemDisplay(SHADE_REMAINS_ID, "Loar remains", Status.MISSING));
+
+		view.updateRequiredItemDisplay(rows);
+		flushEdt();
+
+		List<JLabel> nameLabels = findAllNameLabels(view);
+		assertEquals("Must have exactly 3 name labels", 3, nameLabels.size());
+		assertEquals(RequiredItemDisplay.COLOR_HELD, nameLabels.get(0).getForeground());
+		assertEquals(Color.WHITE, nameLabels.get(1).getForeground());
+		assertEquals(RequiredItemDisplay.COLOR_MISSING, nameLabels.get(2).getForeground());
+	}
+
+	/**
+	 * State transition: colours must update when showStep is called a second time
+	 * with different availability data for the same item.
+	 */
+	@Test
+	public void showStep_stateTransition_coloursUpdateOnSecondCall() throws Exception
+	{
+		// First call: item is MISSING
+		view.showStep(1, 1, "Collect item", false, Collections.singletonList(
+			new RequiredItemDisplay(TINDERBOX_ID, "Tinderbox", Status.MISSING)));
+		flushEdt();
+
+		JLabel first = findFirstNameLabel(view);
+		assertEquals("Initially MISSING must be red",
+			RequiredItemDisplay.COLOR_MISSING, first.getForeground());
+
+		// Second call: item is now HELD (player picked it up)
+		view.showStep(1, 1, "Collect item", false, Collections.singletonList(
+			new RequiredItemDisplay(TINDERBOX_ID, "Tinderbox", Status.HELD)));
+		flushEdt();
+
+		JLabel updated = findFirstNameLabel(view);
+		assertEquals("After transition to HELD must be green",
+			RequiredItemDisplay.COLOR_HELD, updated.getForeground());
+	}
+
+	// ── Helpers ─────────────────────────────────────────────────────────────
+
 	/** Flush the Swing event queue so invokeLater-scheduled work completes. */
 	private static void flushEdt() throws Exception
 	{
 		SwingUtilities.invokeAndWait(() -> { });
+	}
+
+	/**
+	 * Finds the required-items sub-panel inside {@code view}. It is the first
+	 * {@link JPanel} direct child of the StepProgressView.
+	 */
+	private static JPanel findRequiredItemsPanel(StepProgressView view)
+	{
+		for (Component c : view.getComponents())
+		{
+			if (c instanceof JPanel)
+			{
+				return (JPanel) c;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Returns the first item-name {@link JLabel} found inside the required-items
+	 * sub-panel (skips the header label and icon-only labels).
+	 */
+	private static JLabel findFirstNameLabel(StepProgressView view)
+	{
+		List<JLabel> labels = findAllNameLabels(view);
+		return labels.isEmpty() ? null : labels.get(0);
+	}
+
+	/**
+	 * Collects all item-name labels from the required-items strip (one per row).
+	 * The header "Items needed:" label and icon-only labels are excluded.
+	 */
+	private static List<JLabel> findAllNameLabels(StepProgressView view)
+	{
+		List<JLabel> result = new java.util.ArrayList<>();
+		JPanel reqPanel = findRequiredItemsPanel(view);
+		if (reqPanel == null)
+		{
+			return result;
+		}
+		for (Component c : reqPanel.getComponents())
+		{
+			if (!(c instanceof JPanel))
+			{
+				continue;
+			}
+			JPanel rowPanel = (JPanel) c;
+			for (Component child : rowPanel.getComponents())
+			{
+				if (child instanceof JLabel)
+				{
+					JLabel label = (JLabel) child;
+					// Skip icon labels (no text) and pick name labels that have text
+					if (label.getText() != null && !label.getText().isEmpty())
+					{
+						result.add(label);
+					}
+				}
+			}
+		}
+		return result;
 	}
 }


### PR DESCRIPTION
## Summary

Adds an "Items needed:" subsection to `StepProgressView` that lists each required item for the current guidance step, coloured by availability:

- **Green** name label: item held in inventory or equipped
- **White** name label + ℹ "in bank" tooltip suffix: present in last bank scan
- **Red** name label: not found anywhere

Hidden when the active step has no `requiredItemIds`.

## Design highlights

- `RequiredItemDisplay` now carries an `itemId` field so the panel can load the item sprite without re-resolving the ID.
- `StepProgressView` no longer takes `PlayerInventoryState` / `PlayerBankState` directly. It receives pre-resolved `List<RequiredItemDisplay>` rows produced on the client thread by `RequiredItemResolver`, then pushed to the EDT (avoids the `ItemManager` client-thread assert seen in #388).
- `CollectionLogHelperPanel.updateStepProgress` signature updated to match the resolved-row shape.
- `GuidanceOverlayCoordinator` defers resolution via `clientThread.invokeLater` in both `activateGuidance` and `onStepChanged` paths, mirroring the existing overlay resolution pattern.

## Files

| File | +/- |
|---|---|
| `ui/widget/StepProgressView.java` | +230/-? |
| `ui/CollectionLogHelperPanel.java` | +11/-? |
| `guidance/GuidanceOverlayCoordinator.java` | +49/-? |
| `guidance/RequiredItemDisplay.java` | +15/-? |
| `guidance/RequiredItemResolver.java` | +2/-? |
| `test/.../StepProgressViewTest.java` | +219/-? |
| `test/.../RequiredItemResolverTest.java` | +12/-? |

Total: **+415 / -123** across 7 files. **+8 new tests.**

## Test plan

- [ ] Activate guidance on a source with `requiredItemIds` on its first step → "Items needed:" section renders with one row per item.
- [ ] Same scenario, with one required item in inventory and one in bank → first row is green, second is white with the ℹ tooltip.
- [ ] Same scenario, with one missing → that row renders red.
- [ ] Activate guidance on a source whose first step has no `requiredItemIds` → no "Items needed:" header is rendered.
- [ ] Move from inventory → drop → re-pickup the required item → state transitions GREEN → RED → GREEN without a panel rebuild.
- [ ] Toggle through a multi-step sequence where the active step's `requiredItemIds` differs between steps → the section refreshes per step.
- [ ] `./gradlew clean test` — all tests pass (519 + 8 new = 527 expected).

Refs cha-ndler/collection-log-helper#382 (B.5.1)