### PR TITLE
fix(lifecycle): null-check getLocalPlayer() in second subscriber (#434)

### DIFF
--- a/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
@@ -410,9 +410,10 @@ public class GuidanceOverlayCoordinator
 			WorldPoint target = pendingShortestPathTarget;
 			pendingShortestPathTarget = null;
 			Map<String, Object> data = new HashMap<>();
-			if (client.getLocalPlayer() != null)
+			Player lp = client.getLocalPlayer();
+			if (lp != null)
 			{
-				data.put("start", client.getLocalPlayer().getWorldLocation());
+				data.put("start", lp.getWorldLocation());
 			}
 			data.put("target", target);
 			eventBus.post(new PluginMessage("shortestpath", "path", data));

--- a/src/main/java/com/collectionloghelper/lifecycle/GuidanceEventRouter.java
+++ b/src/main/java/com/collectionloghelper/lifecycle/GuidanceEventRouter.java
@@ -42,6 +42,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.MenuAction;
 import net.runelite.api.NPC;
+import net.runelite.api.Player;
 import net.runelite.api.events.ActorDeath;
 import net.runelite.api.events.AnimationChanged;
 import net.runelite.api.events.HitsplatApplied;
@@ -196,11 +197,16 @@ public class GuidanceEventRouter
 	@Subscribe
 	public void onAnimationChanged(AnimationChanged event)
 	{
-		if (!config.guidanceAuthoring() || event.getActor() != client.getLocalPlayer())
+		if (!config.guidanceAuthoring())
 		{
 			return;
 		}
-		int animId = client.getLocalPlayer().getAnimation();
+		Player lp = client.getLocalPlayer();
+		if (lp == null || event.getActor() != lp)
+		{
+			return;
+		}
+		int animId = lp.getAnimation();
 		if (animId != -1)
 		{
 			authoringLogger.log("ANIMATION player=%d", animId);

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorMapPointTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorMapPointTest.java
@@ -41,6 +41,7 @@ import com.collectionloghelper.overlay.WidgetHighlightOverlay;
 import com.collectionloghelper.overlay.WorldMapDestinationOverlay;
 import com.collectionloghelper.overlay.WorldMapRouteOverlay;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
 import java.util.Collections;
 import net.runelite.api.Client;
 import net.runelite.api.coords.WorldPoint;
@@ -197,6 +198,33 @@ public class GuidanceOverlayCoordinatorMapPointTest
 		coordinator.activateGuidance(source, new WorldPoint(3200, 3200, 0), null);
 
 		verify(worldMapPointManager, never()).add(any(CollectionLogWorldMapPoint.class));
+	}
+
+	/**
+	 * Regression test for issue #434: {@link GuidanceOverlayCoordinator#tick()} must not
+	 * NPE when {@code pendingShortestPathTarget} is non-null but {@code getLocalPlayer()}
+	 * returns null (i.e. during the login sequence before the player entity spawns).
+	 *
+	 * <p>The old code called {@code client.getLocalPlayer()} twice — once for the null-check
+	 * and once for {@code .getWorldLocation()} — creating a TOCTOU window.  The fix snapshots
+	 * the player reference once and uses that snapshot exclusively.
+	 */
+	@Test
+	public void tick_nullLocalPlayer_doesNotThrow() throws Exception
+	{
+		// Arrange — inject a pending shortest-path target via reflection to
+		// simulate guidance being active while the player has not yet spawned.
+		Field field = GuidanceOverlayCoordinator.class.getDeclaredField("pendingShortestPathTarget");
+		field.setAccessible(true);
+		field.set(coordinator, new WorldPoint(3200, 3200, 0));
+
+		when(client.getLocalPlayer()).thenReturn(null);
+
+		// Act — must not throw NPE
+		coordinator.tick();
+
+		// Assert — ShortestPath event was still posted (without a "start" key)
+		verify(eventBus).post(any());
 	}
 
 	// ---- helpers ----

--- a/src/test/java/com/collectionloghelper/lifecycle/GuidanceEventRouterTest.java
+++ b/src/test/java/com/collectionloghelper/lifecycle/GuidanceEventRouterTest.java
@@ -336,6 +336,22 @@ public class GuidanceEventRouterTest
 		verifyNoInteractions(authoringLogger);
 	}
 
+	@Test
+	public void testOnAnimationChangedNullLocalPlayerDoesNotThrow()
+	{
+		// Arrange — simulate login: getLocalPlayer() returns null (player not yet spawned)
+		when(config.guidanceAuthoring()).thenReturn(true);
+		when(client.getLocalPlayer()).thenReturn(null);
+		AnimationChanged event = new AnimationChanged();
+		event.setActor(localPlayer);
+
+		// Act — must not throw NPE
+		router.onAnimationChanged(event);
+
+		// Assert — nothing logged; handler bailed out on null player
+		verifyNoInteractions(authoringLogger);
+	}
+
 	// ========================================================================
 	// onNpcSpawned / onNpcDespawned
 	// ========================================================================


### PR DESCRIPTION
## Summary

Fixes #434 — login-time NPE `Cannot invoke "net.runelite.api.Player.getWorldLocation()" because the return value of "net.runelite.api.Client.getLocalPlayer()" is null` that fired 10+ times during the 2026-05-13 validation pass.

**Root cause:** `GuidanceOverlayCoordinator.tick()` called `client.getLocalPlayer()` twice — once for the null-guard and once for `.getWorldLocation()` on the next line. When guidance is active (i.e. `pendingShortestPathTarget` is non-null from a session before logout) and the player entity has not yet spawned during re-login, the first call can return non-null momentarily only for the second call to return null — or both calls return null when `GuidanceMovementTracker.onGameTick` protected its own snapshot but did not protect this independent subscriber. The fix snapshots `getLocalPlayer()` once into a local variable and uses only that snapshot.

**Secondary hardening:** `GuidanceEventRouter.onAnimationChanged()` had the same TOCTOU pattern — `getLocalPlayer()` called in the condition check (line 199) and again for `.getAnimation()` (line 203). Fixed to snapshot once with an explicit null guard.

## Call sites patched

| File | Line (before) | Pattern fixed |
|------|---------------|---------------|
| `src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java` | 413–415 | `if (getLocalPlayer() != null) { getLocalPlayer().getWorldLocation() }` → snapshot `lp`, use `lp.getWorldLocation()` |
| `src/main/java/com/collectionloghelper/lifecycle/GuidanceEventRouter.java` | 199, 203 | `event.getActor() != getLocalPlayer()` + later `getLocalPlayer().getAnimation()` → snapshot `lp`, guard `lp == null` explicitly |

## Tests added

- `GuidanceOverlayCoordinatorMapPointTest.tick_nullLocalPlayer_doesNotThrow` — sets `pendingShortestPathTarget` via reflection, stubs `getLocalPlayer()` → null, calls `tick()`, asserts no exception.
- `GuidanceEventRouterTest.testOnAnimationChangedNullLocalPlayerDoesNotThrow` — authoring on, `getLocalPlayer()` → null, fires `AnimationChanged`, asserts no exception and no log calls.

## Unprotected sites observed but left alone (with reason)

- `GuidanceEventRouter.java:250` — `event.getSource() == client.getLocalPlayer()`: reference equality; when `getLocalPlayer()` is null the comparison is false, not an NPE.
- `GuidanceEventRouter.java:271` — `event.getActor() == client.getLocalPlayer()`: same pattern, safe.
- `GuidanceOverlay.java:178–180` — snapshots into `localPlayer`, then `localPlayer != null && localPlayer.getWorldLocation()...` short-circuits correctly; no TOCTOU.
- `EfficiencyCalculator.java:726` — inline ternary `getLocalPlayer() != null ? getLocalPlayer().getCombatLevel() : 0`; two calls but on single client thread in a pure helper, low-risk; out of scope.

## Test plan

- [x] `./gradlew test` passes
- [x] `./gradlew build` passes