### PR TITLE
chore(overlay): replace magic widget IDs with InterfaceID constants + drawAfterInterface investigation (B.5.7 follow-ups)

### DIFF
--- a/src/main/java/com/collectionloghelper/overlay/DialogHighlightOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/DialogHighlightOverlay.java
@@ -34,6 +34,7 @@ import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import net.runelite.api.Client;
+import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
@@ -44,16 +45,16 @@ import net.runelite.client.ui.overlay.OverlayPosition;
  * with NPCs during guidance. Similar to Quest Helper's dialog highlighting.
  *
  * Widget groups used:
- *   219 = Player dialog choices (multi-option)
- *   231 = NPC dialog (continue)
+ *   InterfaceID.CHATMENU (219) = Player dialog choices (multi-option)
+ *   InterfaceID.CHAT_LEFT (231) = NPC dialog (continue)
  */
 @Singleton
 public class DialogHighlightOverlay extends Overlay
 {
-	private static final int DIALOG_OPTION_GROUP = 219;
+	private static final int DIALOG_OPTION_GROUP = InterfaceID.CHATMENU;
 	private static final int DIALOG_OPTION_CHILD = 1;
 
-	private static final int NPC_DIALOG_GROUP = 231;
+	private static final int NPC_DIALOG_GROUP = InterfaceID.CHAT_LEFT;
 	private static final int NPC_DIALOG_CONTINUE_CHILD = 5;
 
 	private static final int BACKGROUND_PADDING_X = 4;

--- a/src/test/java/com/collectionloghelper/overlay/DialogHighlightOverlayTest.java
+++ b/src/test/java/com/collectionloghelper/overlay/DialogHighlightOverlayTest.java
@@ -32,6 +32,7 @@ import java.awt.Rectangle;
 import java.util.Arrays;
 import java.util.Collections;
 import net.runelite.api.Client;
+import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.widgets.Widget;
 import org.junit.Before;
 import org.junit.Test;
@@ -60,9 +61,9 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class DialogHighlightOverlayTest
 {
-	private static final int DIALOG_OPTION_GROUP = 219;
+	private static final int DIALOG_OPTION_GROUP = InterfaceID.CHATMENU;
 	private static final int DIALOG_OPTION_CHILD = 1;
-	private static final int NPC_DIALOG_GROUP = 231;
+	private static final int NPC_DIALOG_GROUP = InterfaceID.CHAT_LEFT;
 	private static final int NPC_DIALOG_CONTINUE_CHILD = 5;
 
 	@Mock


### PR DESCRIPTION
## Summary

Closes two deferred follow-ups from PR #404 (B.5.7 dialog highlighting audit), tracked in #382.

### (a) Widget ID constants

Replaces bare integer literals in `DialogHighlightOverlay` with named `InterfaceID` constants from `net.runelite.api.gameval.InterfaceID`:

| Literal | Named constant | Description |
|---------|---------------|-------------|
| `219` | `InterfaceID.CHATMENU` | Player dialog choices (multi-option) |
| `231` | `InterfaceID.CHAT_LEFT` | NPC dialog (continue prompt) |

The same substitution is made in `DialogHighlightOverlayTest` so the test constants stay consistent with the production code.

### (b) `drawAfterInterface` investigation

**Decision: skip — not applicable.**

`drawAfterInterface(interfaceId)` is used by overlays on `OverlayLayer.MANUAL` that need to paint *inside* a specific interface's clip region and must wait until that interface has been rendered. In this codebase the only two callers are `WorldMapDestinationOverlay` and `WorldMapRouteOverlay`, both of which set `OverlayLayer.MANUAL` and call `drawAfterInterface(InterfaceID.WORLDMAP)` so they draw on top of the world map surface.

`DialogHighlightOverlay` uses `OverlayLayer.ABOVE_WIDGETS`, which causes the RuneLite overlay manager to paint it unconditionally above all game widgets after every frame — no interface-specific gating is needed or meaningful. Adding `drawAfterInterface` on an `ABOVE_WIDGETS` overlay would have no runtime effect and would be inconsistent with every other `ABOVE_WIDGETS` overlay in the codebase (`GuidanceMinimapOverlay`, `WidgetHighlightOverlay`), neither of which calls it.

## Files changed

- `src/main/java/com/collectionloghelper/overlay/DialogHighlightOverlay.java` — add `InterfaceID` import; replace `219`/`231` literals with named constants; update Javadoc comment
- `src/test/java/com/collectionloghelper/overlay/DialogHighlightOverlayTest.java` — add `InterfaceID` import; replace `219`/`231` literals with named constants

## Test plan

- [x] `./gradlew build` passes (all existing `DialogHighlightOverlayTest` tests green)
- [x] No behaviour change — constants resolve to the same integer values at compile time
- [x] No other files reference the bare `219` or `231` literals in an overlay context

Refs cha-ndler/collection-log-helper#382 (B.5.7 follow-ups)
Deferred from cha-ndler/collection-log-helper#404