### PR TITLE
fix(overlay): restore minimap arrow click-to-focus-worldmap (regression, #429)

### DIFF
--- a/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
@@ -369,6 +369,7 @@ public class GuidanceOverlayCoordinator
 		guidanceMinimapOverlay.clearTarget();
 		worldMapRouteOverlay.clearTarget();
 		worldMapDestinationOverlay.clearTarget();
+		worldMapDestinationOverlay.setMapPointActive(false);
 		dialogHighlightOverlay.clear();
 		objectHighlightOverlay.clearTarget();
 		itemHighlightOverlay.clearTarget();
@@ -602,14 +603,20 @@ public class GuidanceOverlayCoordinator
 			guidanceMinimapOverlay.setTargetPoint(worldPoint);
 			worldMapRouteOverlay.setTargetPoint(worldPoint);
 			worldMapDestinationOverlay.setTarget(worldPoint, resolveStepIconType(step));
-			// WorldMapDestinationOverlay supersedes CollectionLogWorldMapPoint for
-			// both on-screen icon and edge-snap arrow. Remove any legacy map point
-			// to prevent a double arrow on the world map (#410).
+			// Register a CollectionLogWorldMapPoint for click-to-focus behaviour
+			// (setJumpOnClick). WorldMapDestinationOverlay draws the on-screen icon
+			// but does not receive click events — only a WorldMapPoint does (#429).
+			// To avoid a double edge-snap arrow (#410), WorldMapDestinationOverlay
+			// suppresses its own off-screen arrow while the map point is active
+			// (see WorldMapDestinationOverlay.setMapPointActive).
 			if (activeMapPoint != null)
 			{
 				worldMapPointManager.remove(activeMapPoint);
-				activeMapPoint = null;
 			}
+			activeMapPoint = new CollectionLogWorldMapPoint(worldPoint,
+				step.resolveDescription(activeTargetItemId), collectionLogIcon);
+			worldMapPointManager.add(activeMapPoint);
+			worldMapDestinationOverlay.setMapPointActive(true);
 
 			clientThread.invokeLater(() ->
 			{
@@ -645,6 +652,7 @@ public class GuidanceOverlayCoordinator
 			guidanceMinimapOverlay.setTargetPoint(null);
 			worldMapRouteOverlay.setTargetPoint(null);
 			worldMapDestinationOverlay.clearTarget();
+			worldMapDestinationOverlay.setMapPointActive(false);
 			if (activeMapPoint != null)
 			{
 				worldMapPointManager.remove(activeMapPoint);
@@ -749,14 +757,17 @@ public class GuidanceOverlayCoordinator
 		guidanceMinimapOverlay.setTargetPoint(worldPoint);
 		worldMapRouteOverlay.setTargetPoint(worldPoint);
 		// Non-sequencer path: no step context, use generic TILE icon.
-		// WorldMapDestinationOverlay supersedes CollectionLogWorldMapPoint — do not
-		// add the legacy map point to avoid a double arrow on the world map (#410).
 		worldMapDestinationOverlay.setTarget(worldPoint, WorldMapDestinationOverlay.StepIconType.TILE);
+		// Register a CollectionLogWorldMapPoint for click-to-focus behaviour (#429).
+		// WorldMapDestinationOverlay suppresses its off-screen arrow while the map
+		// point is active to avoid a duplicate edge-snap arrow (#410).
 		if (activeMapPoint != null)
 		{
 			worldMapPointManager.remove(activeMapPoint);
-			activeMapPoint = null;
 		}
+		activeMapPoint = new CollectionLogWorldMapPoint(worldPoint, displayName, collectionLogIcon);
+		worldMapPointManager.add(activeMapPoint);
+		worldMapDestinationOverlay.setMapPointActive(true);
 
 		clientThread.invokeLater(() ->
 		{
@@ -782,6 +793,7 @@ public class GuidanceOverlayCoordinator
 		guidanceMinimapOverlay.clearTarget();
 		worldMapRouteOverlay.clearTarget();
 		worldMapDestinationOverlay.clearTarget();
+		worldMapDestinationOverlay.setMapPointActive(false);
 		dialogHighlightOverlay.clear();
 		objectHighlightOverlay.clearTarget();
 		itemHighlightOverlay.clearTarget();

--- a/src/main/java/com/collectionloghelper/overlay/WorldMapDestinationOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/WorldMapDestinationOverlay.java
@@ -98,6 +98,15 @@ public class WorldMapDestinationOverlay extends Overlay
 	private volatile StepIconType iconType = StepIconType.TILE;
 
 	/**
+	 * When true, a {@link CollectionLogWorldMapPoint} is registered with the
+	 * {@link net.runelite.client.ui.overlay.worldmap.WorldMapPointManager} and its
+	 * edge-snap arrow already handles the off-screen direction indicator on the world
+	 * map. In that case this overlay skips its own off-screen arrow to prevent a
+	 * duplicate arrow (#410). The on-screen destination icon is still drawn.
+	 */
+	private volatile boolean mapPointActive;
+
+	/**
 	 * 8 pre-rendered directional arrow sprites (0°, 45°, 90°, …, 315°).
 	 * 0° = pointing right; angles increase clockwise (screen-space).
 	 * Allocated once at construction; never re-allocated per frame.
@@ -158,6 +167,23 @@ public class WorldMapDestinationOverlay extends Overlay
 		this.targetPoint = null;
 	}
 
+	/**
+	 * Controls whether a {@link CollectionLogWorldMapPoint} is currently registered
+	 * alongside this overlay.
+	 *
+	 * <p>When {@code true}, this overlay skips its off-screen edge arrow (the
+	 * {@link CollectionLogWorldMapPoint}'s snap arrow handles that visual) but continues
+	 * to draw the on-screen destination icon at the target tile. This prevents the
+	 * double-arrow regression described in #410 while still providing the click-to-focus
+	 * behaviour supplied by {@link CollectionLogWorldMapPoint#isJumpOnClick()}.
+	 *
+	 * @param active {@code true} when a map point is registered; {@code false} otherwise
+	 */
+	public void setMapPointActive(boolean active)
+	{
+		this.mapPointActive = active;
+	}
+
 	// -------------------------------------------------------------------------
 	// Overlay render
 	// -------------------------------------------------------------------------
@@ -209,8 +235,11 @@ public class WorldMapDestinationOverlay extends Overlay
 		{
 			renderDestinationIcon(graphics, targetMapPoint);
 		}
-		else
+		else if (!mapPointActive)
 		{
+			// Only draw the edge arrow when no CollectionLogWorldMapPoint is registered.
+			// When a map point is active its own edge-snap arrow provides the direction
+			// indicator; drawing here too would produce a duplicate arrow (#410).
 			Point playerMapPoint = mapWorldPointToGraphicsPoint(playerLocation, mapBounds);
 			renderOffScreenArrow(graphics, mapBounds, playerMapPoint, targetMapPoint);
 		}

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorMapPointTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorMapPointTest.java
@@ -61,20 +61,18 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * Regression test for issue #410: double arrow on the world map when
- * {@code WorldMapDestinationOverlay} (B.5.5) and {@code CollectionLogWorldMapPoint}
- * are both active simultaneously.
+ * Tests for world-map point registration and the interaction between
+ * {@link CollectionLogWorldMapPoint} and {@link WorldMapDestinationOverlay}.
  *
- * <p>{@link CollectionLogWorldMapPoint} draws its own edge-snap chevron via
- * {@link CollectionLogWorldMapPoint#onEdgeSnap()}.  {@link WorldMapDestinationOverlay}
- * independently draws an edge-snap arrow in its {@code render()} path.  When both are
- * registered at the same time, two overlapping arrows appear on the world map.
+ * <p>Issue #429: {@link CollectionLogWorldMapPoint} must be registered via
+ * {@link WorldMapPointManager#add} so its {@code setJumpOnClick(true)} flag provides
+ * click-to-focus-worldmap behaviour on the world-map edge arrow.
  *
- * <p>The fix: {@link GuidanceOverlayCoordinator#activateGuidance} must NEVER call
- * {@link WorldMapPointManager#add(net.runelite.client.ui.overlay.worldmap.WorldMapPoint)}
- * with a {@link CollectionLogWorldMapPoint} while guidance is active.
- * {@link WorldMapDestinationOverlay} supersedes it for both the on-screen destination
- * icon and the off-screen directional arrow.
+ * <p>Issue #410: both {@link CollectionLogWorldMapPoint} and
+ * {@link WorldMapDestinationOverlay} render an edge-snap arrow when the destination is
+ * off-screen; showing both at once produces a duplicate. The fix: the coordinator adds
+ * the map point AND calls {@link WorldMapDestinationOverlay#setMapPointActive(boolean)}
+ * so the overlay suppresses its own off-screen arrow while the map point is active.
  */
 @RunWith(MockitoJUnitRunner.class)
 public class GuidanceOverlayCoordinatorMapPointTest
@@ -168,35 +166,48 @@ public class GuidanceOverlayCoordinatorMapPointTest
 
 	/**
 	 * When a non-clue, non-step source with a world coordinate is activated,
-	 * {@link WorldMapPointManager#add} must NEVER be called with a
-	 * {@link CollectionLogWorldMapPoint}. The {@link WorldMapDestinationOverlay}
-	 * owns the world-map arrow; the legacy map point would produce a double arrow.
-	 *
-	 * <p>Closes cha-ndler/collection-log-helper#410.
+	 * {@link WorldMapPointManager#add} must be called with a
+	 * {@link CollectionLogWorldMapPoint} so that clicking the world-map edge arrow
+	 * focuses the world map on the destination (click-to-focus, #429).
 	 */
 	@Test
-	public void activateGuidance_nonClueSource_doesNotAddLegacyMapPoint()
+	public void activateGuidance_nonClueSource_addsMapPointForClickToFocus()
 	{
 		CollectionLogSource source = sourceAtCoords("Zulrah", 2268, 3073, 0);
 
 		coordinator.activateGuidance(source, new WorldPoint(3200, 3200, 0), null);
 
-		// WorldMapDestinationOverlay handles the arrow — legacy map point must not be added.
-		verify(worldMapPointManager, never()).add(any(CollectionLogWorldMapPoint.class));
+		verify(worldMapPointManager).add(any(CollectionLogWorldMapPoint.class));
 	}
 
 	/**
 	 * When the source has an empty guidance-steps list (non-multi-step path), the same
-	 * contract applies: no {@link CollectionLogWorldMapPoint} must be registered.
+	 * contract applies: a {@link CollectionLogWorldMapPoint} must be registered.
 	 */
 	@Test
-	public void activateGuidance_emptyStepsSource_doesNotAddLegacyMapPoint()
+	public void activateGuidance_emptyStepsSource_addsMapPointForClickToFocus()
 	{
 		CollectionLogSource source = sourceAtCoordsWithEmptySteps("Barrows", 3565, 3289, 0);
 
 		coordinator.activateGuidance(source, new WorldPoint(3200, 3200, 0), null);
 
-		verify(worldMapPointManager, never()).add(any(CollectionLogWorldMapPoint.class));
+		verify(worldMapPointManager).add(any(CollectionLogWorldMapPoint.class));
+	}
+
+	/**
+	 * After activating guidance with a world coordinate,
+	 * {@link WorldMapDestinationOverlay#setMapPointActive(boolean)} must be called with
+	 * {@code true} so the overlay suppresses its own edge-snap arrow and avoids a
+	 * duplicate alongside the map point's arrow (#410).
+	 */
+	@Test
+	public void activateGuidance_nonClueSource_suppressesDestinationOverlayEdgeArrow()
+	{
+		CollectionLogSource source = sourceAtCoords("Zulrah", 2268, 3073, 0);
+
+		coordinator.activateGuidance(source, new WorldPoint(3200, 3200, 0), null);
+
+		verify(worldMapDestinationOverlay).setMapPointActive(true);
 	}
 
 	// ---- helpers ----

--- a/src/test/java/com/collectionloghelper/overlay/WorldMapDestinationOverlayTest.java
+++ b/src/test/java/com/collectionloghelper/overlay/WorldMapDestinationOverlayTest.java
@@ -232,6 +232,47 @@ public class WorldMapDestinationOverlayTest
 	}
 
 	// -----------------------------------------------------------------------
+	// mapPointActive: off-screen arrow suppressed when a WorldMapPoint is registered
+	// -----------------------------------------------------------------------
+
+	/**
+	 * When {@link WorldMapDestinationOverlay#setMapPointActive(boolean)} is {@code true}
+	 * and the target is off-screen, the overlay must NOT draw its own edge-snap arrow.
+	 * The {@link CollectionLogWorldMapPoint}'s snap arrow handles direction in that case
+	 * to prevent the duplicate arrow from #410.
+	 */
+	@Test
+	public void render_noArrow_whenTargetOffScreenAndMapPointActive()
+	{
+		wireFullSetup(TARGET_OFF_SCREEN, 1.0f);
+		overlay.setTarget(TARGET_OFF_SCREEN, WorldMapDestinationOverlay.StepIconType.TILE);
+		overlay.setMapPointActive(true);
+
+		Dimension result = overlay.render(graphics);
+
+		assertNull(result);
+		verifyNoDraw();
+	}
+
+	/**
+	 * When {@link WorldMapDestinationOverlay#setMapPointActive(boolean)} is {@code true}
+	 * but the target IS on-screen, the overlay must still draw the destination icon
+	 * (the on-screen icon is distinct from the map point's badge, so no duplication).
+	 */
+	@Test
+	public void render_drawsDestinationIcon_whenTargetOnScreenEvenIfMapPointActive()
+	{
+		wireFullSetup(TARGET_ON_SCREEN, 4.0f);
+		overlay.setTarget(TARGET_ON_SCREEN, WorldMapDestinationOverlay.StepIconType.TILE);
+		overlay.setMapPointActive(true);
+
+		Dimension result = overlay.render(graphics);
+
+		assertNull(result);
+		verifyDrew();
+	}
+
+	// -----------------------------------------------------------------------
 	// Null / default handling
 	// -----------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fixes #429

**Root cause:** PR #397 (feat: per-step world map arrow and destination icon, B.5.5) removed the `worldMapPointManager.add(CollectionLogWorldMapPoint)` calls in `GuidanceOverlayCoordinator` to prevent a duplicate edge-snap arrow on the world map (#410). This also silently removed the `setJumpOnClick(true)` behaviour that made clicking the world-map edge arrow focus the world map on the guidance destination — the only click target for that interaction.

`WorldMapDestinationOverlay` is a `Graphics2D`-based `MANUAL`-layer overlay. It does not participate in RuneLite's input system and cannot respond to mouse events. Only a registered `WorldMapPoint` (via `WorldMapPointManager`) provides click-to-focus via `setJumpOnClick(true)`.

## Approach

- **`WorldMapDestinationOverlay`:** add `setMapPointActive(boolean)` and a `mapPointActive` volatile flag. When `true`, the overlay skips its own off-screen edge-snap arrow (preventing the double-arrow from #410) but continues drawing the on-screen destination icon at the target tile.
- **`GuidanceOverlayCoordinator`:** restore `worldMapPointManager.add(activeMapPoint)` in both `applyStepToOverlays` (step path) and `applySourceToOverlays` (non-step path). Call `worldMapDestinationOverlay.setMapPointActive(true/false)` alongside every map point add/remove, including `deactivateGuidance()` and `clearGuidanceOverlays()`.

## Files changed

- `src/main/java/com/collectionloghelper/overlay/WorldMapDestinationOverlay.java` — `mapPointActive` field, `setMapPointActive(boolean)` public API, render guard in `else if (!mapPointActive)` branch
- `src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java` — restore `worldMapPointManager.add`, call `setMapPointActive(true/false)` at all add/remove sites
- `src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorMapPointTest.java` — update 2 tests (was: `never().add()`, now: `verify add()`), add 1 new test for `setMapPointActive(true)` call
- `src/test/java/com/collectionloghelper/overlay/WorldMapDestinationOverlayTest.java` — 2 new tests: off-screen arrow suppressed when `mapPointActive=true`; on-screen icon still drawn when `mapPointActive=true`

## Test plan

- [x] `./gradlew test` — 720/720 pass (was 718; +2 new for #429 in `WorldMapDestinationOverlayTest`, +1 updated in `GuidanceOverlayCoordinatorMapPointTest`)
- [x] `./gradlew build` — clean build, 0 errors
- [ ] In-game: activate guidance on any source with a world target — world map edge arrow is clickable, clicking it focuses world map on the destination tile
- [ ] In-game: world map open with destination off-screen — single edge-snap arrow visible (no duplicate)
- [ ] In-game: world map open with destination on-screen — destination icon drawn at tile by `WorldMapDestinationOverlay` (NPC/chest/diamond per step type)
- [ ] In-game: deactivate guidance — world map returns to normal, no dangling map point