### PR TITLE
fix(guidance): null-check this.steps in GuidanceSequencer.skipStep (#432)

### DIFF
--- a/src/main/java/com/collectionloghelper/guidance/GuidanceSequencer.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceSequencer.java
@@ -587,16 +587,25 @@ public class GuidanceSequencer
 	 */
 	public void skipStep()
 	{
-		if (!active || steps == null)
+		final List<GuidanceStep> currentSteps = this.steps;
+		if (!active || currentSteps == null)
 		{
-			return;
+			return; // sequence already complete or never started
 		}
 
 		loopIterationsCompleted = 0;
 		currentIndex++;
 		skipSatisfiedSteps();
 
-		if (currentIndex >= steps.size())
+		// skipSatisfiedSteps() may fire onSequenceComplete -> stopSequence(),
+		// nulling this.steps. Snapshot was captured above; use it for size checks.
+		if (this.steps == null)
+		{
+			// sequence completed (and cleaned up) inside skipSatisfiedSteps()
+			return;
+		}
+
+		if (currentIndex >= currentSteps.size())
 		{
 			log.info("Guidance sequence complete (skipped) for {}",
 				activeSource != null ? activeSource.getName() : "?");
@@ -611,7 +620,7 @@ public class GuidanceSequencer
 			GuidanceStep step = getCurrentStep();
 			if (step != null)
 			{
-				log.info("Skipped to step {}/{}: {}", currentIndex + 1, steps.size(), step.getDescription());
+				log.info("Skipped to step {}/{}: {}", currentIndex + 1, currentSteps.size(), step.getDescription());
 				notifyStepChanged(step);
 			}
 		}

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
@@ -1871,4 +1871,46 @@ public class GuidanceSequencerTest
 		// onStepChanged fires to refresh the panel even if index did not change
 		assertNotNull("onStepChanged must fire on sync", lastStep.get());
 	}
+
+	/**
+	 * Regression test for #432.
+	 *
+	 * <p>When skipStep() is called and skipping the last step causes
+	 * skipSatisfiedSteps() to fire onSequenceComplete, which in turn calls
+	 * stopSequence() (nulling this.steps), the subsequent size() call in
+	 * skipStep() must not throw NPE.
+	 */
+	@Test
+	public void skipStep_afterSequenceComplete_doesNotThrow()
+	{
+		// Wire onComplete to call stopSequence(), mimicking GuidanceOverlayCoordinator
+		startSequence(
+			Arrays.asList(makeManualStep("Only step")),
+			s -> {},
+			() -> sequencer.stopSequence()
+		);
+
+		// Must not throw NullPointerException
+		sequencer.skipStep();
+
+		assertFalse("Sequencer must be inactive after skip completes sequence", sequencer.isActive());
+	}
+
+	/**
+	 * Regression test for #432 — variant: skipStep on already-stopped sequencer.
+	 *
+	 * <p>If skipStep() is called after the sequence has already been stopped
+	 * (steps == null), it must silently return without throwing.
+	 */
+	@Test
+	public void skipStep_whenStepsAlreadyNull_doesNotThrow()
+	{
+		startSequence(Arrays.asList(makeManualStep("Only step")));
+		sequencer.stopSequence();
+
+		// steps is now null; calling skipStep must be a no-op
+		sequencer.skipStep();
+
+		assertFalse(sequencer.isActive());
+	}
 }


### PR DESCRIPTION
## Summary

Fixes #432 — `GuidanceSequencer.skipStep` NPE when called after sequence already complete.

### Root cause

`skipStep()` increments `currentIndex` then calls `skipSatisfiedSteps()`. That helper can fire `onSequenceComplete` → `GuidanceOverlayCoordinator.deactivateGuidance()` → `stopSequence()`, which nulls `this.steps`. The `steps.size()` calls immediately after `skipSatisfiedSteps()` then throw NPE.

### Fix — snapshot-then-null-check pattern

```java
public void skipStep()
{
    final List<GuidanceStep> currentSteps = this.steps;
    if (!active || currentSteps == null)
    {
        return; // sequence already complete or never started
    }

    loopIterationsCompleted = 0;
    currentIndex++;
    skipSatisfiedSteps();

    // skipSatisfiedSteps() may fire onSequenceComplete -> stopSequence(),
    // nulling this.steps. Snapshot was captured above; use it for size checks.
    if (this.steps == null)
    {
        // sequence completed (and cleaned up) inside skipSatisfiedSteps()
        return;
    }

    if (currentIndex >= currentSteps.size())
    { ... }
```

### Tests added

- `GuidanceSequencerTest.skipStep_afterSequenceComplete_doesNotThrow()` — wires `onComplete` to call `stopSequence()` (matching `GuidanceOverlayCoordinator` behaviour), skips the only step, asserts no NPE and sequencer is inactive.
- `GuidanceSequencerTest.skipStep_whenStepsAlreadyNull_doesNotThrow()` — calls `stopSequence()` explicitly before `skipStep()`, asserts silent no-op.

## Sibling NPE sites noted but NOT touched (out of scope for this PR)

- `advanceStep()` (lines 648 and 661/675) has the identical pattern: `skipSatisfiedSteps()` called, then `steps.size()` used with only an `active` check (not a null check) after. Tracked under #434.

## Test plan

- [x] `./gradlew test` — BUILD SUCCESSFUL
- [x] `./gradlew build` — BUILD SUCCESSFUL