### PR TITLE
feat(guidance): perItemNpcId schema field for per-item overlay retargeting (B4.3 prep)

### DIFF
--- a/src/main/java/com/collectionloghelper/data/GuidanceStep.java
+++ b/src/main/java/com/collectionloghelper/data/GuidanceStep.java
@@ -63,6 +63,17 @@ public class GuidanceStep
 	/** NPC to highlight for this step (0 = no NPC). */
 	int npcId;
 
+	/**
+	 * Optional per-item override for the step's npcId.  When the active guidance
+	 * target has an entry in this map, the overlay highlights / targets that NPC
+	 * instead of the step's static {@link #npcId}.  Falls back to the static
+	 * npcId when no override applies (null map, null target, target not in map).
+	 *
+	 * <p>Null by default — existing JSON without this field deserialises unchanged.
+	 */
+	@Nullable
+	Map<Integer, Integer> perItemNpcId;
+
 	/** Right-click action to highlight on the NPC (e.g., "Attack", "Talk-to"). */
 	String interactAction;
 
@@ -234,6 +245,28 @@ public class GuidanceStep
 	}
 
 	/**
+	 * Resolves the NPC ID for this step given the active guidance target item.
+	 * When {@link #perItemNpcId} has an entry for {@code targetItemId}, that
+	 * override is returned.  Falls back to {@link #npcId} when the map is null,
+	 * {@code targetItemId} is null, or no entry exists for the target.
+	 *
+	 * @param targetItemId the clog item ID the player is hunting, or {@code null}
+	 * @return the resolved NPC ID (falls back to the static npcId primitive)
+	 */
+	public int resolveNpcId(@Nullable Integer targetItemId)
+	{
+		if (targetItemId != null && perItemNpcId != null)
+		{
+			Integer override = perItemNpcId.get(targetItemId);
+			if (override != null)
+			{
+				return override;
+			}
+		}
+		return npcId;
+	}
+
+	/**
 	 * Returns true if the given NPC ID matches this step's completion NPC.
 	 * Checks both the single completionNpcId and the completionNpcIds list,
 	 * supporting multi-form bosses (e.g., Zulrah's 3 combat forms).
@@ -331,6 +364,7 @@ public class GuidanceStep
 			alt.getWorldY() != null ? alt.getWorldY() : this.worldY,
 			alt.getWorldPlane() != null ? alt.getWorldPlane() : this.worldPlane,
 			alt.getNpcId() != null ? alt.getNpcId() : this.npcId,
+			this.perItemNpcId,
 			alt.getInteractAction() != null ? alt.getInteractAction() : this.interactAction,
 			this.dialogOptions,
 			alt.getTravelTip() != null ? alt.getTravelTip() : this.travelTip,

--- a/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
@@ -431,7 +431,8 @@ public class GuidanceOverlayCoordinator
 		if (guidanceSequencer.isActive() && trackedGuidanceNpc == null)
 		{
 			GuidanceStep step = guidanceSequencer.getRawCurrentStep();
-			if (step != null && step.getNpcId() > 0 && npc.getId() == step.getNpcId())
+			if (step != null && step.resolveNpcId(activeTargetItemId) > 0
+				&& npc.getId() == step.resolveNpcId(activeTargetItemId))
 			{
 				trackedGuidanceNpc = npc;
 				guidanceOverlay.setTrackedNpc(npc);
@@ -594,7 +595,7 @@ public class GuidanceOverlayCoordinator
 			String travelTip = travelCapabilities.selectBestTravelTip(rawTravelTip);
 			guidanceOverlay.setTravelTip(travelTip);
 			log.debug("Travel capabilities for step '{}': {}", step.getDescription(), travelCapabilities.getSummary());
-			guidanceOverlay.setTargetNpcId(step.getNpcId());
+			guidanceOverlay.setTargetNpcId(step.resolveNpcId(activeTargetItemId));
 			guidanceOverlay.setInteractAction(step.getInteractAction());
 			dialogHighlightOverlay.setTargetDialogOptions(step.getDialogOptions());
 			dialogHighlightOverlay.setGuidanceActive(true);
@@ -804,12 +805,13 @@ public class GuidanceOverlayCoordinator
 		trackedGuidanceNpc = null;
 		guidanceOverlay.setTrackedNpc(null);
 
-		if (step == null || step.getNpcId() <= 0)
+		final int resolvedNpcId = step == null ? 0 : step.resolveNpcId(activeTargetItemId);
+		if (resolvedNpcId <= 0)
 		{
 			return;
 		}
 
-		final int targetNpcId = step.getNpcId();
+		final int targetNpcId = resolvedNpcId;
 		clientThread.invokeLater(() ->
 		{
 			WorldView wv = client.getTopLevelWorldView();
@@ -1021,9 +1023,9 @@ public class GuidanceOverlayCoordinator
 	 * NPC steps use the NPC icon, object steps use the object/chest icon,
 	 * and all other steps use the generic tile diamond.
 	 */
-	private static WorldMapDestinationOverlay.StepIconType resolveStepIconType(GuidanceStep step)
+	private WorldMapDestinationOverlay.StepIconType resolveStepIconType(GuidanceStep step)
 	{
-		if (step.getNpcId() > 0)
+		if (step.resolveNpcId(activeTargetItemId) > 0)
 		{
 			return WorldMapDestinationOverlay.StepIconType.NPC;
 		}

--- a/src/test/java/com/collectionloghelper/data/GuidanceStepTest.java
+++ b/src/test/java/com/collectionloghelper/data/GuidanceStepTest.java
@@ -35,8 +35,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 /**
- * Unit tests for {@link GuidanceStep#resolveDescription(Integer)} and the
- * {@code perItemStepDescription} schema field.
+ * Unit tests for {@link GuidanceStep#resolveDescription(Integer)},
+ * {@link GuidanceStep#resolveNpcId(Integer)}, and the
+ * {@code perItemStepDescription} / {@code perItemNpcId} schema fields.
  *
  * <p>Acceptance criteria verified:
  * <ol>
@@ -44,6 +45,10 @@ import static org.junit.Assert.assertNull;
  *   <li>resolveDescription(itemId) returns the override when the map has a matching entry.</li>
  *   <li>resolveDescription(itemId) falls back to static when the map exists but has no entry for the target.</li>
  *   <li>resolveDescription(itemId) falls back to static when the map is null.</li>
+ *   <li>resolveNpcId(null) returns the static npcId.</li>
+ *   <li>resolveNpcId(itemId) returns the override when the map has a matching entry.</li>
+ *   <li>resolveNpcId(itemId) falls back to static when the map exists but has no entry for the target.</li>
+ *   <li>resolveNpcId(itemId) falls back to static when the map is null.</li>
  *   <li>Schema deserialisation: JSON without {@code perItemStepDescription} yields a null field (backwards-compatible).</li>
  *   <li>Schema deserialisation: JSON with {@code perItemStepDescription} populates the map correctly.</li>
  * </ol>
@@ -160,6 +165,63 @@ public class GuidanceStepTest
 		assertEquals("Tier 1 override", step.resolveDescription(1001));
 	}
 
+	// ── resolveNpcId constants ─────────────────────────────────────────────────
+
+	private static final int STATIC_NPC_ID = 5000;
+	private static final int OVERRIDE_NPC_ID = 6001;
+	private static final int OTHER_NPC_ID = 7777;
+
+	// ── resolveNpcId: null targetItemId ───────────────────────────────────────
+
+	@Test
+	public void resolveNpcId_nullTarget_returnsStaticNpcId()
+	{
+		Map<Integer, Integer> npcOverrides = new HashMap<>();
+		npcOverrides.put(ITEM_TIER1, OVERRIDE_NPC_ID);
+
+		GuidanceStep step = stepWithNpcOverrides(STATIC_NPC_ID, npcOverrides);
+
+		assertEquals(STATIC_NPC_ID, step.resolveNpcId(null));
+	}
+
+	// ── resolveNpcId: map has matching entry ──────────────────────────────────
+
+	@Test
+	public void resolveNpcId_targetInMap_returnsOverrideNpcId()
+	{
+		Map<Integer, Integer> npcOverrides = new HashMap<>();
+		npcOverrides.put(ITEM_TIER1, OVERRIDE_NPC_ID);
+		npcOverrides.put(ITEM_TIER5, OTHER_NPC_ID);
+
+		GuidanceStep step = stepWithNpcOverrides(STATIC_NPC_ID, npcOverrides);
+
+		assertEquals(OVERRIDE_NPC_ID, step.resolveNpcId(ITEM_TIER1));
+		assertEquals(OTHER_NPC_ID, step.resolveNpcId(ITEM_TIER5));
+	}
+
+	// ── resolveNpcId: map exists but target not in it ─────────────────────────
+
+	@Test
+	public void resolveNpcId_targetNotInMap_returnsStaticNpcId()
+	{
+		Map<Integer, Integer> npcOverrides = new HashMap<>();
+		npcOverrides.put(ITEM_TIER1, OVERRIDE_NPC_ID);
+
+		GuidanceStep step = stepWithNpcOverrides(STATIC_NPC_ID, npcOverrides);
+
+		assertEquals(STATIC_NPC_ID, step.resolveNpcId(ITEM_UNKNOWN));
+	}
+
+	// ── resolveNpcId: null map ────────────────────────────────────────────────
+
+	@Test
+	public void resolveNpcId_nullMap_returnsStaticNpcId()
+	{
+		GuidanceStep step = stepWithNpcOverrides(STATIC_NPC_ID, null);
+
+		assertEquals(STATIC_NPC_ID, step.resolveNpcId(ITEM_TIER1));
+	}
+
 	// ── Helper ────────────────────────────────────────────────────────────────
 
 	private static GuidanceStep stepWithOverrides(String description,
@@ -169,7 +231,39 @@ public class GuidanceStepTest
 			description,
 			perItemStepDescription,
 			0, 0, 0,       // worldX, worldY, worldPlane
-			0, null, null,  // npcId, interactAction, dialogOptions
+			0, null, null, null,  // npcId, perItemNpcId, interactAction, dialogOptions
+			null, null,     // travelTip, requiredItemIds
+			null,           // perItemRequiredItemIds
+			null,           // recommendedItemIds
+			CompletionCondition.MANUAL,
+			0, 0, 0, 0,    // completionItemId, completionItemCount, completionDistance, completionNpcId
+			null,           // completionNpcIds
+			null,           // worldMessage
+			0, null, null,  // objectId, objectIds, objectInteractAction
+			null, null,     // highlightItemIds, groundItemIds
+			null,           // completionChatPattern
+			0, 0,           // completionVarbitId, completionVarbitValue
+			false,          // useItemOnObject
+			0,              // objectMaxDistance
+			null,           // objectFilterTiles
+			null,           // highlightWidgetIds
+			0, 0,           // loopBackToStep, loopCount
+			null,           // skipIfHasAnyItemIds
+			null,           // dynamicItemObjectTiers
+			null,           // completionZone
+			null,           // conditionalAlternatives
+			null            // section
+		);
+	}
+
+	private static GuidanceStep stepWithNpcOverrides(int npcId,
+		Map<Integer, Integer> perItemNpcId)
+	{
+		return new GuidanceStep(
+			STATIC_DESC,
+			null,           // perItemStepDescription
+			0, 0, 0,       // worldX, worldY, worldPlane
+			npcId, perItemNpcId, null, null,  // npcId, perItemNpcId, interactAction, dialogOptions
 			null, null,     // travelTip, requiredItemIds
 			null,           // perItemRequiredItemIds
 			null,           // recommendedItemIds

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorNpcIdTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorNpcIdTest.java
@@ -41,12 +41,12 @@ import com.collectionloghelper.overlay.ObjectHighlightOverlay;
 import com.collectionloghelper.overlay.WidgetHighlightOverlay;
 import com.collectionloghelper.overlay.WorldMapDestinationOverlay;
 import com.collectionloghelper.overlay.WorldMapRouteOverlay;
-import com.collectionloghelper.ui.CollectionLogHelperPanel;
 import java.lang.reflect.Constructor;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Consumer;
 import net.runelite.api.Client;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.callback.ClientThread;
@@ -63,32 +63,31 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
  * Tests that {@link GuidanceOverlayCoordinator#activateGuidance} passes the
- * per-item-resolved description to the panel's {@code updateStepProgress} call.
+ * per-item-resolved NPC ID to {@link GuidanceOverlay#setTargetNpcId} when a step
+ * has a {@code perItemNpcId} override for the active target item.
  *
  * <p>Acceptance criteria:
  * <ul>
  *   <li>When {@code targetItemId} is non-null and the active step has a matching
- *       {@code perItemStepDescription} entry, {@code updateStepProgress} receives
- *       the override text.</li>
- *   <li>When {@code targetItemId} is null (no item context), {@code updateStepProgress}
- *       receives the static description.</li>
+ *       {@code perItemNpcId} entry, {@code guidanceOverlay.setTargetNpcId} receives
+ *       the override NPC ID.</li>
+ *   <li>When {@code targetItemId} is null (no item context), {@code guidanceOverlay.setTargetNpcId}
+ *       receives the static {@code npcId}.</li>
  * </ul>
  */
 @RunWith(MockitoJUnitRunner.class)
-public class GuidanceOverlayCoordinatorDescriptionTest
+public class GuidanceOverlayCoordinatorNpcIdTest
 {
-	private static final int TARGET_ITEM_ID = 1001;
-	private static final String STATIC_DESC = "Kill soldiers for armour";
-	private static final String OVERRIDE_DESC = "Kill Tier 1 soldiers (40 kills)";
+	private static final int TARGET_ITEM_ID = 2003;
+	private static final int STATIC_NPC_ID = 5000;
+	private static final int OVERRIDE_NPC_ID = 6001;
 
 	@Mock
 	private Client client;
@@ -132,8 +131,6 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 	private GroundItemHighlightOverlay groundItemHighlightOverlay;
 	@Mock
 	private WidgetHighlightOverlay widgetHighlightOverlay;
-	@Mock
-	private CollectionLogHelperPanel panel;
 
 	private GuidanceOverlayCoordinator coordinator;
 
@@ -174,92 +171,102 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 			worldMapRouteOverlay, worldMapDestinationOverlay,
 			groundItemHighlightOverlay, widgetHighlightOverlay);
 
-		coordinator.setPanel(panel);
-
 		when(requirementsChecker.getUnmetRequirements(any())).thenReturn(Collections.emptyList());
 		when(requirementsChecker.buildRequirementRows(any())).thenReturn(Collections.emptyList());
 	}
 
 	/**
-	 * When the active step has a {@code perItemStepDescription} entry for the active
-	 * target item, the coordinator must pass the override text — not the static
-	 * description — to {@code panel.updateStepProgress}.
+	 * When the active step has a {@code perItemNpcId} entry for the active target item,
+	 * the coordinator must pass the override NPC ID to {@code guidanceOverlay.setTargetNpcId}.
 	 */
+	@SuppressWarnings("unchecked")
 	@Test
-	public void activateGuidance_withTargetItemId_panelReceivesOverrideDescription()
+	public void activateGuidance_withTargetItemId_overlayReceivesOverrideNpcId()
 	{
-		Map<Integer, String> descOverrides = new HashMap<>();
-		descOverrides.put(TARGET_ITEM_ID, OVERRIDE_DESC);
+		Map<Integer, Integer> npcOverrides = new HashMap<>();
+		npcOverrides.put(TARGET_ITEM_ID, OVERRIDE_NPC_ID);
 
-		GuidanceStep step = minimalStepWithDescOverride(STATIC_DESC, descOverrides);
-		CollectionLogSource source = sourceWithSteps("Shayzien Armour", step);
+		GuidanceStep step = minimalStepWithNpcOverride(STATIC_NPC_ID, npcOverrides);
+		CollectionLogSource source = sourceWithSteps("Perilous Moons", step);
 
-		// Sequencer reports the step as active at index 0
 		when(guidanceSequencer.isActive()).thenReturn(true);
 		when(guidanceSequencer.getCurrentStep()).thenReturn(step);
 		when(guidanceSequencer.getRawCurrentStep()).thenReturn(step);
 		when(guidanceSequencer.getCurrentIndex()).thenReturn(0);
-		when(guidanceSequencer.getTotalSteps()).thenReturn(1);
-		// getActiveSource is used by onStepChanged (not the activation path); lenient to avoid strict fail
-		org.mockito.Mockito.lenient().when(guidanceSequencer.getActiveSource()).thenReturn(source);
+		when(guidanceSequencer.getActiveSource()).thenReturn(source);
+		// getTotalSteps not needed: panel is null and InfoBox is not created in this test
+		org.mockito.Mockito.lenient().when(guidanceSequencer.getTotalSteps()).thenReturn(1);
+
+		// Capture the onStepChanged callback passed to startSequence and invoke it
+		// synchronously so applyStepToOverlays (which calls setTargetNpcId) runs.
+		doAnswer(inv ->
+		{
+			Consumer<GuidanceStep> onStepChanged = inv.getArgument(1);
+			onStepChanged.accept(step);
+			return null;
+		}).when(guidanceSequencer).startSequence(any(), any(), any());
 
 		coordinator.activateGuidance(source, new WorldPoint(3200, 3200, 0), TARGET_ITEM_ID);
 
-		ArgumentCaptor<String> descCaptor = ArgumentCaptor.forClass(String.class);
-		// The activation path calls the 6-arg overload: (int, int, String, boolean, List, List)
-		verify(panel, atLeastOnce()).updateStepProgress(
-			anyInt(), anyInt(), descCaptor.capture(), anyBoolean(), anyList(), anyList());
+		ArgumentCaptor<Integer> npcIdCaptor = ArgumentCaptor.forClass(Integer.class);
+		verify(guidanceOverlay, atLeastOnce()).setTargetNpcId(npcIdCaptor.capture());
 
-		// The first updateStepProgress call (before deferred item resolution) uses the resolved desc.
-		assertEquals(OVERRIDE_DESC, descCaptor.getAllValues().get(0));
+		assertEquals(OVERRIDE_NPC_ID, (int) npcIdCaptor.getAllValues().get(0));
 	}
 
 	/**
-	 * When no target item is set (null), the coordinator must pass the static description
-	 * even if the step has a non-empty {@code perItemStepDescription} map.
+	 * When no target item is set (null), the coordinator must pass the static NPC ID
+	 * even if the step has a non-empty {@code perItemNpcId} map.
 	 */
+	@SuppressWarnings("unchecked")
 	@Test
-	public void activateGuidance_withNullTargetItemId_panelReceivesStaticDescription()
+	public void activateGuidance_withNullTargetItemId_overlayReceivesStaticNpcId()
 	{
-		Map<Integer, String> descOverrides = new HashMap<>();
-		descOverrides.put(TARGET_ITEM_ID, OVERRIDE_DESC);
+		Map<Integer, Integer> npcOverrides = new HashMap<>();
+		npcOverrides.put(TARGET_ITEM_ID, OVERRIDE_NPC_ID);
 
-		GuidanceStep step = minimalStepWithDescOverride(STATIC_DESC, descOverrides);
-		CollectionLogSource source = sourceWithSteps("Shayzien Armour", step);
+		GuidanceStep step = minimalStepWithNpcOverride(STATIC_NPC_ID, npcOverrides);
+		CollectionLogSource source = sourceWithSteps("Perilous Moons", step);
 
 		when(guidanceSequencer.isActive()).thenReturn(true);
 		when(guidanceSequencer.getCurrentStep()).thenReturn(step);
 		when(guidanceSequencer.getRawCurrentStep()).thenReturn(step);
 		when(guidanceSequencer.getCurrentIndex()).thenReturn(0);
-		when(guidanceSequencer.getTotalSteps()).thenReturn(1);
-		// getActiveSource is used by onStepChanged (not the activation path); lenient to avoid strict fail
-		org.mockito.Mockito.lenient().when(guidanceSequencer.getActiveSource()).thenReturn(source);
+		when(guidanceSequencer.getActiveSource()).thenReturn(source);
+		org.mockito.Mockito.lenient().when(guidanceSequencer.getTotalSteps()).thenReturn(1);
+
+		// Capture the onStepChanged callback passed to startSequence and invoke it
+		// synchronously so applyStepToOverlays (which calls setTargetNpcId) runs.
+		doAnswer(inv ->
+		{
+			Consumer<GuidanceStep> onStepChanged = inv.getArgument(1);
+			onStepChanged.accept(step);
+			return null;
+		}).when(guidanceSequencer).startSequence(any(), any(), any());
 
 		coordinator.activateGuidance(source, new WorldPoint(3200, 3200, 0), null);
 
-		ArgumentCaptor<String> descCaptor = ArgumentCaptor.forClass(String.class);
-		// The activation path calls the 6-arg overload: (int, int, String, boolean, List, List)
-		verify(panel, atLeastOnce()).updateStepProgress(
-			anyInt(), anyInt(), descCaptor.capture(), anyBoolean(), anyList(), anyList());
+		ArgumentCaptor<Integer> npcIdCaptor = ArgumentCaptor.forClass(Integer.class);
+		verify(guidanceOverlay, atLeastOnce()).setTargetNpcId(npcIdCaptor.capture());
 
-		assertEquals(STATIC_DESC, descCaptor.getAllValues().get(0));
+		assertEquals(STATIC_NPC_ID, (int) npcIdCaptor.getAllValues().get(0));
 	}
 
 	// ── helpers ───────────────────────────────────────────────────────────────
 
-	private static GuidanceStep minimalStepWithDescOverride(String description,
-		Map<Integer, String> perItemStepDescription)
+	private static GuidanceStep minimalStepWithNpcOverride(int npcId,
+		Map<Integer, Integer> perItemNpcId)
 	{
 		return new GuidanceStep(
-			description,
-			perItemStepDescription,
-			0, 0, 0,       // worldX, worldY, worldPlane
-			0, null, null, null,  // npcId, perItemNpcId, interactAction, dialogOptions
+			"Kill the boss",
+			null,           // perItemStepDescription
+			3200, 3200, 0, // worldX, worldY, worldPlane — non-zero to reach the NPC branch
+			npcId, perItemNpcId, null, null,  // npcId, perItemNpcId, interactAction, dialogOptions
 			null, null,     // travelTip, requiredItemIds
 			null,           // perItemRequiredItemIds
 			null,           // recommendedItemIds
-			CompletionCondition.MANUAL,
-			0, 0, 0, 0,    // completionItemId, completionItemCount, completionDistance, completionNpcId
+			CompletionCondition.ACTOR_DEATH,
+			0, 0, 0, npcId,  // completionItemId, completionItemCount, completionDistance, completionNpcId
 			null,           // completionNpcIds
 			null,           // worldMessage
 			0, null, null,  // objectId, objectIds, objectInteractAction
@@ -283,7 +290,7 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 	{
 		return new CollectionLogSource(
 			name,
-			CollectionLogCategory.MINIGAMES,
+			CollectionLogCategory.BOSSES,
 			0, 0, 0,
 			0, 0,
 			null, null, null, 0.0,

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
@@ -93,7 +93,7 @@ public class GuidanceSequencerTest
 			description,
 			null,           // perItemStepDescription
 			0, 0, 0,       // worldX, worldY, worldPlane
-			0, null, null,  // npcId, interactAction, dialogOptions
+			0, null, null, null,  // npcId, perItemNpcId, interactAction, dialogOptions
 			null, null,     // travelTip, requiredItemIds
 			null,           // perItemRequiredItemIds
 			null,           // recommendedItemIds
@@ -124,7 +124,7 @@ public class GuidanceSequencerTest
 			"Step: " + condition.name(),
 			null,  // perItemStepDescription
 			0, 0, 0,
-			0, null, null,
+			0, null, null, null,
 			null, null,
 			null,  // perItemRequiredItemIds
 			null,  // recommendedItemIds
@@ -155,7 +155,7 @@ public class GuidanceSequencerTest
 			"Collect " + count + " items",
 			null,  // perItemStepDescription
 			0, 0, 0,
-			0, null, null,
+			0, null, null, null,
 			null, null,
 			null,  // perItemRequiredItemIds
 			null,  // recommendedItemIds
@@ -186,7 +186,7 @@ public class GuidanceSequencerTest
 			"Walk to location",
 			null,  // perItemStepDescription
 			x, y, plane,
-			0, null, null,
+			0, null, null, null,
 			null, null,
 			null,  // perItemRequiredItemIds
 			null,  // recommendedItemIds
@@ -217,7 +217,7 @@ public class GuidanceSequencerTest
 			"Talk to NPC",
 			null,  // perItemStepDescription
 			0, 0, 0,
-			0, null, null,
+			0, null, null, null,
 			null, null,
 			null,  // perItemRequiredItemIds
 			null,  // recommendedItemIds
@@ -248,7 +248,7 @@ public class GuidanceSequencerTest
 			"Kill NPC",
 			null,  // perItemStepDescription
 			0, 0, 0,
-			0, null, null,
+			0, null, null, null,
 			null, null,
 			null,  // perItemRequiredItemIds
 			null,  // recommendedItemIds
@@ -279,7 +279,7 @@ public class GuidanceSequencerTest
 			"Wait for chat",
 			null,  // perItemStepDescription
 			0, 0, 0,
-			0, null, null,
+			0, null, null, null,
 			null, null,
 			null,  // perItemRequiredItemIds
 			null,  // recommendedItemIds
@@ -311,7 +311,7 @@ public class GuidanceSequencerTest
 			description,
 			null,  // perItemStepDescription
 			0, 0, 0,
-			0, null, null,
+			0, null, null, null,
 			null, null,
 			null,  // perItemRequiredItemIds
 			null,  // recommendedItemIds
@@ -342,7 +342,7 @@ public class GuidanceSequencerTest
 			"Go to plane " + plane,
 			null,  // perItemStepDescription
 			0, 0, plane,
-			0, null, null,
+			0, null, null, null,
 			null, null,
 			null,  // perItemRequiredItemIds
 			null,  // recommendedItemIds
@@ -373,7 +373,7 @@ public class GuidanceSequencerTest
 			"Wait for varbit",
 			null,  // perItemStepDescription
 			0, 0, 0,
-			0, null, null,
+			0, null, null, null,
 			null, null,
 			null,  // perItemRequiredItemIds
 			null,  // recommendedItemIds
@@ -404,7 +404,7 @@ public class GuidanceSequencerTest
 			"Step needing items",
 			null,  // perItemStepDescription
 			0, 0, 0,
-			0, null, null,
+			0, null, null, null,
 			null, requiredItemIds,
 			null,  // perItemRequiredItemIds
 			null,  // recommendedItemIds
@@ -777,7 +777,7 @@ public class GuidanceSequencerTest
 			"Kill Zulrah",
 			null,  // perItemStepDescription
 			0, 0, 0,
-			2042, null, null,
+			2042, null, null, null,
 			null, null,
 			null,  // perItemRequiredItemIds
 			null,  // recommendedItemIds
@@ -1246,7 +1246,7 @@ public class GuidanceSequencerTest
 			description,
 			null,  // perItemStepDescription
 			worldX, worldY, 0,
-			0, null, null,
+			0, null, null, null,
 			travelTip, null,
 			null,  // perItemRequiredItemIds
 			null,  // recommendedItemIds
@@ -1472,7 +1472,7 @@ public class GuidanceSequencerTest
 			"No alternatives",
 			null,  // perItemStepDescription
 			3000, 3000, 0,
-			0, null, null,
+			0, null, null, null,
 			null, null,
 			null,  // perItemRequiredItemIds
 			null,  // recommendedItemIds

--- a/src/test/java/com/collectionloghelper/guidance/RequiredItemResolverTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/RequiredItemResolverTest.java
@@ -539,7 +539,7 @@ public class RequiredItemResolverTest
 			"Test step",
 			null,  // perItemStepDescription
 			0, 0, 0,
-			0, null, null,
+			0, null, null, null,
 			null,
 			requiredItemIds,
 			perItemRequiredItemIds,

--- a/src/test/java/com/collectionloghelper/lifecycle/GuidanceEventRouterTest.java
+++ b/src/test/java/com/collectionloghelper/lifecycle/GuidanceEventRouterTest.java
@@ -117,7 +117,7 @@ public class GuidanceEventRouterTest
 			"Talk to NPC",
 			null,  // perItemStepDescription
 			0, 0, 0,
-			0, null, null,
+			0, null, null, null,
 			null, null,
 			null,  // perItemRequiredItemIds
 			null,  // recommendedItemIds

--- a/src/test/java/com/collectionloghelper/ui/widget/StepProgressViewTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/StepProgressViewTest.java
@@ -917,7 +917,7 @@ public class StepProgressViewTest
 			"Step",
 			null,  // perItemStepDescription
 			0, 0, 0,
-			0, null, null,
+			0, null, null, null,
 			null, null,
 			null,  // perItemRequiredItemIds
 			null,  // recommendedItemIds
@@ -943,7 +943,7 @@ public class StepProgressViewTest
 			"Step",
 			null,  // perItemStepDescription
 			0, 0, 0,
-			0, null, null,
+			0, null, null, null,
 			null, null,
 			null,  // perItemRequiredItemIds
 			recommendedItemIds,

--- a/src/test/java/com/collectionloghelper/ui/widget/StepSectionGrouperTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/StepSectionGrouperTest.java
@@ -58,7 +58,7 @@ public class StepSectionGrouperTest
 			"Step",
 			null,  // perItemStepDescription
 			0, 0, 0,
-			0, null, null,
+			0, null, null, null,
 			null, null,
 			null,  // perItemRequiredItemIds
 			null,  // recommendedItemIds


### PR DESCRIPTION
## Summary

- Adds `@Nullable Map<Integer, Integer> perItemNpcId` to `GuidanceStep` — an additive, backwards-compatible schema field that overrides the NPC highlighted by the overlay for a specific target collection-log item
- Adds `GuidanceStep.resolveNpcId(Integer targetItemId)` helper that returns the per-item override NPC ID when the active target matches a map entry, falling back to the static `npcId` primitive in all other cases
- Wires the resolver through `GuidanceOverlayCoordinator` at every site that previously read `step.getNpcId()` for overlay targeting: the main overlay, NPC spawn tracking, NPC scan-on-step-start, and world-map icon type

## Schema change

```java
/**
 * Optional per-item override for the step's npcId.  When the active guidance
 * target has an entry in this map, the overlay highlights / targets that NPC
 * instead of the step's static npcId.  Falls back to the static npcId when
 * no override applies (null map, null target, target not in map).
 *
 * Null by default — existing JSON without this field deserialises unchanged.
 */
@Nullable
Map<Integer, Integer> perItemNpcId;
```

Field placement: immediately after `npcId`, before `interactAction` — keeps per-item override fields adjacent to their base field.

## Coordinator wiring

Four `getNpcId()` → `resolveNpcId(activeTargetItemId)` sites updated:

1. `applyStepToOverlays` — `guidanceOverlay.setTargetNpcId(step.getNpcId())` → `step.resolveNpcId(activeTargetItemId)` (main overlay NPC highlight + minimap arrow flows through here)
2. `onNpcSpawned` — spawn-tracking guard `step.getNpcId() > 0 && npc.getId() == step.getNpcId()` → `resolveNpcId` on both sides
3. `scanForTrackedNpc` — NPC world-view scan uses `resolveNpcId`; also removes the redundant `step == null` early-return by folding it into the resolved-ID check
4. `resolveStepIconType` — world-map destination icon type (`NPC` vs `OBJECT` vs `TILE`) uses `resolveNpcId`; method changed from `private static` to `private` since it now reads `activeTargetItemId`

`source.getNpcId()` in `applySourceToOverlays` (non-sequencer path) is intentionally unchanged — that is a source-level field with no per-item context.

`mergeAlternative` preserves `this.perItemNpcId` when conditional alternatives apply.

## Test-source positional updates

Updated **20 sites** across **7 files**: `GuidanceSequencerTest` (14), `GuidanceStepTest` (1), `GuidanceOverlayCoordinatorDescriptionTest` (1), `GuidanceOverlayCoordinatorNpcIdTest` (1, new file), `RequiredItemResolverTest` (1), `GuidanceEventRouterTest` (1), `StepProgressViewTest` (2), `StepSectionGrouperTest` (1).

## Test plan

- [x] `./gradlew build` — BUILD SUCCESSFUL, 717 tests, 0 failures
- [x] `GuidanceStepTest` — 11 tests total; 4 new: `resolveNpcId(null)` returns static npcId; override returned when map has matching entry (two targets verified); fallback when map exists but target absent; fallback when map is null
- [x] `GuidanceOverlayCoordinatorNpcIdTest` — 2 new tests: `guidanceOverlay.setTargetNpcId` receives override NPC ID when `targetItemId` is set; receives static NPC ID when `targetItemId` is null
- [x] No regression: all 711 pre-existing tests continue to pass; `perItemStepDescription` resolution in `GuidanceOverlayCoordinatorDescriptionTest` unaffected
- [ ] In-client: no per-item NPC data added in this PR — verify no regression on existing Mort'ton guidance

Refs cha-ndler/collection-log-helper#420 (B4.3 prep)