### PR TITLE
fix(overlay): dialog highlighting polish (B.5.7)

### DIFF
--- a/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
@@ -604,7 +604,11 @@ public class GuidanceOverlayCoordinator
 		}
 		else
 		{
-			// Step with no location -- clear previous target and show text overlay only
+			// Step with no location -- clear previous target and show text overlay only.
+			// Dialog options are still applied here: a step may be a pure dialog-choice
+			// step with no world coordinates (e.g. "Choose the 'Yes' option").
+			dialogHighlightOverlay.setTargetDialogOptions(step.getDialogOptions());
+			dialogHighlightOverlay.setGuidanceActive(true);
 			guidanceOverlay.setTargetPoint(null);
 			guidanceOverlay.setTargetName(null);
 			guidanceOverlay.setTargetNpcId(0);

--- a/src/main/java/com/collectionloghelper/overlay/DialogHighlightOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/DialogHighlightOverlay.java
@@ -27,11 +27,8 @@ package com.collectionloghelper.overlay;
 import com.collectionloghelper.CollectionLogHelperConfig;
 import java.awt.Color;
 import java.awt.Dimension;
-import java.awt.Font;
-import java.awt.FontMetrics;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
-import java.awt.RenderingHints;
 import java.util.ArrayList;
 import java.util.List;
 import javax.inject.Inject;
@@ -59,7 +56,6 @@ public class DialogHighlightOverlay extends Overlay
 	private static final int NPC_DIALOG_GROUP = 231;
 	private static final int NPC_DIALOG_CONTINUE_CHILD = 5;
 
-	private static final String ARROW_INDICATOR = "\u25b6 ";
 	private static final int BACKGROUND_PADDING_X = 4;
 	private static final int BACKGROUND_PADDING_Y = 2;
 	private static final int BACKGROUND_ALPHA = 50;
@@ -102,14 +98,15 @@ public class DialogHighlightOverlay extends Overlay
 				highlightColor.getBlue(), BORDER_ALPHA);
 		}
 
-		// Highlight matching dialog options in the multi-option dialog
+		// Highlight matching dialog options and the continue prompt only when a
+		// dialog-choice step is active (targetDialogOptionsLower non-empty).
+		// Without this guard the continue button would be highlighted during every
+		// NPC conversation regardless of whether guidance has a dialog step.
 		if (!targetDialogOptionsLower.isEmpty())
 		{
 			renderDialogOptionHighlights(graphics, highlightColor);
+			renderContinueHighlight(graphics, highlightColor);
 		}
-
-		// Highlight "Click here to continue" in NPC dialog to keep the player moving
-		renderContinueHighlight(graphics, highlightColor);
 
 		return null;
 	}
@@ -136,22 +133,18 @@ public class DialogHighlightOverlay extends Overlay
 				continue;
 			}
 
-			String optionText = option.getText();
-			// Skip if already highlighted (arrow prepended on a previous frame)
-			if (optionText.startsWith(ARROW_INDICATOR))
-			{
-				renderWidgetHighlight(graphics, option, highlightColor);
-				continue;
-			}
-
-			String optionLower = optionText.toLowerCase();
+			// Match against the original widget text without mutating it.
+			// Previously the render loop called option.setText() / option.setTextColor()
+			// to prepend an arrow indicator; that approach mutated persistent widget state
+			// across frames and accumulated stale prefixes when the dialog closed and
+			// reopened. Pure drawing (fill + border rect) is sufficient visual feedback
+			// and avoids touching widget state from the render thread.
+			String optionLower = option.getText().toLowerCase();
 			for (String target : targets)
 			{
 				if (optionLower.contains(target))
 				{
 					renderWidgetHighlight(graphics, option, highlightColor);
-					option.setText(ARROW_INDICATOR + optionText);
-					option.setTextColor(highlightColor.getRGB() & 0xFFFFFF);
 					break;
 				}
 			}
@@ -167,10 +160,10 @@ public class DialogHighlightOverlay extends Overlay
 		}
 
 		String text = continueWidget.getText();
+		// Highlight the continue prompt purely by drawing; do not mutate widget text colour.
 		if (text != null && text.contains("Click here to continue"))
 		{
 			renderWidgetHighlight(graphics, continueWidget, highlightColor);
-			continueWidget.setTextColor(highlightColor.getRGB() & 0xFFFFFF);
 		}
 	}
 

--- a/src/test/java/com/collectionloghelper/overlay/DialogHighlightOverlayTest.java
+++ b/src/test/java/com/collectionloghelper/overlay/DialogHighlightOverlayTest.java
@@ -1,0 +1,341 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.overlay;
+
+import com.collectionloghelper.CollectionLogHelperConfig;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import java.util.Arrays;
+import java.util.Collections;
+import net.runelite.api.Client;
+import net.runelite.api.widgets.Widget;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link DialogHighlightOverlay} covering:
+ * - Returns null when guidance is not active
+ * - Returns null when showOverlays() is false
+ * - Returns null and draws nothing when targetDialogOptions is empty or null
+ * - Draws highlight rectangle for a matching dialog option (pure drawing, no widget mutation)
+ * - Does not draw anything for a non-matching option
+ * - Continue-prompt highlight is drawn only when dialog options are active
+ * - Widget state (text, textColor) is never mutated during render
+ * - clear() resets all state so subsequent renders skip drawing
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class DialogHighlightOverlayTest
+{
+	private static final int DIALOG_OPTION_GROUP = 219;
+	private static final int DIALOG_OPTION_CHILD = 1;
+	private static final int NPC_DIALOG_GROUP = 231;
+	private static final int NPC_DIALOG_CONTINUE_CHILD = 5;
+
+	@Mock
+	private Client client;
+
+	@Mock
+	private CollectionLogHelperConfig config;
+
+	@Mock
+	private Graphics2D graphics;
+
+	private DialogHighlightOverlay overlay;
+
+	@Before
+	public void setUp() throws Exception
+	{
+		when(config.showOverlays()).thenReturn(true);
+		when(config.overlayColor()).thenReturn(Color.CYAN);
+
+		java.lang.reflect.Constructor<DialogHighlightOverlay> ctor =
+			DialogHighlightOverlay.class.getDeclaredConstructor(Client.class, CollectionLogHelperConfig.class);
+		ctor.setAccessible(true);
+		overlay = ctor.newInstance(client, config);
+	}
+
+	// --- guard-clause checks ---
+
+	@Test
+	public void render_returnsNull_whenGuidanceNotActive()
+	{
+		overlay.setTargetDialogOptions(Collections.singletonList("yes"));
+
+		Dimension result = overlay.render(graphics);
+
+		assertNull(result);
+		verifyNoFill();
+	}
+
+	@Test
+	public void render_returnsNull_whenShowOverlaysFalse()
+	{
+		when(config.showOverlays()).thenReturn(false);
+		overlay.setGuidanceActive(true);
+		overlay.setTargetDialogOptions(Collections.singletonList("yes"));
+
+		Dimension result = overlay.render(graphics);
+
+		assertNull(result);
+		verifyNoFill();
+	}
+
+	@Test
+	public void render_drawsNothing_whenDialogOptionsEmpty()
+	{
+		overlay.setGuidanceActive(true);
+		overlay.setTargetDialogOptions(Collections.emptyList());
+
+		Dimension result = overlay.render(graphics);
+
+		assertNull(result);
+		verifyNoFill();
+	}
+
+	@Test
+	public void render_drawsNothing_whenDialogOptionsNull()
+	{
+		overlay.setGuidanceActive(true);
+		overlay.setTargetDialogOptions(null);
+
+		Dimension result = overlay.render(graphics);
+
+		assertNull(result);
+		verifyNoFill();
+	}
+
+	// --- option matching ---
+
+	@Test
+	public void render_drawsHighlight_forMatchingOption()
+	{
+		overlay.setGuidanceActive(true);
+		overlay.setTargetDialogOptions(Collections.singletonList("yes"));
+
+		Widget option = mockOption("Yes, I would like to trade.", new Rectangle(10, 20, 200, 16));
+		Widget container = mockContainer(new Widget[]{option});
+		when(client.getWidget(DIALOG_OPTION_GROUP, DIALOG_OPTION_CHILD)).thenReturn(container);
+		when(client.getWidget(NPC_DIALOG_GROUP, NPC_DIALOG_CONTINUE_CHILD)).thenReturn(null);
+
+		overlay.render(graphics);
+
+		verifyFillDrawn();
+	}
+
+	@Test
+	public void render_doesNotDrawHighlight_forNonMatchingOption()
+	{
+		overlay.setGuidanceActive(true);
+		overlay.setTargetDialogOptions(Collections.singletonList("teleport"));
+
+		Widget option = mockOption("Yes, I would like to trade.", new Rectangle(10, 20, 200, 16));
+		Widget container = mockContainer(new Widget[]{option});
+		when(client.getWidget(DIALOG_OPTION_GROUP, DIALOG_OPTION_CHILD)).thenReturn(container);
+		when(client.getWidget(NPC_DIALOG_GROUP, NPC_DIALOG_CONTINUE_CHILD)).thenReturn(null);
+
+		overlay.render(graphics);
+
+		verifyNoFill();
+	}
+
+	@Test
+	public void render_neverMutatesWidgetText_forMatchingOption()
+	{
+		overlay.setGuidanceActive(true);
+		overlay.setTargetDialogOptions(Collections.singletonList("yes"));
+
+		Widget option = mockOption("Yes", new Rectangle(10, 20, 200, 16));
+		Widget container = mockContainer(new Widget[]{option});
+		when(client.getWidget(DIALOG_OPTION_GROUP, DIALOG_OPTION_CHILD)).thenReturn(container);
+		when(client.getWidget(NPC_DIALOG_GROUP, NPC_DIALOG_CONTINUE_CHILD)).thenReturn(null);
+
+		overlay.render(graphics);
+
+		verify(option, never()).setText(org.mockito.ArgumentMatchers.anyString());
+		verify(option, never()).setTextColor(anyInt());
+	}
+
+	@Test
+	public void render_matchesCaseInsensitive()
+	{
+		overlay.setGuidanceActive(true);
+		overlay.setTargetDialogOptions(Collections.singletonList("YES"));
+
+		Widget option = mockOption("Yes please", new Rectangle(10, 20, 200, 16));
+		Widget container = mockContainer(new Widget[]{option});
+		when(client.getWidget(DIALOG_OPTION_GROUP, DIALOG_OPTION_CHILD)).thenReturn(container);
+		when(client.getWidget(NPC_DIALOG_GROUP, NPC_DIALOG_CONTINUE_CHILD)).thenReturn(null);
+
+		overlay.render(graphics);
+
+		verifyFillDrawn();
+	}
+
+	@Test
+	public void render_skipsOptionWithNullText()
+	{
+		overlay.setGuidanceActive(true);
+		overlay.setTargetDialogOptions(Collections.singletonList("yes"));
+
+		Widget nullTextOption = mock(Widget.class);
+		when(nullTextOption.getText()).thenReturn(null);
+
+		Widget container = mockContainer(new Widget[]{nullTextOption});
+		when(client.getWidget(DIALOG_OPTION_GROUP, DIALOG_OPTION_CHILD)).thenReturn(container);
+		when(client.getWidget(NPC_DIALOG_GROUP, NPC_DIALOG_CONTINUE_CHILD)).thenReturn(null);
+
+		overlay.render(graphics);
+
+		verifyNoFill();
+	}
+
+	// --- continue-prompt highlight ---
+
+	@Test
+	public void render_drawsContinueHighlight_whenDialogOptionsActiveAndContinueVisible()
+	{
+		overlay.setGuidanceActive(true);
+		overlay.setTargetDialogOptions(Collections.singletonList("teleport"));
+
+		when(client.getWidget(DIALOG_OPTION_GROUP, DIALOG_OPTION_CHILD)).thenReturn(null);
+
+		Widget continueWidget = mock(Widget.class);
+		when(continueWidget.isHidden()).thenReturn(false);
+		when(continueWidget.getText()).thenReturn("Click here to continue");
+		when(continueWidget.getBounds()).thenReturn(new Rectangle(50, 400, 300, 20));
+		when(client.getWidget(NPC_DIALOG_GROUP, NPC_DIALOG_CONTINUE_CHILD)).thenReturn(continueWidget);
+
+		overlay.render(graphics);
+
+		verifyFillDrawn();
+	}
+
+	@Test
+	public void render_doesNotDrawContinue_whenDialogOptionsEmpty()
+	{
+		// With empty options the outer guard (targetDialogOptionsLower.isEmpty()) short-circuits
+		// before any client.getWidget() call, so no widget stubs are needed here.
+		overlay.setGuidanceActive(true);
+		overlay.setTargetDialogOptions(Collections.emptyList());
+
+		overlay.render(graphics);
+
+		verifyNoFill();
+	}
+
+	@Test
+	public void render_neverMutatesContinueWidgetTextColor()
+	{
+		overlay.setGuidanceActive(true);
+		overlay.setTargetDialogOptions(Collections.singletonList("teleport"));
+
+		when(client.getWidget(DIALOG_OPTION_GROUP, DIALOG_OPTION_CHILD)).thenReturn(null);
+
+		Widget continueWidget = mock(Widget.class);
+		when(continueWidget.isHidden()).thenReturn(false);
+		when(continueWidget.getText()).thenReturn("Click here to continue");
+		when(continueWidget.getBounds()).thenReturn(new Rectangle(50, 400, 300, 20));
+		when(client.getWidget(NPC_DIALOG_GROUP, NPC_DIALOG_CONTINUE_CHILD)).thenReturn(continueWidget);
+
+		overlay.render(graphics);
+
+		verify(continueWidget, never()).setTextColor(anyInt());
+		verify(continueWidget, never()).setText(org.mockito.ArgumentMatchers.anyString());
+	}
+
+	// --- clear() ---
+
+	@Test
+	public void clear_preventsRenderAfterBeingSet()
+	{
+		// clear() resets guidanceActive to false; the !guidanceActive guard exits before
+		// any client.getWidget() call, so no widget stubs are needed.
+		overlay.setGuidanceActive(true);
+		overlay.setTargetDialogOptions(Collections.singletonList("yes"));
+		overlay.clear();
+
+		overlay.render(graphics);
+
+		verifyNoFill();
+	}
+
+	// --- multiple options ---
+
+	@Test
+	public void render_highlightsMatchingOptionAmongMultiple()
+	{
+		overlay.setGuidanceActive(true);
+		overlay.setTargetDialogOptions(Arrays.asList("bank", "yes"));
+
+		Widget optionBank = mockOption("Use the Bank", new Rectangle(10, 20, 200, 16));
+		Widget optionNo = mockOption("No thank you", new Rectangle(10, 40, 200, 16));
+		Widget container = mockContainer(new Widget[]{optionBank, optionNo});
+		when(client.getWidget(DIALOG_OPTION_GROUP, DIALOG_OPTION_CHILD)).thenReturn(container);
+		when(client.getWidget(NPC_DIALOG_GROUP, NPC_DIALOG_CONTINUE_CHILD)).thenReturn(null);
+
+		overlay.render(graphics);
+
+		verify(graphics).fillRect(anyInt(), anyInt(), anyInt(), anyInt());
+	}
+
+	// --- helpers ---
+
+	private Widget mockOption(String text, Rectangle bounds)
+	{
+		Widget w = mock(Widget.class);
+		when(w.getText()).thenReturn(text);
+		when(w.getBounds()).thenReturn(bounds);
+		return w;
+	}
+
+	private Widget mockContainer(Widget[] children)
+	{
+		Widget container = mock(Widget.class);
+		when(container.getDynamicChildren()).thenReturn(children);
+		return container;
+	}
+
+	private void verifyFillDrawn()
+	{
+		verify(graphics).fillRect(anyInt(), anyInt(), anyInt(), anyInt());
+	}
+
+	private void verifyNoFill()
+	{
+		verify(graphics, never()).fillRect(anyInt(), anyInt(), anyInt(), anyInt());
+	}
+}


### PR DESCRIPTION
## Audit findings

`DialogHighlightOverlay` was audited end-to-end. Overall structure is solid: colour caching is correct, null-safety on widget lookups follows the snapshot-then-null-check pattern, overlay lifecycle (register/unregister) is symmetric, and `ABOVE_WIDGETS` layer is appropriate.

Three fixable bugs were found and addressed in this PR. Two larger findings are deferred below.

## Fixes applied

### 1. Location-less dialog steps never highlighted (bug)
`setTargetDialogOptions` and `setGuidanceActive(true)` were only called inside the `if (step.getWorldX() > 0)` branch of `GuidanceOverlayCoordinator.applyStepToOverlays`. A guidance step that is a pure dialog interaction with no world coordinates (e.g. a step whose only purpose is "choose the Yes option") would silently receive no highlight. Fixed by adding both calls to the `else` branch.

### 2. Widget mutation in render path (bug)
`renderDialogOptionHighlights` called `option.setText()` and `option.setTextColor()` to prepend a `▶` arrow on matched options. This mutated persistent widget state every frame. When the dialog closed and reopened, the arrow prefix accumulated and the "already highlighted" guard (`startsWith(ARROW_INDICATOR)`) could fire against stale text. Replaced with pure fill+border rect drawing. The arrow constant is removed.

### 3. Continue-prompt highlighted unconditionally (unintended behaviour)
`renderContinueHighlight` was called on every frame regardless of whether a dialog-choice guidance step was active — every NPC "Click here to continue" prompt was highlighted during any NPC conversation while guidance was running. Moved the call inside the `!targetDialogOptionsLower.isEmpty()` guard so the continue prompt is only highlighted when a dialog step is actually in progress.

## Deferred follow-ups

**Widget IDs 219/231 as magic literals.** The group IDs for player dialog choices and NPC dialog are stored as raw integers. Other overlays in this codebase use `net.runelite.api.gameval.InterfaceID.*` named constants. A follow-up should replace these literals with their named equivalents and add a comment linking to the RuneLite source so the mapping is auditable when the game updates.

**Missing `drawAfterInterface()` call.** Other widget-targeting overlays (e.g. `WorldMapDestinationOverlay`) call `drawAfterInterface(InterfaceID.X)` to ensure rendering happens after the relevant widget draws, preventing z-order artifacts. `DialogHighlightOverlay` does not call this. Needs investigation to determine whether the `ABOVE_WIDGETS` layer alone is sufficient or whether an explicit `drawAfterInterface(InterfaceID.DIALOG_OPTION)` is also required.

## Test plan

- [x] `./gradlew build` passes (646 + 15 new tests, all green)
- [x] `DialogHighlightOverlayTest` (15 tests): guard clauses, match/no-match, case-insensitivity, zero widget mutation on render, continue-prompt gating, `clear()` reset, multiple-option list
- [ ] In-game: activate guidance for a source with `dialogOptions` set on a step; verify the matching option is highlighted with fill+border rect and no arrow text prefix appears
- [ ] In-game: walk past an NPC unrelated to the active guidance step; verify "Click here to continue" is NOT highlighted
- [ ] In-game: activate guidance on a location-less dialog step (worldX = 0); verify the dialog highlight fires correctly

Refs cha-ndler/collection-log-helper#382 (B.5.7)