### PR TITLE
fix(guidance): null-check this.steps in GuidanceSequencer.advanceStep (#439)

### DIFF
--- a/src/main/java/com/collectionloghelper/guidance/GuidanceSequencer.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceSequencer.java
@@ -632,7 +632,8 @@ public class GuidanceSequencer
 	 */
 	public void advanceStep()
 	{
-		if (!active || steps == null)
+		final List<GuidanceStep> currentSteps = this.steps;
+		if (!active || currentSteps == null)
 		{
 			return;
 		}
@@ -649,12 +650,21 @@ public class GuidanceSequencer
 					loopIterationsCompleted, completingStep.getLoopCount(), completingStep.getLoopBackToStep());
 				currentIndex = targetIndex;
 				skipSatisfiedSteps();
+
+				// skipSatisfiedSteps() may fire onSequenceComplete -> stopSequence(),
+				// nulling this.steps. Snapshot was captured above; use it for size checks.
+				if (this.steps == null)
+				{
+					// sequence completed (and cleaned up) inside skipSatisfiedSteps()
+					return;
+				}
+
 				if (active)
 				{
 					GuidanceStep step = getCurrentStep();
 					if (step != null)
 					{
-						log.info("Resumed at step {}/{}: {}", currentIndex + 1, steps.size(), step.getDescription());
+						log.info("Resumed at step {}/{}: {}", currentIndex + 1, currentSteps.size(), step.getDescription());
 						notifyStepChanged(step);
 					}
 				}
@@ -667,7 +677,15 @@ public class GuidanceSequencer
 		currentIndex++;
 		skipSatisfiedSteps();
 
-		if (currentIndex >= steps.size())
+		// skipSatisfiedSteps() may fire onSequenceComplete -> stopSequence(),
+		// nulling this.steps. Snapshot was captured above; use it for size checks.
+		if (this.steps == null)
+		{
+			// sequence completed (and cleaned up) inside skipSatisfiedSteps()
+			return;
+		}
+
+		if (currentIndex >= currentSteps.size())
 		{
 			log.info("Guidance sequence complete for {}", activeSource != null ? activeSource.getName() : "?");
 			active = false;
@@ -681,7 +699,7 @@ public class GuidanceSequencer
 			GuidanceStep step = getCurrentStep();
 			if (step != null)
 			{
-				log.info("Advanced to step {}/{}: {}", currentIndex + 1, steps.size(), step.getDescription());
+				log.info("Advanced to step {}/{}: {}", currentIndex + 1, currentSteps.size(), step.getDescription());
 				notifyStepChanged(step);
 			}
 		}

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
@@ -1913,4 +1913,46 @@ public class GuidanceSequencerTest
 
 		assertFalse(sequencer.isActive());
 	}
+
+	/**
+	 * Regression test for #439.
+	 *
+	 * <p>When advanceStep() is called on a single-step sequence and
+	 * skipSatisfiedSteps() fires onSequenceComplete, which in turn calls
+	 * stopSequence() (nulling this.steps), the subsequent size() call in
+	 * advanceStep() must not throw NPE.
+	 */
+	@Test
+	public void advanceStep_afterSequenceComplete_doesNotThrow()
+	{
+		// Wire onComplete to call stopSequence(), mimicking GuidanceOverlayCoordinator
+		startSequence(
+			Arrays.asList(makeManualStep("Only step")),
+			s -> {},
+			() -> sequencer.stopSequence()
+		);
+
+		// Must not throw NullPointerException
+		sequencer.advanceStep();
+
+		assertFalse("Sequencer must be inactive after advance completes sequence", sequencer.isActive());
+	}
+
+	/**
+	 * Regression test for #439 — variant: advanceStep on already-stopped sequencer.
+	 *
+	 * <p>If advanceStep() is called after the sequence has already been stopped
+	 * (steps == null), it must silently return without throwing.
+	 */
+	@Test
+	public void advanceStep_whenStepsAlreadyNull_doesNotThrow()
+	{
+		startSequence(Arrays.asList(makeManualStep("Only step")));
+		sequencer.stopSequence();
+
+		// steps is now null; calling advanceStep must be a no-op
+		sequencer.advanceStep();
+
+		assertFalse(sequencer.isActive());
+	}
 }


### PR DESCRIPTION
## Summary

Fixes #439 — mirrors the re-entrant null guard from PR #435 (`skipStep`) into `advanceStep`.

`advanceStep` had two `skipSatisfiedSteps()` call-sites where `this.steps` could be nulled before the subsequent `size()` references:

- **Loop branch** (~line 652): after looping back, `skipSatisfiedSteps()` could fire `onSequenceComplete → stopSequence() → steps = null`, then `steps.size()` in the log line NPEs.
- **Main advance branch** (~line 678): same shape — increment, `skipSatisfiedSteps()`, then `steps.size()` check NPEs.

**Diff pattern (mirrors #435 exactly):**
```java
// Before
public void advanceStep() {
    if (!active || steps == null) { return; }
    ...
    skipSatisfiedSteps();
    if (currentIndex >= steps.size()) { ... }  // NPE if stopSequence() was called above
}

// After
public void advanceStep() {
    final List<GuidanceStep> currentSteps = this.steps;
    if (!active || currentSteps == null) { return; }
    ...
    skipSatisfiedSteps();
    if (this.steps == null) { return; }  // re-entrant guard
    if (currentIndex >= currentSteps.size()) { ... }  // safe snapshot
}
```

## Tests added

- `advanceStep_afterSequenceComplete_doesNotThrow()` — wires `onComplete` to call `stopSequence()` (mirroring coordinator callback chain), calls `advanceStep()` on a single-step sequence, asserts no exception and inactive state.
- `advanceStep_whenStepsAlreadyNull_doesNotThrow()` — explicit `stopSequence()` first, then `advanceStep()`, asserts silent no-op.

## Sibling sites audited

- `startSequence()`: safe — `if (active)` block after `skipSatisfiedSteps()` already guards; `stopSequence()` sets `active = false` before `steps = null`.
- `syncToCurrentState()`: safe — `if (!active) return;` guard after `skipSatisfiedSteps()` catches the case.
- No other public methods call `skipSatisfiedSteps()`.