### PR TITLE
feat(panel): collapsible step sections via section field on GuidanceStep (B.5.4)

### DIFF
--- a/src/main/java/com/collectionloghelper/data/GuidanceStep.java
+++ b/src/main/java/com/collectionloghelper/data/GuidanceStep.java
@@ -157,6 +157,14 @@ public class GuidanceStep
 	 */
 	List<ConditionalAlternative> conditionalAlternatives;
 
+	/**
+	 * Section label used to group consecutive steps into named collapsible blocks in the panel.
+	 * Null by default — steps without a section render in the flat (ungrouped) layout.
+	 * When ANY step in the active source has a non-null section, all steps are rendered
+	 * with section headers; null-section steps are placed in an "Other" group.
+	 */
+	String section;
+
 	public int getCompletionDistance()
 	{
 		return completionDistance > 0 ? completionDistance : 5;
@@ -292,7 +300,8 @@ public class GuidanceStep
 			this.skipIfHasAnyItemIds,
 			this.dynamicItemObjectTiers,
 			this.completionZone,
-			null // merged steps don't carry alternatives (already resolved)
+			null, // merged steps don't carry alternatives (already resolved)
+			this.section
 		);
 	}
 }

--- a/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
@@ -256,19 +256,21 @@ public class GuidanceOverlayCoordinator
 				final String stepDesc = step != null ? step.getDescription() : "";
 				final boolean stepManual =
 					step != null && step.getCompletionCondition() == CompletionCondition.MANUAL;
+				final List<GuidanceStep> sourceSteps =
+					source.getGuidanceSteps() != null ? source.getGuidanceSteps() : Collections.emptyList();
 				panel.setGuidanceState(true, source, requirementRows);
 				// Show step text immediately without items; resolve names on the client
 				// thread (~1 tick) to avoid the EDT assert in ItemManager#getItemComposition
 				// (see cha-ndler/collection-log-helper#388).
 				panel.updateStepProgress(landedIdx, stepTotal, stepDesc, stepManual,
-					Collections.emptyList());
+					Collections.emptyList(), sourceSteps);
 				final GuidanceStep rawForResolve = rawStep;
 				clientThread.invokeLater(() ->
 				{
 					final List<RequiredItemDisplay> resolvedItems =
 						requiredItemResolver.resolve(rawForResolve);
 					panel.updateStepProgress(landedIdx, stepTotal, stepDesc, stepManual,
-						resolvedItems);
+						resolvedItems, sourceSteps);
 				});
 			}
 			// Add InfoBox showing the correct landed step (not always "1/N")
@@ -834,18 +836,22 @@ public class GuidanceOverlayCoordinator
 			final String desc = step.getDescription();
 			final boolean isManual = step.getCompletionCondition() == CompletionCondition.MANUAL;
 			final GuidanceStep rawStep = guidanceSequencer.getRawCurrentStep();
+			final CollectionLogSource stepChangeSource = guidanceSequencer.getActiveSource();
+			final List<GuidanceStep> sourceSteps = stepChangeSource != null
+				&& stepChangeSource.getGuidanceSteps() != null
+				? stepChangeSource.getGuidanceSteps() : Collections.emptyList();
 
 			// Push description + step progress to the panel immediately (safe from any thread
 			// because showStep dispatches to the EDT). Required-item resolution is deferred
 			// to the client thread because RequiredItemResolver.resolve() calls
 			// ItemManager.getItemComposition, which asserts caller-is-client-thread. See
 			// cha-ndler/collection-log-helper#388 for the original trace.
-			panel.updateStepProgress(current, total, desc, isManual, Collections.emptyList());
+			panel.updateStepProgress(current, total, desc, isManual, Collections.emptyList(), sourceSteps);
 			clientThread.invokeLater(() ->
 			{
 				final List<RequiredItemDisplay> resolvedItems =
 					requiredItemResolver.resolve(rawStep);
-				panel.updateStepProgress(current, total, desc, isManual, resolvedItems);
+				panel.updateStepProgress(current, total, desc, isManual, resolvedItems, sourceSteps);
 			});
 		}
 	}

--- a/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
@@ -619,7 +619,7 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 	}
 
 	/**
-	 * Updates the step progress banner with current step info.
+	 * Updates the step progress banner with current step info (flat layout).
 	 *
 	 * @param requiredItems pre-resolved display rows from
 	 *                      {@link com.collectionloghelper.guidance.RequiredItemResolver};
@@ -629,6 +629,21 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 		List<RequiredItemDisplay> requiredItems)
 	{
 		stepProgressView.showStep(current, total, description, isManual, requiredItems);
+	}
+
+	/**
+	 * Updates the step progress banner with current step info, enabling collapsible
+	 * section blocks when {@code allSteps} contains steps with section labels.
+	 *
+	 * @param requiredItems pre-resolved display rows; may be {@code null} or empty
+	 * @param allSteps      full ordered step list for the active source; used to compute
+	 *                      section groups — pass an empty list for flat layout
+	 */
+	public void updateStepProgress(int current, int total, String description, boolean isManual,
+		List<RequiredItemDisplay> requiredItems,
+		List<com.collectionloghelper.data.GuidanceStep> allSteps)
+	{
+		stepProgressView.showStep(current, total, description, isManual, requiredItems, allSteps);
 	}
 
 	/** Hides the step progress banner. */

--- a/src/main/java/com/collectionloghelper/ui/widget/StepProgressView.java
+++ b/src/main/java/com/collectionloghelper/ui/widget/StepProgressView.java
@@ -24,6 +24,7 @@
  */
 package com.collectionloghelper.ui.widget;
 
+import com.collectionloghelper.data.GuidanceStep;
 import com.collectionloghelper.guidance.RequiredItemDisplay;
 import java.awt.Color;
 import java.awt.Dimension;
@@ -31,7 +32,9 @@ import java.awt.Font;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
@@ -47,8 +50,19 @@ import net.runelite.client.util.AsyncBufferedImage;
 
 /**
  * Shared widget that displays the multi-step guidance progress bar,
- * the required-items subsection (with colour-coded availability), and the
+ * the required-items subsection (with colour-coded availability), the
+ * collapsible step sections (when any step carries a section label), and the
  * Next Step / Skip buttons.
+ *
+ * <h3>Section rendering (B.5.4)</h3>
+ * <p>When the active source has at least one step with a non-null
+ * {@link GuidanceStep#getSection()} value, steps are grouped into named
+ * collapsible blocks computed by {@link StepSectionGrouper}. Each block
+ * shows a header: "▼ {Section Name} (N steps)" when expanded, or
+ * "▶ {Section Name} (N steps)" when collapsed. Clicking the header toggles
+ * the block. The section containing the active step is always force-expanded.
+ * When no step in the source has a section label the flat single-line layout
+ * is used unchanged.
  *
  * <p>Required-item rows are passed in as pre-resolved {@link RequiredItemDisplay}
  * objects (name + status already determined on the client thread by
@@ -70,12 +84,24 @@ public class StepProgressView extends JPanel
 	/** Tooltip suffix appended to items whose status is IN_BANK. */
 	private static final String IN_BANK_TOOLTIP_SUFFIX = " ℹ in bank";
 
+	private static final Color BG = new Color(25, 35, 55);
+	private static final Color SECTION_HEADER_FG = new Color(200, 200, 200);
+	private static final Color SECTION_HEADER_ACTIVE_FG = new Color(80, 180, 255);
+
 	private final ItemManager itemManager;
 
 	private final JLabel stepProgressLabel;
 	private final JPanel requiredItemsPanel;
+	/** Container rendered when the source uses section labels (sectioned mode). */
+	private final JPanel sectionsPanel;
 	private final JButton nextStepButton;
 	private final JButton skipStepButton;
+
+	/**
+	 * Per-section collapse state. True = expanded. New sections default to collapsed
+	 * (except for the active-step section which is force-expanded on each render).
+	 */
+	private final Map<String, Boolean> sectionExpandState = new HashMap<>();
 
 	private Runnable stepAdvancer;
 	private Runnable stepSkipper;
@@ -85,7 +111,7 @@ public class StepProgressView extends JPanel
 		this.itemManager = itemManager;
 
 		setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
-		setBackground(new Color(25, 35, 55));
+		setBackground(BG);
 		setBorder(BorderFactory.createCompoundBorder(
 			BorderFactory.createLineBorder(new Color(80, 150, 220), 1),
 			BorderFactory.createEmptyBorder(4, 6, 4, 6)
@@ -102,14 +128,21 @@ public class StepProgressView extends JPanel
 
 		requiredItemsPanel = new JPanel();
 		requiredItemsPanel.setLayout(new BoxLayout(requiredItemsPanel, BoxLayout.Y_AXIS));
-		requiredItemsPanel.setBackground(new Color(25, 35, 55));
+		requiredItemsPanel.setBackground(BG);
 		requiredItemsPanel.setAlignmentX(LEFT_ALIGNMENT);
 		requiredItemsPanel.setVisible(false);
 		add(requiredItemsPanel);
 
+		sectionsPanel = new JPanel();
+		sectionsPanel.setLayout(new BoxLayout(sectionsPanel, BoxLayout.Y_AXIS));
+		sectionsPanel.setBackground(BG);
+		sectionsPanel.setAlignmentX(LEFT_ALIGNMENT);
+		sectionsPanel.setVisible(false);
+		add(sectionsPanel);
+
 		JPanel stepButtonRow = new JPanel();
 		stepButtonRow.setLayout(new BoxLayout(stepButtonRow, BoxLayout.X_AXIS));
-		stepButtonRow.setBackground(new Color(25, 35, 55));
+		stepButtonRow.setBackground(BG);
 		stepButtonRow.setAlignmentX(LEFT_ALIGNMENT);
 
 		nextStepButton = new JButton("Next Step");
@@ -156,7 +189,7 @@ public class StepProgressView extends JPanel
 	}
 
 	/**
-	 * Shows and populates the step progress panel.
+	 * Shows and populates the step progress panel (flat layout — no section grouping).
 	 * Safe to call from any thread.
 	 *
 	 * @param current       one-based step index
@@ -170,15 +203,51 @@ public class StepProgressView extends JPanel
 	public void showStep(int current, int total, String description, boolean isManual,
 		List<RequiredItemDisplay> requiredItems)
 	{
+		showStep(current, total, description, isManual, requiredItems, Collections.emptyList());
+	}
+
+	/**
+	 * Shows and populates the step progress panel, rendering collapsible section blocks
+	 * when {@code allSteps} contains at least one step with a non-null section label.
+	 * Safe to call from any thread.
+	 *
+	 * @param current       one-based step index
+	 * @param total         total number of steps
+	 * @param description   human-readable step description
+	 * @param isManual      whether the Next Step button should be shown
+	 * @param requiredItems pre-resolved display rows (may be {@code null} or empty)
+	 * @param allSteps      full ordered step list for the active source; used to compute
+	 *                      section groups. Pass an empty list to force flat layout.
+	 */
+	public void showStep(int current, int total, String description, boolean isManual,
+		List<RequiredItemDisplay> requiredItems, List<GuidanceStep> allSteps)
+	{
 		final List<RequiredItemDisplay> rows =
 			requiredItems != null ? requiredItems : Collections.emptyList();
+		final List<GuidanceStep> steps =
+			allSteps != null ? allSteps : Collections.emptyList();
+		final List<StepSectionGroup> groups = StepSectionGrouper.group(steps);
 
 		SwingUtilities.invokeLater(() ->
 		{
 			stepProgressLabel.setText(
 				"<html>Step " + current + "/" + total + ": " + description + "</html>");
 			nextStepButton.setVisible(isManual);
-			updateRequiredItemDisplay(rows);
+
+			if (groups.isEmpty())
+			{
+				// Flat layout — hide sections, show required items inline
+				sectionsPanel.setVisible(false);
+				updateRequiredItemDisplay(rows);
+			}
+			else
+			{
+				// Sectioned layout — hide inline required items, render section blocks
+				requiredItemsPanel.removeAll();
+				requiredItemsPanel.setVisible(false);
+				updateSectionDisplay(groups, current, rows);
+			}
+
 			setVisible(true);
 			revalidate();
 			if (getParent() != null)
@@ -202,6 +271,8 @@ public class StepProgressView extends JPanel
 		{
 			requiredItemsPanel.removeAll();
 			requiredItemsPanel.setVisible(false);
+			sectionsPanel.removeAll();
+			sectionsPanel.setVisible(false);
 			setVisible(false);
 			revalidate();
 			if (getParent() != null)
@@ -210,6 +281,160 @@ public class StepProgressView extends JPanel
 			}
 		});
 	}
+
+	// ── Section rendering ────────────────────────────────────────────────────
+
+	/**
+	 * Rebuilds the collapsible section blocks.
+	 *
+	 * <p>The section containing {@code activeStepIndex} is force-expanded and its
+	 * required-item rows are rendered immediately below the step label. Other sections
+	 * respect their stored collapse state (defaulting to collapsed).
+	 *
+	 * <p>Must be called on the EDT.
+	 *
+	 * @param groups          ordered section groups from {@link StepSectionGrouper#group}
+	 * @param activeStepIndex 1-based index of the currently active step
+	 * @param requiredItems   display rows for the active step
+	 */
+	void updateSectionDisplay(List<StepSectionGroup> groups, int activeStepIndex,
+		List<RequiredItemDisplay> requiredItems)
+	{
+		sectionsPanel.removeAll();
+
+		String activeSectionName = StepSectionGrouper.sectionNameFor(groups, activeStepIndex);
+
+		// Force-expand the active section
+		if (activeSectionName != null)
+		{
+			sectionExpandState.put(activeSectionName, Boolean.TRUE);
+		}
+
+		for (StepSectionGroup group : groups)
+		{
+			boolean isActiveSection = group.getName().equals(activeSectionName);
+			boolean expanded = sectionExpandState.getOrDefault(group.getName(), Boolean.FALSE);
+
+			JPanel block = buildSectionBlock(group, isActiveSection, expanded, activeStepIndex, requiredItems);
+			block.setAlignmentX(LEFT_ALIGNMENT);
+			sectionsPanel.add(block);
+			sectionsPanel.add(Box.createVerticalStrut(2));
+		}
+
+		sectionsPanel.setVisible(true);
+		sectionsPanel.revalidate();
+		sectionsPanel.repaint();
+	}
+
+	/**
+	 * Builds a single collapsible section block: a clickable header row + a body
+	 * panel containing the step indices (and required-item rows for the active step
+	 * when expanded).
+	 *
+	 * <p>Must be called on the EDT.
+	 */
+	private JPanel buildSectionBlock(StepSectionGroup group, boolean isActiveSection,
+		boolean expanded, int activeStepIndex, List<RequiredItemDisplay> requiredItems)
+	{
+		JPanel block = new JPanel();
+		block.setLayout(new BoxLayout(block, BoxLayout.Y_AXIS));
+		block.setBackground(BG);
+		block.setAlignmentX(LEFT_ALIGNMENT);
+		block.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
+
+		// Body panel (shown when expanded)
+		JPanel body = new JPanel();
+		body.setLayout(new BoxLayout(body, BoxLayout.Y_AXIS));
+		body.setBackground(new Color(20, 28, 45));
+		body.setBorder(BorderFactory.createEmptyBorder(2, 8, 2, 0));
+		body.setAlignmentX(LEFT_ALIGNMENT);
+		body.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
+
+		for (int stepIdx : group.getStepIndices())
+		{
+			boolean isActive = stepIdx == activeStepIndex;
+			Color stepFg = isActive ? SECTION_HEADER_ACTIVE_FG : new Color(160, 160, 160);
+
+			JLabel stepLabel = new JLabel("• Step " + stepIdx);
+			stepLabel.setFont(FontManager.getRunescapeSmallFont());
+			stepLabel.setForeground(stepFg);
+			stepLabel.setAlignmentX(LEFT_ALIGNMENT);
+			body.add(stepLabel);
+
+			if (isActive && requiredItems != null && !requiredItems.isEmpty())
+			{
+				JPanel itemsInSection = new JPanel();
+				itemsInSection.setLayout(new BoxLayout(itemsInSection, BoxLayout.Y_AXIS));
+				itemsInSection.setBackground(new Color(20, 28, 45));
+				itemsInSection.setBorder(BorderFactory.createEmptyBorder(0, 8, 0, 0));
+				itemsInSection.setAlignmentX(LEFT_ALIGNMENT);
+				itemsInSection.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
+
+				JLabel neededLabel = new JLabel("Items needed:");
+				neededLabel.setFont(FontManager.getRunescapeSmallFont().deriveFont(Font.BOLD));
+				neededLabel.setForeground(new Color(180, 180, 180));
+				neededLabel.setAlignmentX(LEFT_ALIGNMENT);
+				itemsInSection.add(neededLabel);
+				itemsInSection.add(Box.createVerticalStrut(2));
+
+				for (RequiredItemDisplay row : requiredItems)
+				{
+					JPanel rowPanel = buildItemRow(row);
+					rowPanel.setAlignmentX(LEFT_ALIGNMENT);
+					itemsInSection.add(rowPanel);
+					itemsInSection.add(Box.createVerticalStrut(2));
+				}
+
+				body.add(itemsInSection);
+			}
+		}
+
+		body.setVisible(expanded);
+
+		// Header button
+		int stepCount = group.getStepIndices().size();
+		String headerText = buildHeaderText(group.getName(), stepCount, expanded);
+
+		JButton header = new JButton(headerText);
+		header.setFont(FontManager.getRunescapeSmallFont().deriveFont(Font.BOLD));
+		header.setForeground(isActiveSection ? SECTION_HEADER_ACTIVE_FG : SECTION_HEADER_FG);
+		header.setBackground(new Color(35, 45, 65));
+		header.setBorderPainted(false);
+		header.setFocusPainted(false);
+		header.setContentAreaFilled(true);
+		header.setHorizontalAlignment(SwingConstants.LEFT);
+		header.setAlignmentX(LEFT_ALIGNMENT);
+		header.setMaximumSize(new Dimension(Integer.MAX_VALUE, 20));
+
+		final String groupName = group.getName();
+		header.addActionListener(e ->
+		{
+			boolean nowExpanded = !body.isVisible();
+			sectionExpandState.put(groupName, nowExpanded);
+			body.setVisible(nowExpanded);
+			header.setText(buildHeaderText(groupName, stepCount, nowExpanded));
+			sectionsPanel.revalidate();
+			sectionsPanel.repaint();
+			revalidate();
+			if (getParent() != null)
+			{
+				getParent().revalidate();
+			}
+		});
+
+		block.add(header);
+		block.add(body);
+		return block;
+	}
+
+	/** Formats the section header text with the expand/collapse arrow glyph. */
+	private static String buildHeaderText(String sectionName, int stepCount, boolean isExpanded)
+	{
+		String arrow = isExpanded ? "▼ " : "▶ ";
+		return arrow + sectionName + " (" + stepCount + " step" + (stepCount == 1 ? "" : "s") + ")";
+	}
+
+	// ── Flat required-items display (unchanged from B.5.1) ───────────────────
 
 	/**
 	 * Rebuilds the required-items subsection from pre-resolved display rows.
@@ -266,7 +491,7 @@ public class StepProgressView extends JPanel
 	{
 		JPanel rowPanel = new JPanel();
 		rowPanel.setLayout(new BoxLayout(rowPanel, BoxLayout.X_AXIS));
-		rowPanel.setBackground(new Color(25, 35, 55));
+		rowPanel.setBackground(BG);
 		rowPanel.setMaximumSize(new Dimension(Integer.MAX_VALUE, 32));
 
 		// --- Icon ---

--- a/src/main/java/com/collectionloghelper/ui/widget/StepSectionGroup.java
+++ b/src/main/java/com/collectionloghelper/ui/widget/StepSectionGroup.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.ui.widget;
+
+import java.util.List;
+import lombok.Value;
+
+/**
+ * A named group of consecutive guidance steps that share the same section label.
+ *
+ * <p>Used by {@link StepProgressView} to render collapsible section blocks. Steps with
+ * a null section are placed into an "Other" group when at least one other step in the
+ * sequence has a non-null section label.
+ */
+@Value
+public class StepSectionGroup
+{
+	/** Sentinel name used for steps with a null section when sectioned display is active. */
+	public static final String OTHER_SECTION_NAME = "Other";
+
+	/** Display label for the section header (e.g. "Travel", "Other"). */
+	String name;
+
+	/**
+	 * 1-based step indices (original position in the full step list) belonging to this
+	 * group, in order.
+	 */
+	List<Integer> stepIndices;
+}

--- a/src/main/java/com/collectionloghelper/ui/widget/StepSectionGrouper.java
+++ b/src/main/java/com/collectionloghelper/ui/widget/StepSectionGrouper.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.ui.widget;
+
+import com.collectionloghelper.data.GuidanceStep;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Builds the ordered list of {@link StepSectionGroup}s from a flat step list.
+ *
+ * <h3>Grouping rules</h3>
+ * <ul>
+ *   <li>A step's section label is obtained via {@link GuidanceStep#getSection()}.</li>
+ *   <li>If <em>no</em> step in the list has a non-null section, this method returns an
+ *       empty list — the caller should use the flat layout instead.</li>
+ *   <li>Consecutive steps with the same section label (including consecutive null-section
+ *       steps) are merged into one {@link StepSectionGroup}.</li>
+ *   <li>Steps with a null section use the sentinel name
+ *       {@link StepSectionGroup#OTHER_SECTION_NAME}.</li>
+ * </ul>
+ *
+ * <p>Step indices in the returned groups are 1-based to match the "Step N/total" display
+ * convention used throughout the panel.
+ */
+public final class StepSectionGrouper
+{
+	private StepSectionGrouper()
+	{
+	}
+
+	/**
+	 * Converts a flat list of guidance steps into an ordered list of section groups.
+	 *
+	 * @param steps the full ordered list of steps for the active source; must not be null
+	 * @return ordered groups, or an empty list when no step carries a section label
+	 */
+	public static List<StepSectionGroup> group(List<GuidanceStep> steps)
+	{
+		if (steps == null || steps.isEmpty())
+		{
+			return Collections.emptyList();
+		}
+
+		boolean anySectionSet = false;
+		for (GuidanceStep step : steps)
+		{
+			if (step.getSection() != null)
+			{
+				anySectionSet = true;
+				break;
+			}
+		}
+
+		if (!anySectionSet)
+		{
+			return Collections.emptyList();
+		}
+
+		List<StepSectionGroup> groups = new ArrayList<>();
+		String currentLabel = null;
+		List<Integer> currentIndices = new ArrayList<>();
+
+		for (int i = 0; i < steps.size(); i++)
+		{
+			String label = steps.get(i).getSection();
+			String effectiveLabel = label != null ? label : StepSectionGroup.OTHER_SECTION_NAME;
+
+			if (currentLabel == null)
+			{
+				// First step: start the first group
+				currentLabel = effectiveLabel;
+				currentIndices.add(i + 1); // 1-based
+			}
+			else if (effectiveLabel.equals(currentLabel))
+			{
+				// Same section as the running group — extend it
+				currentIndices.add(i + 1);
+			}
+			else
+			{
+				// Section changed — close the current group and start a new one
+				groups.add(new StepSectionGroup(currentLabel, Collections.unmodifiableList(currentIndices)));
+				currentLabel = effectiveLabel;
+				currentIndices = new ArrayList<>();
+				currentIndices.add(i + 1);
+			}
+		}
+
+		// Close the final open group
+		if (currentLabel != null && !currentIndices.isEmpty())
+		{
+			groups.add(new StepSectionGroup(currentLabel, Collections.unmodifiableList(currentIndices)));
+		}
+
+		return Collections.unmodifiableList(groups);
+	}
+
+	/**
+	 * Returns the name of the section that contains {@code oneBasedStepIndex}, or
+	 * {@code null} if the step index is not found in any group.
+	 *
+	 * @param groups        the ordered group list from {@link #group}
+	 * @param oneBasedIndex 1-based step index
+	 */
+	public static String sectionNameFor(List<StepSectionGroup> groups, int oneBasedIndex)
+	{
+		for (StepSectionGroup group : groups)
+		{
+			if (group.getStepIndices().contains(oneBasedIndex))
+			{
+				return group.getName();
+			}
+		}
+		return null;
+	}
+}

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
@@ -110,7 +110,8 @@ public class GuidanceSequencerTest
 			null,           // skipIfHasAnyItemIds
 			null,           // dynamicItemObjectTiers
 			null,           // completionZone
-			null            // conditionalAlternatives
+			null,           // conditionalAlternatives
+			null            // section
 		);
 	}
 
@@ -137,7 +138,8 @@ public class GuidanceSequencerTest
 			null,  // skipIfHasAnyItemIds
 			null,  // dynamicItemObjectTiers
 			null,  // completionZone
-			null   // conditionalAlternatives
+			null,  // conditionalAlternatives
+			null   // section
 		);
 	}
 
@@ -164,7 +166,8 @@ public class GuidanceSequencerTest
 			null,  // skipIfHasAnyItemIds
 			null,  // dynamicItemObjectTiers
 			null,  // completionZone
-			null   // conditionalAlternatives
+			null,  // conditionalAlternatives
+			null   // section
 		);
 	}
 
@@ -191,7 +194,8 @@ public class GuidanceSequencerTest
 			null,  // skipIfHasAnyItemIds
 			null,  // dynamicItemObjectTiers
 			null,  // completionZone
-			null   // conditionalAlternatives
+			null,  // conditionalAlternatives
+			null   // section
 		);
 	}
 
@@ -218,7 +222,8 @@ public class GuidanceSequencerTest
 			null,  // skipIfHasAnyItemIds
 			null,  // dynamicItemObjectTiers
 			null,  // completionZone
-			null   // conditionalAlternatives
+			null,  // conditionalAlternatives
+			null   // section
 		);
 	}
 
@@ -245,7 +250,8 @@ public class GuidanceSequencerTest
 			null,  // skipIfHasAnyItemIds
 			null,  // dynamicItemObjectTiers
 			null,  // completionZone
-			null   // conditionalAlternatives
+			null,  // conditionalAlternatives
+			null   // section
 		);
 	}
 
@@ -272,7 +278,8 @@ public class GuidanceSequencerTest
 			null,  // skipIfHasAnyItemIds
 			null,  // dynamicItemObjectTiers
 			null,  // completionZone
-			null   // conditionalAlternatives
+			null,  // conditionalAlternatives
+			null   // section
 		);
 	}
 
@@ -300,7 +307,8 @@ public class GuidanceSequencerTest
 			null,  // skipIfHasAnyItemIds
 			null,  // dynamicItemObjectTiers
 			null,  // completionZone
-			null   // conditionalAlternatives
+			null,  // conditionalAlternatives
+			null   // section
 		);
 	}
 
@@ -327,7 +335,8 @@ public class GuidanceSequencerTest
 			null,  // skipIfHasAnyItemIds
 			null,  // dynamicItemObjectTiers
 			null,  // completionZone
-			null   // conditionalAlternatives
+			null,  // conditionalAlternatives
+			null   // section
 		);
 	}
 
@@ -354,7 +363,8 @@ public class GuidanceSequencerTest
 			null,  // skipIfHasAnyItemIds
 			null,  // dynamicItemObjectTiers
 			null,  // completionZone
-			null   // conditionalAlternatives
+			null,  // conditionalAlternatives
+			null   // section
 		);
 	}
 
@@ -381,7 +391,8 @@ public class GuidanceSequencerTest
 			null,  // skipIfHasAnyItemIds
 			null,  // dynamicItemObjectTiers
 			null,  // completionZone
-			null   // conditionalAlternatives
+			null,  // conditionalAlternatives
+			null   // section
 		);
 	}
 
@@ -745,10 +756,11 @@ public class GuidanceSequencerTest
 			false,
 			0, null, null,
 			0, 0,
-			null,
-			null,
-			null,
-			null
+			null,  // skipIfHasAnyItemIds
+			null,  // dynamicItemObjectTiers
+			null,  // completionZone
+			null,  // conditionalAlternatives
+			null   // section
 		);
 
 		List<GuidanceStep> steps = Arrays.asList(
@@ -1212,10 +1224,11 @@ public class GuidanceSequencerTest
 			null,
 			null,
 			0, 0,
-			null,
-			null,
-			null,
-			alternatives
+			null,  // skipIfHasAnyItemIds
+			null,  // dynamicItemObjectTiers
+			null,  // completionZone
+			alternatives,
+			null   // section
 		);
 	}
 
@@ -1434,10 +1447,11 @@ public class GuidanceSequencerTest
 			null,
 			null,
 			0, 0,
-			null,
-			null,
-			null,
-			Collections.emptyList()  // empty list of alternatives
+			null,  // skipIfHasAnyItemIds
+			null,  // dynamicItemObjectTiers
+			null,  // completionZone
+			Collections.emptyList(),  // empty list of alternatives
+			null   // section
 		);
 
 		List<GuidanceStep> steps = Arrays.asList(step);

--- a/src/test/java/com/collectionloghelper/guidance/RequiredItemResolverTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/RequiredItemResolverTest.java
@@ -273,10 +273,11 @@ public class RequiredItemResolverTest
 			null,
 			null,
 			0, 0,
-			null,
-			null,
-			null,
-			null
+			null,  // skipIfHasAnyItemIds
+			null,  // dynamicItemObjectTiers
+			null,  // completionZone
+			null,  // conditionalAlternatives
+			null   // section
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/lifecycle/GuidanceEventRouterTest.java
+++ b/src/test/java/com/collectionloghelper/lifecycle/GuidanceEventRouterTest.java
@@ -134,7 +134,8 @@ public class GuidanceEventRouterTest
 			null,  // skipIfHasAnyItemIds
 			null,  // dynamicItemObjectTiers
 			null,  // completionZone
-			null   // conditionalAlternatives
+			null,  // conditionalAlternatives
+			null   // section
 		);
 	}
 

--- a/src/test/java/com/collectionloghelper/ui/widget/StepProgressViewTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/StepProgressViewTest.java
@@ -24,6 +24,8 @@
  */
 package com.collectionloghelper.ui.widget;
 
+import com.collectionloghelper.data.CompletionCondition;
+import com.collectionloghelper.data.GuidanceStep;
 import com.collectionloghelper.guidance.RequiredItemDisplay;
 import com.collectionloghelper.guidance.RequiredItemDisplay.Status;
 import net.runelite.client.game.ItemManager;
@@ -32,6 +34,7 @@ import java.awt.Component;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
@@ -282,6 +285,143 @@ public class StepProgressViewTest
 			RequiredItemDisplay.COLOR_HELD, updated.getForeground());
 	}
 
+	// ── Section rendering tests (B.5.4) ─────────────────────────────────────
+
+	/**
+	 * When the step list contains no section labels the sectionsPanel must stay hidden
+	 * and the flat required-items panel is used instead.
+	 */
+	@Test
+	public void showStep_withNoSectionData_sectionsPanelHidden() throws Exception
+	{
+		List<GuidanceStep> noSectionSteps = Arrays.asList(stepWithSection(null), stepWithSection(null));
+		view.showStep(1, 2, "Travel", false, Collections.emptyList(), noSectionSteps);
+		flushEdt();
+
+		JPanel sectionsPanel = findSectionsPanel(view);
+		assertNotNull("sectionsPanel must be present in widget", sectionsPanel);
+		assertFalse("sectionsPanel must be hidden when no step has a section",
+			sectionsPanel.isVisible());
+	}
+
+	/**
+	 * When at least one step in allSteps has a section label, the sectionsPanel
+	 * must become visible and contain at least one section header button.
+	 */
+	@Test
+	public void showStep_withSectionData_sectionsPanelVisible() throws Exception
+	{
+		List<GuidanceStep> steps = Arrays.asList(
+			stepWithSection("Travel"),
+			stepWithSection("Combat"));
+		view.showStep(1, 2, "Walk to boss", false, Collections.emptyList(), steps);
+		flushEdt();
+
+		JPanel sectionsPanel = findSectionsPanel(view);
+		assertNotNull(sectionsPanel);
+		assertTrue("sectionsPanel must be visible when steps have sections",
+			sectionsPanel.isVisible());
+		// At least two header buttons (one per section)
+		List<JButton> buttons = findAllButtons(sectionsPanel);
+		assertEquals("Must have one header button per section", 2, buttons.size());
+	}
+
+	/**
+	 * The active step's section header must begin with the expanded arrow "▼".
+	 * Other sections default to collapsed "▶".
+	 */
+	@Test
+	public void showStep_activeSectionForceExpanded_showsDownArrow() throws Exception
+	{
+		// 3 steps: step 1 in "Travel", step 2 in "Combat", step 3 in "Travel"
+		List<GuidanceStep> steps = Arrays.asList(
+			stepWithSection("Travel"),
+			stepWithSection("Combat"),
+			stepWithSection("Travel"));
+		// Active step = step 2 (in "Combat")
+		view.showStep(2, 3, "Fight the boss", false, Collections.emptyList(), steps);
+		flushEdt();
+
+		JPanel sectionsPanel = findSectionsPanel(view);
+		List<JButton> buttons = findAllButtons(sectionsPanel);
+		assertEquals("Must have 3 header buttons (Travel, Combat, Travel)", 3, buttons.size());
+
+		// Travel (step 1) — not active, should be collapsed
+		assertTrue("Inactive section must start with collapse arrow",
+			buttons.get(0).getText().startsWith("▶"));
+		// Combat (step 2) — active, must be expanded
+		assertTrue("Active section must start with expand arrow",
+			buttons.get(1).getText().startsWith("▼"));
+		// Travel (step 3) — not active, should be collapsed
+		assertTrue("Inactive section must start with collapse arrow",
+			buttons.get(2).getText().startsWith("▶"));
+	}
+
+	/**
+	 * When switching to a different active step, the previously active section
+	 * can remain expanded (user toggled it) but the new active section is
+	 * force-expanded.
+	 */
+	@Test
+	public void showStep_activeStepChanges_newSectionForceExpanded() throws Exception
+	{
+		List<GuidanceStep> steps = Arrays.asList(
+			stepWithSection("Starting off"),
+			stepWithSection("Travel"));
+
+		// First render: step 1 active
+		view.showStep(1, 2, "Start", false, Collections.emptyList(), steps);
+		flushEdt();
+
+		// Second render: step 2 becomes active
+		view.showStep(2, 2, "Walk", false, Collections.emptyList(), steps);
+		flushEdt();
+
+		JPanel sectionsPanel = findSectionsPanel(view);
+		List<JButton> buttons = findAllButtons(sectionsPanel);
+		assertEquals(2, buttons.size());
+		// "Travel" section (button index 1) must be force-expanded
+		assertTrue("New active section must show expanded arrow after step change",
+			buttons.get(1).getText().startsWith("▼"));
+	}
+
+	/**
+	 * When showStep is called with sections, the inline required-items panel
+	 * (flat layout) must be hidden — items are shown inside the active section body.
+	 */
+	@Test
+	public void showStep_withSections_inlineRequiredItemsPanelHidden() throws Exception
+	{
+		List<GuidanceStep> steps = Collections.singletonList(stepWithSection("Travel"));
+		List<RequiredItemDisplay> items = Collections.singletonList(
+			new RequiredItemDisplay(TINDERBOX_ID, "Tinderbox", Status.HELD));
+
+		view.showStep(1, 1, "Go somewhere", false, items, steps);
+		flushEdt();
+
+		// The flat requiredItemsPanel (first JPanel child) must be hidden in sectioned mode
+		JPanel reqPanel = findRequiredItemsPanel(view);
+		assertNotNull(reqPanel);
+		assertFalse("Inline required-items panel must be hidden in sectioned mode",
+			reqPanel.isVisible());
+	}
+
+	/**
+	 * hideStep must also clear the sections panel.
+	 */
+	@Test
+	public void hideStep_afterSectionedShow_sectionsPanelHidden() throws Exception
+	{
+		List<GuidanceStep> steps = Collections.singletonList(stepWithSection("Combat"));
+		view.showStep(1, 1, "Fight", false, Collections.emptyList(), steps);
+		flushEdt();
+		assertTrue("sectionsPanel must be visible before hide", findSectionsPanel(view).isVisible());
+
+		view.hideStep();
+		flushEdt();
+		assertFalse("sectionsPanel must be hidden after hideStep", findSectionsPanel(view).isVisible());
+	}
+
 	// ── Helpers ─────────────────────────────────────────────────────────────
 
 	/** Flush the Swing event queue so invokeLater-scheduled work completes. */
@@ -349,5 +489,81 @@ public class StepProgressViewTest
 			}
 		}
 		return result;
+	}
+
+	/**
+	 * Finds the sectionsPanel — the second {@link JPanel} direct child of the
+	 * StepProgressView (after the requiredItemsPanel).
+	 */
+	private static JPanel findSectionsPanel(StepProgressView view)
+	{
+		int panelCount = 0;
+		for (Component c : view.getComponents())
+		{
+			if (c instanceof JPanel)
+			{
+				panelCount++;
+				if (panelCount == 2)
+				{
+					return (JPanel) c;
+				}
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Collects all {@link JButton} components found directly inside {@code panel}
+	 * or inside any direct JPanel child (section block container).
+	 */
+	private static List<JButton> findAllButtons(JPanel panel)
+	{
+		List<JButton> result = new java.util.ArrayList<>();
+		if (panel == null)
+		{
+			return result;
+		}
+		for (Component c : panel.getComponents())
+		{
+			if (c instanceof JButton)
+			{
+				result.add((JButton) c);
+			}
+			else if (c instanceof JPanel)
+			{
+				// Section block: first child is the header JButton
+				for (Component child : ((JPanel) c).getComponents())
+				{
+					if (child instanceof JButton)
+					{
+						result.add((JButton) child);
+					}
+				}
+			}
+		}
+		return result;
+	}
+
+	/** Builds a minimal {@link GuidanceStep} with the given section label (may be null). */
+	private static GuidanceStep stepWithSection(String section)
+	{
+		return new GuidanceStep(
+			"Step",
+			0, 0, 0,
+			0, null, null,
+			null, null,
+			CompletionCondition.MANUAL,
+			0, 0, 0, 0,
+			null, null,
+			0, null, null,
+			null, null,
+			null,
+			0, 0,
+			false,
+			0, null, null,
+			0, 0,
+			null, null, null, null,
+			section
+		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/ui/widget/StepSectionGrouperTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/StepSectionGrouperTest.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.ui.widget;
+
+import com.collectionloghelper.data.CompletionCondition;
+import com.collectionloghelper.data.GuidanceStep;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link StepSectionGrouper}.
+ *
+ * <p>Covers:
+ * <ul>
+ *   <li>Empty/null inputs return empty groups</li>
+ *   <li>All-null sections returns empty groups (flat layout)</li>
+ *   <li>All-same section collapses into one group</li>
+ *   <li>Consecutive same-section steps merge; switch starts new group</li>
+ *   <li>Null-section steps become "Other" when sectioned mode is active</li>
+ *   <li>Consecutive null-section runs merge into one "Other" block</li>
+ *   <li>{@link StepSectionGrouper#sectionNameFor} returns correct section or null</li>
+ * </ul>
+ */
+public class StepSectionGrouperTest
+{
+	/** Builds a minimal GuidanceStep with the given section label (may be null). */
+	private static GuidanceStep step(String section)
+	{
+		return new GuidanceStep(
+			"Step",
+			0, 0, 0,
+			0, null, null,
+			null, null,
+			CompletionCondition.MANUAL,
+			0, 0, 0, 0,
+			null, null,
+			0, null, null,
+			null, null,
+			null,
+			0, 0,
+			false,
+			0, null, null,
+			0, 0,
+			null, null, null, null,
+			section
+		);
+	}
+
+	// ── Empty / no-section inputs ────────────────────────────────────────────
+
+	@Test
+	public void group_nullList_returnsEmpty()
+	{
+		assertTrue(StepSectionGrouper.group(null).isEmpty());
+	}
+
+	@Test
+	public void group_emptyList_returnsEmpty()
+	{
+		assertTrue(StepSectionGrouper.group(Collections.emptyList()).isEmpty());
+	}
+
+	@Test
+	public void group_allNullSections_returnsEmptyForFlatLayout()
+	{
+		List<GuidanceStep> steps = Arrays.asList(step(null), step(null), step(null));
+		assertTrue("No sections set — must return empty list for flat layout",
+			StepSectionGrouper.group(steps).isEmpty());
+	}
+
+	// ── Single section ───────────────────────────────────────────────────────
+
+	@Test
+	public void group_allSameSectionLabel_oneGroup()
+	{
+		List<GuidanceStep> steps = Arrays.asList(
+			step("Travel"), step("Travel"), step("Travel"));
+
+		List<StepSectionGroup> groups = StepSectionGrouper.group(steps);
+		assertEquals(1, groups.size());
+		assertEquals("Travel", groups.get(0).getName());
+		assertEquals(Arrays.asList(1, 2, 3), groups.get(0).getStepIndices());
+	}
+
+	// ── Consecutive same-section steps merge; switch starts new group ────────
+
+	@Test
+	public void group_twoDistinctSections_twoGroups()
+	{
+		List<GuidanceStep> steps = Arrays.asList(
+			step("Starting off"),
+			step("Starting off"),
+			step("Combat"),
+			step("Combat"));
+
+		List<StepSectionGroup> groups = StepSectionGrouper.group(steps);
+		assertEquals(2, groups.size());
+
+		assertEquals("Starting off", groups.get(0).getName());
+		assertEquals(Arrays.asList(1, 2), groups.get(0).getStepIndices());
+
+		assertEquals("Combat", groups.get(1).getName());
+		assertEquals(Arrays.asList(3, 4), groups.get(1).getStepIndices());
+	}
+
+	@Test
+	public void group_alternatingLabels_noMergeAcrossInterleave()
+	{
+		// A, B, A should produce three groups (A is not consecutive the second time)
+		List<GuidanceStep> steps = Arrays.asList(
+			step("Travel"),
+			step("Combat"),
+			step("Travel"));
+
+		List<StepSectionGroup> groups = StepSectionGrouper.group(steps);
+		assertEquals(3, groups.size());
+		assertEquals("Travel", groups.get(0).getName());
+		assertEquals("Combat", groups.get(1).getName());
+		assertEquals("Travel", groups.get(2).getName());
+	}
+
+	// ── Null-section steps become "Other" ────────────────────────────────────
+
+	@Test
+	public void group_nullSectionAmongSectioned_becomesOther()
+	{
+		// Steps: null, "Travel", null
+		// Because "Travel" is set, sectioned mode activates; null becomes "Other"
+		List<GuidanceStep> steps = Arrays.asList(
+			step(null),
+			step("Travel"),
+			step(null));
+
+		List<StepSectionGroup> groups = StepSectionGrouper.group(steps);
+		assertEquals(3, groups.size());
+		assertEquals(StepSectionGroup.OTHER_SECTION_NAME, groups.get(0).getName());
+		assertEquals("Travel", groups.get(1).getName());
+		assertEquals(StepSectionGroup.OTHER_SECTION_NAME, groups.get(2).getName());
+	}
+
+	@Test
+	public void group_consecutiveNullSections_mergedIntoOneOtherGroup()
+	{
+		List<GuidanceStep> steps = Arrays.asList(
+			step(null),
+			step(null),
+			step("Loot"));
+
+		List<StepSectionGroup> groups = StepSectionGrouper.group(steps);
+		assertEquals(2, groups.size());
+		assertEquals(StepSectionGroup.OTHER_SECTION_NAME, groups.get(0).getName());
+		assertEquals(Arrays.asList(1, 2), groups.get(0).getStepIndices());
+		assertEquals("Loot", groups.get(1).getName());
+	}
+
+	// ── 1-based step indices ─────────────────────────────────────────────────
+
+	@Test
+	public void group_stepIndicesAreOneBased()
+	{
+		List<GuidanceStep> steps = Arrays.asList(
+			step("A"),
+			step("B"),
+			step("A"));
+
+		List<StepSectionGroup> groups = StepSectionGrouper.group(steps);
+		// A at position 0 → index 1; B at position 1 → index 2; A at position 2 → index 3
+		assertEquals(Arrays.asList(1), groups.get(0).getStepIndices());
+		assertEquals(Arrays.asList(2), groups.get(1).getStepIndices());
+		assertEquals(Arrays.asList(3), groups.get(2).getStepIndices());
+	}
+
+	// ── sectionNameFor ───────────────────────────────────────────────────────
+
+	@Test
+	public void sectionNameFor_knownIndex_returnsCorrectSection()
+	{
+		List<GuidanceStep> steps = Arrays.asList(step("Alpha"), step("Alpha"), step("Beta"));
+		List<StepSectionGroup> groups = StepSectionGrouper.group(steps);
+
+		assertEquals("Alpha", StepSectionGrouper.sectionNameFor(groups, 1));
+		assertEquals("Alpha", StepSectionGrouper.sectionNameFor(groups, 2));
+		assertEquals("Beta",  StepSectionGrouper.sectionNameFor(groups, 3));
+	}
+
+	@Test
+	public void sectionNameFor_unknownIndex_returnsNull()
+	{
+		List<GuidanceStep> steps = Collections.singletonList(step("Alpha"));
+		List<StepSectionGroup> groups = StepSectionGrouper.group(steps);
+
+		assertNull(StepSectionGrouper.sectionNameFor(groups, 99));
+	}
+
+	@Test
+	public void sectionNameFor_emptyGroups_returnsNull()
+	{
+		assertNull(StepSectionGrouper.sectionNameFor(Collections.emptyList(), 1));
+	}
+}


### PR DESCRIPTION
## Summary

- Adds nullable `String section` field to `GuidanceStep` (additive, backward-compatible; missing JSON key defaults to null via Jackson)
- New `StepSectionGrouper` utility groups a flat step list into `StepSectionGroup` records keyed by consecutive section label runs
- `StepProgressView` gains a second `showStep` overload accepting `List<GuidanceStep> allSteps`; when the list contains at least one non-null section, the widget renders named collapsible blocks instead of the flat layout
- Section containing the active step is force-expanded on every render; other sections default to collapsed and respect user toggle state
- `GuidanceOverlayCoordinator` passes the active source's full step list to both `updateStepProgress` call sites (initial skip-chain landing and step-change callback)
- B.5.1 "Items needed:" rows are attached to the active step inside its section body in sectioned mode; the standalone `requiredItemsPanel` is hidden so items don't appear twice

## Design choices

**Null-section interleaving → "Other" group (not ungrouped above first section)**

Consecutive steps with `section: null` are placed in an "Other" group rather than rendered above the first section. This keeps the step list visually consistent: every step always belongs to exactly one named block regardless of where null-section steps appear in the sequence. Consecutive null-section runs merge into a single "Other" block.

**Collapse state persists across step transitions within a session**

`sectionExpandState` (a `Map<String, Boolean>` keyed by section name) is not cleared on `hideStep()`. User expand/collapse preferences survive step advances within the same guidance session. Sections from a prior session that share a name (e.g. "Travel") will carry their expansion state to the next session — acceptable UX for v1.

**No changes to `drop_rates.json`** — data authoring is deferred to B.5.4b.

## Test plan

- [ ] `StepSectionGrouperTest` (12 tests): null/empty inputs, all-null sections → flat fallback, single section, two distinct sections, alternating labels → no non-consecutive merge, null → Other, consecutive nulls → one Other block, 1-based indices, `sectionNameFor` lookup
- [ ] `StepProgressViewTest` (6 new tests): sectionsPanel hidden when no sections, visible with sections + correct header count, force-expand arrow on active section, force-expand on step change, inline requiredItemsPanel hidden in sectioned mode, sectionsPanel cleared by hideStep
- [ ] All 23 `StepProgressViewTest` tests pass (B.5.1 regression: HELD/IN_BANK/MISSING colours, state-transition, visibility contract)
- [ ] `./gradlew build` passes

Refs cha-ndler/collection-log-helper#382 (B.5.4)