### PR TITLE
feat(panel): recommended items section per guidance step (B.5.2)

### DIFF
--- a/src/main/java/com/collectionloghelper/data/GuidanceStep.java
+++ b/src/main/java/com/collectionloghelper/data/GuidanceStep.java
@@ -61,6 +61,16 @@ public class GuidanceStep
 	/** Item IDs that must be in inventory before this step can proceed. */
 	List<Integer> requiredItemIds;
 
+	/**
+	 * Soft-recommended item IDs for this step: food, prayer potions, anti-venom,
+	 * combat gear, teleports, etc. Items that materially improve the run but are
+	 * not strictly required to complete the step.
+	 *
+	 * <p>Null by default — existing JSON without this field deserialises unchanged.
+	 * The panel hides the "Recommended:" subsection when this list is null or empty.
+	 */
+	List<Integer> recommendedItemIds;
+
 	/** How the system detects this step is complete. */
 	CompletionCondition completionCondition;
 
@@ -276,6 +286,7 @@ public class GuidanceStep
 			this.dialogOptions,
 			alt.getTravelTip() != null ? alt.getTravelTip() : this.travelTip,
 			this.requiredItemIds,
+			this.recommendedItemIds,
 			alt.getCompletionCondition() != null ? alt.getCompletionCondition() : this.completionCondition,
 			this.completionItemId,
 			this.completionItemCount,

--- a/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
@@ -269,8 +269,10 @@ public class GuidanceOverlayCoordinator
 				{
 					final List<RequiredItemDisplay> resolvedItems =
 						requiredItemResolver.resolve(rawForResolve);
+					final List<RequiredItemDisplay> resolvedRecommended =
+						requiredItemResolver.resolveRecommended(rawForResolve);
 					panel.updateStepProgress(landedIdx, stepTotal, stepDesc, stepManual,
-						resolvedItems, sourceSteps);
+						resolvedItems, resolvedRecommended, sourceSteps);
 				});
 			}
 			// Add InfoBox showing the correct landed step (not always "1/N")
@@ -846,12 +848,16 @@ public class GuidanceOverlayCoordinator
 			// to the client thread because RequiredItemResolver.resolve() calls
 			// ItemManager.getItemComposition, which asserts caller-is-client-thread. See
 			// cha-ndler/collection-log-helper#388 for the original trace.
-			panel.updateStepProgress(current, total, desc, isManual, Collections.emptyList(), sourceSteps);
+			panel.updateStepProgress(current, total, desc, isManual,
+				Collections.emptyList(), Collections.emptyList(), sourceSteps);
 			clientThread.invokeLater(() ->
 			{
 				final List<RequiredItemDisplay> resolvedItems =
 					requiredItemResolver.resolve(rawStep);
-				panel.updateStepProgress(current, total, desc, isManual, resolvedItems, sourceSteps);
+				final List<RequiredItemDisplay> resolvedRecommended =
+					requiredItemResolver.resolveRecommended(rawStep);
+				panel.updateStepProgress(current, total, desc, isManual,
+					resolvedItems, resolvedRecommended, sourceSteps);
 			});
 		}
 	}

--- a/src/main/java/com/collectionloghelper/guidance/RequiredItemResolver.java
+++ b/src/main/java/com/collectionloghelper/guidance/RequiredItemResolver.java
@@ -64,20 +64,43 @@ public class RequiredItemResolver
 	}
 
 	/**
-	 * Resolves a step's required item IDs into display rows.
-	 * Returns an empty list when the step is null, has no required items,
-	 * or the list contains only invalid IDs.
+	 * Resolves a step's {@code requiredItemIds} into display rows.
+	 * Returns an empty list when the step is null or has no required items.
 	 */
 	public List<RequiredItemDisplay> resolve(GuidanceStep step)
 	{
-		if (step == null
-			|| step.getRequiredItemIds() == null
-			|| step.getRequiredItemIds().isEmpty())
+		if (step == null)
 		{
 			return Collections.emptyList();
 		}
+		return resolveIds(step.getRequiredItemIds());
+	}
 
-		List<Integer> ids = step.getRequiredItemIds();
+	/**
+	 * Resolves a step's {@code recommendedItemIds} into display rows.
+	 * Returns an empty list when the step is null or has no recommended items.
+	 */
+	public List<RequiredItemDisplay> resolveRecommended(GuidanceStep step)
+	{
+		if (step == null)
+		{
+			return Collections.emptyList();
+		}
+		return resolveIds(step.getRecommendedItemIds());
+	}
+
+	/**
+	 * Resolves an arbitrary list of item IDs into display rows.
+	 * Returns an empty list when {@code ids} is null or empty, or contains
+	 * only invalid IDs. Shared implementation for both required and recommended
+	 * item resolution so colouring logic stays consistent.
+	 */
+	public List<RequiredItemDisplay> resolveIds(List<Integer> ids)
+	{
+		if (ids == null || ids.isEmpty())
+		{
+			return Collections.emptyList();
+		}
 		List<RequiredItemDisplay> out = new ArrayList<>(ids.size());
 		for (Integer itemId : ids)
 		{

--- a/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
@@ -635,15 +635,37 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 	 * Updates the step progress banner with current step info, enabling collapsible
 	 * section blocks when {@code allSteps} contains steps with section labels.
 	 *
-	 * @param requiredItems pre-resolved display rows; may be {@code null} or empty
-	 * @param allSteps      full ordered step list for the active source; used to compute
-	 *                      section groups — pass an empty list for flat layout
+	 * @param requiredItems    pre-resolved required-item display rows; may be {@code null}
+	 *                         or empty
+	 * @param allSteps         full ordered step list for the active source; used to compute
+	 *                         section groups — pass an empty list for flat layout
 	 */
 	public void updateStepProgress(int current, int total, String description, boolean isManual,
 		List<RequiredItemDisplay> requiredItems,
 		List<com.collectionloghelper.data.GuidanceStep> allSteps)
 	{
 		stepProgressView.showStep(current, total, description, isManual, requiredItems, allSteps);
+	}
+
+	/**
+	 * Updates the step progress banner with current step info, both required and
+	 * recommended items, and enables collapsible section blocks when {@code allSteps}
+	 * contains steps with section labels.
+	 *
+	 * @param requiredItems    pre-resolved required-item display rows; may be {@code null}
+	 *                         or empty
+	 * @param recommendedItems pre-resolved recommended-item display rows; may be
+	 *                         {@code null} or empty
+	 * @param allSteps         full ordered step list for the active source; used to compute
+	 *                         section groups — pass an empty list for flat layout
+	 */
+	public void updateStepProgress(int current, int total, String description, boolean isManual,
+		List<RequiredItemDisplay> requiredItems,
+		List<RequiredItemDisplay> recommendedItems,
+		List<com.collectionloghelper.data.GuidanceStep> allSteps)
+	{
+		stepProgressView.showStep(current, total, description, isManual,
+			requiredItems, recommendedItems, allSteps);
 	}
 
 	/** Hides the step progress banner. */

--- a/src/main/java/com/collectionloghelper/ui/widget/StepProgressView.java
+++ b/src/main/java/com/collectionloghelper/ui/widget/StepProgressView.java
@@ -64,10 +64,10 @@ import net.runelite.client.util.AsyncBufferedImage;
  * When no step in the source has a section label the flat single-line layout
  * is used unchanged.
  *
- * <p>Required-item rows are passed in as pre-resolved {@link RequiredItemDisplay}
- * objects (name + status already determined on the client thread by
- * {@link com.collectionloghelper.guidance.RequiredItemResolver}) so this widget
- * never touches inventory/bank state directly.
+ * <p>Required-item rows and recommended-item rows are passed in as pre-resolved
+ * {@link RequiredItemDisplay} objects (name + status already determined on the
+ * client thread by {@link com.collectionloghelper.guidance.RequiredItemResolver})
+ * so this widget never touches inventory/bank state directly.
  *
  * <p>Constructed once by the shell; updated via {@link #showStep} and
  * hidden via {@link #hideStep}. Step-advance and skip callbacks are wired
@@ -92,6 +92,7 @@ public class StepProgressView extends JPanel
 
 	private final JLabel stepProgressLabel;
 	private final JPanel requiredItemsPanel;
+	private final JPanel recommendedItemsPanel;
 	/** Container rendered when the source uses section labels (sectioned mode). */
 	private final JPanel sectionsPanel;
 	private final JButton nextStepButton;
@@ -132,6 +133,13 @@ public class StepProgressView extends JPanel
 		requiredItemsPanel.setAlignmentX(LEFT_ALIGNMENT);
 		requiredItemsPanel.setVisible(false);
 		add(requiredItemsPanel);
+
+		recommendedItemsPanel = new JPanel();
+		recommendedItemsPanel.setLayout(new BoxLayout(recommendedItemsPanel, BoxLayout.Y_AXIS));
+		recommendedItemsPanel.setBackground(BG);
+		recommendedItemsPanel.setAlignmentX(LEFT_ALIGNMENT);
+		recommendedItemsPanel.setVisible(false);
+		add(recommendedItemsPanel);
 
 		sectionsPanel = new JPanel();
 		sectionsPanel.setLayout(new BoxLayout(sectionsPanel, BoxLayout.Y_AXIS));
@@ -203,7 +211,8 @@ public class StepProgressView extends JPanel
 	public void showStep(int current, int total, String description, boolean isManual,
 		List<RequiredItemDisplay> requiredItems)
 	{
-		showStep(current, total, description, isManual, requiredItems, Collections.emptyList());
+		showStep(current, total, description, isManual, requiredItems,
+			Collections.<RequiredItemDisplay>emptyList(), Collections.<GuidanceStep>emptyList());
 	}
 
 	/**
@@ -211,19 +220,48 @@ public class StepProgressView extends JPanel
 	 * when {@code allSteps} contains at least one step with a non-null section label.
 	 * Safe to call from any thread.
 	 *
-	 * @param current       one-based step index
-	 * @param total         total number of steps
-	 * @param description   human-readable step description
-	 * @param isManual      whether the Next Step button should be shown
-	 * @param requiredItems pre-resolved display rows (may be {@code null} or empty)
-	 * @param allSteps      full ordered step list for the active source; used to compute
-	 *                      section groups. Pass an empty list to force flat layout.
+	 * @param current            one-based step index
+	 * @param total              total number of steps
+	 * @param description        human-readable step description
+	 * @param isManual           whether the Next Step button should be shown
+	 * @param requiredItems      pre-resolved required-item display rows (may be {@code null}
+	 *                           or empty)
+	 * @param allSteps           full ordered step list for the active source; used to compute
+	 *                           section groups. Pass an empty list to force flat layout.
 	 */
 	public void showStep(int current, int total, String description, boolean isManual,
 		List<RequiredItemDisplay> requiredItems, List<GuidanceStep> allSteps)
 	{
+		showStep(current, total, description, isManual, requiredItems,
+			Collections.<RequiredItemDisplay>emptyList(), allSteps);
+	}
+
+	/**
+	 * Shows and populates the step progress panel, rendering both the required-items and
+	 * recommended-items subsections, and collapsible section blocks when {@code allSteps}
+	 * contains at least one step with a non-null section label.
+	 * Safe to call from any thread.
+	 *
+	 * @param current            one-based step index
+	 * @param total              total number of steps
+	 * @param description        human-readable step description
+	 * @param isManual           whether the Next Step button should be shown
+	 * @param requiredItems      pre-resolved required-item display rows (may be {@code null}
+	 *                           or empty)
+	 * @param recommendedItems   pre-resolved recommended-item display rows (may be
+	 *                           {@code null} or empty); hidden when empty
+	 * @param allSteps           full ordered step list for the active source; used to
+	 *                           compute section groups. Pass an empty list to force flat
+	 *                           layout.
+	 */
+	public void showStep(int current, int total, String description, boolean isManual,
+		List<RequiredItemDisplay> requiredItems, List<RequiredItemDisplay> recommendedItems,
+		List<GuidanceStep> allSteps)
+	{
 		final List<RequiredItemDisplay> rows =
 			requiredItems != null ? requiredItems : Collections.emptyList();
+		final List<RequiredItemDisplay> recRows =
+			recommendedItems != null ? recommendedItems : Collections.emptyList();
 		final List<GuidanceStep> steps =
 			allSteps != null ? allSteps : Collections.emptyList();
 		final List<StepSectionGroup> groups = StepSectionGrouper.group(steps);
@@ -236,16 +274,19 @@ public class StepProgressView extends JPanel
 
 			if (groups.isEmpty())
 			{
-				// Flat layout — hide sections, show required items inline
+				// Flat layout — hide sections, show required and recommended items inline
 				sectionsPanel.setVisible(false);
 				updateRequiredItemDisplay(rows);
+				updateRecommendedItemDisplay(recRows);
 			}
 			else
 			{
-				// Sectioned layout — hide inline required items, render section blocks
+				// Sectioned layout — hide inline panels, render section blocks
 				requiredItemsPanel.removeAll();
 				requiredItemsPanel.setVisible(false);
-				updateSectionDisplay(groups, current, rows);
+				recommendedItemsPanel.removeAll();
+				recommendedItemsPanel.setVisible(false);
+				updateSectionDisplay(groups, current, rows, recRows);
 			}
 
 			setVisible(true);
@@ -271,6 +312,8 @@ public class StepProgressView extends JPanel
 		{
 			requiredItemsPanel.removeAll();
 			requiredItemsPanel.setVisible(false);
+			recommendedItemsPanel.removeAll();
+			recommendedItemsPanel.setVisible(false);
 			sectionsPanel.removeAll();
 			sectionsPanel.setVisible(false);
 			setVisible(false);
@@ -288,17 +331,19 @@ public class StepProgressView extends JPanel
 	 * Rebuilds the collapsible section blocks.
 	 *
 	 * <p>The section containing {@code activeStepIndex} is force-expanded and its
-	 * required-item rows are rendered immediately below the step label. Other sections
-	 * respect their stored collapse state (defaulting to collapsed).
+	 * required-item and recommended-item rows are rendered immediately below the step
+	 * label. Other sections respect their stored collapse state (defaulting to
+	 * collapsed).
 	 *
 	 * <p>Must be called on the EDT.
 	 *
-	 * @param groups          ordered section groups from {@link StepSectionGrouper#group}
-	 * @param activeStepIndex 1-based index of the currently active step
-	 * @param requiredItems   display rows for the active step
+	 * @param groups           ordered section groups from {@link StepSectionGrouper#group}
+	 * @param activeStepIndex  1-based index of the currently active step
+	 * @param requiredItems    required-item display rows for the active step
+	 * @param recommendedItems recommended-item display rows for the active step
 	 */
 	void updateSectionDisplay(List<StepSectionGroup> groups, int activeStepIndex,
-		List<RequiredItemDisplay> requiredItems)
+		List<RequiredItemDisplay> requiredItems, List<RequiredItemDisplay> recommendedItems)
 	{
 		sectionsPanel.removeAll();
 
@@ -315,7 +360,8 @@ public class StepProgressView extends JPanel
 			boolean isActiveSection = group.getName().equals(activeSectionName);
 			boolean expanded = sectionExpandState.getOrDefault(group.getName(), Boolean.FALSE);
 
-			JPanel block = buildSectionBlock(group, isActiveSection, expanded, activeStepIndex, requiredItems);
+			JPanel block = buildSectionBlock(group, isActiveSection, expanded,
+				activeStepIndex, requiredItems, recommendedItems);
 			block.setAlignmentX(LEFT_ALIGNMENT);
 			sectionsPanel.add(block);
 			sectionsPanel.add(Box.createVerticalStrut(2));
@@ -327,14 +373,25 @@ public class StepProgressView extends JPanel
 	}
 
 	/**
+	 * Overload retained for backwards compatibility with existing test callers that
+	 * do not yet pass recommended items.
+	 */
+	void updateSectionDisplay(List<StepSectionGroup> groups, int activeStepIndex,
+		List<RequiredItemDisplay> requiredItems)
+	{
+		updateSectionDisplay(groups, activeStepIndex, requiredItems, Collections.emptyList());
+	}
+
+	/**
 	 * Builds a single collapsible section block: a clickable header row + a body
-	 * panel containing the step indices (and required-item rows for the active step
-	 * when expanded).
+	 * panel containing the step indices (and required-item + recommended-item rows
+	 * for the active step when expanded).
 	 *
 	 * <p>Must be called on the EDT.
 	 */
 	private JPanel buildSectionBlock(StepSectionGroup group, boolean isActiveSection,
-		boolean expanded, int activeStepIndex, List<RequiredItemDisplay> requiredItems)
+		boolean expanded, int activeStepIndex, List<RequiredItemDisplay> requiredItems,
+		List<RequiredItemDisplay> recommendedItems)
 	{
 		JPanel block = new JPanel();
 		block.setLayout(new BoxLayout(block, BoxLayout.Y_AXIS));
@@ -387,6 +444,33 @@ public class StepProgressView extends JPanel
 
 				body.add(itemsInSection);
 			}
+
+			if (isActive && recommendedItems != null && !recommendedItems.isEmpty())
+			{
+				JPanel recInSection = new JPanel();
+				recInSection.setLayout(new BoxLayout(recInSection, BoxLayout.Y_AXIS));
+				recInSection.setBackground(new Color(20, 28, 45));
+				recInSection.setBorder(BorderFactory.createEmptyBorder(0, 8, 0, 0));
+				recInSection.setAlignmentX(LEFT_ALIGNMENT);
+				recInSection.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
+
+				JLabel recLabel = new JLabel("Recommended:");
+				recLabel.setFont(FontManager.getRunescapeSmallFont().deriveFont(Font.BOLD));
+				recLabel.setForeground(new Color(180, 180, 180));
+				recLabel.setAlignmentX(LEFT_ALIGNMENT);
+				recInSection.add(recLabel);
+				recInSection.add(Box.createVerticalStrut(2));
+
+				for (RequiredItemDisplay row : recommendedItems)
+				{
+					JPanel rowPanel = buildItemRow(row);
+					rowPanel.setAlignmentX(LEFT_ALIGNMENT);
+					recInSection.add(rowPanel);
+					recInSection.add(Box.createVerticalStrut(2));
+				}
+
+				body.add(recInSection);
+			}
 		}
 
 		body.setVisible(expanded);
@@ -434,7 +518,7 @@ public class StepProgressView extends JPanel
 		return arrow + sectionName + " (" + stepCount + " step" + (stepCount == 1 ? "" : "s") + ")";
 	}
 
-	// ── Flat required-items display (unchanged from B.5.1) ───────────────────
+	// ── Flat required/recommended-items display ─────────────────────────────
 
 	/**
 	 * Rebuilds the required-items subsection from pre-resolved display rows.
@@ -454,33 +538,60 @@ public class StepProgressView extends JPanel
 	 */
 	void updateRequiredItemDisplay(List<RequiredItemDisplay> rows)
 	{
-		requiredItemsPanel.removeAll();
+		updateItemSubsection(requiredItemsPanel, "Items needed:", rows);
+	}
+
+	/**
+	 * Rebuilds the recommended-items subsection from pre-resolved display rows.
+	 * Uses the same row layout as {@link #updateRequiredItemDisplay} so colouring
+	 * (green/white+ℹ/red) is identical.
+	 * The subsection is hidden when {@code rows} is empty.
+	 * Must be called on the EDT.
+	 *
+	 * @param rows pre-resolved display rows from
+	 *             {@link com.collectionloghelper.guidance.RequiredItemResolver#resolveRecommended}
+	 */
+	void updateRecommendedItemDisplay(List<RequiredItemDisplay> rows)
+	{
+		updateItemSubsection(recommendedItemsPanel, "Recommended:", rows);
+	}
+
+	/**
+	 * Shared implementation for both the required-items and recommended-items
+	 * subsections. Clears {@code panel}, populates it with a header label and one
+	 * row per entry, then sets its visibility based on whether {@code rows} is empty.
+	 * Must be called on the EDT.
+	 */
+	private void updateItemSubsection(JPanel panel, String headerText,
+		List<RequiredItemDisplay> rows)
+	{
+		panel.removeAll();
 
 		if (rows == null || rows.isEmpty())
 		{
-			requiredItemsPanel.setVisible(false);
+			panel.setVisible(false);
 			return;
 		}
 
-		JLabel headerLabel = new JLabel("Items needed:");
+		JLabel headerLabel = new JLabel(headerText);
 		headerLabel.setFont(FontManager.getRunescapeSmallFont().deriveFont(Font.BOLD));
 		headerLabel.setForeground(new Color(180, 180, 180));
 		headerLabel.setAlignmentX(LEFT_ALIGNMENT);
-		requiredItemsPanel.add(headerLabel);
+		panel.add(headerLabel);
 
-		requiredItemsPanel.add(Box.createVerticalStrut(2));
+		panel.add(Box.createVerticalStrut(2));
 
 		for (RequiredItemDisplay row : rows)
 		{
 			JPanel rowPanel = buildItemRow(row);
 			rowPanel.setAlignmentX(LEFT_ALIGNMENT);
-			requiredItemsPanel.add(rowPanel);
-			requiredItemsPanel.add(Box.createVerticalStrut(2));
+			panel.add(rowPanel);
+			panel.add(Box.createVerticalStrut(2));
 		}
 
-		requiredItemsPanel.setVisible(true);
-		requiredItemsPanel.revalidate();
-		requiredItemsPanel.repaint();
+		panel.setVisible(true);
+		panel.revalidate();
+		panel.repaint();
 	}
 
 	/**

--- a/src/test/java/com/collectionloghelper/data/DropRateDatabaseTest.java
+++ b/src/test/java/com/collectionloghelper/data/DropRateDatabaseTest.java
@@ -300,4 +300,78 @@ public class DropRateDatabaseTest
 		assertNotNull(source);
 		assertTrue(source.getKillTimeSeconds() > 0);
 	}
+
+	// ========================================================================
+	// GuidanceStep.recommendedItemIds — schema deserialization (B.5.2)
+	// ========================================================================
+
+	/**
+	 * A GuidanceStep JSON with {@code recommendedItemIds} present must
+	 * deserialise the list correctly.
+	 */
+	@Test
+	public void guidanceStep_withRecommendedItemIds_deserializesCorrectly()
+	{
+		Gson gson = new GsonBuilder().create();
+		String json =
+			"{\"description\":\"Test step\","
+			+ "\"completionCondition\":\"MANUAL\","
+			+ "\"requiredItemIds\":[590],"
+			+ "\"recommendedItemIds\":[4151,2440]}";
+
+		GuidanceStep step = gson.fromJson(json, GuidanceStep.class);
+
+		assertNotNull("Step must not be null", step);
+		assertNotNull("requiredItemIds must be deserialised", step.getRequiredItemIds());
+		assertEquals(1, step.getRequiredItemIds().size());
+		assertEquals(Integer.valueOf(590), step.getRequiredItemIds().get(0));
+
+		assertNotNull("recommendedItemIds must be deserialised", step.getRecommendedItemIds());
+		assertEquals(2, step.getRecommendedItemIds().size());
+		assertEquals(Integer.valueOf(4151), step.getRecommendedItemIds().get(0));
+		assertEquals(Integer.valueOf(2440), step.getRecommendedItemIds().get(1));
+	}
+
+	/**
+	 * A GuidanceStep JSON without {@code recommendedItemIds} (existing data)
+	 * must deserialise with a null field — no NPE, backwards compatible.
+	 */
+	@Test
+	public void guidanceStep_withoutRecommendedItemIds_nullField()
+	{
+		Gson gson = new GsonBuilder().create();
+		String json =
+			"{\"description\":\"Legacy step\","
+			+ "\"completionCondition\":\"MANUAL\","
+			+ "\"requiredItemIds\":[590]}";
+
+		GuidanceStep step = gson.fromJson(json, GuidanceStep.class);
+
+		assertNotNull("Step must not be null", step);
+		assertNull("recommendedItemIds must be null when absent from JSON",
+			step.getRecommendedItemIds());
+	}
+
+	/**
+	 * The real drop_rates.json (no recommendedItemIds yet) must still parse
+	 * without errors — i.e. the additive schema is backwards compatible.
+	 */
+	@Test
+	public void load_existingDataParsesWithoutRecommendedItemIds()
+	{
+		// If we got here the @Before loaded successfully — just verify all
+		// guidance steps that exist have null recommendedItemIds (no data yet).
+		for (CollectionLogSource source : database.getAllSources())
+		{
+			if (source.getGuidanceSteps() == null)
+			{
+				continue;
+			}
+			for (GuidanceStep step : source.getGuidanceSteps())
+			{
+				assertNull("Existing data must not have recommendedItemIds set (B.5.2b is pending)",
+					step.getRecommendedItemIds());
+			}
+		}
+	}
 }

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
@@ -94,6 +94,7 @@ public class GuidanceSequencerTest
 			0, 0, 0,       // worldX, worldY, worldPlane
 			0, null, null,  // npcId, interactAction, dialogOptions
 			null, null,     // travelTip, requiredItemIds
+			null,           // recommendedItemIds
 			CompletionCondition.MANUAL,
 			0, 0, 0, 0,    // completionItemId, completionItemCount, completionDistance, completionNpcId
 			null,           // completionNpcIds
@@ -122,6 +123,7 @@ public class GuidanceSequencerTest
 			0, 0, 0,
 			0, null, null,
 			null, null,
+			null,  // recommendedItemIds
 			condition,
 			completionItemId, 0, 0, 0,
 			null,  // completionNpcIds
@@ -150,6 +152,7 @@ public class GuidanceSequencerTest
 			0, 0, 0,
 			0, null, null,
 			null, null,
+			null,  // recommendedItemIds
 			CompletionCondition.INVENTORY_HAS_ITEM,
 			itemId, count, 0, 0,
 			null,  // completionNpcIds
@@ -178,6 +181,7 @@ public class GuidanceSequencerTest
 			x, y, plane,
 			0, null, null,
 			null, null,
+			null,  // recommendedItemIds
 			CompletionCondition.ARRIVE_AT_TILE,
 			0, 0, distance, 0,
 			null,  // completionNpcIds
@@ -206,6 +210,7 @@ public class GuidanceSequencerTest
 			0, 0, 0,
 			0, null, null,
 			null, null,
+			null,  // recommendedItemIds
 			CompletionCondition.NPC_TALKED_TO,
 			0, 0, 0, npcId,
 			null,  // completionNpcIds
@@ -234,6 +239,7 @@ public class GuidanceSequencerTest
 			0, 0, 0,
 			0, null, null,
 			null, null,
+			null,  // recommendedItemIds
 			CompletionCondition.ACTOR_DEATH,
 			0, 0, 0, npcId,
 			null,  // completionNpcIds
@@ -262,6 +268,7 @@ public class GuidanceSequencerTest
 			0, 0, 0,
 			0, null, null,
 			null, null,
+			null,  // recommendedItemIds
 			CompletionCondition.CHAT_MESSAGE_RECEIVED,
 			0, 0, 0, 0,
 			null,  // completionNpcIds
@@ -291,6 +298,7 @@ public class GuidanceSequencerTest
 			0, 0, 0,
 			0, null, null,
 			null, null,
+			null,  // recommendedItemIds
 			condition,
 			0, 0, 0, completionNpcId,
 			null,  // completionNpcIds
@@ -319,6 +327,7 @@ public class GuidanceSequencerTest
 			0, 0, plane,
 			0, null, null,
 			null, null,
+			null,  // recommendedItemIds
 			CompletionCondition.PLAYER_ON_PLANE,
 			0, 0, 0, 0,
 			null,  // completionNpcIds
@@ -347,6 +356,7 @@ public class GuidanceSequencerTest
 			0, 0, 0,
 			0, null, null,
 			null, null,
+			null,  // recommendedItemIds
 			CompletionCondition.VARBIT_AT_LEAST,
 			0, 0, 0, 0,
 			null,  // completionNpcIds
@@ -375,6 +385,7 @@ public class GuidanceSequencerTest
 			0, 0, 0,
 			0, null, null,
 			null, requiredItemIds,
+			null,  // recommendedItemIds
 			CompletionCondition.MANUAL,
 			0, 0, 0, 0,
 			null,  // completionNpcIds
@@ -745,6 +756,7 @@ public class GuidanceSequencerTest
 			0, 0, 0,
 			2042, null, null,
 			null, null,
+			null,  // recommendedItemIds
 			CompletionCondition.ACTOR_DEATH,
 			0, 0, 0, 0,
 			Arrays.asList(2042, 2043, 2044),  // completionNpcIds
@@ -1211,6 +1223,7 @@ public class GuidanceSequencerTest
 			worldX, worldY, 0,
 			0, null, null,
 			travelTip, null,
+			null,  // recommendedItemIds
 			CompletionCondition.ARRIVE_AT_TILE,
 			0, 0, 5, 0,
 			null,  // completionNpcIds
@@ -1434,6 +1447,7 @@ public class GuidanceSequencerTest
 			3000, 3000, 0,
 			0, null, null,
 			null, null,
+			null,  // recommendedItemIds
 			CompletionCondition.MANUAL,
 			0, 0, 0, 0,
 			null,  // completionNpcIds

--- a/src/test/java/com/collectionloghelper/guidance/RequiredItemResolverTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/RequiredItemResolverTest.java
@@ -249,9 +249,135 @@ public class RequiredItemResolverTest
 			TINDERBOX, rows.get(0).getItemId());
 	}
 
+	// ── resolveRecommended (B.5.2) ──────────────────────────────────────────
+
+	@Test
+	public void resolveRecommendedReturnsEmptyForNullStep()
+	{
+		assertTrue("Null step must yield an empty recommended result",
+			resolver.resolveRecommended(null).isEmpty());
+	}
+
+	@Test
+	public void resolveRecommendedReturnsEmptyWhenFieldIsNull()
+	{
+		GuidanceStep step = stepWithRequiredAndRecommendedItems(null, null);
+		assertTrue(resolver.resolveRecommended(step).isEmpty());
+	}
+
+	@Test
+	public void resolveRecommendedReturnsEmptyWhenFieldIsEmptyList()
+	{
+		GuidanceStep step = stepWithRequiredAndRecommendedItems(null, Collections.emptyList());
+		assertTrue(resolver.resolveRecommended(step).isEmpty());
+	}
+
+	@Test
+	public void resolveRecommendedHeldInInventory_resolvesToHeld()
+	{
+		when(inventoryState.hasItem(TINDERBOX)).thenReturn(true);
+
+		List<RequiredItemDisplay> rows = resolver.resolveRecommended(
+			stepWithRequiredAndRecommendedItems(null, Collections.singletonList(TINDERBOX)));
+
+		assertEquals(1, rows.size());
+		assertEquals(Status.HELD, rows.get(0).getStatus());
+		assertEquals("Tinderbox", rows.get(0).getName());
+	}
+
+	@Test
+	public void resolveRecommendedInBank_resolvesToInBank()
+	{
+		when(bankState.hasItem(PYRE_LOGS)).thenReturn(true);
+
+		List<RequiredItemDisplay> rows = resolver.resolveRecommended(
+			stepWithRequiredAndRecommendedItems(null, Collections.singletonList(PYRE_LOGS)));
+
+		assertEquals(1, rows.size());
+		assertEquals(Status.IN_BANK, rows.get(0).getStatus());
+	}
+
+	@Test
+	public void resolveRecommendedMissing_resolvesToMissing()
+	{
+		List<RequiredItemDisplay> rows = resolver.resolveRecommended(
+			stepWithRequiredAndRecommendedItems(null, Collections.singletonList(SHADE_REMAINS)));
+
+		assertEquals(1, rows.size());
+		assertEquals(Status.MISSING, rows.get(0).getStatus());
+	}
+
+	/**
+	 * Verifies that required and recommended lists are resolved independently and
+	 * produce separate display rows with correct statuses each.
+	 */
+	@Test
+	public void resolveRequiredAndRecommendedAreIndependent()
+	{
+		when(inventoryState.hasItem(TINDERBOX)).thenReturn(true);
+		when(bankState.hasItem(PYRE_LOGS)).thenReturn(true);
+
+		GuidanceStep step = stepWithRequiredAndRecommendedItems(
+			Collections.singletonList(TINDERBOX),
+			Collections.singletonList(PYRE_LOGS));
+
+		List<RequiredItemDisplay> required = resolver.resolve(step);
+		List<RequiredItemDisplay> recommended = resolver.resolveRecommended(step);
+
+		assertEquals(1, required.size());
+		assertEquals(Status.HELD, required.get(0).getStatus());
+
+		assertEquals(1, recommended.size());
+		assertEquals(Status.IN_BANK, recommended.get(0).getStatus());
+	}
+
+	// ── resolveIds (B.5.2) ──────────────────────────────────────────────────
+
+	@Test
+	public void resolveIdsNullReturnsEmpty()
+	{
+		assertTrue(resolver.resolveIds(null).isEmpty());
+	}
+
+	@Test
+	public void resolveIdsEmptyListReturnsEmpty()
+	{
+		assertTrue(resolver.resolveIds(Collections.emptyList()).isEmpty());
+	}
+
+	@Test
+	public void resolveIdsFiltersInvalidIds()
+	{
+		// IDs <= 0 are invalid and must be skipped
+		List<RequiredItemDisplay> rows = resolver.resolveIds(Arrays.asList(0, -1, null));
+		assertTrue("Invalid item IDs must be skipped", rows.isEmpty());
+
+		// itemManager must never be called for invalid IDs
+		verify(itemManager, never()).getItemComposition(0);
+	}
+
+	@Test
+	public void resolveIdsProducesCorrectRowsForValidIds()
+	{
+		when(inventoryState.hasItem(TINDERBOX)).thenReturn(true);
+
+		List<RequiredItemDisplay> rows = resolver.resolveIds(Collections.singletonList(TINDERBOX));
+
+		assertEquals(1, rows.size());
+		assertEquals(TINDERBOX, rows.get(0).getItemId());
+		assertEquals("Tinderbox", rows.get(0).getName());
+		assertEquals(Status.HELD, rows.get(0).getStatus());
+	}
+
 	// --- Helpers ---
 
 	private static GuidanceStep stepWithRequiredItems(List<Integer> requiredItemIds)
+	{
+		return stepWithRequiredAndRecommendedItems(requiredItemIds, null);
+	}
+
+	private static GuidanceStep stepWithRequiredAndRecommendedItems(
+		List<Integer> requiredItemIds, List<Integer> recommendedItemIds)
 	{
 		return new GuidanceStep(
 			"Test step",
@@ -259,6 +385,7 @@ public class RequiredItemResolverTest
 			0, null, null,
 			null,
 			requiredItemIds,
+			recommendedItemIds,
 			CompletionCondition.MANUAL,
 			0, 0, 0, 0,
 			null,

--- a/src/test/java/com/collectionloghelper/lifecycle/GuidanceEventRouterTest.java
+++ b/src/test/java/com/collectionloghelper/lifecycle/GuidanceEventRouterTest.java
@@ -118,6 +118,7 @@ public class GuidanceEventRouterTest
 			0, 0, 0,
 			0, null, null,
 			null, null,
+			null,  // recommendedItemIds
 			CompletionCondition.NPC_TALKED_TO,
 			0, 0, 0, npcId,
 			null,  // completionNpcIds

--- a/src/test/java/com/collectionloghelper/ui/widget/StepProgressViewTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/StepProgressViewTest.java
@@ -422,6 +422,164 @@ public class StepProgressViewTest
 		assertFalse("sectionsPanel must be hidden after hideStep", findSectionsPanel(view).isVisible());
 	}
 
+	// ── Recommended-items subsection tests (B.5.2) ──────────────────────────
+
+	/**
+	 * When required items are empty but recommended items are populated, the
+	 * "Recommended:" subsection must be visible and the "Items needed:" panel hidden.
+	 */
+	@Test
+	public void updateRecommendedItemDisplay_withRows_subsectionVisible() throws Exception
+	{
+		List<RequiredItemDisplay> recRows = Collections.singletonList(
+			new RequiredItemDisplay(TINDERBOX_ID, "Tinderbox", Status.HELD));
+
+		view.showStep(1, 1, "Boss fight", false,
+			Collections.<RequiredItemDisplay>emptyList(),
+			recRows,
+			Collections.<GuidanceStep>emptyList());
+		flushEdt();
+
+		JPanel recPanel = findRecommendedItemsPanel(view);
+		assertNotNull("recommendedItemsPanel must be present in widget", recPanel);
+		assertTrue("recommendedItemsPanel must be visible when rows are non-empty",
+			recPanel.isVisible());
+		// Required panel must be hidden since we passed empty
+		JPanel reqPanel = findRequiredItemsPanel(view);
+		assertFalse("Required items panel must be hidden when required list is empty",
+			reqPanel.isVisible());
+	}
+
+	/**
+	 * When recommended items list is empty the subsection must remain hidden.
+	 */
+	@Test
+	public void updateRecommendedItemDisplay_emptyList_subsectionHidden() throws Exception
+	{
+		view.showStep(1, 1, "No rec items", false,
+			Collections.<RequiredItemDisplay>emptyList(),
+			Collections.<RequiredItemDisplay>emptyList(),
+			Collections.<GuidanceStep>emptyList());
+		flushEdt();
+
+		JPanel recPanel = findRecommendedItemsPanel(view);
+		assertFalse("recommendedItemsPanel must be hidden when recommended list is empty",
+			recPanel.isVisible());
+	}
+
+	/**
+	 * Both sections must be visible when both required and recommended lists are populated.
+	 */
+	@Test
+	public void showStep_bothRequiredAndRecommended_bothSectionsVisible() throws Exception
+	{
+		List<RequiredItemDisplay> req = Collections.singletonList(
+			new RequiredItemDisplay(TINDERBOX_ID, "Tinderbox", Status.HELD));
+		List<RequiredItemDisplay> rec = Collections.singletonList(
+			new RequiredItemDisplay(PYRE_LOGS_ID, "Pyre logs", Status.MISSING));
+
+		view.showStep(1, 1, "Do thing", false, req, rec, Collections.<GuidanceStep>emptyList());
+		flushEdt();
+
+		assertTrue("Items needed panel must be visible when required list populated",
+			findRequiredItemsPanel(view).isVisible());
+		assertTrue("Recommended panel must be visible when recommended list populated",
+			findRecommendedItemsPanel(view).isVisible());
+	}
+
+	/**
+	 * Recommended rows use the same colour semantics as required rows (HELD=green,
+	 * IN_BANK=white+tooltip, MISSING=red). Parameterised across all three statuses.
+	 */
+	@Test
+	public void updateRecommendedItemDisplay_heldStatus_greenLabel() throws Exception
+	{
+		view.updateRecommendedItemDisplay(Collections.singletonList(
+			new RequiredItemDisplay(TINDERBOX_ID, "Tinderbox", Status.HELD)));
+		flushEdt();
+
+		JLabel label = findFirstRecommendedNameLabel(view);
+		assertNotNull(label);
+		assertEquals("HELD recommended row must use green colour",
+			RequiredItemDisplay.COLOR_HELD, label.getForeground());
+	}
+
+	@Test
+	public void updateRecommendedItemDisplay_inBankStatus_whiteLabelWithTooltip() throws Exception
+	{
+		view.updateRecommendedItemDisplay(Collections.singletonList(
+			new RequiredItemDisplay(PYRE_LOGS_ID, "Pyre logs", Status.IN_BANK)));
+		flushEdt();
+
+		JLabel label = findFirstRecommendedNameLabel(view);
+		assertNotNull(label);
+		assertEquals("IN_BANK recommended row must use white colour",
+			Color.WHITE, label.getForeground());
+		assertTrue("IN_BANK recommended tooltip must contain 'in bank'",
+			label.getToolTipText() != null && label.getToolTipText().contains("in bank"));
+	}
+
+	@Test
+	public void updateRecommendedItemDisplay_missingStatus_redLabel() throws Exception
+	{
+		view.updateRecommendedItemDisplay(Collections.singletonList(
+			new RequiredItemDisplay(SHADE_REMAINS_ID, "Loar remains", Status.MISSING)));
+		flushEdt();
+
+		JLabel label = findFirstRecommendedNameLabel(view);
+		assertNotNull(label);
+		assertEquals("MISSING recommended row must use red colour",
+			RequiredItemDisplay.COLOR_MISSING, label.getForeground());
+	}
+
+	/**
+	 * hideStep must clear both required and recommended panels.
+	 */
+	@Test
+	public void hideStep_clearsBothItemPanels() throws Exception
+	{
+		List<RequiredItemDisplay> req = Collections.singletonList(
+			new RequiredItemDisplay(TINDERBOX_ID, "Tinderbox", Status.HELD));
+		List<RequiredItemDisplay> rec = Collections.singletonList(
+			new RequiredItemDisplay(PYRE_LOGS_ID, "Pyre logs", Status.MISSING));
+
+		view.showStep(1, 1, "Do thing", false, req, rec, Collections.<GuidanceStep>emptyList());
+		flushEdt();
+
+		view.hideStep();
+		flushEdt();
+
+		assertFalse("Required panel must be hidden after hideStep",
+			findRequiredItemsPanel(view).isVisible());
+		assertFalse("Recommended panel must be hidden after hideStep",
+			findRecommendedItemsPanel(view).isVisible());
+	}
+
+	/**
+	 * Schema-level: a step constructed with a non-null recommendedItemIds list
+	 * exposes the list correctly via getRecommendedItemIds().
+	 */
+	@Test
+	public void guidanceStep_recommendedItemIds_accessible()
+	{
+		List<Integer> recIds = Arrays.asList(TINDERBOX_ID, PYRE_LOGS_ID);
+		GuidanceStep step = stepWithRecommendedItems(recIds);
+		assertEquals("recommendedItemIds must be accessible via getter",
+			recIds, step.getRecommendedItemIds());
+	}
+
+	/**
+	 * Schema-level: a step constructed without recommendedItemIds (null) has
+	 * a null getter return rather than an empty list.
+	 */
+	@Test
+	public void guidanceStep_recommendedItemIds_nullWhenAbsent()
+	{
+		GuidanceStep step = stepWithSection(null); // no recommendedItemIds
+		assertFalse("recommendedItemIds must be null when not set",
+			step.getRecommendedItemIds() != null);
+	}
+
 	// ── Helpers ─────────────────────────────────────────────────────────────
 
 	/** Flush the Swing event queue so invokeLater-scheduled work completes. */
@@ -441,6 +599,59 @@ public class StepProgressViewTest
 			if (c instanceof JPanel)
 			{
 				return (JPanel) c;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Finds the recommended-items sub-panel inside {@code view}. It is the second
+	 * {@link JPanel} direct child of the StepProgressView (after requiredItemsPanel).
+	 */
+	private static JPanel findRecommendedItemsPanel(StepProgressView view)
+	{
+		int panelCount = 0;
+		for (Component c : view.getComponents())
+		{
+			if (c instanceof JPanel)
+			{
+				panelCount++;
+				if (panelCount == 2)
+				{
+					return (JPanel) c;
+				}
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Returns the first item-name label from the recommended-items sub-panel.
+	 */
+	private static JLabel findFirstRecommendedNameLabel(StepProgressView view)
+	{
+		JPanel recPanel = findRecommendedItemsPanel(view);
+		if (recPanel == null)
+		{
+			return null;
+		}
+		for (Component c : recPanel.getComponents())
+		{
+			if (!(c instanceof JPanel))
+			{
+				continue;
+			}
+			JPanel rowPanel = (JPanel) c;
+			for (Component child : rowPanel.getComponents())
+			{
+				if (child instanceof JLabel)
+				{
+					JLabel label = (JLabel) child;
+					if (label.getText() != null && !label.getText().isEmpty())
+					{
+						return label;
+					}
+				}
 			}
 		}
 		return null;
@@ -492,8 +703,8 @@ public class StepProgressViewTest
 	}
 
 	/**
-	 * Finds the sectionsPanel — the second {@link JPanel} direct child of the
-	 * StepProgressView (after the requiredItemsPanel).
+	 * Finds the sectionsPanel — the third {@link JPanel} direct child of the
+	 * StepProgressView (after requiredItemsPanel and recommendedItemsPanel).
 	 */
 	private static JPanel findSectionsPanel(StepProgressView view)
 	{
@@ -503,7 +714,7 @@ public class StepProgressViewTest
 			if (c instanceof JPanel)
 			{
 				panelCount++;
-				if (panelCount == 2)
+				if (panelCount == 3)
 				{
 					return (JPanel) c;
 				}
@@ -552,6 +763,7 @@ public class StepProgressViewTest
 			0, 0, 0,
 			0, null, null,
 			null, null,
+			null,  // recommendedItemIds
 			CompletionCondition.MANUAL,
 			0, 0, 0, 0,
 			null, null,
@@ -564,6 +776,30 @@ public class StepProgressViewTest
 			0, 0,
 			null, null, null, null,
 			section
+		);
+	}
+
+	/** Builds a minimal {@link GuidanceStep} with the given recommendedItemIds. */
+	private static GuidanceStep stepWithRecommendedItems(List<Integer> recommendedItemIds)
+	{
+		return new GuidanceStep(
+			"Step",
+			0, 0, 0,
+			0, null, null,
+			null, null,
+			recommendedItemIds,
+			CompletionCondition.MANUAL,
+			0, 0, 0, 0,
+			null, null,
+			0, null, null,
+			null, null,
+			null,
+			0, 0,
+			false,
+			0, null, null,
+			0, 0,
+			null, null, null, null,
+			null
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/ui/widget/StepSectionGrouperTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/StepSectionGrouperTest.java
@@ -59,6 +59,7 @@ public class StepSectionGrouperTest
 			0, 0, 0,
 			0, null, null,
 			null, null,
+			null,  // recommendedItemIds
 			CompletionCondition.MANUAL,
 			0, 0, 0, 0,
 			null, null,


### PR DESCRIPTION
## Summary

- Adds `recommendedItemIds: List<Integer>` field to `GuidanceStep` (additive, null by default; existing JSON without the field deserialises unchanged).
- Renders a **"Recommended:"** subsection below "Items needed:" inside `StepProgressView` using identical bank-scan colouring (green = held, white+ℹ = in bank, red = missing).
- Both sections coexist when both lists are populated; each section hides independently when its list is null/empty.
- Works in both flat layout (no section labels) and sectioned layout (B.5.4 collapsible blocks).

## Resolver design choice

**Option (b):** Extracted `resolveIds(List<Integer>)` as the shared core implementation. Both `resolve(GuidanceStep)` (required) and `resolveRecommended(GuidanceStep)` (recommended) delegate to it. This avoids duplicating the invalid-ID filter, name-lookup, and status-resolution logic. The coordinator calls each method once per step change on the client thread, then pushes both lists to the panel in a single `updateStepProgress` call.

## Implementation notes

- `updateItemSubsection(JPanel, String, List<RequiredItemDisplay>)` private helper in `StepProgressView` eliminates duplication between the two flat-layout subsections.
- `GuidanceOverlayCoordinator` resolves both required and recommended on the client thread (same `clientThread.invokeLater` pattern as B.5.1) to satisfy the `ItemManager#getItemComposition` thread assertion.
- No `drop_rates.json` edits — data backfill is B.5.2b.

## Test plan

- [x] `DropRateDatabaseTest`: schema deserialization with `recommendedItemIds` present and absent (null) — backwards compatibility with real `drop_rates.json`
- [x] `RequiredItemResolverTest`: `resolveRecommended` null step, null field, empty list, HELD/IN_BANK/MISSING statuses, independence from required list; `resolveIds` null/empty/invalid-ID filtering
- [x] `StepProgressViewTest`: recommended panel visible/hidden, both panels coexist, all 3 colour statuses match required-items colouring, `hideStep` clears both panels, schema getter tests; `findSectionsPanel` helper updated for new panel child order
- [x] All 631 existing tests pass; `./gradlew build` green

Refs cha-ndler/collection-log-helper#382 (B.5.2)