### PR TITLE
feat(panel): Reset and Sync buttons for repeatable guidance activities (#369)

### DIFF
--- a/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
@@ -243,12 +243,16 @@ public class CollectionLogHelperPlugin extends Plugin
 			filter -> configManager.setConfiguration("collectionloghelper", "afkFilter", filter.name()),
 			sort -> configManager.setConfiguration("collectionloghelper", "efficientSortMode", sort.name()));
 		panel.setMode(config.defaultMode());
-		// Route step-advance and skip through the client thread so overlay
-		// rescans (e.g. ObjectHighlightOverlay.rescanScene) fire in the same
-		// game-frame as auto-completion events rather than the next tick.
+		// Route step-advance, skip, reset, and sync through the client thread
+		// so overlay rescans fire in the same game-frame as auto-completion
+		// events. Reset and Sync require RequirementsChecker / inventory state
+		// that are client-thread-only, matching the pattern established in
+		// commits c528d0ae and cha-ndler/collection-log-helper#409.
 		panel.setStepCallbacks(
 			() -> clientThread.invokeLater(guidanceSequencer::advanceStep),
-			() -> clientThread.invokeLater(guidanceSequencer::skipStep)
+			() -> clientThread.invokeLater(guidanceSequencer::skipStep),
+			() -> clientThread.invokeLater(guidanceSequencer::restartFromStep0),
+			() -> clientThread.invokeLater(guidanceSequencer::syncToCurrentState)
 		);
 
 		// Wire coordinator with references it needs from the plugin

--- a/src/main/java/com/collectionloghelper/guidance/GuidanceSequencer.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceSequencer.java
@@ -219,6 +219,96 @@ public class GuidanceSequencer
 		return loopIterationsCompleted;
 	}
 
+	/**
+	 * Replaces the step-changed callback without restarting the sequence.
+	 * Used by tests to observe step-change notifications after
+	 * {@link #startSequence} has already been called.
+	 */
+	public void setOnStepChanged(Consumer<GuidanceStep> callback)
+	{
+		this.onStepChanged = callback;
+	}
+
+	/**
+	 * Forces the guidance sequence back to step 1 (index 0) WITHOUT running the
+	 * skip-chain. Used by the Reset button to let the user replay the full
+	 * sequence from the beginning even if their current state already satisfies
+	 * earlier steps.
+	 *
+	 * <p>The sequence remains active and all callbacks are preserved. Loop
+	 * counters and resolved-alternative caches are cleared so the sequence
+	 * behaves as if it were freshly started at step 0.
+	 *
+	 * <p>No-op if the sequencer is not currently active.
+	 */
+	public void restartFromStep0()
+	{
+		if (!active || steps == null)
+		{
+			return;
+		}
+
+		currentIndex = 0;
+		loopIterationsCompleted = 0;
+		cumulativeActionCount = 0;
+		resolvedAlternatives.clear();
+		// Do NOT call skipSatisfiedSteps() — Reset forces step 0 unconditionally.
+
+		GuidanceStep step = getCurrentStep();
+		if (step != null)
+		{
+			log.info("Guidance sequence reset to step 1/{} for {}",
+				steps.size(), activeSource != null ? activeSource.getName() : "?");
+			notifyStepChanged(step);
+		}
+	}
+
+	/**
+	 * Re-evaluates the activation skip-chain from step 0 against current player
+	 * state and jumps to the first unsatisfied step. Used by the Sync button to
+	 * let the user catch up after picking up items or travelling while guidance
+	 * was already active.
+	 *
+	 * <p>Unlike Reset, Sync does NOT change {@link #active}, does NOT clear
+	 * callbacks, and does NOT stop/restart the underlying sequence — it only
+	 * moves the index forward (or backward, if {@link #isStepAlreadySatisfied}
+	 * semantics allow) to the correct position.
+	 *
+	 * <p>Always fires {@link #notifyStepChanged} so the panel and overlays
+	 * refresh even if the index did not change.
+	 *
+	 * <p>No-op if the sequencer is not currently active.
+	 */
+	public void syncToCurrentState()
+	{
+		if (!active || steps == null)
+		{
+			return;
+		}
+
+		currentIndex = 0;
+		loopIterationsCompleted = 0;
+		resolvedAlternatives.clear();
+		// Re-run the skip-chain to find the first unsatisfied step
+		skipSatisfiedSteps();
+
+		if (!active)
+		{
+			// All steps already satisfied — sequence completed via skipSatisfiedSteps
+			log.info("Sync completed sequence immediately (all steps already satisfied) for {}",
+				activeSource != null ? activeSource.getName() : "?");
+			return;
+		}
+
+		GuidanceStep step = getCurrentStep();
+		if (step != null)
+		{
+			log.info("Guidance synced to step {}/{} for {}",
+				currentIndex + 1, steps.size(), activeSource != null ? activeSource.getName() : "?");
+			notifyStepChanged(step);
+		}
+	}
+
 	public int getCumulativeActionCount()
 	{
 		return cumulativeActionCount;

--- a/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
@@ -680,6 +680,16 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 		stepProgressView.setCallbacks(advancer, skipper);
 	}
 
+	/**
+	 * Sets callbacks for all four step-control buttons: Next Step, Skip, Reset,
+	 * and Sync. Any callback may be {@code null}.
+	 */
+	public void setStepCallbacks(Runnable advancer, Runnable skipper,
+		Runnable resetter, Runnable syncer)
+	{
+		stepProgressView.setCallbacks(advancer, skipper, resetter, syncer);
+	}
+
 	public void hideClueGuidance()
 	{
 		guidanceBannerView.hideClueGuidance();

--- a/src/main/java/com/collectionloghelper/ui/widget/StepProgressView.java
+++ b/src/main/java/com/collectionloghelper/ui/widget/StepProgressView.java
@@ -97,6 +97,8 @@ public class StepProgressView extends JPanel
 	private final JPanel sectionsPanel;
 	private final JButton nextStepButton;
 	private final JButton skipStepButton;
+	private final JButton resetButton;
+	private final JButton syncButton;
 
 	/**
 	 * Per-section collapse state. True = expanded. New sections default to collapsed
@@ -106,6 +108,8 @@ public class StepProgressView extends JPanel
 
 	private Runnable stepAdvancer;
 	private Runnable stepSkipper;
+	private Runnable stepResetter;
+	private Runnable stepSyncer;
 
 	public StepProgressView(ItemManager itemManager)
 	{
@@ -182,6 +186,38 @@ public class StepProgressView extends JPanel
 		});
 		stepButtonRow.add(skipStepButton);
 
+		stepButtonRow.add(Box.createHorizontalStrut(4));
+
+		resetButton = new JButton("Reset");
+		resetButton.setFont(FontManager.getRunescapeSmallFont());
+		resetButton.setBackground(new Color(70, 50, 50));
+		resetButton.setForeground(new Color(200, 200, 200));
+		resetButton.setToolTipText("Restart from step 1");
+		resetButton.addActionListener(e ->
+		{
+			if (stepResetter != null)
+			{
+				stepResetter.run();
+			}
+		});
+		stepButtonRow.add(resetButton);
+
+		stepButtonRow.add(Box.createHorizontalStrut(4));
+
+		syncButton = new JButton("Sync");
+		syncButton.setFont(FontManager.getRunescapeSmallFont());
+		syncButton.setBackground(new Color(50, 60, 80));
+		syncButton.setForeground(new Color(200, 200, 200));
+		syncButton.setToolTipText("Re-evaluate current state");
+		syncButton.addActionListener(e ->
+		{
+			if (stepSyncer != null)
+			{
+				stepSyncer.run();
+			}
+		});
+		stepButtonRow.add(syncButton);
+
 		add(Box.createVerticalStrut(3));
 		add(stepButtonRow);
 	}
@@ -194,6 +230,23 @@ public class StepProgressView extends JPanel
 	{
 		this.stepAdvancer = advancer;
 		this.stepSkipper = skipper;
+	}
+
+	/**
+	 * Sets all four step-control callbacks: advance, skip, reset, and sync.
+	 * Any callback may be {@code null} (the corresponding button click will be a no-op).
+	 *
+	 * @param advancer  callback for the Next Step button
+	 * @param skipper   callback for the Skip button
+	 * @param resetter  callback for the Reset button (restart from step 1, no skip-chain)
+	 * @param syncer    callback for the Sync button (re-evaluate skip-chain against current state)
+	 */
+	public void setCallbacks(Runnable advancer, Runnable skipper, Runnable resetter, Runnable syncer)
+	{
+		this.stepAdvancer = advancer;
+		this.stepSkipper = skipper;
+		this.stepResetter = resetter;
+		this.stepSyncer = syncer;
 	}
 
 	/**

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
@@ -1641,4 +1641,206 @@ public class GuidanceSequencerTest
 		assertEquals("Landed step should be 'Pick up shade key'",
 			"Pick up shade key", landedStep.get().getDescription());
 	}
+
+	// ---- restartFromStep0 tests (Reset button) ────────────────────────────
+
+	/**
+	 * restartFromStep0 when the sequencer is active: index must return to 0,
+	 * sequencer must remain active, and onStepChanged must fire with step 0.
+	 */
+	@Test
+	public void testRestartFromStep0_resetsToFirstStep()
+	{
+		List<GuidanceStep> steps = Arrays.asList(
+			makeManualStep("Step 1"),
+			makeManualStep("Step 2"),
+			makeManualStep("Step 3")
+		);
+
+		AtomicReference<GuidanceStep> lastStep = new AtomicReference<>();
+		startSequence(steps, s -> lastStep.set(s), () -> {});
+
+		// Advance to step 2
+		sequencer.advanceStep();
+		assertEquals(1, sequencer.getCurrentIndex());
+
+		// Reset: must return to step 0 without skip-chain
+		sequencer.restartFromStep0();
+
+		assertTrue("Sequencer must remain active after reset", sequencer.isActive());
+		assertEquals("Index must be 0 after reset", 0, sequencer.getCurrentIndex());
+		assertNotNull("onStepChanged must fire after reset", lastStep.get());
+		assertEquals("Step 1", lastStep.get().getDescription());
+	}
+
+	/**
+	 * restartFromStep0 must NOT run the skip-chain even when the first step's
+	 * completion condition is already satisfied (that is the whole point of Reset).
+	 * Approach: startSequence lands at step 0 (default mocks have inventory empty),
+	 * then we update the mock to say the item is present, sync forward to step 1,
+	 * and verify Reset takes us back to step 0 unconditionally.
+	 */
+	@Test
+	public void testRestartFromStep0_forceStep0EvenIfSatisfied()
+	{
+		int itemId = 590;
+		// @Before already sets lenient defaults: hasItemCount and hasItem return false.
+		// Startsequence skip-chain lands at step 0 because inventory is empty by default.
+
+		List<GuidanceStep> steps = Arrays.asList(
+			makeInventoryHasItemStep(itemId, 1), // step 0
+			makeManualStep("Step 2")             // step 1
+		);
+
+		startSequence(steps);
+		assertEquals("Should start at step 0", 0, sequencer.getCurrentIndex());
+
+		// Now mock reports inventory has the item (player picked it up mid-session).
+		// INVENTORY_HAS_ITEM only checks hasItemCount; hasItem is not needed here.
+		when(inventoryState.hasItemCount(itemId, 1)).thenReturn(true);
+
+		// Sync forward so skip-chain pushes to step 1
+		sequencer.syncToCurrentState();
+		assertEquals("Sync should have advanced to step 1", 1, sequencer.getCurrentIndex());
+
+		// Reset: force back to step 0 even though the condition is satisfied
+		sequencer.restartFromStep0();
+
+		assertEquals("restartFromStep0 must land on step 0 regardless of satisfaction",
+			0, sequencer.getCurrentIndex());
+		assertTrue(sequencer.isActive());
+	}
+
+	/**
+	 * restartFromStep0 is a no-op when the sequencer is not active.
+	 */
+	@Test
+	public void testRestartFromStep0_noopWhenInactive()
+	{
+		assertFalse(sequencer.isActive());
+		// Must not throw
+		sequencer.restartFromStep0();
+		assertFalse(sequencer.isActive());
+	}
+
+	/**
+	 * restartFromStep0 resets the loop counter so loops replay from the beginning.
+	 */
+	@Test
+	public void testRestartFromStep0_resetsLoopCounter()
+	{
+		List<GuidanceStep> steps = Arrays.asList(
+			makeManualStep("Step 1"),
+			makeLoopingStep("Step 2 (loop)", CompletionCondition.ACTOR_DEATH, 1234, 1, 3)
+		);
+
+		startSequence(steps);
+		sequencer.advanceStep(); // move to step 2 (index 1)
+		// Simulate one loop iteration completing
+		sequencer.onNpcDeath(1234);
+		// loopIterationsCompleted is 1 now
+
+		sequencer.restartFromStep0();
+		assertEquals(0, sequencer.getCurrentIndex());
+		// After reset, loop counter should be cleared so the loop replays fully
+		assertEquals(0, sequencer.getLoopIterationsCompleted());
+	}
+
+	// ---- syncToCurrentState tests (Sync button) ───────────────────────────
+
+	/**
+	 * syncToCurrentState re-runs the skip-chain from step 0 without stopping the
+	 * underlying sequence. If the player has satisfied step 0, the sequencer
+	 * must advance forward to the first unsatisfied step.
+	 * Approach: startSequence lands at step 0 (default mocks have inventory empty),
+	 * then we update the mock and call sync to jump to step 1.
+	 */
+	@Test
+	public void testSyncToCurrentState_advancesToFirstUnsatisfiedStep()
+	{
+		int itemId = 590;
+		// @Before already sets lenient defaults: inventory empty, lands at step 0.
+
+		List<GuidanceStep> steps = Arrays.asList(
+			makeInventoryHasItemStep(itemId, 1), // step 0
+			makeManualStep("Step 2"),            // step 1
+			makeManualStep("Step 3")             // step 2
+		);
+
+		startSequence(steps);
+		assertEquals("Should start at step 0", 0, sequencer.getCurrentIndex());
+
+		// Player picked up the item mid-session.
+		// INVENTORY_HAS_ITEM only checks hasItemCount; hasItem is not needed here.
+		when(inventoryState.hasItemCount(itemId, 1)).thenReturn(true);
+
+		AtomicReference<GuidanceStep> lastStep = new AtomicReference<>();
+		sequencer.setOnStepChanged(s -> lastStep.set(s));
+
+		// Sync: re-evaluate from step 0, should jump to step 1
+		sequencer.syncToCurrentState();
+
+		assertTrue("Sequencer must remain active after sync", sequencer.isActive());
+		assertEquals("Should advance to step 1 (first unsatisfied)", 1, sequencer.getCurrentIndex());
+		assertNotNull("onStepChanged must fire with new step", lastStep.get());
+		assertEquals("Step 2", lastStep.get().getDescription());
+	}
+
+	/**
+	 * syncToCurrentState must NOT stop the sequence — active flag stays true and
+	 * callbacks remain wired.
+	 */
+	@Test
+	public void testSyncToCurrentState_doesNotStopSequence()
+	{
+		List<GuidanceStep> steps = Arrays.asList(
+			makeManualStep("Step 1"),
+			makeManualStep("Step 2")
+		);
+		AtomicBoolean completeFired = new AtomicBoolean(false);
+		startSequence(steps, s -> {}, () -> completeFired.set(true));
+
+		sequencer.syncToCurrentState();
+
+		assertTrue("Sequence must remain active after sync", sequencer.isActive());
+		assertFalse("onSequenceComplete must not fire on sync", completeFired.get());
+		assertNotNull("Active source must remain set after sync", sequencer.getActiveSource());
+	}
+
+	/**
+	 * syncToCurrentState is a no-op when the sequencer is not active.
+	 */
+	@Test
+	public void testSyncToCurrentState_noopWhenInactive()
+	{
+		assertFalse(sequencer.isActive());
+		// Must not throw
+		sequencer.syncToCurrentState();
+		assertFalse(sequencer.isActive());
+	}
+
+	/**
+	 * syncToCurrentState when no steps are satisfied fires onStepChanged to
+	 * refresh the panel but does not change the index.
+	 */
+	@Test
+	public void testSyncToCurrentState_staysAtCurrentIfAlreadyCorrect()
+	{
+		List<GuidanceStep> steps = Arrays.asList(
+			makeManualStep("Step 1"),
+			makeManualStep("Step 2")
+		);
+
+		AtomicReference<GuidanceStep> lastStep = new AtomicReference<>();
+		startSequence(steps, s -> lastStep.set(s), () -> {});
+		assertEquals(0, sequencer.getCurrentIndex());
+
+		// Sync with no newly-satisfied steps — must remain at step 0
+		sequencer.setOnStepChanged(s -> lastStep.set(s));
+		sequencer.syncToCurrentState();
+
+		assertEquals("Index must not change when no steps are satisfied", 0, sequencer.getCurrentIndex());
+		// onStepChanged fires to refresh the panel even if index did not change
+		assertNotNull("onStepChanged must fire on sync", lastStep.get());
+	}
 }

--- a/src/test/java/com/collectionloghelper/ui/widget/StepProgressViewTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/StepProgressViewTest.java
@@ -34,6 +34,7 @@ import java.awt.Component;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -753,6 +754,160 @@ public class StepProgressViewTest
 			}
 		}
 		return result;
+	}
+
+	// ── Reset / Sync button tests (#369) ────────────────────────────────────
+
+	/**
+	 * After construction the Reset and Sync buttons must be present in the
+	 * step-button row (findable via findButtonByText).
+	 */
+	@Test
+	public void construction_hasResetAndSyncButtons()
+	{
+		assertNotNull("Reset button must exist after construction", findButtonByText(view, "Reset"));
+		assertNotNull("Sync button must exist after construction", findButtonByText(view, "Sync"));
+	}
+
+	/**
+	 * The Reset button must invoke the reset callback when clicked.
+	 */
+	@Test
+	public void resetButton_click_invokesResetCallback() throws Exception
+	{
+		AtomicBoolean resetFired = new AtomicBoolean(false);
+		view.setCallbacks(() -> {}, () -> {}, () -> resetFired.set(true), () -> {});
+		flushEdt();
+
+		JButton resetBtn = findButtonByText(view, "Reset");
+		assertNotNull("Reset button must be present", resetBtn);
+		SwingUtilities.invokeAndWait(() -> resetBtn.doClick());
+
+		assertTrue("Reset callback must fire when Reset button is clicked", resetFired.get());
+	}
+
+	/**
+	 * The Sync button must invoke the sync callback when clicked.
+	 */
+	@Test
+	public void syncButton_click_invokesSyncCallback() throws Exception
+	{
+		AtomicBoolean syncFired = new AtomicBoolean(false);
+		view.setCallbacks(() -> {}, () -> {}, () -> {}, () -> syncFired.set(true));
+		flushEdt();
+
+		JButton syncBtn = findButtonByText(view, "Sync");
+		assertNotNull("Sync button must be present", syncBtn);
+		SwingUtilities.invokeAndWait(() -> syncBtn.doClick());
+
+		assertTrue("Sync callback must fire when Sync button is clicked", syncFired.get());
+	}
+
+	/**
+	 * setCallbacks(advancer, skipper) two-arg overload must remain valid after the
+	 * new four-arg overload is introduced — existing callers are not broken.
+	 */
+	@Test
+	public void setCallbacks_twoArg_doesNotThrow()
+	{
+		view.setCallbacks(() -> {}, () -> {});
+	}
+
+	/**
+	 * When setCallbacks is called with null reset/sync callbacks, clicking the buttons
+	 * must not throw a NullPointerException.
+	 */
+	@Test
+	public void resetAndSyncButtons_nullCallbacks_doNotThrow() throws Exception
+	{
+		view.setCallbacks(() -> {}, () -> {}, null, null);
+		flushEdt();
+
+		JButton resetBtn = findButtonByText(view, "Reset");
+		JButton syncBtn = findButtonByText(view, "Sync");
+		assertNotNull(resetBtn);
+		assertNotNull(syncBtn);
+		SwingUtilities.invokeAndWait(() ->
+		{
+			resetBtn.doClick();
+			syncBtn.doClick();
+		});
+	}
+
+	/**
+	 * The Reset button has the tooltip "Restart from step 1".
+	 */
+	@Test
+	public void resetButton_hasExpectedTooltip()
+	{
+		JButton resetBtn = findButtonByText(view, "Reset");
+		assertNotNull(resetBtn);
+		assertEquals("Restart from step 1", resetBtn.getToolTipText());
+	}
+
+	/**
+	 * The Sync button has the tooltip "Re-evaluate current state".
+	 */
+	@Test
+	public void syncButton_hasExpectedTooltip()
+	{
+		JButton syncBtn = findButtonByText(view, "Sync");
+		assertNotNull(syncBtn);
+		assertEquals("Re-evaluate current state", syncBtn.getToolTipText());
+	}
+
+	// ── Helpers (Reset/Sync) ─────────────────────────────────────────────────
+
+	/**
+	 * Finds the first {@link JButton} anywhere in {@code root}'s component tree
+	 * whose text equals {@code text}. Searches recursively.
+	 */
+	private static JButton findButtonByText(JPanel root, String text)
+	{
+		for (Component c : root.getComponents())
+		{
+			if (c instanceof JButton)
+			{
+				JButton btn = (JButton) c;
+				if (text.equals(btn.getText()))
+				{
+					return btn;
+				}
+			}
+			else if (c instanceof JPanel)
+			{
+				JButton found = findButtonInPanel((JPanel) c, text);
+				if (found != null)
+				{
+					return found;
+				}
+			}
+		}
+		return null;
+	}
+
+	private static JButton findButtonInPanel(JPanel panel, String text)
+	{
+		for (Component c : panel.getComponents())
+		{
+			if (c instanceof JButton)
+			{
+				JButton btn = (JButton) c;
+				if (text.equals(btn.getText()))
+				{
+					return btn;
+				}
+			}
+			else if (c instanceof JPanel)
+			{
+				JButton found = findButtonInPanel((JPanel) c, text);
+				if (found != null)
+				{
+					return found;
+				}
+			}
+		}
+		return null;
 	}
 
 	/** Builds a minimal {@link GuidanceStep} with the given section label (may be null). */


### PR DESCRIPTION
## Summary

- Adds **Reset** and **Sync** buttons to the `StepProgressView` step-button row, alongside the existing Next Step and Skip buttons, addressing the need for users to replay repeatable activities (e.g. Shades of Mort'ton chest runs) without stopping and re-activating guidance manually.
- Both buttons are routed through `clientThread.invokeLater`, matching the pattern established in #409 for step-advance and skip.

## Behaviour

### Reset
Calls `GuidanceSequencer.restartFromStep0()`: forces the sequence index back to 0 **without** running the skip-chain. The user can replay the full sequence even if their current state already satisfies earlier steps. Loop counters (`loopIterationsCompleted`, `cumulativeActionCount`) and the resolved-alternatives cache are cleared. The sequence remains active and all callbacks are preserved.

### Sync
Calls `GuidanceSequencer.syncToCurrentState()`: re-runs the activation skip-chain from step 0 against current player state and jumps to the first unsatisfied step. Unlike Reset, this does **not** stop or restart the underlying sequence — it only repositions the index and fires `onStepChanged` to refresh the panel and overlays. If Sync determines all steps are already satisfied, the sequence completes normally (same as activation behaviour).

## Sequencer touch points

| Method | Purpose |
|--------|---------|
| `GuidanceSequencer.restartFromStep0()` | Reset — index=0, no skip-chain |
| `GuidanceSequencer.syncToCurrentState()` | Sync — re-runs skip-chain, repositions index |
| `GuidanceSequencer.setOnStepChanged(Consumer)` | Test helper: observe step changes after `startSequence` |
| `StepProgressView.setCallbacks(Runnable, Runnable, Runnable, Runnable)` | 4-arg overload adding reset + sync; 2-arg overload unchanged |
| `CollectionLogHelperPanel.setStepCallbacks(Runnable, Runnable, Runnable, Runnable)` | Delegates to StepProgressView |

## Test plan

- [ ] `GuidanceSequencerTest.testRestartFromStep0_resetsToFirstStep` — index returns to 0, `onStepChanged` fires
- [ ] `GuidanceSequencerTest.testRestartFromStep0_forceStep0EvenIfSatisfied` — Reset stays at 0 even when skip-chain would advance past it
- [ ] `GuidanceSequencerTest.testRestartFromStep0_noopWhenInactive` — no-op when sequencer not active
- [ ] `GuidanceSequencerTest.testRestartFromStep0_resetsLoopCounter` — loop counter cleared on reset
- [ ] `GuidanceSequencerTest.testSyncToCurrentState_advancesToFirstUnsatisfiedStep` — sync jumps forward when new state satisfies earlier steps
- [ ] `GuidanceSequencerTest.testSyncToCurrentState_doesNotStopSequence` — active flag and callbacks preserved
- [ ] `GuidanceSequencerTest.testSyncToCurrentState_noopWhenInactive` — no-op when sequencer not active
- [ ] `GuidanceSequencerTest.testSyncToCurrentState_staysAtCurrentIfAlreadyCorrect` — fires `onStepChanged` even when index unchanged
- [ ] `StepProgressViewTest.construction_hasResetAndSyncButtons` — buttons present after construction
- [ ] `StepProgressViewTest.resetButton_click_invokesResetCallback` — click fires callback
- [ ] `StepProgressViewTest.syncButton_click_invokesSyncCallback` — click fires callback
- [ ] `StepProgressViewTest.setCallbacks_twoArg_doesNotThrow` — legacy overload unbroken
- [ ] `StepProgressViewTest.resetAndSyncButtons_nullCallbacks_doNotThrow` — null-safe
- [ ] `StepProgressViewTest.resetButton_hasExpectedTooltip` — "Restart from step 1"
- [ ] `StepProgressViewTest.syncButton_hasExpectedTooltip` — "Re-evaluate current state"
- [ ] `./gradlew build` passes (698 → 715 tests, 0 failures)

Closes cha-ndler/collection-log-helper#369