### PR TITLE
data(guidance): backfill requiredItemIds across 20 high-impact sources (B.5.1b)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -585,6 +585,7 @@
         "objectInteractAction": "Open",
         "npcId": 3162,
         "interactAction": "Attack",
+        "requiredItemIds": [9419],
         "completionCondition": "ACTOR_DEATH",
         "completionNpcId": 3162
       }
@@ -4579,6 +4580,7 @@
         "worldX": 1636,
         "worldY": 3673,
         "worldPlane": 0,
+        "requiredItemIds": [19685],
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20
       },
@@ -4652,6 +4654,7 @@
         "worldX": 1233,
         "worldY": 3731,
         "worldPlane": 0,
+        "requiredItemIds": [22875, 952],
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20
       },
@@ -6646,6 +6649,7 @@
         "worldPlane": 0,
         "npcId": 1673,
         "interactAction": "Attack",
+        "requiredItemIds": [952],
         "completionCondition": "VARBIT_AT_LEAST",
         "completionVarbitId": 458,
         "completionVarbitValue": 1
@@ -6657,6 +6661,7 @@
         "worldPlane": 0,
         "npcId": 1672,
         "interactAction": "Attack",
+        "requiredItemIds": [952],
         "completionCondition": "VARBIT_AT_LEAST",
         "completionVarbitId": 457,
         "completionVarbitValue": 1
@@ -6668,6 +6673,7 @@
         "worldPlane": 0,
         "npcId": 1677,
         "interactAction": "Attack",
+        "requiredItemIds": [952],
         "completionCondition": "VARBIT_AT_LEAST",
         "completionVarbitId": 462,
         "completionVarbitValue": 1
@@ -6679,6 +6685,7 @@
         "worldPlane": 0,
         "npcId": 1676,
         "interactAction": "Attack",
+        "requiredItemIds": [952],
         "completionCondition": "VARBIT_AT_LEAST",
         "completionVarbitId": 461,
         "completionVarbitValue": 1
@@ -6690,6 +6697,7 @@
         "worldPlane": 0,
         "npcId": 1675,
         "interactAction": "Attack",
+        "requiredItemIds": [952],
         "completionCondition": "VARBIT_AT_LEAST",
         "completionVarbitId": 460,
         "completionVarbitValue": 1
@@ -6701,6 +6709,7 @@
         "worldPlane": 0,
         "npcId": 1674,
         "interactAction": "Attack",
+        "requiredItemIds": [952],
         "completionCondition": "VARBIT_AT_LEAST",
         "completionVarbitId": 459,
         "completionVarbitValue": 1
@@ -6841,6 +6850,7 @@
         "worldX": 3135,
         "worldY": 2840,
         "worldPlane": 0,
+        "requiredItemIds": [311],
         "completionCondition": "MANUAL"
       },
       {
@@ -6959,6 +6969,7 @@
         "worldPlane": 0,
         "objectId": 29322,
         "objectInteractAction": "Enter",
+        "requiredItemIds": [590, 1351],
         "completionCondition": "MANUAL"
       },
       {
@@ -19443,6 +19454,7 @@
         "worldPlane": 0,
         "npcId": 7690,
         "interactAction": "Talk-to",
+        "requiredItemIds": [6570],
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 15
       },


### PR DESCRIPTION
## Summary

Adds `requiredItemIds` to guidance steps for 7 high-impact sources where items are mechanically required (player literally cannot complete the step without them). Feeds the "Items needed:" subsection introduced in PR #398 (B.5.1).

**Scope:** Only hard-gating items. Food, prayer pots, teleports, and combat gear are excluded (those belong to B.5.2 recommended items).

---

## Sources modified

| Source | Step | Item(s) added | Item ID(s) | Wiki basis |
|--------|------|---------------|------------|------------|
| Kree'arra | Step 4 — enter Armadyl boss room | Mithril grapple (bolt+rope) | 9419 | Armadyl GWD room entry requires grapple-cross; no other entry method |
| Skotizo | Step 1 — use dark totem on Dark Altar | Dark totem | 19685 | Consumed on use; no totem = no Skotizo instance |
| Hespori | Step 1 — plant Hespori seed | Hespori seed, Spade | 22875, 952 | Seed required to grow; spade required to plant |
| Barrows | Steps 2–7 — dig into each mound | Spade | 952 | Digging mechanic requires spade in inventory |
| Tempoross | Step 2 — fish harpoonfish | Harpoon | 311 | Harpoonfish fishing requires harpoon; not provided by minigame |
| Wintertodt | Step 2 — chop and feed braziers | Tinderbox, Axe (any) | 590, 1351 | Tinderbox to light brazier; axe to chop bruma roots — both mechanically blocked without item |
| The Inferno | Step 1 — sacrifice fire cape to enter | Fire cape | 6570 | TzHaar-Ket-Keh consumes fire cape; no cape = no entry |

**Sources with no required items (correctly excluded):**
Vorkath, Cerberus, Zulrah, Alchemical Hydra, Phantom Muspah, Demonic gorillas, Chambers of Xeric, Theatre of Blood, Tombs of Amascut, General Graardor, Commander Zilyana, K'ril Tsutsaroth, Sarachnis, Callisto, Gauntlet / Corrupted Gauntlet, Zalcano — none have item-gated entry or kill steps under the conservative B.5.1b definition.

---

## Verification

- **Em-dash mojibake check:** `grep â drop_rates.json` — 0 matches. File encodes clean UTF-8.
- **Schema unchanged:** No Java files modified.
- **Field order:** `requiredItemIds` placed before `completionCondition` in all new entries, consistent with `GuidanceStep.java` field declaration order.
- **Build/test:** `./gradlew test` — BUILD SUCCESSFUL

## Test plan

- [ ] `./gradlew test` passes (DropRateDatabaseTest, schema validation)
- [ ] Dev client spot-check: Barrows guidance panel shows spade in "Items needed:" on dig steps
- [ ] Dev client spot-check: The Inferno guidance panel shows fire cape in "Items needed:" on entry step
- [ ] Dev client spot-check: Skotizo guidance panel shows dark totem in "Items needed:" on step 1

Refs cha-ndler/collection-log-helper#382 (B.5.1b)