### PR TITLE
feat(rank): sort Category Focus items by efficiency (#370)

### DIFF
--- a/src/main/java/com/collectionloghelper/efficiency/EfficiencyCalculator.java
+++ b/src/main/java/com/collectionloghelper/efficiency/EfficiencyCalculator.java
@@ -213,6 +213,15 @@ public class EfficiencyCalculator
 					continue;
 				}
 
+				// Sequential drop dependency: skip items whose predecessor has not
+				// yet been obtained (they cannot drop until the prior item is owned).
+				// Mirrors the same guard in scoreSource — see issue #134.
+				if (item.isRequiresPrevious() && i > 0
+					&& !collectionState.isItemObtained(items.get(i - 1).getItemId()))
+				{
+					continue;
+				}
+
 				// Score is only meaningful for unobtained items; obtained items
 				// still get a score so within-bucket ordering is consistent.
 				double score = scoreIndividualItem(item, source, killsPerHour, killTimeSeconds, rolls)

--- a/src/main/java/com/collectionloghelper/efficiency/EfficiencyCalculator.java
+++ b/src/main/java/com/collectionloghelper/efficiency/EfficiencyCalculator.java
@@ -152,6 +152,97 @@ public class EfficiencyCalculator
 		return results;
 	}
 
+	/**
+	 * Returns all items belonging to {@code category} ranked for display in
+	 * Category Focus mode.
+	 *
+	 * <p>Sort rules:
+	 * <ol>
+	 *   <li>Unobtained items first, ordered by descending per-item efficiency score.</li>
+	 *   <li>Obtained items last (when {@code hideObtained} is {@code false}),
+	 *       also ordered by descending score.</li>
+	 *   <li>Score ties break alphabetically on item name (deterministic).</li>
+	 *   <li>Locked items interleave at their natural score position — NOT segregated
+	 *       to the bottom (same rule as Efficient mode, issue #392).</li>
+	 * </ol>
+	 *
+	 * <p>When {@code hideObtained} is {@code true} obtained items are omitted
+	 * entirely (existing behaviour preserved).
+	 */
+	public List<RankedCategoryItem> rankItemsByEfficiencyForCategory(
+		CollectionLogCategory category, boolean hideObtained)
+	{
+		int afkMinLevel = config.afkFilter().getMinAfkLevel();
+		boolean hideLocked = config.hideLockedContent();
+
+		List<RankedCategoryItem> unobtained = new ArrayList<>();
+		List<RankedCategoryItem> obtained = new ArrayList<>();
+
+		for (CollectionLogSource source : database.getAllSources())
+		{
+			if (source.getCategory() != category)
+			{
+				continue;
+			}
+
+			boolean locked = !requirementsChecker.isAccessible(source.getName());
+			if (hideLocked && locked)
+			{
+				continue;
+			}
+			if (afkMinLevel > 0 && source.getAfkLevel() < afkMinLevel)
+			{
+				continue;
+			}
+
+			int killTimeSeconds = getEffectiveKillTime(source);
+			double killsPerHour = killTimeSeconds > 0 ? 3600.0 / killTimeSeconds : 0;
+			int rolls = source.getRollsPerKill();
+			List<com.collectionloghelper.data.CollectionLogItem> items = source.getItems();
+
+			// Slayer boost factor for this source (1.0 if not on task)
+			double slayerBoost = isOnSlayerTask(source) ? SLAYER_TASK_BOOST : 1.0;
+
+			for (int i = 0; i < items.size(); i++)
+			{
+				com.collectionloghelper.data.CollectionLogItem item = items.get(i);
+				boolean itemObtained = collectionState.isItemObtained(item.getItemId());
+
+				if (hideObtained && itemObtained)
+				{
+					continue;
+				}
+
+				// Score is only meaningful for unobtained items; obtained items
+				// still get a score so within-bucket ordering is consistent.
+				double score = scoreIndividualItem(item, source, killsPerHour, killTimeSeconds, rolls)
+					* slayerBoost;
+
+				RankedCategoryItem ranked = new RankedCategoryItem(item, source, score, locked, itemObtained);
+				if (itemObtained)
+				{
+					obtained.add(ranked);
+				}
+				else
+				{
+					unobtained.add(ranked);
+				}
+			}
+		}
+
+		Comparator<RankedCategoryItem> byScoreDescThenName =
+			Comparator.comparingDouble(RankedCategoryItem::getScore).reversed()
+				.thenComparing(r -> r.getItem().getName());
+
+		unobtained.sort(byScoreDescThenName);
+		obtained.sort(byScoreDescThenName);
+
+		List<RankedCategoryItem> result = new ArrayList<>(unobtained.size() + obtained.size());
+		result.addAll(unobtained);
+		result.addAll(obtained);
+		return result;
+	}
+
 	public List<ScoredItem> filterPetsOnly()
 	{
 		List<ScoredItem> results = new ArrayList<>();

--- a/src/main/java/com/collectionloghelper/efficiency/RankedCategoryItem.java
+++ b/src/main/java/com/collectionloghelper/efficiency/RankedCategoryItem.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.efficiency;
+
+import com.collectionloghelper.data.CollectionLogItem;
+import com.collectionloghelper.data.CollectionLogSource;
+import lombok.Value;
+
+/**
+ * A single collection-log item together with its parent source and the
+ * per-item efficiency score, used to drive the sorted item list inside
+ * Category Focus mode.
+ *
+ * <p>Sort order (descending efficiency, obtained items sink):
+ * <ol>
+ *   <li>Unobtained items rank first, ordered by descending {@link #score}.</li>
+ *   <li>Obtained items rank after all unobtained, also ordered by descending score.</li>
+ *   <li>Ties on score break alphabetically on {@link CollectionLogItem#getName()}.</li>
+ * </ol>
+ *
+ * <p>Locked items interleave with unlocked items at their natural score position;
+ * they are NOT segregated to the bottom (consistent with Efficient mode, issue #392).
+ */
+@Value
+public class RankedCategoryItem
+{
+	CollectionLogItem item;
+	CollectionLogSource source;
+	/**
+	 * Per-item efficiency score (same units as {@link ScoredItem#getScore()}).
+	 * Computed by {@link EfficiencyCalculator#scoreIndividualItem}.
+	 */
+	double score;
+	boolean locked;
+	boolean obtained;
+}

--- a/src/main/java/com/collectionloghelper/ui/CategorySummaryPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/CategorySummaryPanel.java
@@ -29,6 +29,7 @@ import com.collectionloghelper.data.CollectionLogItem;
 import com.collectionloghelper.data.CollectionLogSource;
 import com.collectionloghelper.data.PlayerCollectionState;
 import com.collectionloghelper.data.RequirementsChecker;
+import com.collectionloghelper.efficiency.RankedCategoryItem;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
@@ -57,12 +58,17 @@ public class CategorySummaryPanel extends JPanel
 
 	// Data retained for lazy population
 	private List<CollectionLogSource> lazySources;
+	/** Non-null when using efficiency-sorted display (Category Focus mode). */
+	private List<RankedCategoryItem> lazyRankedItems;
 	private PlayerCollectionState lazyCollectionState;
 	private RequirementsChecker lazyRequirementsChecker;
 	private ItemManager lazyItemManager;
 	private ItemClickHandler lazyClickHandler;
 	private boolean lazyHideObtained;
 
+	/**
+	 * Constructs a panel that displays items in wiki/source order (default behaviour).
+	 */
 	public CategorySummaryPanel(CollectionLogCategory category, List<CollectionLogSource> sources,
 		PlayerCollectionState collectionState, RequirementsChecker requirementsChecker,
 		ItemManager itemManager, ItemClickHandler clickHandler, boolean hideObtained)
@@ -142,7 +148,133 @@ public class CategorySummaryPanel extends JPanel
 		});
 	}
 
+	/**
+	 * Private constructor for the efficiency-sorted path. Use
+	 * {@link #withEfficiencySort} to construct.
+	 *
+	 * <p>A private constructor is required because Java's type erasure makes
+	 * {@code List<RankedCategoryItem>} and {@code List<CollectionLogSource>}
+	 * indistinguishable at the JVM level, preventing a second public overload.
+	 */
+	private CategorySummaryPanel(CollectionLogCategory category, List<RankedCategoryItem> rankedItems,
+		PlayerCollectionState collectionState, RequirementsChecker requirementsChecker,
+		ItemManager itemManager, ItemClickHandler clickHandler, boolean hideObtained,
+		@SuppressWarnings("unused") boolean efficiencySentinel)
+	{
+		this.categoryName = category.getDisplayName();
+		this.lazyRankedItems = rankedItems;
+		this.lazySources = null;
+		this.lazyCollectionState = collectionState;
+		this.lazyRequirementsChecker = requirementsChecker;
+		this.lazyItemManager = itemManager;
+		this.lazyClickHandler = clickHandler;
+		this.lazyHideObtained = hideObtained;
+
+		setLayout(new BorderLayout());
+		setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		setBorder(BorderFactory.createEmptyBorder(0, 0, 4, 0));
+		setAlignmentX(LEFT_ALIGNMENT);
+		setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
+
+		JPanel headerPanel = new JPanel(new BorderLayout(8, 0));
+		headerPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		headerPanel.setBorder(BorderFactory.createEmptyBorder(6, 8, 6, 8));
+
+		obtained = collectionState.getCategoryCount(category);
+		total = collectionState.getCategoryMax(category);
+
+		nameLabel = new JLabel(
+			String.format("▶ %s (%d/%d)", category.getDisplayName(), obtained, total));
+		nameLabel.setFont(FontManager.getRunescapeSmallFont());
+		nameLabel.setForeground(Color.WHITE);
+		headerPanel.add(nameLabel, BorderLayout.WEST);
+
+		JPanel progressBar = new ProgressBar(obtained, total);
+		progressBar.setPreferredSize(new Dimension(80, 12));
+		headerPanel.add(progressBar, BorderLayout.EAST);
+
+		add(headerPanel, BorderLayout.NORTH);
+
+		itemsContainer = new JPanel();
+		itemsContainer.setLayout(new BoxLayout(itemsContainer, BoxLayout.Y_AXIS));
+		itemsContainer.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		itemsContainer.setVisible(false);
+
+		add(itemsContainer, BorderLayout.CENTER);
+
+		headerPanel.addMouseListener(new java.awt.event.MouseAdapter()
+		{
+			@Override
+			public void mouseClicked(java.awt.event.MouseEvent e)
+			{
+				expanded = !expanded;
+				if (expanded && !populated)
+				{
+					populateItems();
+				}
+				itemsContainer.setVisible(expanded);
+				nameLabel.setText(String.format("%s %s (%d/%d)",
+					expanded ? "▼" : "▶",
+					category.getDisplayName(), obtained, total));
+				revalidate();
+			}
+
+			@Override
+			public void mouseEntered(java.awt.event.MouseEvent e)
+			{
+				headerPanel.setBackground(ColorScheme.DARKER_GRAY_HOVER_COLOR);
+			}
+
+			@Override
+			public void mouseExited(java.awt.event.MouseEvent e)
+			{
+				headerPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+			}
+		});
+	}
+
+	/**
+	 * Creates a {@link CategorySummaryPanel} that displays items sorted by
+	 * descending efficiency score (Category Focus mode).
+	 *
+	 * <p>Sort rules (applied by
+	 * {@link com.collectionloghelper.efficiency.EfficiencyCalculator#rankItemsByEfficiencyForCategory}
+	 * before this method is called):
+	 * <ul>
+	 *   <li>Unobtained items first, by descending score.</li>
+	 *   <li>Obtained items last (when shown), also by descending score.</li>
+	 *   <li>Score ties break alphabetically on item name.</li>
+	 *   <li>Locked items interleave at their natural score position (issue #392).</li>
+	 * </ul>
+	 *
+	 * @param rankedItems pre-sorted list from
+	 *        {@link com.collectionloghelper.efficiency.EfficiencyCalculator#rankItemsByEfficiencyForCategory}
+	 */
+	public static CategorySummaryPanel withEfficiencySort(
+		CollectionLogCategory category, List<RankedCategoryItem> rankedItems,
+		PlayerCollectionState collectionState, RequirementsChecker requirementsChecker,
+		ItemManager itemManager, ItemClickHandler clickHandler, boolean hideObtained)
+	{
+		return new CategorySummaryPanel(category, rankedItems, collectionState,
+			requirementsChecker, itemManager, clickHandler, hideObtained, true);
+	}
+
 	private void populateItems()
+	{
+		if (lazyRankedItems != null)
+		{
+			populateRankedItems();
+		}
+		else
+		{
+			populateSourceItems();
+		}
+	}
+
+	/**
+	 * Populates items in wiki/source order (original behaviour).
+	 */
+	private void populateSourceItems()
 	{
 		// Capture click handler in local variable — the field is nulled after
 		// population, but lambdas passed to ItemRowPanel must remain valid
@@ -166,8 +298,32 @@ public class CategorySummaryPanel extends JPanel
 			}
 		}
 		populated = true;
-		// Release references no longer needed
 		lazySources = null;
+		lazyCollectionState = null;
+		lazyRequirementsChecker = null;
+		lazyItemManager = null;
+		lazyClickHandler = null;
+	}
+
+	/**
+	 * Populates items in efficiency-score order using the pre-sorted ranked list.
+	 */
+	private void populateRankedItems()
+	{
+		final ItemClickHandler clickHandler = lazyClickHandler;
+
+		for (RankedCategoryItem ranked : lazyRankedItems)
+		{
+			CollectionLogItem item = ranked.getItem();
+			CollectionLogSource source = ranked.getSource();
+			ItemRowPanel row = new ItemRowPanel(item, source, ranked.isObtained(),
+				ranked.getScore(), ranked.isLocked(),
+				lazyRequirementsChecker.getUnmetRequirements(source.getName()),
+				lazyItemManager, () -> clickHandler.onItemClicked(item, source));
+			itemsContainer.add(row);
+		}
+		populated = true;
+		lazyRankedItems = null;
 		lazyCollectionState = null;
 		lazyRequirementsChecker = null;
 		lazyItemManager = null;

--- a/src/main/java/com/collectionloghelper/ui/CategorySummaryPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/CategorySummaryPanel.java
@@ -184,7 +184,7 @@ public class CategorySummaryPanel extends JPanel
 		total = collectionState.getCategoryMax(category);
 
 		nameLabel = new JLabel(
-			String.format("▶ %s (%d/%d)", category.getDisplayName(), obtained, total));
+			String.format("\u25B6 %s (%d/%d)", category.getDisplayName(), obtained, total));
 		nameLabel.setFont(FontManager.getRunescapeSmallFont());
 		nameLabel.setForeground(Color.WHITE);
 		headerPanel.add(nameLabel, BorderLayout.WEST);
@@ -214,7 +214,7 @@ public class CategorySummaryPanel extends JPanel
 				}
 				itemsContainer.setVisible(expanded);
 				nameLabel.setText(String.format("%s %s (%d/%d)",
-					expanded ? "▼" : "▶",
+					expanded ? "\u25BC" : "\u25B6",
 					category.getDisplayName(), obtained, total));
 				revalidate();
 			}

--- a/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
@@ -387,7 +387,7 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 			new SearchModeController(this, config, database, collectionState, calculator,
 				requirementsChecker, itemManager));
 		modeControllers.put(Mode.CATEGORY_FOCUS,
-			new CategoryModeController(this, config, database, collectionState, calculator,
+			new CategoryModeController(this, config, collectionState, calculator,
 				requirementsChecker, itemManager));
 		modeControllers.put(Mode.EFFICIENT,
 			new EfficientModeController(this, config, collectionState, calculator,

--- a/src/main/java/com/collectionloghelper/ui/mode/CategoryModeController.java
+++ b/src/main/java/com/collectionloghelper/ui/mode/CategoryModeController.java
@@ -26,11 +26,10 @@ package com.collectionloghelper.ui.mode;
 
 import com.collectionloghelper.CollectionLogHelperConfig;
 import com.collectionloghelper.data.CollectionLogCategory;
-import com.collectionloghelper.data.CollectionLogSource;
-import com.collectionloghelper.data.DropRateDatabase;
 import com.collectionloghelper.data.PlayerCollectionState;
 import com.collectionloghelper.data.RequirementsChecker;
 import com.collectionloghelper.efficiency.EfficiencyCalculator;
+import com.collectionloghelper.efficiency.RankedCategoryItem;
 import com.collectionloghelper.efficiency.ScoredItem;
 import com.collectionloghelper.ui.CategorySummaryPanel;
 import java.util.List;
@@ -45,7 +44,6 @@ public class CategoryModeController implements PanelModeController
 {
 	private final PanelShellContext shell;
 	private final CollectionLogHelperConfig config;
-	private final DropRateDatabase database;
 	private final PlayerCollectionState collectionState;
 	private final EfficiencyCalculator calculator;
 	private final RequirementsChecker requirementsChecker;
@@ -54,7 +52,6 @@ public class CategoryModeController implements PanelModeController
 	public CategoryModeController(
 		PanelShellContext shell,
 		CollectionLogHelperConfig config,
-		DropRateDatabase database,
 		PlayerCollectionState collectionState,
 		EfficiencyCalculator calculator,
 		RequirementsChecker requirementsChecker,
@@ -62,7 +59,6 @@ public class CategoryModeController implements PanelModeController
 	{
 		this.shell = shell;
 		this.config = config;
-		this.database = database;
 		this.collectionState = collectionState;
 		this.calculator = calculator;
 		this.requirementsChecker = requirementsChecker;
@@ -78,17 +74,22 @@ public class CategoryModeController implements PanelModeController
 			return;
 		}
 
-		// Top Pick for this category — always an accessible source
+		// Top Pick for this category — always an accessible (unlocked) source
 		List<ScoredItem> categoryScored = calculator.filterByCategory(category);
 		categoryScored.stream()
 			.filter(s -> !s.isLocked())
 			.findFirst()
 			.ifPresent(topPick -> shell.addToList(shell.createQuickGuidePanel(topPick)));
 
-		List<CollectionLogSource> sources = database.getSourcesByCategory(category);
-		CategorySummaryPanel summary = new CategorySummaryPanel(
-			category, sources, collectionState, requirementsChecker, itemManager,
-			shell::showDetail, config.hideObtainedItems());
+		// Items sorted by descending efficiency score. Unobtained items first;
+		// obtained items sink to the bottom (but remain visible when hideObtained=false).
+		// Locked items interleave at their natural score position (issue #392 rule).
+		boolean hideObtained = config.hideObtainedItems();
+		List<RankedCategoryItem> rankedItems =
+			calculator.rankItemsByEfficiencyForCategory(category, hideObtained);
+		CategorySummaryPanel summary = CategorySummaryPanel.withEfficiencySort(
+			category, rankedItems, collectionState, requirementsChecker, itemManager,
+			shell::showDetail, hideObtained);
 		shell.addToList(summary);
 	}
 }

--- a/src/test/java/com/collectionloghelper/efficiency/EfficiencyCalculatorTest.java
+++ b/src/test/java/com/collectionloghelper/efficiency/EfficiencyCalculatorTest.java
@@ -1431,4 +1431,60 @@ public class EfficiencyCalculatorTest
 		assertEquals("Slow obtained", result.get(1).getItem().getName());
 		assertTrue(result.get(1).isObtained());
 	}
+
+	/**
+	 * Items with requiresPrevious=true whose predecessor is not yet obtained
+	 * must be excluded from the ranked list (they cannot drop yet).
+	 * Mirrors the same guard in {@link EfficiencyCalculator#scoreSource}.
+	 */
+	@Test
+	public void testRankItemsByEfficiency_requiresPrevious_predecessorNotObtained_excluded()
+	{
+		// Two sequential items: A (base), B (requiresPrevious)
+		// Neither obtained — B cannot drop yet, so only A should appear.
+		CollectionLogItem itemA = makeItem(1, "Base item", 0.05);
+		CollectionLogItem itemB = makeItemRequiresPrevious(2, "Sequential item", 0.05);
+
+		CollectionLogSource source = makeSource("Sequential Boss", CollectionLogCategory.BOSSES,
+			60, Arrays.asList(itemA, itemB));
+
+		when(database.getAllSources()).thenReturn(Collections.singletonList(source));
+		when(collectionState.isItemObtained(1)).thenReturn(false);
+		when(collectionState.isItemObtained(2)).thenReturn(false);
+
+		List<RankedCategoryItem> result =
+			calculator.rankItemsByEfficiencyForCategory(CollectionLogCategory.BOSSES, false);
+
+		assertEquals("Only the base item should appear — sequential item excluded", 1, result.size());
+		assertEquals("Base item", result.get(0).getItem().getName());
+	}
+
+	/**
+	 * Items with requiresPrevious=true appear once their predecessor is obtained.
+	 */
+	@Test
+	public void testRankItemsByEfficiency_requiresPrevious_predecessorObtained_included()
+	{
+		CollectionLogItem itemA = makeItem(1, "Base item", 0.05);
+		CollectionLogItem itemB = makeItemRequiresPrevious(2, "Sequential item", 0.05);
+
+		CollectionLogSource source = makeSource("Sequential Boss", CollectionLogCategory.BOSSES,
+			60, Arrays.asList(itemA, itemB));
+
+		when(database.getAllSources()).thenReturn(Collections.singletonList(source));
+		// Predecessor obtained — item B can now drop
+		when(collectionState.isItemObtained(1)).thenReturn(true);
+		when(collectionState.isItemObtained(2)).thenReturn(false);
+
+		List<RankedCategoryItem> result =
+			calculator.rankItemsByEfficiencyForCategory(CollectionLogCategory.BOSSES, false);
+
+		// Item A is obtained and shown (hideObtained=false), item B is unobtained and shown
+		assertEquals(2, result.size());
+		// B (unobtained) ranks first, A (obtained) sinks to bottom
+		assertEquals("Sequential item", result.get(0).getItem().getName());
+		assertFalse(result.get(0).isObtained());
+		assertEquals("Base item", result.get(1).getItem().getName());
+		assertTrue(result.get(1).isObtained());
+	}
 }

--- a/src/test/java/com/collectionloghelper/efficiency/EfficiencyCalculatorTest.java
+++ b/src/test/java/com/collectionloghelper/efficiency/EfficiencyCalculatorTest.java
@@ -37,6 +37,7 @@ import com.collectionloghelper.data.RequirementsChecker;
 import com.collectionloghelper.data.RewardType;
 import com.collectionloghelper.data.SlayerMasterDatabase;
 import com.collectionloghelper.data.SlayerTaskState;
+import com.collectionloghelper.efficiency.RankedCategoryItem;
 import java.lang.reflect.Constructor;
 import java.util.Arrays;
 import java.util.Collections;
@@ -1208,5 +1209,226 @@ public class EfficiencyCalculatorTest
 		when(config.raidTeamSize()).thenReturn(RaidTeamSize.TRIO);
 		effectiveTime = calculator.getEffectiveKillTime(source);
 		assertEquals(1440, effectiveTime);
+	}
+
+	// --- rankItemsByEfficiencyForCategory (issue #370) ---
+
+	/**
+	 * Unobtained items should precede obtained items, each bucket sorted
+	 * by descending per-item efficiency score.
+	 */
+	@Test
+	public void testRankItemsByEfficiency_unobtainedFirstThenObtained()
+	{
+		// Source A: fast drop (score high), item obtained
+		// Source B: slow drop (score low), item NOT obtained
+		// Source C: medium drop, item NOT obtained
+		// Expected order: C (medium, unobtained), B (slow, unobtained), A (fast, obtained)
+		CollectionLogItem fastObtained = makeItem(1, "Fast item", 0.1);     // score=600
+		CollectionLogItem mediumMissing = makeItem(2, "Medium item", 0.05); // score=300
+		CollectionLogItem slowMissing = makeItem(3, "Slow item", 0.02);    // score=120
+
+		CollectionLogSource sourceA = makeSource("Source A", CollectionLogCategory.BOSSES,
+			60, Collections.singletonList(fastObtained));
+		CollectionLogSource sourceB = makeSource("Source B", CollectionLogCategory.BOSSES,
+			60, Collections.singletonList(slowMissing));
+		CollectionLogSource sourceC = makeSource("Source C", CollectionLogCategory.BOSSES,
+			60, Collections.singletonList(mediumMissing));
+
+		when(database.getAllSources()).thenReturn(Arrays.asList(sourceA, sourceB, sourceC));
+		when(collectionState.isItemObtained(1)).thenReturn(true);
+		when(collectionState.isItemObtained(2)).thenReturn(false);
+		when(collectionState.isItemObtained(3)).thenReturn(false);
+
+		List<RankedCategoryItem> result =
+			calculator.rankItemsByEfficiencyForCategory(CollectionLogCategory.BOSSES, false);
+
+		assertEquals(3, result.size());
+		// Unobtained first: medium (score 300) then slow (score 120)
+		assertEquals("Medium item", result.get(0).getItem().getName());
+		assertFalse(result.get(0).isObtained());
+		assertEquals("Slow item", result.get(1).getItem().getName());
+		assertFalse(result.get(1).isObtained());
+		// Obtained last
+		assertEquals("Fast item", result.get(2).getItem().getName());
+		assertTrue(result.get(2).isObtained());
+	}
+
+	/**
+	 * Locked items interleave by score — they are NOT segregated to the bottom
+	 * (same rule as Efficient mode, issue #392).
+	 */
+	@Test
+	public void testRankItemsByEfficiency_lockedItemInterleavesByScore()
+	{
+		CollectionLogItem fastItem = makeItem(1, "Fast", 0.1);   // score=600
+		CollectionLogItem medItem = makeItem(2, "Medium", 0.05); // score=300  (locked source)
+		CollectionLogItem slowItem = makeItem(3, "Slow", 0.02);  // score=120
+
+		CollectionLogSource unlockFast = makeSource("Unlocked Fast", CollectionLogCategory.BOSSES,
+			60, Collections.singletonList(fastItem));
+		CollectionLogSource lockedMed = makeSource("Locked Medium", CollectionLogCategory.BOSSES,
+			60, Collections.singletonList(medItem));
+		CollectionLogSource unlockSlow = makeSource("Unlocked Slow", CollectionLogCategory.BOSSES,
+			60, Collections.singletonList(slowItem));
+
+		when(database.getAllSources()).thenReturn(Arrays.asList(unlockFast, lockedMed, unlockSlow));
+		when(requirementsChecker.isAccessible("Unlocked Fast")).thenReturn(true);
+		when(requirementsChecker.isAccessible("Locked Medium")).thenReturn(false);
+		when(requirementsChecker.isAccessible("Unlocked Slow")).thenReturn(true);
+		when(collectionState.isItemObtained(anyInt())).thenReturn(false);
+
+		List<RankedCategoryItem> result =
+			calculator.rankItemsByEfficiencyForCategory(CollectionLogCategory.BOSSES, false);
+
+		assertEquals(3, result.size());
+		assertEquals("Fast", result.get(0).getItem().getName());
+		assertFalse(result.get(0).isLocked());
+		// Locked medium item interleaves at its natural score position (#2)
+		assertEquals("Medium", result.get(1).getItem().getName());
+		assertTrue("Locked item must be flagged but interleave by score", result.get(1).isLocked());
+		assertEquals("Slow", result.get(2).getItem().getName());
+		assertFalse(result.get(2).isLocked());
+	}
+
+	/**
+	 * When hideObtained is true, obtained items are filtered out entirely.
+	 */
+	@Test
+	public void testRankItemsByEfficiency_hideObtainedFiltersThemOut()
+	{
+		CollectionLogItem unobtained = makeItem(1, "Missing", 0.05);
+		CollectionLogItem obtained = makeItem(2, "Got it", 0.1);
+
+		CollectionLogSource source = makeSource("Source", CollectionLogCategory.BOSSES,
+			60, Arrays.asList(unobtained, obtained));
+
+		when(database.getAllSources()).thenReturn(Collections.singletonList(source));
+		when(collectionState.isItemObtained(1)).thenReturn(false);
+		when(collectionState.isItemObtained(2)).thenReturn(true);
+
+		List<RankedCategoryItem> result =
+			calculator.rankItemsByEfficiencyForCategory(CollectionLogCategory.BOSSES, true);
+
+		assertEquals(1, result.size());
+		assertEquals("Missing", result.get(0).getItem().getName());
+		assertFalse(result.get(0).isObtained());
+	}
+
+	/**
+	 * Empty category returns empty list without errors.
+	 */
+	@Test
+	public void testRankItemsByEfficiency_emptyCategory_returnsEmpty()
+	{
+		when(database.getAllSources()).thenReturn(Collections.emptyList());
+
+		List<RankedCategoryItem> result =
+			calculator.rankItemsByEfficiencyForCategory(CollectionLogCategory.BOSSES, false);
+
+		assertNotNull(result);
+		assertTrue(result.isEmpty());
+	}
+
+	/**
+	 * Single-item category returns exactly one ranked entry.
+	 */
+	@Test
+	public void testRankItemsByEfficiency_singleItemCategory()
+	{
+		CollectionLogItem item = makeItem(1, "Solo drop", 0.05);
+		CollectionLogSource source = makeSource("Solo Boss", CollectionLogCategory.BOSSES,
+			60, Collections.singletonList(item));
+
+		when(database.getAllSources()).thenReturn(Collections.singletonList(source));
+		when(collectionState.isItemObtained(1)).thenReturn(false);
+
+		List<RankedCategoryItem> result =
+			calculator.rankItemsByEfficiencyForCategory(CollectionLogCategory.BOSSES, false);
+
+		assertEquals(1, result.size());
+		assertEquals("Solo drop", result.get(0).getItem().getName());
+		assertFalse(result.get(0).isObtained());
+		assertFalse(result.get(0).isLocked());
+	}
+
+	/**
+	 * Items with equal scores sort alphabetically by item name (deterministic tie-break).
+	 */
+	@Test
+	public void testRankItemsByEfficiency_tieBreakAlphabetical()
+	{
+		// Three items all with identical drop rates — scores will be equal
+		CollectionLogItem itemZ = makeItem(1, "Zephyr helm", 0.01);
+		CollectionLogItem itemA = makeItem(2, "Abyssal whip", 0.01);
+		CollectionLogItem itemM = makeItem(3, "Magic longbow", 0.01);
+
+		CollectionLogSource source = makeSource("Tie Boss", CollectionLogCategory.BOSSES,
+			60, Arrays.asList(itemZ, itemA, itemM));
+
+		when(database.getAllSources()).thenReturn(Collections.singletonList(source));
+		when(collectionState.isItemObtained(anyInt())).thenReturn(false);
+
+		List<RankedCategoryItem> result =
+			calculator.rankItemsByEfficiencyForCategory(CollectionLogCategory.BOSSES, false);
+
+		assertEquals(3, result.size());
+		assertEquals("Abyssal whip", result.get(0).getItem().getName());
+		assertEquals("Magic longbow", result.get(1).getItem().getName());
+		assertEquals("Zephyr helm", result.get(2).getItem().getName());
+	}
+
+	/**
+	 * Items from a different category should not appear in the results.
+	 */
+	@Test
+	public void testRankItemsByEfficiency_ignoresOtherCategories()
+	{
+		CollectionLogItem bossItem = makeItem(1, "Boss drop", 0.05);
+		CollectionLogItem clueItem = makeItem(2, "Clue reward", 0.05);
+
+		CollectionLogSource bossSource = makeSource("Boss", CollectionLogCategory.BOSSES,
+			60, Collections.singletonList(bossItem));
+		CollectionLogSource clueSource = makeSource("Clue", CollectionLogCategory.CLUES,
+			60, Collections.singletonList(clueItem));
+
+		when(database.getAllSources()).thenReturn(Arrays.asList(bossSource, clueSource));
+		when(collectionState.isItemObtained(anyInt())).thenReturn(false);
+		// clueEstimator is NOT stubbed — the clue source is filtered out before
+		// getEffectiveKillTime is called (category != BOSSES).
+
+		List<RankedCategoryItem> result =
+			calculator.rankItemsByEfficiencyForCategory(CollectionLogCategory.BOSSES, false);
+
+		assertEquals(1, result.size());
+		assertEquals("Boss drop", result.get(0).getItem().getName());
+	}
+
+	/**
+	 * Obtained items within the obtained bucket are also ordered by descending score,
+	 * with alphabetical tie-break.
+	 */
+	@Test
+	public void testRankItemsByEfficiency_obtainedBucketSortedByScore()
+	{
+		CollectionLogItem slowObtained = makeItem(1, "Slow obtained", 0.01);   // score=60
+		CollectionLogItem fastObtained = makeItem(2, "Fast obtained", 0.1);    // score=600
+
+		CollectionLogSource source = makeSource("Source", CollectionLogCategory.BOSSES,
+			60, Arrays.asList(slowObtained, fastObtained));
+
+		when(database.getAllSources()).thenReturn(Collections.singletonList(source));
+		when(collectionState.isItemObtained(1)).thenReturn(true);
+		when(collectionState.isItemObtained(2)).thenReturn(true);
+
+		List<RankedCategoryItem> result =
+			calculator.rankItemsByEfficiencyForCategory(CollectionLogCategory.BOSSES, false);
+
+		assertEquals(2, result.size());
+		// Both obtained; higher score first
+		assertEquals("Fast obtained", result.get(0).getItem().getName());
+		assertTrue(result.get(0).isObtained());
+		assertEquals("Slow obtained", result.get(1).getItem().getName());
+		assertTrue(result.get(1).isObtained());
 	}
 }

--- a/src/test/java/com/collectionloghelper/ui/mode/CategoryModeControllerTest.java
+++ b/src/test/java/com/collectionloghelper/ui/mode/CategoryModeControllerTest.java
@@ -26,10 +26,10 @@ package com.collectionloghelper.ui.mode;
 
 import com.collectionloghelper.CollectionLogHelperConfig;
 import com.collectionloghelper.data.CollectionLogCategory;
-import com.collectionloghelper.data.DropRateDatabase;
 import com.collectionloghelper.data.PlayerCollectionState;
 import com.collectionloghelper.data.RequirementsChecker;
 import com.collectionloghelper.efficiency.EfficiencyCalculator;
+import com.collectionloghelper.efficiency.RankedCategoryItem;
 import java.util.Collections;
 import net.runelite.client.game.ItemManager;
 import org.junit.Before;
@@ -40,7 +40,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -51,9 +50,6 @@ public class CategoryModeControllerTest
 
 	@Mock
 	private CollectionLogHelperConfig config;
-
-	@Mock
-	private DropRateDatabase database;
 
 	@Mock
 	private PlayerCollectionState collectionState;
@@ -73,7 +69,7 @@ public class CategoryModeControllerTest
 	public void setUp()
 	{
 		controller = new CategoryModeController(
-			shell, config, database, collectionState, calculator, requirementsChecker, itemManager);
+			shell, config, collectionState, calculator, requirementsChecker, itemManager);
 	}
 
 	@Test
@@ -85,9 +81,10 @@ public class CategoryModeControllerTest
 		// Act
 		controller.buildView();
 
-		// Assert — no scoring or database work happens
+		// Assert — no scoring work happens when no category is selected
 		verify(calculator, never()).filterByCategory(org.mockito.ArgumentMatchers.any());
-		verifyNoInteractions(database);
+		verify(calculator, never()).rankItemsByEfficiencyForCategory(
+			org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.anyBoolean());
 	}
 
 	@Test
@@ -96,13 +93,18 @@ public class CategoryModeControllerTest
 		// Arrange
 		when(shell.getSelectedCategory()).thenReturn(CollectionLogCategory.BOSSES);
 		when(calculator.filterByCategory(CollectionLogCategory.BOSSES)).thenReturn(Collections.emptyList());
-		when(database.getSourcesByCategory(CollectionLogCategory.BOSSES)).thenReturn(Collections.emptyList());
+		when(calculator.rankItemsByEfficiencyForCategory(
+			CollectionLogCategory.BOSSES, false))
+			.thenReturn(Collections.<RankedCategoryItem>emptyList());
 		when(config.hideObtainedItems()).thenReturn(false);
+		when(collectionState.getCategoryCount(CollectionLogCategory.BOSSES)).thenReturn(0);
+		when(collectionState.getCategoryMax(CollectionLogCategory.BOSSES)).thenReturn(0);
 
 		// Act
 		controller.buildView();
 
-		// Assert — at least the summary panel is added (no top-pick since list is empty)
+		// Assert — the efficiency-sorted summary panel is added
 		verify(shell).addToList(org.mockito.ArgumentMatchers.any(com.collectionloghelper.ui.CategorySummaryPanel.class));
+		verify(calculator).rankItemsByEfficiencyForCategory(CollectionLogCategory.BOSSES, false);
 	}
 }


### PR DESCRIPTION
## Summary

- `EfficiencyCalculator.rankItemsByEfficiencyForCategory(category, hideObtained)` returns a flat `List<RankedCategoryItem>` (one entry per item) sorted by descending per-item efficiency score
- `CategorySummaryPanel.withEfficiencySort(...)` static factory wires the ranked list into the existing lazy-populate infrastructure without breaking the source-order constructor (factory avoids Java type-erasure clash between `List<RankedCategoryItem>` and `List<CollectionLogSource>`)
- `CategoryModeController` drives both paths: `filterByCategory` for the Top Pick banner (unchanged), `rankItemsByEfficiencyForCategory` for the item list

## Sort rule

1. Unobtained items first — descending efficiency score
2. Obtained items last when shown (`hideObtained=false`) — also descending score within the bucket
3. Score ties break alphabetically on item name (deterministic)
4. Locked items interleave at their natural score position — NOT segregated to bottom (preserves rule from #392)

## Test plan

- [x] `testRankItemsByEfficiency_unobtainedFirstThenObtained` — unobtained precede obtained; each bucket sorted by descending score
- [x] `testRankItemsByEfficiency_lockedItemInterleavesByScore` — locked item at natural score position, not bottom
- [x] `testRankItemsByEfficiency_hideObtainedFiltersThemOut` — obtained items excluded when flag is on
- [x] `testRankItemsByEfficiency_emptyCategory_returnsEmpty` — no crash on empty category
- [x] `testRankItemsByEfficiency_singleItemCategory` — single item returns correctly
- [x] `testRankItemsByEfficiency_tieBreakAlphabetical` — equal-score items sorted A→Z
- [x] `testRankItemsByEfficiency_ignoresOtherCategories` — only target category items included
- [x] `testRankItemsByEfficiency_obtainedBucketSortedByScore` — obtained bucket also score-sorted
- [x] `buildViewAddsSummaryPanelForSelectedCategory` updated to verify `rankItemsByEfficiencyForCategory` is called
- [x] `./gradlew build` — 677 tests, 0 failures

Closes cha-ndler/collection-log-helper#370