### PR TITLE
data(perilous-moons): per-Moon NPC retarget + step description (B4.3 backfill)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -7657,10 +7657,38 @@
       },
       {
         "description": "Complete Perilous Moons. Fight the three Moon bosses in sequence. Each has unique mechanics — learn the safe tiles and prayer switches",
+        "perItemStepDescription": {
+          "29019": "Fight the Blue Moon and open the Lunar Chest to receive your Blue Moon armour.",
+          "29013": "Fight the Blue Moon and open the Lunar Chest to receive your Blue Moon armour.",
+          "29016": "Fight the Blue Moon and open the Lunar Chest to receive your Blue Moon armour.",
+          "28988": "Fight the Blue Moon and open the Lunar Chest to receive the Blue Moon spear.",
+          "29028": "Fight the Blood Moon and open the Lunar Chest to receive your Blood Moon armour.",
+          "29022": "Fight the Blood Moon and open the Lunar Chest to receive your Blood Moon armour.",
+          "29025": "Fight the Blood Moon and open the Lunar Chest to receive your Blood Moon armour.",
+          "28997": "Fight the Blood Moon and open the Lunar Chest to receive the dual macuahuitl.",
+          "29010": "Fight the Eclipse Moon and open the Lunar Chest to receive your Eclipse Moon armour.",
+          "29004": "Fight the Eclipse Moon and open the Lunar Chest to receive your Eclipse Moon armour.",
+          "29007": "Fight the Eclipse Moon and open the Lunar Chest to receive your Eclipse Moon armour.",
+          "29000": "Fight the Eclipse Moon and open the Lunar Chest to receive the eclipse atlatl."
+        },
         "worldX": 1435,
         "worldY": 3131,
         "worldPlane": 0,
         "npcId": 13011,
+        "perItemNpcId": {
+          "29019": 13013,
+          "29013": 13013,
+          "29016": 13013,
+          "28988": 13013,
+          "29028": 13011,
+          "29022": 13011,
+          "29025": 13011,
+          "28997": 13011,
+          "29010": 13012,
+          "29004": 13012,
+          "29007": 13012,
+          "29000": 13012
+        },
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
         "completionNpcId": 13011


### PR DESCRIPTION
## Summary

- Adds `perItemNpcId` and `perItemStepDescription` to the Perilous Moons fight step in `drop_rates.json`
- Previously the fight step hardcoded `npcId: 13011` (Blood Moon) for all 13 items — actively misdirecting hunters of Blue Moon and Eclipse Moon gear (~67% of item targets)
- The 12 Moon-specific items now each resolve to the correct boss NPC for overlay targeting and display the correct per-Moon step description
- Item 28991 (Atlatl dart) drops from all three Moons and intentionally receives no override — the static fallbacks remain in place for it and for no-target sessions

## Per-item mapping table

| Item ID | Item | Moon | NPC ID | Step description |
|---------|------|------|--------|-----------------|
| 29019 | Blue moon helm | Blue Moon | 13013 | Fight the Blue Moon and open the Lunar Chest to receive your Blue Moon armour. |
| 29013 | Blue moon chestplate | Blue Moon | 13013 | Fight the Blue Moon and open the Lunar Chest to receive your Blue Moon armour. |
| 29016 | Blue moon tassets | Blue Moon | 13013 | Fight the Blue Moon and open the Lunar Chest to receive your Blue Moon armour. |
| 28988 | Blue moon spear | Blue Moon | 13013 | Fight the Blue Moon and open the Lunar Chest to receive the Blue Moon spear. |
| 29028 | Blood moon helm | Blood Moon | 13011 | Fight the Blood Moon and open the Lunar Chest to receive your Blood Moon armour. |
| 29022 | Blood moon chestplate | Blood Moon | 13011 | Fight the Blood Moon and open the Lunar Chest to receive your Blood Moon armour. |
| 29025 | Blood moon tassets | Blood Moon | 13011 | Fight the Blood Moon and open the Lunar Chest to receive your Blood Moon armour. |
| 28997 | Dual macuahuitl | Blood Moon | 13011 | Fight the Blood Moon and open the Lunar Chest to receive the dual macuahuitl. |
| 29010 | Eclipse moon helm | Eclipse Moon | 13012 | Fight the Eclipse Moon and open the Lunar Chest to receive your Eclipse Moon armour. |
| 29004 | Eclipse moon chestplate | Eclipse Moon | 13012 | Fight the Eclipse Moon and open the Lunar Chest to receive your Eclipse Moon armour. |
| 29007 | Eclipse moon tassets | Eclipse Moon | 13012 | Fight the Eclipse Moon and open the Lunar Chest to receive your Eclipse Moon armour. |
| 29000 | Eclipse atlatl | Eclipse Moon | 13012 | Fight the Eclipse Moon and open the Lunar Chest to receive the eclipse atlatl. |
| 28991 | Atlatl dart | All three | — (no override) | (falls back to static description) |

NPC IDs verified against the OSRS Wiki (Blood Moon: 13011, Eclipse Moon: 13012, Blue Moon: 13013) and RuneLite `NpcID` constants (`PMOON_BOSS_BLOOD_MOON_VIS`, `PMOON_BOSS_ECLIPSE_MOON_VIS`, `PMOON_BOSS_BLUE_MOON_VIS`).

Note: RuneLite `ItemID` constants for items 29013/29016/29019/28988 carry the stale internal names `FROST_MOON_*` / `FROSTMOON_SPEAR` from a pre-release rename; the wiki and in-game names are Blue Moon, which match the existing entries in `drop_rates.json`.

## Checks

- Em-dash mojibake (`â`): 0 occurrences in `drop_rates.json`
- `./gradlew test`: BUILD SUCCESSFUL

Refs cha-ndler/collection-log-helper#420 (B4.3.1), cha-ndler/collection-log-helper#421, cha-ndler/collection-log-helper#423