### PR TITLE
fix(overlay): use resolveDescription for in-game overlay sites missed by PR #421

### DIFF
--- a/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
@@ -538,7 +538,7 @@ public class GuidanceOverlayCoordinator
 		objectHighlightOverlay.setTargetObjectIds(step.getAllObjectIds());
 		objectHighlightOverlay.setObjectInteractAction(step.getObjectInteractAction());
 		objectHighlightOverlay.setUseItemOnObject(step.isUseItemOnObject());
-		objectHighlightOverlay.setTooltipText(step.getDescription());
+		objectHighlightOverlay.setTooltipText(step.resolveDescription(activeTargetItemId));
 
 		itemHighlightOverlay.setTargetItemIds(step.getHighlightItemIds());
 
@@ -586,7 +586,7 @@ public class GuidanceOverlayCoordinator
 			WorldPoint worldPoint = new WorldPoint(step.getWorldX(), step.getWorldY(), step.getWorldPlane());
 			guidanceOverlay.setTargetPoint(worldPoint);
 			guidanceOverlay.setTargetName(sourceName);
-			guidanceOverlay.setLocationDescription(step.getDescription());
+			guidanceOverlay.setLocationDescription(step.resolveDescription(activeTargetItemId));
 			String rawTravelTip = step.getTravelTip();
 			if ((rawTravelTip == null || rawTravelTip.isEmpty()) && source != null)
 			{
@@ -650,7 +650,7 @@ public class GuidanceOverlayCoordinator
 				worldMapPointManager.remove(activeMapPoint);
 				activeMapPoint = null;
 			}
-			guidanceOverlay.setClueGuidanceText(step.getDescription());
+			guidanceOverlay.setClueGuidanceText(step.resolveDescription(activeTargetItemId));
 			clientThread.invokeLater(() ->
 			{
 				client.clearHintArrow();


### PR DESCRIPTION
## Summary

PR #421 (perItemStepDescription schema + coordinator wiring) wired `step.resolveDescription(activeTargetItemId)` at panel-update sites in `GuidanceOverlayCoordinator` but missed every site that pushes the description to the **in-game overlay** (not the side panel).

Result: side panel correctly applies the per-item override for target-aware sources (Shayzien tier text, Perilous Moons per-Moon text); in-game overlay still shows the static description.

## Discovery

2026-05-13 in-client validation pass. Operator selected Eclipse moon chestplate as the target item:

- **Side panel** correctly read: 'Fight the Eclipse Moon and open the Lunar Chest to receive your Eclipse Moon armour.'
- **In-game overlay** showed (incorrectly): 'Complete Perilous Moons. Fight the three Moon bosses in sequence...'

## Fixed sites

| Line | Site | Affects |
|---|---|---|
| 541 | `objectHighlightOverlay.setTooltipText` | Hover tooltip on highlighted 3D-scene object |
| 589 | `guidanceOverlay.setLocationDescription` | Main in-game guidance overlay text |
| 653 | `guidanceOverlay.setClueGuidanceText` | Clue-tier sources' overlay text |

All three now use `step.resolveDescription(activeTargetItemId)`, mirroring the PR #421 panel-update wiring at lines 277 and 869.

## Out of scope

Three more sites use `step.getDescription()` for tooltip text at lines 714, 726, 851. Leaving those for now since they're tooltips inside conditional flows that may need separate care — file as follow-up if validation surfaces issues there.

Also out of scope: F7 — em-dash mojibake (`â€"`) in the in-game overlay renderer. Data file has correct UTF-8 (bytes `e2 80 94`); the overlay renders it as Windows-1252 on display. Separate font/charset fix.

## Test plan

- [x] `./gradlew test` — BUILD SUCCESSFUL
- [ ] In-client: activate guidance on a Perilous Moons item (e.g. Eclipse moon chestplate) → Skip to step 2 → **in-game overlay** should now read 'Fight the Eclipse Moon and open the Lunar Chest...' matching the side panel
- [ ] Same flow on Shayzien Tier 2 item → in-game overlay step-2 text should say 'tier 2' not 'tier 5'

Refs cha-ndler/collection-log-helper#421, #423, #425.