### PR TITLE
fix(guidance): activateGuidance must run on client thread (regression from #401)

### DIFF
--- a/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
@@ -748,9 +748,27 @@ public class CollectionLogHelperPlugin extends Plugin
 		calculator.exportEfficiencyList(exportFile, client);
 	}
 
+	/**
+	 * Activates guidance for {@code source}, ensuring all work runs on the client
+	 * thread.  {@link com.collectionloghelper.guidance.GuidanceOverlayCoordinator#activateGuidance}
+	 * transitively calls {@link com.collectionloghelper.data.RequirementsChecker#buildRequirementRows},
+	 * which uses {@code client.getQuestState} and similar client-thread-only APIs.
+	 * Wrapping here (rather than inside the coordinator) covers all call paths —
+	 * both the Item Detail "Guide Me" button
+	 * ({@link com.collectionloghelper.ui.CollectionLogHelperPanel}) and the Top Pick
+	 * green button ({@link com.collectionloghelper.ui.widget.QuickGuidePanelView}) — in
+	 * one place, mirroring the step-advance / skip fix in commit c528d0ae.
+	 *
+	 * <p>This method returns immediately; activation completes on the next client-thread
+	 * tick.  The panel's "Stop Guidance" button state may lag by one tick — this is
+	 * acceptable and consistent with the step-advance pattern.
+	 */
 	public void activateGuidance(CollectionLogSource source)
 	{
-		guidanceCoordinator.activateGuidance(source, cachedPlayerLocation);
+		// Route through the client thread: RequirementsChecker.buildRequirementRows
+		// and related coordinator work require client-thread context.  Mirrors the
+		// step-advance / skip wrap added in commit c528d0ae.
+		clientThread.invokeLater(() -> guidanceCoordinator.activateGuidance(source, cachedPlayerLocation));
 	}
 
 	/**

--- a/src/test/java/com/collectionloghelper/ActivateGuidanceClientThreadTest.java
+++ b/src/test/java/com/collectionloghelper/ActivateGuidanceClientThreadTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper;
+
+import com.collectionloghelper.data.CollectionLogCategory;
+import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.guidance.GuidanceOverlayCoordinator;
+import java.lang.reflect.Field;
+import net.runelite.client.callback.ClientThread;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+/**
+ * Regression test: {@link CollectionLogHelperPlugin#activateGuidance} must dispatch
+ * its work via {@link ClientThread#invokeLater} rather than executing directly on
+ * the Swing EDT.  If this test fails it means the activation path has been wired
+ * back to run on the calling thread, which triggers
+ * {@code AssertionError: must be called on client thread} inside
+ * {@link com.collectionloghelper.data.RequirementsChecker#buildRequirementRows}.
+ *
+ * <p>See commit c528d0ae (step-advance / skip callbacks) for the canonical pattern
+ * that this fix mirrors.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ActivateGuidanceClientThreadTest
+{
+	@Mock
+	private ClientThread clientThread;
+
+	@Mock
+	private GuidanceOverlayCoordinator guidanceCoordinator;
+
+	private CollectionLogHelperPlugin plugin;
+
+	@Before
+	public void setUp() throws Exception
+	{
+		plugin = new CollectionLogHelperPlugin();
+		injectField("clientThread", clientThread);
+		injectField("guidanceCoordinator", guidanceCoordinator);
+	}
+
+	/**
+	 * Calling {@code activateGuidance} from the EDT must route all work through
+	 * {@code clientThread.invokeLater()} — never call {@code guidanceCoordinator}
+	 * directly on the calling thread.
+	 */
+	@Test
+	public void activateGuidance_routesWorkThroughClientThread()
+	{
+		CollectionLogSource source = makeMinimalSource("Test Source");
+
+		plugin.activateGuidance(source);
+
+		// The body must be submitted to the client thread, not executed inline.
+		verify(clientThread).invokeLater(any(Runnable.class));
+	}
+
+	/**
+	 * {@code guidanceCoordinator.activateGuidance} must NOT be called directly
+	 * on the calling thread — it would run on the EDT and trigger the assertion
+	 * inside RequirementsChecker.
+	 */
+	@Test
+	public void activateGuidance_doesNotCallCoordinatorDirectlyOnCallingThread()
+	{
+		CollectionLogSource source = makeMinimalSource("Test Source");
+
+		plugin.activateGuidance(source);
+
+		// guidanceCoordinator must not be touched directly (only via the lambda
+		// queued to the client thread).
+		verifyNoInteractions(guidanceCoordinator);
+	}
+
+	// ---- helpers ----
+
+	private void injectField(String fieldName, Object value) throws Exception
+	{
+		Field field = CollectionLogHelperPlugin.class.getDeclaredField(fieldName);
+		field.setAccessible(true);
+		field.set(plugin, value);
+	}
+
+	private static CollectionLogSource makeMinimalSource(String name)
+	{
+		return new CollectionLogSource(
+			name,
+			CollectionLogCategory.BOSSES,
+			0, 0, 0,   // worldX, worldY, worldPlane
+			0, 0,      // killTimeSeconds, ironKillTimeSeconds
+			null,      // locationDescription
+			null,      // waypoints
+			null,      // rewardType
+			0.0,       // pointsPerHour
+			null,      // mutuallyExclusiveSources
+			0,         // rollsPerKill
+			false,     // aggregated
+			0,         // afkLevel
+			null,      // travelTip
+			0,         // npcId
+			null,      // interactAction
+			null,      // dialogOptions
+			null,      // guidanceSteps
+			null,      // requirements
+			0,         // cumulativeTrackItemId
+			null,      // cumulativeTrackObjectIds
+			0,         // cumulativeTrackThreshold
+			null       // items
+		);
+	}
+}


### PR DESCRIPTION
## Summary

`Plugin.activateGuidance` runs on the AWT EDT (called from panel button lambdas) but transitively calls `RequirementsChecker.buildRequirementRows`, which uses client-thread-only RuneLite APIs (`client.getQuestState`, `client.getRealSkillLevel`, diary varbit reads).

Result, observed in the 2026-05-13 in-client validation pass: every Guide Me click fired `AssertionError: must be called on client thread`. Some sources activated anyway (the assertion is non-fatal — it propagates, `buildRequirementRows` aborts, requirements panel stays empty, downstream activation continues). Other sources (Shades of Mort'ton) failed to activate entirely.

## Root cause

Latent gap exposed by PR #401 (B.5.3 — general requirements panel):
- Prior commit `c528d0ae` correctly routed **step-advance** and **skip** callbacks through `clientThread`.
- That commit did NOT wrap the **initial activation** entry point in `Plugin.activateGuidance`.
- PR #401 added `RequirementsChecker.buildRequirementRows` to the coordinator's `activateGuidance` body. Before #401, the activation code path didn't need the client thread strictly — it does now.

## Fix

Wrap the body of `Plugin.activateGuidance(...)` in `clientThread.invokeLater(...)`, mirroring the `c528d0ae` pattern. Single-site fix covers both UI entry points:

- `CollectionLogHelperPanel.lambda$showDetail$7` (Item Detail Guide Me button)
- `QuickGuidePanelView.lambda$create$0` (Top Pick green Guide Me button)

Both flow through `Plugin::activateGuidance`, so wrapping there is sufficient.

## Why `invokeLater` and not `invoke`

`invokeLater` queues the work on the game thread asynchronously — correct for an EDT caller. `invoke` attempts synchronous dispatch and can deadlock when called from the EDT. Matches the `c528d0ae` pattern exactly.

## Side effects

Activation now completes on the next client-thread tick instead of synchronously. The panel's \"Stop Guidance\" button state may lag by one tick. This is acceptable and consistent with how step-advance / skip already behave.

## Regression test

`ActivateGuidanceClientThreadTest` (new) mocks `ClientThread` and asserts that `invokeLater` is called when `Plugin.activateGuidance` runs from the calling thread. This catches future EDT regressions in CI rather than in-game.

## Stack trace (from validation pass)

\`\`\`
java.lang.AssertionError: must be called on client thread
  at com.collectionloghelper.data.RequirementsChecker.buildRequirementRows(RequirementsChecker.java:181)
  at com.collectionloghelper.guidance.GuidanceOverlayCoordinator.activateGuidance(GuidanceOverlayCoordinator.java:224)
  at com.collectionloghelper.CollectionLogHelperPlugin.activateGuidance(CollectionLogHelperPlugin.java:753)
  at com.collectionloghelper.ui.CollectionLogHelperPanel.lambda\$showDetail\$7(CollectionLogHelperPanel.java:586)
  at com.collectionloghelper.ui.ItemDetailPanel.lambda\$new\$2(ItemDetailPanel.java:225)
\`\`\`

## Test plan

- [x] Local: \`./gradlew build\` passes (CI will confirm).
- [ ] In-client: click Guide Me on Shades of Mort'ton (which fully failed pre-fix) → guidance activates, step strip renders, no AssertionError in \`client.log\`.
- [ ] In-client: click the Top Pick green Guide Me button on any source → guidance activates cleanly.
- [ ] In-client: click Guide Me from the Item Detail view (any locked item) → guidance activates cleanly.
- [ ] In-client: \`client.log\` grep \`AssertionError\` after 5 minutes of Guide Me / Stop Guidance cycles → ZERO matches.
- [ ] Regression: step-advance and skip (\`c528d0ae\`) still work — overlays update on the same tick.

## References

- Pattern source: commit \`c528d0ae\` (fix: route step-advance and skip callbacks through client thread).
- Regression vector: PR #401 (feat(panel): general requirements (quest/skill/diary) in guidance header (B.5.3)).
- Surfaced: 2026-05-13 in-client validation pass against master HEAD \`1d03b74d\`.