### PR TITLE
data(mort-ton): add pyre logs + shade remains to requiredItemIds (Fiyr tier)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -11807,13 +11807,15 @@
     "travelTip": "Minigame teleport -> Shades of Mort'ton, or Mort'ton teleport scroll",
     "guidanceSteps": [
       {
-        "description": "Bank: bring pyre logs, shade remains, and a tinderbox to Mort'ton",
+        "description": "Bank: bring Fiyr pyre logs, Fiyr shade remains, and a tinderbox to Mort'ton (or any matching shade tier)",
         "worldX": 3488,
         "worldY": 3283,
         "worldPlane": 0,
         "travelTip": "Minigame teleport -> Shades of Mort'ton | Barrows teleport + run south | Mort'ton teleport scroll | Fairy ring BKR",
         "requiredItemIds": [
-          590
+          590,
+          3410,
+          3446
         ],
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 25,
@@ -11827,7 +11829,9 @@
         "objectId": 4093,
         "objectInteractAction": "Build",
         "requiredItemIds": [
-          590
+          590,
+          3410,
+          3446
         ],
         "skipIfHasAnyItemIds": [
           3450,


### PR DESCRIPTION
## Summary

B.5.1b backfill (#400) added only tinderbox (590) to Mort'ton's Bank prep step \`requiredItemIds\`. The Skilling step also only had tinderbox. Pyre logs + shade remains were missing from both steps even though they are mechanically required to burn shades and obtain gold keys — which drop the actual clog items.

Surfaced by 2026-05-13 in-client validation: the operator noted the \"Items needed:\" subsection should show pyre logs and shade remains alongside tinderbox.

## Tier choice — Fiyr

Per OSRS Wiki best-clog-efficient tier guidance:

- **Fiyr** (shade remains \`3410\`, pyre logs \`3446\`) — requires 80 Prayer; gold keys drop the better clog item tiers at higher rates.
- Most players grinding Shades for clog will be ≥ 80 Prayer, so Fiyr is the realistic canonical pick.
- Lower tiers (Loar/Phrin/Riyl/Asyn) still work mechanically. Description now says \"Fiyr pyre logs, Fiyr shade remains... (or any matching shade tier)\" so players using a different tier aren't misled into thinking the source is broken.

The schema does not support OR-semantics on \`requiredItemIds\` today (that's a Tier B1 composable-conditions milestone). Listing only Fiyr keeps the panel uncluttered. When B1 lands, we can expand to alternate-tier rows.

## Changes

Two steps in Shades of Mort'ton source:

- **Bank prep** step: \`requiredItemIds: [590]\` → \`[590, 3410, 3446]\`. Description updated to reference Fiyr tier.
- **Skilling** step: \`requiredItemIds: [590]\` → \`[590, 3410, 3446]\`.

\`+7 / -3\` lines in \`drop_rates.json\` only. No code change.

## Test plan

- [x] \`./gradlew test\` — BUILD SUCCESSFUL.
- [x] Em-dash mojibake check: \`grep -c\` for the UTF-8 em-dash byte sequence in \`drop_rates.json\` returns 0.
- [ ] In-client: activate Mort'ton guidance without pyre logs / shade remains in inventory → \"Items needed:\" subsection shows three rows (Tinderbox, Fiyr shade remains, Fiyr pyre logs) coloured by inventory/bank/missing state.
- [ ] In-client: withdraw one Fiyr shade remains from bank → that row transitions WHITE → GREEN within ~1 tick.

## Notes

- Discovered post-validation; not a regression in any single PR — gap in the original B.5.1b backfill scope (PR #400's conservative \"hard-gated only\" rule excluded shade remains/pyre logs because they're consumable per-cycle rather than carry-forever items, but the panel's purpose is to surface what the player needs to bring for the trip, so they belong in \`requiredItemIds\`).
- Future similar data-backfill audits should check sources where the description explicitly names items — those items belong in \`requiredItemIds\`.

Refs cha-ndler/collection-log-helper#382 (B.5.1b follow-up).