### PR TITLE
feat(guidance): perItemStepDescription schema field for per-item step descriptions (B4.3 prep)

### DIFF
--- a/src/main/java/com/collectionloghelper/data/GuidanceStep.java
+++ b/src/main/java/com/collectionloghelper/data/GuidanceStep.java
@@ -43,6 +43,18 @@ public class GuidanceStep
 	/** Human-readable description of what to do in this step. */
 	String description;
 
+	/**
+	 * Optional per-item override for the step's description text.  When the active
+	 * guidance has a specific target collection-log item AND this map has an entry
+	 * for that item, the override string is used in place of {@link #description}.
+	 * Falls back to the static description when no override applies (null map, null
+	 * target, or target not present in the map).
+	 *
+	 * <p>Null by default — existing JSON without this field deserialises unchanged.
+	 */
+	@Nullable
+	Map<Integer, String> perItemStepDescription;
+
 	/** Target world coordinates for this step (0 = no location). */
 	int worldX;
 	int worldY;
@@ -200,6 +212,28 @@ public class GuidanceStep
 	}
 
 	/**
+	 * Resolves the description for this step given the active guidance target item.
+	 * When {@link #perItemStepDescription} has an entry for {@code targetItemId}, that
+	 * override is returned.  Falls back to {@link #description} when the map is null,
+	 * {@code targetItemId} is null, or no entry exists for the target.
+	 *
+	 * @param targetItemId the clog item ID the player is hunting, or {@code null}
+	 * @return the resolved description string (never null if {@link #description} is set)
+	 */
+	public String resolveDescription(@Nullable Integer targetItemId)
+	{
+		if (targetItemId != null && perItemStepDescription != null)
+		{
+			String override = perItemStepDescription.get(targetItemId);
+			if (override != null)
+			{
+				return override;
+			}
+		}
+		return description;
+	}
+
+	/**
 	 * Returns true if the given NPC ID matches this step's completion NPC.
 	 * Checks both the single completionNpcId and the completionNpcIds list,
 	 * supporting multi-form bosses (e.g., Zulrah's 3 combat forms).
@@ -292,6 +326,7 @@ public class GuidanceStep
 	{
 		return new GuidanceStep(
 			alt.getDescription() != null ? alt.getDescription() : this.description,
+			this.perItemStepDescription,
 			alt.getWorldX() != null ? alt.getWorldX() : this.worldX,
 			alt.getWorldY() != null ? alt.getWorldY() : this.worldY,
 			alt.getWorldPlane() != null ? alt.getWorldPlane() : this.worldPlane,

--- a/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
@@ -222,7 +222,6 @@ public class GuidanceOverlayCoordinator
 	public void activateGuidance(CollectionLogSource source, WorldPoint cachedPlayerLocation,
 		@Nullable Integer targetItemId)
 	{
-		this.activeTargetItemId = targetItemId;
 		// Note: deliberately NO early-return on config.showOverlays() here.
 		// Show Overlays controls whether *overlays render*, not whether
 		// guidance is active. Each overlay's render() method self-gates
@@ -243,8 +242,10 @@ public class GuidanceOverlayCoordinator
 		// Build requirement rows on the client thread (snapshot); passed to the panel header.
 		final List<RequirementRow> requirementRows = requirementsChecker.buildRequirementRows(source);
 
-		// Clear any existing guidance first, including InfoBox and sequencer
+		// Clear any existing guidance first, including InfoBox and sequencer.
+		// deactivateGuidance() resets activeTargetItemId to null, so restore it afterwards.
 		deactivateGuidance();
+		this.activeTargetItemId = targetItemId;
 
 		// If source has multi-step guidance, start the sequencer
 		if (source.getGuidanceSteps() != null && !source.getGuidanceSteps().isEmpty())
@@ -273,7 +274,7 @@ public class GuidanceOverlayCoordinator
 			{
 				final int landedIdx = guidanceSequencer.getCurrentIndex() + 1;
 				final int stepTotal = guidanceSequencer.getTotalSteps();
-				final String stepDesc = step != null ? step.getDescription() : "";
+				final String stepDesc = step != null ? step.resolveDescription(activeTargetItemId) : "";
 				final boolean stepManual =
 					step != null && step.getCompletionCondition() == CompletionCondition.MANUAL;
 				final List<GuidanceStep> sourceSteps =
@@ -863,7 +864,7 @@ public class GuidanceOverlayCoordinator
 		{
 			final int current = guidanceSequencer.getCurrentIndex() + 1;
 			final int total = guidanceSequencer.getTotalSteps();
-			final String desc = step.getDescription();
+			final String desc = step.resolveDescription(activeTargetItemId);
 			final boolean isManual = step.getCompletionCondition() == CompletionCondition.MANUAL;
 			final GuidanceStep rawStep = guidanceSequencer.getRawCurrentStep();
 			final CollectionLogSource stepChangeSource = guidanceSequencer.getActiveSource();

--- a/src/test/java/com/collectionloghelper/data/GuidanceStepTest.java
+++ b/src/test/java/com/collectionloghelper/data/GuidanceStepTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Unit tests for {@link GuidanceStep#resolveDescription(Integer)} and the
+ * {@code perItemStepDescription} schema field.
+ *
+ * <p>Acceptance criteria verified:
+ * <ol>
+ *   <li>resolveDescription(null) returns the static description.</li>
+ *   <li>resolveDescription(itemId) returns the override when the map has a matching entry.</li>
+ *   <li>resolveDescription(itemId) falls back to static when the map exists but has no entry for the target.</li>
+ *   <li>resolveDescription(itemId) falls back to static when the map is null.</li>
+ *   <li>Schema deserialisation: JSON without {@code perItemStepDescription} yields a null field (backwards-compatible).</li>
+ *   <li>Schema deserialisation: JSON with {@code perItemStepDescription} populates the map correctly.</li>
+ * </ol>
+ */
+public class GuidanceStepTest
+{
+	private static final int ITEM_TIER1 = 1001;
+	private static final int ITEM_TIER5 = 1005;
+	private static final int ITEM_UNKNOWN = 9999;
+
+	private static final String STATIC_DESC = "Kill soldiers for armour";
+	private static final String TIER1_DESC = "Kill Tier 1 soldiers for tier 1 armour (40 kills)";
+	private static final String TIER5_DESC = "Kill Tier 5 soldiers for tier 5 armour (200 kills)";
+
+	// ── resolveDescription: null targetItemId ──────────────────────────────────
+
+	@Test
+	public void resolveDescription_nullTarget_returnsStaticDescription()
+	{
+		Map<Integer, String> overrides = new HashMap<>();
+		overrides.put(ITEM_TIER1, TIER1_DESC);
+
+		GuidanceStep step = stepWithOverrides(STATIC_DESC, overrides);
+
+		assertEquals(STATIC_DESC, step.resolveDescription(null));
+	}
+
+	// ── resolveDescription: map has matching entry ─────────────────────────────
+
+	@Test
+	public void resolveDescription_targetInMap_returnsOverride()
+	{
+		Map<Integer, String> overrides = new HashMap<>();
+		overrides.put(ITEM_TIER1, TIER1_DESC);
+		overrides.put(ITEM_TIER5, TIER5_DESC);
+
+		GuidanceStep step = stepWithOverrides(STATIC_DESC, overrides);
+
+		assertEquals(TIER1_DESC, step.resolveDescription(ITEM_TIER1));
+		assertEquals(TIER5_DESC, step.resolveDescription(ITEM_TIER5));
+	}
+
+	// ── resolveDescription: map exists but target not in it ───────────────────
+
+	@Test
+	public void resolveDescription_targetNotInMap_returnsStaticDescription()
+	{
+		Map<Integer, String> overrides = new HashMap<>();
+		overrides.put(ITEM_TIER1, TIER1_DESC);
+
+		GuidanceStep step = stepWithOverrides(STATIC_DESC, overrides);
+
+		assertEquals(STATIC_DESC, step.resolveDescription(ITEM_UNKNOWN));
+	}
+
+	// ── resolveDescription: null map ──────────────────────────────────────────
+
+	@Test
+	public void resolveDescription_nullMap_returnsStaticDescription()
+	{
+		GuidanceStep step = stepWithOverrides(STATIC_DESC, null);
+
+		assertEquals(STATIC_DESC, step.resolveDescription(ITEM_TIER1));
+	}
+
+	// ── resolveDescription: empty map ─────────────────────────────────────────
+
+	@Test
+	public void resolveDescription_emptyMap_returnsStaticDescription()
+	{
+		GuidanceStep step = stepWithOverrides(STATIC_DESC, Collections.emptyMap());
+
+		assertEquals(STATIC_DESC, step.resolveDescription(ITEM_TIER1));
+	}
+
+	// ── Schema deserialisation: backwards-compatible (no field) ───────────────
+
+	@Test
+	public void deserialise_jsonWithoutPerItemStepDescription_fieldIsNull()
+	{
+		Gson gson = new GsonBuilder().create();
+		String json = "{"
+			+ "\"description\":\"Kill soldiers\","
+			+ "\"completionCondition\":\"MANUAL\""
+			+ "}";
+
+		GuidanceStep step = gson.fromJson(json, GuidanceStep.class);
+
+		assertEquals("Kill soldiers", step.getDescription());
+		assertNull("perItemStepDescription should be null when absent from JSON",
+			step.getPerItemStepDescription());
+	}
+
+	// ── Schema deserialisation: field present ─────────────────────────────────
+
+	@Test
+	public void deserialise_jsonWithPerItemStepDescription_populatesMap()
+	{
+		Gson gson = new GsonBuilder().create();
+		String json = "{"
+			+ "\"description\":\"Kill soldiers\","
+			+ "\"perItemStepDescription\":{\"1001\":\"Tier 1 override\",\"1005\":\"Tier 5 override\"},"
+			+ "\"completionCondition\":\"MANUAL\""
+			+ "}";
+
+		GuidanceStep step = gson.fromJson(json, GuidanceStep.class);
+
+		// Gson deserialises JSON object keys as Strings; the Map<Integer,String> type
+		// token causes Gson to parse "1001" as Integer 1001 via standard type adaptation.
+		Map<Integer, String> map = step.getPerItemStepDescription();
+		assertEquals("Tier 1 override", map.get(1001));
+		assertEquals("Tier 5 override", map.get(1005));
+		assertEquals("Kill soldiers", step.resolveDescription(9999));
+		assertEquals("Tier 1 override", step.resolveDescription(1001));
+	}
+
+	// ── Helper ────────────────────────────────────────────────────────────────
+
+	private static GuidanceStep stepWithOverrides(String description,
+		Map<Integer, String> perItemStepDescription)
+	{
+		return new GuidanceStep(
+			description,
+			perItemStepDescription,
+			0, 0, 0,       // worldX, worldY, worldPlane
+			0, null, null,  // npcId, interactAction, dialogOptions
+			null, null,     // travelTip, requiredItemIds
+			null,           // perItemRequiredItemIds
+			null,           // recommendedItemIds
+			CompletionCondition.MANUAL,
+			0, 0, 0, 0,    // completionItemId, completionItemCount, completionDistance, completionNpcId
+			null,           // completionNpcIds
+			null,           // worldMessage
+			0, null, null,  // objectId, objectIds, objectInteractAction
+			null, null,     // highlightItemIds, groundItemIds
+			null,           // completionChatPattern
+			0, 0,           // completionVarbitId, completionVarbitValue
+			false,          // useItemOnObject
+			0,              // objectMaxDistance
+			null,           // objectFilterTiles
+			null,           // highlightWidgetIds
+			0, 0,           // loopBackToStep, loopCount
+			null,           // skipIfHasAnyItemIds
+			null,           // dynamicItemObjectTiers
+			null,           // completionZone
+			null,           // conditionalAlternatives
+			null            // section
+		);
+	}
+}

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorDescriptionTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorDescriptionTest.java
@@ -1,0 +1,297 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.guidance;
+
+import com.collectionloghelper.CollectionLogHelperConfig;
+import com.collectionloghelper.data.CollectionLogCategory;
+import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.data.CompletionCondition;
+import com.collectionloghelper.data.GuidanceStep;
+import com.collectionloghelper.data.PlayerInventoryState;
+import com.collectionloghelper.data.PlayerTravelCapabilities;
+import com.collectionloghelper.data.RequirementsChecker;
+import com.collectionloghelper.overlay.DialogHighlightOverlay;
+import com.collectionloghelper.overlay.GroundItemHighlightOverlay;
+import com.collectionloghelper.overlay.GuidanceMinimapOverlay;
+import com.collectionloghelper.overlay.GuidanceOverlay;
+import com.collectionloghelper.overlay.ItemHighlightOverlay;
+import com.collectionloghelper.overlay.ObjectHighlightOverlay;
+import com.collectionloghelper.overlay.WidgetHighlightOverlay;
+import com.collectionloghelper.overlay.WorldMapDestinationOverlay;
+import com.collectionloghelper.overlay.WorldMapRouteOverlay;
+import com.collectionloghelper.ui.CollectionLogHelperPanel;
+import java.lang.reflect.Constructor;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import net.runelite.api.Client;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.eventbus.EventBus;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
+import net.runelite.client.ui.overlay.worldmap.WorldMapPointManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests that {@link GuidanceOverlayCoordinator#activateGuidance} passes the
+ * per-item-resolved description to the panel's {@code updateStepProgress} call.
+ *
+ * <p>Acceptance criteria:
+ * <ul>
+ *   <li>When {@code targetItemId} is non-null and the active step has a matching
+ *       {@code perItemStepDescription} entry, {@code updateStepProgress} receives
+ *       the override text.</li>
+ *   <li>When {@code targetItemId} is null (no item context), {@code updateStepProgress}
+ *       receives the static description.</li>
+ * </ul>
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class GuidanceOverlayCoordinatorDescriptionTest
+{
+	private static final int TARGET_ITEM_ID = 1001;
+	private static final String STATIC_DESC = "Kill soldiers for armour";
+	private static final String OVERRIDE_DESC = "Kill Tier 1 soldiers (40 kills)";
+
+	@Mock
+	private Client client;
+	@Mock
+	private ClientThread clientThread;
+	@Mock
+	private EventBus eventBus;
+	@Mock
+	private CollectionLogHelperConfig config;
+	@Mock
+	private GuidanceSequencer guidanceSequencer;
+	@Mock
+	private RequirementsChecker requirementsChecker;
+	@Mock
+	private PlayerTravelCapabilities travelCapabilities;
+	@Mock
+	private PlayerInventoryState playerInventoryState;
+	@Mock
+	private ItemManager itemManager;
+	@Mock
+	private RequiredItemResolver requiredItemResolver;
+	@Mock
+	private WorldMapPointManager worldMapPointManager;
+	@Mock
+	private InfoBoxManager infoBoxManager;
+	@Mock
+	private GuidanceOverlay guidanceOverlay;
+	@Mock
+	private GuidanceMinimapOverlay guidanceMinimapOverlay;
+	@Mock
+	private DialogHighlightOverlay dialogHighlightOverlay;
+	@Mock
+	private ObjectHighlightOverlay objectHighlightOverlay;
+	@Mock
+	private ItemHighlightOverlay itemHighlightOverlay;
+	@Mock
+	private WorldMapRouteOverlay worldMapRouteOverlay;
+	@Mock
+	private WorldMapDestinationOverlay worldMapDestinationOverlay;
+	@Mock
+	private GroundItemHighlightOverlay groundItemHighlightOverlay;
+	@Mock
+	private WidgetHighlightOverlay widgetHighlightOverlay;
+	@Mock
+	private CollectionLogHelperPanel panel;
+
+	private GuidanceOverlayCoordinator coordinator;
+
+	@Before
+	public void setUp() throws Exception
+	{
+		Constructor<GuidanceOverlayCoordinator> ctor =
+			GuidanceOverlayCoordinator.class.getDeclaredConstructor(
+				Client.class,
+				ClientThread.class,
+				EventBus.class,
+				CollectionLogHelperConfig.class,
+				GuidanceSequencer.class,
+				RequirementsChecker.class,
+				PlayerTravelCapabilities.class,
+				PlayerInventoryState.class,
+				ItemManager.class,
+				RequiredItemResolver.class,
+				WorldMapPointManager.class,
+				InfoBoxManager.class,
+				GuidanceOverlay.class,
+				GuidanceMinimapOverlay.class,
+				DialogHighlightOverlay.class,
+				ObjectHighlightOverlay.class,
+				ItemHighlightOverlay.class,
+				WorldMapRouteOverlay.class,
+				WorldMapDestinationOverlay.class,
+				GroundItemHighlightOverlay.class,
+				WidgetHighlightOverlay.class);
+		ctor.setAccessible(true);
+		coordinator = ctor.newInstance(
+			client, clientThread, eventBus, config,
+			guidanceSequencer, requirementsChecker, travelCapabilities,
+			playerInventoryState, itemManager, requiredItemResolver,
+			worldMapPointManager, infoBoxManager,
+			guidanceOverlay, guidanceMinimapOverlay, dialogHighlightOverlay,
+			objectHighlightOverlay, itemHighlightOverlay,
+			worldMapRouteOverlay, worldMapDestinationOverlay,
+			groundItemHighlightOverlay, widgetHighlightOverlay);
+
+		coordinator.setPanel(panel);
+
+		when(requirementsChecker.getUnmetRequirements(any())).thenReturn(Collections.emptyList());
+		when(requirementsChecker.buildRequirementRows(any())).thenReturn(Collections.emptyList());
+	}
+
+	/**
+	 * When the active step has a {@code perItemStepDescription} entry for the active
+	 * target item, the coordinator must pass the override text — not the static
+	 * description — to {@code panel.updateStepProgress}.
+	 */
+	@Test
+	public void activateGuidance_withTargetItemId_panelReceivesOverrideDescription()
+	{
+		Map<Integer, String> descOverrides = new HashMap<>();
+		descOverrides.put(TARGET_ITEM_ID, OVERRIDE_DESC);
+
+		GuidanceStep step = minimalStepWithDescOverride(STATIC_DESC, descOverrides);
+		CollectionLogSource source = sourceWithSteps("Shayzien Armour", step);
+
+		// Sequencer reports the step as active at index 0
+		when(guidanceSequencer.isActive()).thenReturn(true);
+		when(guidanceSequencer.getCurrentStep()).thenReturn(step);
+		when(guidanceSequencer.getRawCurrentStep()).thenReturn(step);
+		when(guidanceSequencer.getCurrentIndex()).thenReturn(0);
+		when(guidanceSequencer.getTotalSteps()).thenReturn(1);
+		// getActiveSource is used by onStepChanged (not the activation path); lenient to avoid strict fail
+		org.mockito.Mockito.lenient().when(guidanceSequencer.getActiveSource()).thenReturn(source);
+
+		coordinator.activateGuidance(source, new WorldPoint(3200, 3200, 0), TARGET_ITEM_ID);
+
+		ArgumentCaptor<String> descCaptor = ArgumentCaptor.forClass(String.class);
+		// The activation path calls the 6-arg overload: (int, int, String, boolean, List, List)
+		verify(panel, atLeastOnce()).updateStepProgress(
+			anyInt(), anyInt(), descCaptor.capture(), anyBoolean(), anyList(), anyList());
+
+		// The first updateStepProgress call (before deferred item resolution) uses the resolved desc.
+		assertEquals(OVERRIDE_DESC, descCaptor.getAllValues().get(0));
+	}
+
+	/**
+	 * When no target item is set (null), the coordinator must pass the static description
+	 * even if the step has a non-empty {@code perItemStepDescription} map.
+	 */
+	@Test
+	public void activateGuidance_withNullTargetItemId_panelReceivesStaticDescription()
+	{
+		Map<Integer, String> descOverrides = new HashMap<>();
+		descOverrides.put(TARGET_ITEM_ID, OVERRIDE_DESC);
+
+		GuidanceStep step = minimalStepWithDescOverride(STATIC_DESC, descOverrides);
+		CollectionLogSource source = sourceWithSteps("Shayzien Armour", step);
+
+		when(guidanceSequencer.isActive()).thenReturn(true);
+		when(guidanceSequencer.getCurrentStep()).thenReturn(step);
+		when(guidanceSequencer.getRawCurrentStep()).thenReturn(step);
+		when(guidanceSequencer.getCurrentIndex()).thenReturn(0);
+		when(guidanceSequencer.getTotalSteps()).thenReturn(1);
+		// getActiveSource is used by onStepChanged (not the activation path); lenient to avoid strict fail
+		org.mockito.Mockito.lenient().when(guidanceSequencer.getActiveSource()).thenReturn(source);
+
+		coordinator.activateGuidance(source, new WorldPoint(3200, 3200, 0), null);
+
+		ArgumentCaptor<String> descCaptor = ArgumentCaptor.forClass(String.class);
+		// The activation path calls the 6-arg overload: (int, int, String, boolean, List, List)
+		verify(panel, atLeastOnce()).updateStepProgress(
+			anyInt(), anyInt(), descCaptor.capture(), anyBoolean(), anyList(), anyList());
+
+		assertEquals(STATIC_DESC, descCaptor.getAllValues().get(0));
+	}
+
+	// ── helpers ───────────────────────────────────────────────────────────────
+
+	private static GuidanceStep minimalStepWithDescOverride(String description,
+		Map<Integer, String> perItemStepDescription)
+	{
+		return new GuidanceStep(
+			description,
+			perItemStepDescription,
+			0, 0, 0,       // worldX, worldY, worldPlane
+			0, null, null,  // npcId, interactAction, dialogOptions
+			null, null,     // travelTip, requiredItemIds
+			null,           // perItemRequiredItemIds
+			null,           // recommendedItemIds
+			CompletionCondition.MANUAL,
+			0, 0, 0, 0,    // completionItemId, completionItemCount, completionDistance, completionNpcId
+			null,           // completionNpcIds
+			null,           // worldMessage
+			0, null, null,  // objectId, objectIds, objectInteractAction
+			null, null,     // highlightItemIds, groundItemIds
+			null,           // completionChatPattern
+			0, 0,           // completionVarbitId, completionVarbitValue
+			false,          // useItemOnObject
+			0,              // objectMaxDistance
+			null,           // objectFilterTiles
+			null,           // highlightWidgetIds
+			0, 0,           // loopBackToStep, loopCount
+			null,           // skipIfHasAnyItemIds
+			null,           // dynamicItemObjectTiers
+			null,           // completionZone
+			null,           // conditionalAlternatives
+			null            // section
+		);
+	}
+
+	private static CollectionLogSource sourceWithSteps(String name, GuidanceStep... steps)
+	{
+		return new CollectionLogSource(
+			name,
+			CollectionLogCategory.MINIGAMES,
+			0, 0, 0,
+			0, 0,
+			null, null, null, 0.0,
+			null, 0, false, 0,
+			null, 0, null, null,
+			Arrays.asList(steps),
+			null, 0, null, 0,
+			Collections.emptyList()
+		);
+	}
+}

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
@@ -91,6 +91,7 @@ public class GuidanceSequencerTest
 	{
 		return new GuidanceStep(
 			description,
+			null,           // perItemStepDescription
 			0, 0, 0,       // worldX, worldY, worldPlane
 			0, null, null,  // npcId, interactAction, dialogOptions
 			null, null,     // travelTip, requiredItemIds
@@ -121,6 +122,7 @@ public class GuidanceSequencerTest
 	{
 		return new GuidanceStep(
 			"Step: " + condition.name(),
+			null,  // perItemStepDescription
 			0, 0, 0,
 			0, null, null,
 			null, null,
@@ -151,6 +153,7 @@ public class GuidanceSequencerTest
 	{
 		return new GuidanceStep(
 			"Collect " + count + " items",
+			null,  // perItemStepDescription
 			0, 0, 0,
 			0, null, null,
 			null, null,
@@ -181,6 +184,7 @@ public class GuidanceSequencerTest
 	{
 		return new GuidanceStep(
 			"Walk to location",
+			null,  // perItemStepDescription
 			x, y, plane,
 			0, null, null,
 			null, null,
@@ -211,6 +215,7 @@ public class GuidanceSequencerTest
 	{
 		return new GuidanceStep(
 			"Talk to NPC",
+			null,  // perItemStepDescription
 			0, 0, 0,
 			0, null, null,
 			null, null,
@@ -241,6 +246,7 @@ public class GuidanceSequencerTest
 	{
 		return new GuidanceStep(
 			"Kill NPC",
+			null,  // perItemStepDescription
 			0, 0, 0,
 			0, null, null,
 			null, null,
@@ -271,6 +277,7 @@ public class GuidanceSequencerTest
 	{
 		return new GuidanceStep(
 			"Wait for chat",
+			null,  // perItemStepDescription
 			0, 0, 0,
 			0, null, null,
 			null, null,
@@ -302,6 +309,7 @@ public class GuidanceSequencerTest
 	{
 		return new GuidanceStep(
 			description,
+			null,  // perItemStepDescription
 			0, 0, 0,
 			0, null, null,
 			null, null,
@@ -332,6 +340,7 @@ public class GuidanceSequencerTest
 	{
 		return new GuidanceStep(
 			"Go to plane " + plane,
+			null,  // perItemStepDescription
 			0, 0, plane,
 			0, null, null,
 			null, null,
@@ -362,6 +371,7 @@ public class GuidanceSequencerTest
 	{
 		return new GuidanceStep(
 			"Wait for varbit",
+			null,  // perItemStepDescription
 			0, 0, 0,
 			0, null, null,
 			null, null,
@@ -392,6 +402,7 @@ public class GuidanceSequencerTest
 	{
 		return new GuidanceStep(
 			"Step needing items",
+			null,  // perItemStepDescription
 			0, 0, 0,
 			0, null, null,
 			null, requiredItemIds,
@@ -764,6 +775,7 @@ public class GuidanceSequencerTest
 		// Simulates Zulrah: NPC can die as any of 3 forms (2042, 2043, 2044)
 		GuidanceStep multiFormKillStep = new GuidanceStep(
 			"Kill Zulrah",
+			null,  // perItemStepDescription
 			0, 0, 0,
 			2042, null, null,
 			null, null,
@@ -1232,6 +1244,7 @@ public class GuidanceSequencerTest
 	{
 		return new GuidanceStep(
 			description,
+			null,  // perItemStepDescription
 			worldX, worldY, 0,
 			0, null, null,
 			travelTip, null,
@@ -1457,6 +1470,7 @@ public class GuidanceSequencerTest
 	{
 		GuidanceStep step = new GuidanceStep(
 			"No alternatives",
+			null,  // perItemStepDescription
 			3000, 3000, 0,
 			0, null, null,
 			null, null,

--- a/src/test/java/com/collectionloghelper/guidance/RequiredItemResolverTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/RequiredItemResolverTest.java
@@ -537,6 +537,7 @@ public class RequiredItemResolverTest
 	{
 		return new GuidanceStep(
 			"Test step",
+			null,  // perItemStepDescription
 			0, 0, 0,
 			0, null, null,
 			null,

--- a/src/test/java/com/collectionloghelper/lifecycle/GuidanceEventRouterTest.java
+++ b/src/test/java/com/collectionloghelper/lifecycle/GuidanceEventRouterTest.java
@@ -115,6 +115,7 @@ public class GuidanceEventRouterTest
 	{
 		return new GuidanceStep(
 			"Talk to NPC",
+			null,  // perItemStepDescription
 			0, 0, 0,
 			0, null, null,
 			null, null,

--- a/src/test/java/com/collectionloghelper/ui/widget/StepProgressViewTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/StepProgressViewTest.java
@@ -915,6 +915,7 @@ public class StepProgressViewTest
 	{
 		return new GuidanceStep(
 			"Step",
+			null,  // perItemStepDescription
 			0, 0, 0,
 			0, null, null,
 			null, null,
@@ -940,6 +941,7 @@ public class StepProgressViewTest
 	{
 		return new GuidanceStep(
 			"Step",
+			null,  // perItemStepDescription
 			0, 0, 0,
 			0, null, null,
 			null, null,

--- a/src/test/java/com/collectionloghelper/ui/widget/StepSectionGrouperTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/StepSectionGrouperTest.java
@@ -56,6 +56,7 @@ public class StepSectionGrouperTest
 	{
 		return new GuidanceStep(
 			"Step",
+			null,  // perItemStepDescription
 			0, 0, 0,
 			0, null, null,
 			null, null,


### PR DESCRIPTION
## Summary

- Adds `@Nullable Map<Integer, String> perItemStepDescription` to `GuidanceStep` — an additive, backwards-compatible schema field that overrides the step description text for a specific target collection-log item
- Adds `GuidanceStep.resolveDescription(Integer targetItemId)` helper that returns the per-item override when the active target matches a map entry, falling back to the static `description` in all other cases
- Wires the resolver through `GuidanceOverlayCoordinator` so both the activation skip-chain landing and the step-change callback pass the resolved description to `panel.updateStepProgress`
- Fixes a pre-existing ordering bug where `activeTargetItemId` was set before `deactivateGuidance()` (which clears it) — this silently broke both `perItemRequiredItemIds` (B4.1) and the new field; now restored after the deactivate call

## Schema change

```java
/**
 * Optional per-item override for the step's description text.  When the active
 * guidance has a specific target collection-log item AND this map has an entry
 * for that item, the override string is used in place of {@link #description}.
 * Falls back to the static description when no override applies (null map, null
 * target, or target not present in the map).
 *
 * <p>Null by default — existing JSON without this field deserialises unchanged.
 */
@Nullable
Map<Integer, String> perItemStepDescription;
```

Field placement: immediately after `description`, before `worldX` — keeps per-item override fields adjacent.

## Coordinator wiring

Two sites in `GuidanceOverlayCoordinator` updated from `step.getDescription()` to `step.resolveDescription(activeTargetItemId)`:
1. Activation skip-chain landing (initial step push on `activateGuidance`)
2. `onStepChanged` callback (step transition path)

No signature changes to `activateGuidance` or `deactivateGuidance`.

## Test-source positional updates

Updated **19 sites** across **5 files**: `GuidanceSequencerTest` (14), `RequiredItemResolverTest` (1), `GuidanceEventRouterTest` (1), `StepProgressViewTest` (2), `StepSectionGrouperTest` (1).

## Test plan

- [x] `./gradlew build` — BUILD SUCCESSFUL, 711 tests, 0 failures
- [x] `GuidanceStepTest` — 8 tests: `resolveDescription(null)` returns static desc; override returned when map has matching entry; fallback when map exists but target absent; fallback when map is null; fallback when map is empty; Gson deserialisation without field (null); Gson deserialisation with field (map populated + resolve verified)
- [x] `GuidanceOverlayCoordinatorDescriptionTest` — 2 tests: `updateStepProgress` receives override desc when `targetItemId` set; receives static desc when `targetItemId` is null
- [ ] In-client: no per-item data added in this PR — verify no regression on existing Mort'ton guidance (Bronze lock target should still show Loar consumables)

Refs cha-ndler/collection-log-helper#420 (B4.3 prep)