### PR TITLE
data(perilous-moons): widen step 1 completion + add inner dungeon step (#431)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -7653,7 +7653,15 @@
         "worldY": 3131,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 100
+      },
+      {
+        "description": "Enter Cam Torum and make your way north through the city to the Neypotzli dungeon entrance",
+        "worldX": 1435,
+        "worldY": 9700,
+        "worldPlane": 0,
+        "completionCondition": "ARRIVE_AT_TILE",
+        "completionDistance": 80
       },
       {
         "description": "Complete Perilous Moons. Fight the three Moon bosses in sequence. Each has unique mechanics — learn the safe tiles and prayer switches",


### PR DESCRIPTION
Fixes #431

## Problem

Perilous Moons step 1 used `ARRIVE_AT_TILE` at `(1435, 3131)` with `completionDistance: 20`. Players who quetzal-whistle to the Cam Torum landing site may land 25–40+ tiles from that point and never cross the 20-tile threshold on the surface. Once they enter Cam Torum underground, the surface coords no longer match, so step 1 never auto-fires.

Additionally, after entering Cam Torum there was no guidance pointing players north through the city to the Neypotzli dungeon entrance before the "Fight the Moons" step.

## Changes

| Step | Before | After |
|------|--------|-------|
| 1 — Travel to Cam Torum | `completionDistance: 20` at `(1435, 3131)` | `completionDistance: 100` at `(1435, 3131)` |
| 2 — Enter Neypotzli | *(missing)* | New `ARRIVE_AT_TILE` at `(1435, 9700)` `completionDistance: 80` |
| 3 — Fight the Moons | step 2 (unchanged) | step 3 (unchanged) |

### Step 1 widening rationale
`completionDistance: 100` covers the full surface approach from any quetzal-whistle landing site near the Cam Torum entrance (Ralos' Rise area, roughly centred on `(1435, 3131)`).

### New intermediate step rationale
After entering Cam Torum underground, players must run north through the city to reach Neypotzli. The intermediate step targets `(1435, 9700)` — the approximate midpoint of Cam Torum's underground layout — with `completionDistance: 80`, which covers the entire city from the southern entry gate to the northernmost Neypotzli dungeon entrance.

Cam Torum underground is instance/template content not covered by static cache dumps, so exact entrance object coords could not be confirmed from cache data. A wide `ARRIVE_AT_TILE` covering the approach is used per the issue's fallback guidance.

## Sources consulted
- https://oldschool.runescape.wiki/w/Perilous_Moons — confirms Cam Torum entrance at southern Ralos' Rise; Neypotzli accessed from northernmost Cam Torum
- https://oldschool.runescape.wiki/w/Cam_Torum — confirms city layout and Neypotzli location at north end
- https://oldschool.runescape.wiki/w/Neypotzli — confirms entrance from northernmost Cam Torum

## Hygiene checks
- Em-dash check (`grep â` on `drop_rates.json`): 0 matches — clean
- JSON parse validation: passes (225 sources)
- `./gradlew test`: BUILD SUCCESSFUL
- `./gradlew build`: BUILD SUCCESSFUL