### PR TITLE
feat(panel): general requirements (quest/skill/diary) in guidance header (B.5.3)

### DIFF
--- a/src/main/java/com/collectionloghelper/data/RequirementRow.java
+++ b/src/main/java/com/collectionloghelper/data/RequirementRow.java
@@ -24,18 +24,43 @@
  */
 package com.collectionloghelper.data;
 
-import java.util.List;
+import java.awt.Color;
 import lombok.Value;
 
+/**
+ * A single display row in the guidance-header requirements section.
+ *
+ * <p>Rows are produced by {@link RequirementsChecker#buildRequirementRows} on the
+ * client thread and consumed on the EDT by {@link com.collectionloghelper.ui.widget.RequirementsView}.
+ */
 @Value
-public class SourceRequirements
+public class RequirementRow
 {
-	List<String> quests;
-	List<SkillRequirement> skills;
-	/**
-	 * Achievement diary requirements, e.g. {@code "LUMBRIDGE_HARD"}, {@code "KANDARIN_ELITE"}.
-	 * Format: {@code <AREA>_<TIER>} where TIER is EASY, MEDIUM, HARD, or ELITE.
-	 * May be {@code null} when the source has no diary prerequisites.
-	 */
-	List<String> diaries;
+	/** The category this row belongs to. */
+	Category category;
+
+	/** Human-readable requirement label, e.g. "Dragon Slayer II" or "Agility 70". */
+	String label;
+
+	/** Human-readable state text, e.g. "COMPLETED", "level 65/70", "NOT STARTED". */
+	String stateText;
+
+	/** Display colour reflecting whether the requirement is met. */
+	Color color;
+
+	/** Whether the player currently satisfies this requirement. */
+	boolean met;
+
+	/** Requirement category — used to group rows under sub-headers in the view. */
+	public enum Category
+	{
+		QUEST,
+		SKILL,
+		DIARY
+	}
+
+	// Pre-defined colours
+	public static final Color COLOR_MET = new Color(80, 200, 80);
+	public static final Color COLOR_IN_PROGRESS = new Color(255, 200, 0);
+	public static final Color COLOR_UNMET = new Color(220, 60, 60);
 }

--- a/src/main/java/com/collectionloghelper/data/RequirementsChecker.java
+++ b/src/main/java/com/collectionloghelper/data/RequirementsChecker.java
@@ -24,6 +24,8 @@
  */
 package com.collectionloghelper.data;
 
+import java.awt.Color;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -36,6 +38,7 @@ import net.runelite.api.Client;
 import net.runelite.api.Quest;
 import net.runelite.api.QuestState;
 import net.runelite.api.Skill;
+import net.runelite.api.Varbits;
 
 @Slf4j
 @Singleton
@@ -146,6 +149,138 @@ public class RequirementsChecker
 			return true;
 		}
 		return checkRequirementsDetail(requirements).isEmpty();
+	}
+
+	/**
+	 * Build a display-ready list of {@link RequirementRow}s for the given source.
+	 * Must be called on the client thread (reads live client state).
+	 * Returns an empty list when the source has no requirements.
+	 */
+	public List<RequirementRow> buildRequirementRows(CollectionLogSource source)
+	{
+		if (source == null)
+		{
+			return Collections.emptyList();
+		}
+		SourceRequirements requirements = source.getRequirements();
+		if (requirements == null)
+		{
+			return Collections.emptyList();
+		}
+
+		List<RequirementRow> rows = new ArrayList<>();
+
+		// --- Quest rows ---
+		if (requirements.getQuests() != null)
+		{
+			for (String questName : requirements.getQuests())
+			{
+				try
+				{
+					Quest quest = Quest.valueOf(questName);
+					QuestState state = quest.getState(client);
+					String label = formatEnumName(questName);
+					String stateText;
+					Color color;
+					boolean met;
+					switch (state)
+					{
+						case FINISHED:
+							stateText = "COMPLETED";
+							color = RequirementRow.COLOR_MET;
+							met = true;
+							break;
+						case IN_PROGRESS:
+							stateText = "IN PROGRESS";
+							color = RequirementRow.COLOR_IN_PROGRESS;
+							met = false;
+							break;
+						default:
+							stateText = "NOT STARTED";
+							color = RequirementRow.COLOR_UNMET;
+							met = false;
+							break;
+					}
+					rows.add(new RequirementRow(RequirementRow.Category.QUEST, label, stateText, color, met));
+				}
+				catch (IllegalArgumentException e)
+				{
+					log.warn("Unknown quest enum for requirement row: {}", questName);
+				}
+			}
+		}
+
+		// --- Skill rows ---
+		if (requirements.getSkills() != null)
+		{
+			for (SkillRequirement skillReq : requirements.getSkills())
+			{
+				try
+				{
+					Skill skill = Skill.valueOf(skillReq.getSkill());
+					int playerLevel = client.getRealSkillLevel(skill);
+					int required = skillReq.getLevel();
+					String label = formatEnumName(skillReq.getSkill()) + " " + required;
+					String stateText = "level " + playerLevel + "/" + required;
+					boolean met = playerLevel >= required;
+					Color color = met ? RequirementRow.COLOR_MET : RequirementRow.COLOR_UNMET;
+					rows.add(new RequirementRow(RequirementRow.Category.SKILL, label, stateText, color, met));
+				}
+				catch (IllegalArgumentException e)
+				{
+					log.warn("Unknown skill enum for requirement row: {}", skillReq.getSkill());
+				}
+			}
+		}
+
+		// --- Diary rows ---
+		if (requirements.getDiaries() != null)
+		{
+			for (String diaryName : requirements.getDiaries())
+			{
+				int varbitId = resolveDiaryVarbit(diaryName);
+				String label = formatEnumName(diaryName);
+				boolean met;
+				if (varbitId < 0)
+				{
+					// Unrecognised diary — treat as unmet and warn
+					log.warn("Unknown diary requirement: {}", diaryName);
+					met = false;
+				}
+				else
+				{
+					met = client.getVarbitValue(varbitId) == 1;
+				}
+				String stateText = met ? "COMPLETED" : "NOT COMPLETED";
+				Color color = met ? RequirementRow.COLOR_MET : RequirementRow.COLOR_UNMET;
+				rows.add(new RequirementRow(RequirementRow.Category.DIARY, label, stateText, color, met));
+			}
+		}
+
+		return Collections.unmodifiableList(rows);
+	}
+
+	/**
+	 * Resolves a diary requirement string such as {@code "LUMBRIDGE_HARD"} to the
+	 * matching {@link Varbits} constant using reflection on the {@code DIARY_<name>}
+	 * field naming convention. Returns {@code -1} if the constant is not found.
+	 */
+	static int resolveDiaryVarbit(String diaryName)
+	{
+		if (diaryName == null || diaryName.isEmpty())
+		{
+			return -1;
+		}
+		String fieldName = "DIARY_" + diaryName.toUpperCase();
+		try
+		{
+			Field f = Varbits.class.getField(fieldName);
+			return f.getInt(null);
+		}
+		catch (NoSuchFieldException | IllegalAccessException e)
+		{
+			return -1;
+		}
 	}
 
 	private List<String> checkRequirements(CollectionLogSource source)

--- a/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
@@ -35,6 +35,7 @@ import com.collectionloghelper.data.ItemObjectTier;
 import com.collectionloghelper.data.PlayerCollectionState;
 import com.collectionloghelper.data.PlayerInventoryState;
 import com.collectionloghelper.data.PlayerTravelCapabilities;
+import com.collectionloghelper.data.RequirementRow;
 import com.collectionloghelper.data.RequirementsChecker;
 import com.collectionloghelper.overlay.CollectionLogWorldMapPoint;
 import com.collectionloghelper.overlay.DialogHighlightOverlay;
@@ -219,6 +220,9 @@ public class GuidanceOverlayCoordinator
 				"[Collection Log Helper] Warning: " + source.getName() + " requires " + unmetList, "");
 		}
 
+		// Build requirement rows on the client thread (snapshot); passed to the panel header.
+		final List<RequirementRow> requirementRows = requirementsChecker.buildRequirementRows(source);
+
 		// Clear any existing guidance first, including InfoBox and sequencer
 		deactivateGuidance();
 
@@ -252,7 +256,7 @@ public class GuidanceOverlayCoordinator
 				final String stepDesc = step != null ? step.getDescription() : "";
 				final boolean stepManual =
 					step != null && step.getCompletionCondition() == CompletionCondition.MANUAL;
-				panel.setGuidanceState(true, source);
+				panel.setGuidanceState(true, source, requirementRows);
 				// Show step text immediately without items; resolve names on the client
 				// thread (~1 tick) to avoid the EDT assert in ItemManager#getItemComposition
 				// (see cha-ndler/collection-log-helper#388).
@@ -315,7 +319,7 @@ public class GuidanceOverlayCoordinator
 		// Always update panel guidance state from the plugin
 		if (panel != null)
 		{
-			panel.setGuidanceState(true, source);
+			panel.setGuidanceState(true, source, requirementRows);
 			panel.hideStepProgress();
 		}
 
@@ -362,7 +366,7 @@ public class GuidanceOverlayCoordinator
 		{
 			panel.hideClueGuidance();
 			panel.hideStepProgress();
-			panel.setGuidanceState(false, null);
+			panel.setGuidanceState(false, null, null);
 		}
 
 		log.debug("Guidance deactivated");

--- a/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
@@ -35,6 +35,7 @@ import com.collectionloghelper.data.DropRateDatabase;
 import com.collectionloghelper.data.PlayerBankState;
 import com.collectionloghelper.data.PlayerCollectionState;
 import com.collectionloghelper.data.PlayerInventoryState;
+import com.collectionloghelper.data.RequirementRow;
 import com.collectionloghelper.data.RequirementsChecker;
 import com.collectionloghelper.guidance.RequiredItemDisplay;
 import com.collectionloghelper.data.SlayerTaskState;
@@ -596,13 +597,14 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 		return quickGuidePanelView.create(topItem, guidanceActive, guidedSource);
 	}
 
-	public void setGuidanceState(boolean active, CollectionLogSource source)
+	public void setGuidanceState(boolean active, CollectionLogSource source,
+		List<RequirementRow> requirementRows)
 	{
 		guidanceActive = active;
 		guidedSource = source;
 		if (active && source != null)
 		{
-			guidanceBannerView.showGuidance(source);
+			guidanceBannerView.showGuidance(source, requirementRows);
 		}
 		else
 		{

--- a/src/main/java/com/collectionloghelper/ui/widget/GuidanceBannerView.java
+++ b/src/main/java/com/collectionloghelper/ui/widget/GuidanceBannerView.java
@@ -25,10 +25,12 @@
 package com.collectionloghelper.ui.widget;
 
 import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.data.RequirementRow;
 import com.collectionloghelper.data.RequirementsChecker;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
+import java.util.Collections;
 import java.util.List;
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
@@ -57,6 +59,9 @@ public class GuidanceBannerView extends JPanel
 	private final JPanel guidanceBannerPanel;
 	private final JLabel guidanceBannerLabel;
 	private final JLabel requirementsWarningLabel;
+
+	// Per-source requirements section (quest / skill / diary rows)
+	private final RequirementsView requirementsView;
 
 	// Clue-guidance banner (purple/blue)
 	private final JPanel clueGuidanceBanner;
@@ -96,6 +101,12 @@ public class GuidanceBannerView extends JPanel
 
 		add(guidanceBannerPanel);
 
+		// Per-source requirements section (hidden by default; shown when source has requirements)
+		requirementsView = new RequirementsView();
+		requirementsView.setAlignmentX(CENTER_ALIGNMENT);
+		requirementsView.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
+		add(requirementsView);
+
 		// Clue guidance banner (hidden by default)
 		clueGuidanceBanner = new JPanel(new BorderLayout());
 		clueGuidanceBanner.setBackground(new Color(40, 40, 60));
@@ -112,11 +123,18 @@ public class GuidanceBannerView extends JPanel
 	}
 
 	/**
-	 * Shows the guidance headline for the given source.
-	 * Handles {@code null} source by hiding the banner.
+	 * Shows the guidance headline for the given source and, below it, the
+	 * per-source requirements section.
+	 *
+	 * <p>Handles {@code null} source by hiding the banner.
 	 * Safe to call from any thread.
+	 *
+	 * @param source  the source being guided (may be {@code null})
+	 * @param requirementRows pre-built requirement rows produced by
+	 *                        {@link com.collectionloghelper.data.RequirementsChecker#buildRequirementRows}
+	 *                        on the client thread; may be {@code null} or empty
 	 */
-	public void showGuidance(CollectionLogSource source)
+	public void showGuidance(CollectionLogSource source, List<RequirementRow> requirementRows)
 	{
 		if (source == null)
 		{
@@ -126,6 +144,8 @@ public class GuidanceBannerView extends JPanel
 		// Snapshot before dispatch
 		final String sourceName = source.getName();
 		final List<String> unmet = requirementsChecker.getUnmetRequirements(sourceName);
+		final List<RequirementRow> rows =
+			requirementRows != null ? requirementRows : Collections.emptyList();
 
 		SwingUtilities.invokeLater(() ->
 		{
@@ -148,10 +168,14 @@ public class GuidanceBannerView extends JPanel
 				guidanceBannerPanel.getParent().revalidate();
 			}
 		});
+
+		// Delegate to RequirementsView \u2014 hides itself when rows is empty
+		requirementsView.showRequirements(rows);
 	}
 
 	/**
-	 * Hides the active-guidance headline. Safe to call from any thread.
+	 * Hides the active-guidance headline and requirements section.
+	 * Safe to call from any thread.
 	 */
 	public void hideGuidance()
 	{
@@ -165,6 +189,7 @@ public class GuidanceBannerView extends JPanel
 				guidanceBannerPanel.getParent().revalidate();
 			}
 		});
+		requirementsView.hideRequirements();
 	}
 
 	/**

--- a/src/main/java/com/collectionloghelper/ui/widget/RequirementsView.java
+++ b/src/main/java/com/collectionloghelper/ui/widget/RequirementsView.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.ui.widget;
+
+import com.collectionloghelper.data.RequirementRow;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.util.Collections;
+import java.util.List;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+import net.runelite.client.ui.FontManager;
+
+/**
+ * Displays per-source quest, skill, and diary requirements in the guidance panel
+ * header area — below the "Guiding: &lt;source&gt;" headline and above the step strip.
+ *
+ * <p>Each requirement is one text row coloured by met/unmet state:
+ * <ul>
+ *   <li><b>Quest</b> — GREEN (COMPLETED), YELLOW (IN PROGRESS), RED (NOT STARTED)</li>
+ *   <li><b>Skill</b> — GREEN (level met), RED (level not met)</li>
+ *   <li><b>Diary</b> — GREEN (COMPLETED), RED (NOT COMPLETED)</li>
+ * </ul>
+ *
+ * <p>The entire panel is hidden when the source has no requirements (no empty header).
+ *
+ * <p><b>Note:</b> The public hide method is named {@code hideRequirements} (not {@code hide})
+ * to avoid shadowing the deprecated {@link java.awt.Component#hide()} — see issue #353.
+ */
+public class RequirementsView extends JPanel
+{
+	private static final Color BACKGROUND = new Color(20, 30, 20);
+	private static final Color BORDER_COLOR = new Color(60, 120, 60);
+	private static final Color HEADER_COLOR = new Color(160, 160, 160);
+
+	RequirementsView()
+	{
+		setOpaque(true);
+		setBackground(BACKGROUND);
+		setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+		setBorder(BorderFactory.createCompoundBorder(
+			BorderFactory.createLineBorder(BORDER_COLOR, 1),
+			BorderFactory.createEmptyBorder(3, 6, 3, 6)
+		));
+		setAlignmentX(LEFT_ALIGNMENT);
+		setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
+		setVisible(false);
+	}
+
+	/**
+	 * Populates and shows the requirements section from pre-built display rows.
+	 * Safe to call from any thread.
+	 *
+	 * @param rows display rows produced by
+	 *             {@link com.collectionloghelper.data.RequirementsChecker#buildRequirementRows}
+	 *             on the client thread; may be {@code null} or empty (section will hide)
+	 */
+	public void showRequirements(List<RequirementRow> rows)
+	{
+		final List<RequirementRow> safeRows = (rows != null) ? rows : Collections.emptyList();
+		SwingUtilities.invokeLater(() -> updateRows(safeRows));
+	}
+
+	/**
+	 * Hides the requirements section and clears all rows.
+	 * Safe to call from any thread.
+	 *
+	 * <p>Intentionally named {@code hideRequirements} (not {@code hide}) — see class
+	 * Javadoc and issue #353 for why overriding {@link java.awt.Component#hide()}
+	 * would break {@link #setVisible}.
+	 */
+	public void hideRequirements()
+	{
+		SwingUtilities.invokeLater(() ->
+		{
+			removeAll();
+			setVisible(false);
+			revalidate();
+			if (getParent() != null)
+			{
+				getParent().revalidate();
+			}
+		});
+	}
+
+	/**
+	 * Rebuilds requirement rows and toggles visibility. Must be called on the EDT.
+	 */
+	void updateRows(List<RequirementRow> rows)
+	{
+		removeAll();
+
+		if (rows.isEmpty())
+		{
+			setVisible(false);
+			revalidate();
+			if (getParent() != null)
+			{
+				getParent().revalidate();
+			}
+			return;
+		}
+
+		JLabel header = new JLabel("Requirements:");
+		header.setFont(FontManager.getRunescapeSmallFont().deriveFont(Font.BOLD));
+		header.setForeground(HEADER_COLOR);
+		header.setAlignmentX(LEFT_ALIGNMENT);
+		add(header);
+		add(Box.createVerticalStrut(2));
+
+		RequirementRow.Category lastCategory = null;
+		for (RequirementRow row : rows)
+		{
+			// Insert a small gap between category groups
+			if (lastCategory != null && lastCategory != row.getCategory())
+			{
+				add(Box.createVerticalStrut(1));
+			}
+			lastCategory = row.getCategory();
+
+			JLabel rowLabel = buildRowLabel(row);
+			rowLabel.setAlignmentX(LEFT_ALIGNMENT);
+			add(rowLabel);
+		}
+
+		setVisible(true);
+		revalidate();
+		repaint();
+		if (getParent() != null)
+		{
+			getParent().revalidate();
+		}
+	}
+
+	/**
+	 * Builds a single-line label: "{label} — {stateText}", coloured by the row's state.
+	 */
+	private JLabel buildRowLabel(RequirementRow row)
+	{
+		String text = row.getLabel() + " — " + row.getStateText();
+		JLabel label = new JLabel(text);
+		label.setFont(FontManager.getRunescapeSmallFont());
+		label.setForeground(row.getColor());
+		label.setToolTipText(text);
+		return label;
+	}
+}

--- a/src/test/java/com/collectionloghelper/data/CollectionLogSourceTest.java
+++ b/src/test/java/com/collectionloghelper/data/CollectionLogSourceTest.java
@@ -120,7 +120,7 @@ public class CollectionLogSourceTest
 	@Test
 	public void getWorldPointWithChecker_firstAccessible()
 	{
-		SourceRequirements reqs = new SourceRequirements(Collections.singletonList("DRAGON_SLAYER_II"), null);
+		SourceRequirements reqs = new SourceRequirements(Collections.singletonList("DRAGON_SLAYER_II"), null, null);
 		Waypoint wp1 = new Waypoint("Shortcut", 2500, 2600, 0, reqs);
 		Waypoint wp2 = new Waypoint("Walk", 3500, 3600, 0, null);
 
@@ -134,7 +134,7 @@ public class CollectionLogSourceTest
 	@Test
 	public void getWorldPointWithChecker_firstLocked_fallsToSecond()
 	{
-		SourceRequirements reqs = new SourceRequirements(Collections.singletonList("DRAGON_SLAYER_II"), null);
+		SourceRequirements reqs = new SourceRequirements(Collections.singletonList("DRAGON_SLAYER_II"), null, null);
 		Waypoint wp1 = new Waypoint("Shortcut", 2500, 2600, 0, reqs);
 		Waypoint wp2 = new Waypoint("Walk", 3500, 3600, 0, null);
 
@@ -148,8 +148,8 @@ public class CollectionLogSourceTest
 	@Test
 	public void getWorldPointWithChecker_allLocked_fallsToLast()
 	{
-		SourceRequirements reqs1 = new SourceRequirements(Collections.singletonList("QUEST_A"), null);
-		SourceRequirements reqs2 = new SourceRequirements(Collections.singletonList("QUEST_B"), null);
+		SourceRequirements reqs1 = new SourceRequirements(Collections.singletonList("QUEST_A"), null, null);
+		SourceRequirements reqs2 = new SourceRequirements(Collections.singletonList("QUEST_B"), null, null);
 		Waypoint wp1 = new Waypoint("Best", 1000, 1000, 0, reqs1);
 		Waypoint wp2 = new Waypoint("Alt", 2000, 2000, 0, reqs2);
 
@@ -224,7 +224,7 @@ public class CollectionLogSourceTest
 	@Test
 	public void getDisplayLocationWithChecker_allLockedFallsToLastName()
 	{
-		SourceRequirements reqs = new SourceRequirements(Collections.singletonList("QUEST_A"), null);
+		SourceRequirements reqs = new SourceRequirements(Collections.singletonList("QUEST_A"), null, null);
 		Waypoint wp1 = new Waypoint("First", 1000, 1000, 0, reqs);
 		Waypoint wp2 = new Waypoint("Last", 2000, 2000, 0, reqs);
 

--- a/src/test/java/com/collectionloghelper/data/RequirementsCheckerTest.java
+++ b/src/test/java/com/collectionloghelper/data/RequirementsCheckerTest.java
@@ -24,6 +24,7 @@
  */
 package com.collectionloghelper.data;
 
+import net.runelite.api.Varbits;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -95,5 +96,60 @@ public class RequirementsCheckerTest
 	public void formatEnumName_romanNumeralVII()
 	{
 		assertEquals("Part VII", RequirementsChecker.formatEnumName("PART_VII"));
+	}
+
+	// =========================================================================
+	// resolveDiaryVarbit — static resolver for DIARY_<AREA>_<TIER> Varbits constants
+	// =========================================================================
+
+	@Test
+	public void resolveDiaryVarbit_knownDiary_returnsPositiveVarbit()
+	{
+		int varbit = RequirementsChecker.resolveDiaryVarbit("ARDOUGNE_ELITE");
+		assertTrue("Known diary must resolve to a positive varbit ID", varbit > 0);
+		assertEquals(Varbits.DIARY_ARDOUGNE_ELITE, varbit);
+	}
+
+	@Test
+	public void resolveDiaryVarbit_lumbridgeHard_returnsExpected()
+	{
+		int varbit = RequirementsChecker.resolveDiaryVarbit("LUMBRIDGE_HARD");
+		assertEquals(Varbits.DIARY_LUMBRIDGE_HARD, varbit);
+	}
+
+	@Test
+	public void resolveDiaryVarbit_kandarin_medium_returnsExpected()
+	{
+		int varbit = RequirementsChecker.resolveDiaryVarbit("KANDARIN_MEDIUM");
+		assertEquals(Varbits.DIARY_KANDARIN_MEDIUM, varbit);
+	}
+
+	@Test
+	public void resolveDiaryVarbit_unknownDiary_returnsMinusOne()
+	{
+		int varbit = RequirementsChecker.resolveDiaryVarbit("NONEXISTENT_AREA_ELITE");
+		assertEquals("Unknown diary must return -1", -1, varbit);
+	}
+
+	@Test
+	public void resolveDiaryVarbit_nullInput_returnsMinusOne()
+	{
+		int varbit = RequirementsChecker.resolveDiaryVarbit(null);
+		assertEquals("Null diary must return -1", -1, varbit);
+	}
+
+	@Test
+	public void resolveDiaryVarbit_emptyInput_returnsMinusOne()
+	{
+		int varbit = RequirementsChecker.resolveDiaryVarbit("");
+		assertEquals("Empty diary must return -1", -1, varbit);
+	}
+
+	@Test
+	public void resolveDiaryVarbit_lowercaseInput_resolvedCorrectly()
+	{
+		// resolveDiaryVarbit normalises to uppercase internally
+		int varbit = RequirementsChecker.resolveDiaryVarbit("ardougne_easy");
+		assertEquals(Varbits.DIARY_ARDOUGNE_EASY, varbit);
 	}
 }

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
@@ -1183,12 +1183,12 @@ public class GuidanceSequencerTest
 
 	private SourceRequirements makeQuestRequirement(String questName)
 	{
-		return new SourceRequirements(Arrays.asList(questName), null);
+		return new SourceRequirements(Arrays.asList(questName), null, null);
 	}
 
 	private SourceRequirements makeSkillRequirement(String skill, int level)
 	{
-		return new SourceRequirements(null, Arrays.asList(new SkillRequirement(skill, level)));
+		return new SourceRequirements(null, Arrays.asList(new SkillRequirement(skill, level)), null);
 	}
 
 	private GuidanceStep makeStepWithAlternatives(String description, int worldX, int worldY,

--- a/src/test/java/com/collectionloghelper/ui/widget/GuidanceBannerViewTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/GuidanceBannerViewTest.java
@@ -26,9 +26,11 @@ package com.collectionloghelper.ui.widget;
 
 import com.collectionloghelper.data.CollectionLogCategory;
 import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.data.RequirementRow;
 import com.collectionloghelper.data.RequirementsChecker;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -71,7 +73,7 @@ public class GuidanceBannerViewTest
 		CollectionLogSource source = makeSource("Zulrah");
 		Mockito.when(requirementsChecker.getUnmetRequirements("Zulrah"))
 			.thenReturn(Collections.emptyList());
-		view.showGuidance(source);
+		view.showGuidance(source, Collections.emptyList());
 	}
 
 	@Test
@@ -80,7 +82,7 @@ public class GuidanceBannerViewTest
 		CollectionLogSource source = makeSource("Vorkath");
 		Mockito.when(requirementsChecker.getUnmetRequirements("Vorkath"))
 			.thenReturn(Arrays.asList("Dragon Slayer II"));
-		view.showGuidance(source);
+		view.showGuidance(source, Collections.emptyList());
 	}
 
 	@Test
@@ -93,7 +95,7 @@ public class GuidanceBannerViewTest
 	public void showGuidance_nullSource_doesNotThrow()
 	{
 		// snapshot-then-null-check: null source hides the banner
-		view.showGuidance(null);
+		view.showGuidance(null, null);
 	}
 
 	@Test
@@ -107,5 +109,134 @@ public class GuidanceBannerViewTest
 	public void hideClueGuidance_doesNotThrow()
 	{
 		view.hideClueGuidance();
+	}
+
+	// =========================================================================
+	// B.5.3 — requirements section (quest / skill / diary rows)
+	// =========================================================================
+
+	/** Helper: a RequirementRow coloured green (met). */
+	private static RequirementRow metQuestRow(String label)
+	{
+		return new RequirementRow(RequirementRow.Category.QUEST, label,
+			"COMPLETED", RequirementRow.COLOR_MET, true);
+	}
+
+	/** Helper: a RequirementRow coloured red (unmet). */
+	private static RequirementRow unmetQuestRow(String label)
+	{
+		return new RequirementRow(RequirementRow.Category.QUEST, label,
+			"NOT STARTED", RequirementRow.COLOR_UNMET, false);
+	}
+
+	/** Helper: a met skill row. */
+	private static RequirementRow metSkillRow(String label)
+	{
+		return new RequirementRow(RequirementRow.Category.SKILL, label,
+			"level 75/70", RequirementRow.COLOR_MET, true);
+	}
+
+	/** Helper: an unmet skill row. */
+	private static RequirementRow unmetSkillRow(String label)
+	{
+		return new RequirementRow(RequirementRow.Category.SKILL, label,
+			"level 60/70", RequirementRow.COLOR_UNMET, false);
+	}
+
+	@Test
+	public void showGuidance_allRequirementsMet_doesNotThrow()
+	{
+		CollectionLogSource source = makeSource("Vorkath");
+		Mockito.when(requirementsChecker.getUnmetRequirements("Vorkath"))
+			.thenReturn(Collections.emptyList());
+
+		List<RequirementRow> rows = Arrays.asList(
+			metQuestRow("Dragon Slayer II"),
+			metSkillRow("Agility 70")
+		);
+
+		// All green — should not throw and should show the banner
+		view.showGuidance(source, rows);
+	}
+
+	@Test
+	public void showGuidance_oneUnmetRequirement_doesNotThrow()
+	{
+		CollectionLogSource source = makeSource("Vorkath");
+		Mockito.when(requirementsChecker.getUnmetRequirements("Vorkath"))
+			.thenReturn(Arrays.asList("Dragon Slayer II"));
+
+		List<RequirementRow> rows = Arrays.asList(
+			unmetQuestRow("Dragon Slayer II"),
+			metSkillRow("Agility 70")
+		);
+
+		// Mixed — should not throw
+		view.showGuidance(source, rows);
+	}
+
+	@Test
+	public void showGuidance_noRequirements_emptyRowList_doesNotThrow()
+	{
+		CollectionLogSource source = makeSource("Giant Mole");
+		Mockito.when(requirementsChecker.getUnmetRequirements("Giant Mole"))
+			.thenReturn(Collections.emptyList());
+
+		// Empty list → requirements section should be hidden (no-throw contract)
+		view.showGuidance(source, Collections.emptyList());
+	}
+
+	@Test
+	public void showGuidance_nullRowList_doesNotThrow()
+	{
+		CollectionLogSource source = makeSource("Giant Mole");
+		Mockito.when(requirementsChecker.getUnmetRequirements("Giant Mole"))
+			.thenReturn(Collections.emptyList());
+
+		// null rows treated as empty
+		view.showGuidance(source, null);
+	}
+
+	@Test
+	public void stateTransition_unmetBecomingMet_doesNotThrow()
+	{
+		CollectionLogSource source = makeSource("Vorkath");
+		Mockito.when(requirementsChecker.getUnmetRequirements("Vorkath"))
+			.thenReturn(Collections.emptyList());
+
+		// First call: skill not yet met
+		List<RequirementRow> firstRows = Collections.singletonList(unmetSkillRow("Agility 70"));
+		view.showGuidance(source, firstRows);
+
+		// Second call: skill is now met (simulates level-up between refreshes)
+		List<RequirementRow> secondRows = Collections.singletonList(metSkillRow("Agility 70"));
+		view.showGuidance(source, secondRows);
+	}
+
+	@Test
+	public void hideGuidance_clearsRequirementsSection_doesNotThrow()
+	{
+		CollectionLogSource source = makeSource("Vorkath");
+		Mockito.when(requirementsChecker.getUnmetRequirements("Vorkath"))
+			.thenReturn(Collections.emptyList());
+
+		view.showGuidance(source, Collections.singletonList(metQuestRow("Dragon Slayer II")));
+		// Deactivating guidance should clear the requirements section
+		view.hideGuidance();
+	}
+
+	@Test
+	public void showGuidance_diaryRequirement_doesNotThrow()
+	{
+		CollectionLogSource source = makeSource("Lumbridge Source");
+		Mockito.when(requirementsChecker.getUnmetRequirements("Lumbridge Source"))
+			.thenReturn(Collections.emptyList());
+
+		List<RequirementRow> rows = Collections.singletonList(
+			new RequirementRow(RequirementRow.Category.DIARY, "Lumbridge Elite",
+				"COMPLETED", RequirementRow.COLOR_MET, true)
+		);
+
+		view.showGuidance(source, rows);
 	}
 }

--- a/src/test/java/com/collectionloghelper/ui/widget/RequirementsViewTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/RequirementsViewTest.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.ui.widget;
+
+import com.collectionloghelper.data.RequirementRow;
+import java.awt.Component;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import javax.swing.JLabel;
+import javax.swing.SwingUtilities;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link RequirementsView} (B.5.3 requirements section).
+ *
+ * <p>Covers:
+ * <ul>
+ *   <li>Construction — view starts hidden</li>
+ *   <li>All-met: section is visible, all labels green</li>
+ *   <li>One-unmet: section is visible, unmet label red, met label green</li>
+ *   <li>No requirements: section is hidden (no empty header)</li>
+ *   <li>State transition: label colour updates when rows change between calls</li>
+ *   <li>hideRequirements: section hidden and rows cleared</li>
+ *   <li>Diary row: correct label text rendered</li>
+ * </ul>
+ */
+public class RequirementsViewTest
+{
+	private RequirementsView view;
+
+	// Helpers
+	private static RequirementRow metQuestRow(String label)
+	{
+		return new RequirementRow(RequirementRow.Category.QUEST, label,
+			"COMPLETED", RequirementRow.COLOR_MET, true);
+	}
+
+	private static RequirementRow inProgressQuestRow(String label)
+	{
+		return new RequirementRow(RequirementRow.Category.QUEST, label,
+			"IN PROGRESS", RequirementRow.COLOR_IN_PROGRESS, false);
+	}
+
+	private static RequirementRow unmetQuestRow(String label)
+	{
+		return new RequirementRow(RequirementRow.Category.QUEST, label,
+			"NOT STARTED", RequirementRow.COLOR_UNMET, false);
+	}
+
+	private static RequirementRow metSkillRow(String label, String state)
+	{
+		return new RequirementRow(RequirementRow.Category.SKILL, label,
+			state, RequirementRow.COLOR_MET, true);
+	}
+
+	private static RequirementRow unmetSkillRow(String label, String state)
+	{
+		return new RequirementRow(RequirementRow.Category.SKILL, label,
+			state, RequirementRow.COLOR_UNMET, false);
+	}
+
+	@Before
+	public void setUp()
+	{
+		view = new RequirementsView();
+	}
+
+	@Test
+	public void constructsWithoutThrowing()
+	{
+		assertNotNull(view);
+	}
+
+	@Test
+	public void initiallyHidden()
+	{
+		assertFalse("RequirementsView should start hidden", view.isVisible());
+	}
+
+	@Test
+	public void updateRows_emptyList_hidden()
+	{
+		view.updateRows(Collections.emptyList());
+		assertFalse("Empty rows: view must remain hidden", view.isVisible());
+	}
+
+	@Test
+	public void updateRows_allMet_sectionVisible()
+	{
+		List<RequirementRow> rows = Arrays.asList(
+			metQuestRow("Dragon Slayer II"),
+			metSkillRow("Agility 70", "level 75/70")
+		);
+		view.updateRows(rows);
+		assertTrue("All-met rows: view must be visible", view.isVisible());
+	}
+
+	@Test
+	public void updateRows_allMet_labelsGreen()
+	{
+		List<RequirementRow> rows = Collections.singletonList(
+			metQuestRow("Dragon Slayer II")
+		);
+		view.updateRows(rows);
+
+		JLabel rowLabel = findFirstRowLabel(view);
+		assertNotNull("Expected at least one row label", rowLabel);
+		assertEquals("Met row must be green",
+			RequirementRow.COLOR_MET, rowLabel.getForeground());
+	}
+
+	@Test
+	public void updateRows_oneUnmet_sectionVisible()
+	{
+		List<RequirementRow> rows = Arrays.asList(
+			metQuestRow("Dragon Slayer II"),
+			unmetSkillRow("Agility 70", "level 60/70")
+		);
+		view.updateRows(rows);
+		assertTrue("Mixed rows: view must be visible", view.isVisible());
+	}
+
+	@Test
+	public void updateRows_oneUnmet_unmetLabelRed()
+	{
+		List<RequirementRow> rows = Collections.singletonList(
+			unmetQuestRow("Dragon Slayer II")
+		);
+		view.updateRows(rows);
+
+		JLabel rowLabel = findFirstRowLabel(view);
+		assertNotNull("Expected at least one row label", rowLabel);
+		assertEquals("Unmet row must be red",
+			RequirementRow.COLOR_UNMET, rowLabel.getForeground());
+	}
+
+	@Test
+	public void updateRows_inProgressQuest_yellow()
+	{
+		List<RequirementRow> rows = Collections.singletonList(
+			inProgressQuestRow("Dragon Slayer II")
+		);
+		view.updateRows(rows);
+
+		JLabel rowLabel = findFirstRowLabel(view);
+		assertNotNull(rowLabel);
+		assertEquals("In-progress quest must be yellow",
+			RequirementRow.COLOR_IN_PROGRESS, rowLabel.getForeground());
+	}
+
+	@Test
+	public void stateTransition_unmetBecomingMet_colourUpdates()
+	{
+		// First call: skill unmet
+		view.updateRows(Collections.singletonList(
+			unmetSkillRow("Agility 70", "level 60/70")
+		));
+		JLabel firstLabel = findFirstRowLabel(view);
+		assertNotNull(firstLabel);
+		assertEquals(RequirementRow.COLOR_UNMET, firstLabel.getForeground());
+
+		// Second call: skill now met (simulates a level-up between refreshes)
+		view.updateRows(Collections.singletonList(
+			metSkillRow("Agility 70", "level 75/70")
+		));
+		JLabel secondLabel = findFirstRowLabel(view);
+		assertNotNull(secondLabel);
+		assertEquals("After level-up, row must switch to green",
+			RequirementRow.COLOR_MET, secondLabel.getForeground());
+	}
+
+	@Test
+	public void hideRequirements_hidesSection() throws Exception
+	{
+		view.updateRows(Collections.singletonList(metQuestRow("Dragon Slayer II")));
+		assertTrue(view.isVisible());
+
+		view.hideRequirements();
+		flushEdt();
+		assertFalse("hideRequirements must hide the section", view.isVisible());
+	}
+
+	@Test
+	public void hideRequirements_clearsRows() throws Exception
+	{
+		view.updateRows(Collections.singletonList(metQuestRow("Dragon Slayer II")));
+		view.hideRequirements();
+		flushEdt();
+		assertEquals("hideRequirements must remove all child components",
+			0, view.getComponentCount());
+	}
+
+	@Test
+	public void updateRows_diaryRow_renderedCorrectly()
+	{
+		RequirementRow diaryRow = new RequirementRow(
+			RequirementRow.Category.DIARY,
+			"Lumbridge Elite",
+			"COMPLETED",
+			RequirementRow.COLOR_MET,
+			true
+		);
+		view.updateRows(Collections.singletonList(diaryRow));
+		assertTrue(view.isVisible());
+
+		JLabel rowLabel = findFirstRowLabel(view);
+		assertNotNull(rowLabel);
+		assertTrue("Diary label must contain the diary name",
+			rowLabel.getText().contains("Lumbridge Elite"));
+		assertEquals(RequirementRow.COLOR_MET, rowLabel.getForeground());
+	}
+
+	@Test
+	public void updateRows_rowLabelContainsStateText()
+	{
+		RequirementRow row = metSkillRow("Agility 70", "level 75/70");
+		view.updateRows(Collections.singletonList(row));
+
+		JLabel rowLabel = findFirstRowLabel(view);
+		assertNotNull(rowLabel);
+		assertTrue("Row label must contain state text",
+			rowLabel.getText().contains("level 75/70"));
+	}
+
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	/** Flush the Swing event queue so invokeLater-scheduled work completes. */
+	private static void flushEdt() throws Exception
+	{
+		SwingUtilities.invokeAndWait(() -> { });
+	}
+
+	/**
+	 * Finds the first non-header JLabel child of the view (the first requirement row label).
+	 * Skips the bold "Requirements:" header by checking whether the font is bold.
+	 */
+	private static JLabel findFirstRowLabel(RequirementsView view)
+	{
+		for (int i = 0; i < view.getComponentCount(); i++)
+		{
+			Component c = view.getComponent(i);
+			if (c instanceof JLabel)
+			{
+				JLabel label = (JLabel) c;
+				// Skip the bold "Requirements:" header label
+				if (label.getFont() != null && label.getFont().isBold())
+				{
+					continue;
+				}
+				return label;
+			}
+		}
+		return null;
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a **Requirements** subsection to the guidance panel header (below "Guiding: \<source\>", above the step strip) showing quest, skill, and diary prerequisites per source
- Each row is colour-coded: GREEN = met (quest COMPLETED / skill level met / diary COMPLETED), YELLOW = in progress (quests only), RED = unmet
- Section is hidden entirely when the source has no requirements (no empty header)
- Diary requirements use the new `diaries` field on `SourceRequirements` (format: `"LUMBRIDGE_HARD"`) resolved via `Varbits.DIARY_*` reflection

## Services reused

- `RequirementsChecker` — existing singleton; extended with `buildRequirementRows(CollectionLogSource)` (client thread) and static `resolveDiaryVarbit(String)` helper
- `RequirementsChecker.formatEnumName` — reused for human-readable quest/skill/diary labels
- `RequirementsChecker.getUnmetRequirements` — unchanged; still drives the existing orange warning label in `GuidanceBannerView`
- `SourceRequirements` — extended with `diaries: List<String>`; Gson default-null for existing JSON entries

## Test plan

- [x] `RequirementsViewTest` — 13 new tests: construction, all-met visible/green, one-unmet visible/red, empty list hidden, IN_PROGRESS yellow, state transition (level-up), hideRequirements clears, diary row label, state text in label
- [x] `GuidanceBannerViewTest` — 7 new tests: all-met, one-unmet, no-requirements, null rows, state transition, hide-clears, diary row
- [x] `RequirementsCheckerTest` — 7 new tests: `resolveDiaryVarbit` for known diaries, unknown, null, empty, lowercase normalisation
- [x] Existing tests updated for `SourceRequirements` 3-arg constructor (`CollectionLogSourceTest`, `GuidanceSequencerTest`)
- [x] `./gradlew build` — BUILD SUCCESSFUL, 620 tests, 0 failures

Refs cha-ndler/collection-log-helper#382 (B.5.3)