### PR TITLE
fix(charset): force UTF-8 when loading guidance step text (#433)

### DIFF
--- a/src/main/java/com/collectionloghelper/data/DropRateDatabase.java
+++ b/src/main/java/com/collectionloghelper/data/DropRateDatabase.java
@@ -29,6 +29,7 @@ import com.google.gson.reflect.TypeToken;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumMap;
@@ -65,7 +66,7 @@ public class DropRateDatabase
 			}
 
 			Type listType = new TypeToken<List<CollectionLogSource>>(){}.getType();
-			sources = gson.fromJson(new InputStreamReader(is), listType);
+			sources = gson.fromJson(new InputStreamReader(is, StandardCharsets.UTF_8), listType);
 
 			itemsById = sources.stream()
 				.flatMap(s -> s.getItems().stream())

--- a/src/main/java/com/collectionloghelper/data/SlayerMasterDatabase.java
+++ b/src/main/java/com/collectionloghelper/data/SlayerMasterDatabase.java
@@ -29,6 +29,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -67,7 +68,7 @@ public class SlayerMasterDatabase
 				return;
 			}
 
-			JsonObject root = gson.fromJson(new InputStreamReader(is), JsonObject.class);
+			JsonObject root = gson.fromJson(new InputStreamReader(is, StandardCharsets.UTF_8), JsonObject.class);
 			JsonObject masters = root.getAsJsonObject("masters");
 			if (masters == null)
 			{

--- a/src/main/java/com/collectionloghelper/data/VerifiedSceneIdRegistry.java
+++ b/src/main/java/com/collectionloghelper/data/VerifiedSceneIdRegistry.java
@@ -32,6 +32,7 @@ import com.google.gson.reflect.TypeToken;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -105,7 +106,7 @@ public class VerifiedSceneIdRegistry
 				return empty();
 			}
 
-			InputStreamReader reader = new InputStreamReader(is);
+			InputStreamReader reader = new InputStreamReader(is, StandardCharsets.UTF_8);
 			JsonElement parsed = new JsonParser().parse(reader);
 			return parseRoot(parsed.getAsJsonObject(), gson);
 		}

--- a/src/test/java/com/collectionloghelper/data/DropRateDatabaseTest.java
+++ b/src/test/java/com/collectionloghelper/data/DropRateDatabaseTest.java
@@ -28,6 +28,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import java.lang.reflect.Field;
 import java.util.List;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -350,6 +351,72 @@ public class DropRateDatabaseTest
 		assertNotNull("Step must not be null", step);
 		assertNull("recommendedItemIds must be null when absent from JSON",
 			step.getRecommendedItemIds());
+	}
+
+	// ========================================================================
+	// Charset regression — issue #433
+	// ========================================================================
+
+	/**
+	 * Verifies that em-dash characters in step descriptions are loaded correctly
+	 * as the Unicode em-dash (U+2014, "—") rather than the Windows-1252 mojibake
+	 * sequence "â€"" that results from reading UTF-8 bytes with the platform
+	 * default charset on Windows.
+	 *
+	 * <p>The Perilous Moons step 3 description ("… Each has unique mechanics — learn
+	 * the safe tiles …") is the known reproducer from issue #433.
+	 */
+	@Test
+	public void load_guidanceStepDescriptions_noCharsetCorruption()
+	{
+		final String MOJIBAKE = "â€”"; // UTF-8 em-dash bytes misread as Windows-1252
+		final String EM_DASH   = "—";              // correct em-dash
+
+		boolean foundAtLeastOneEmDash = false;
+
+		for (CollectionLogSource source : database.getAllSources())
+		{
+			if (source.getGuidanceSteps() == null)
+			{
+				continue;
+			}
+			for (GuidanceStep step : source.getGuidanceSteps())
+			{
+				String desc = step.getDescription();
+				if (desc != null)
+				{
+					assertFalse(
+						"Mojibake em-dash detected in description for source '"
+							+ source.getName() + "': " + desc,
+						desc.contains(MOJIBAKE));
+					if (desc.contains(EM_DASH))
+					{
+						foundAtLeastOneEmDash = true;
+					}
+				}
+
+				if (step.getPerItemStepDescription() != null)
+				{
+					for (Map.Entry<Integer, String> entry : step.getPerItemStepDescription().entrySet())
+					{
+						String override = entry.getValue();
+						if (override != null)
+						{
+							assertFalse(
+								"Mojibake em-dash detected in perItemStepDescription (item "
+									+ entry.getKey() + ") for source '" + source.getName()
+									+ "': " + override,
+								override.contains(MOJIBAKE));
+						}
+					}
+				}
+			}
+		}
+
+		assertTrue(
+			"Expected at least one em-dash in guidance step descriptions — "
+				+ "test data may be empty or step sources changed",
+			foundAtLeastOneEmDash);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes #433 — em-dash characters in guidance step descriptions rendered as mojibake (`â€"`) in the in-game overlay on Windows.

**Root cause (`DropRateDatabase.java:68`):** `new InputStreamReader(is)` uses the platform-default charset. On Windows that is Windows-1252, which misinterprets the three UTF-8 bytes of U+2014 (em-dash, `e2 80 94`) as the three-character sequence `â€"`. The `drop_rates.json` file bytes are correct UTF-8 — the corruption is introduced at load time.

**Fix:** pass `StandardCharsets.UTF_8` explicitly to every `InputStreamReader` that opens a bundled JSON resource:

- `DropRateDatabase.java:68` — primary reproducer (`drop_rates.json`, guidance step descriptions)
- `SlayerMasterDatabase.java:70` — same pattern (`slayer_task_weights.json`)
- `VerifiedSceneIdRegistry.java:108` — same pattern (`verified_scene_ids.json`)

**Test:** new `load_guidanceStepDescriptions_noCharsetCorruption()` in `DropRateDatabaseTest` scans all loaded step descriptions and `perItemStepDescription` override strings, asserting:
1. No string contains the mojibake sequence `â€"`.
2. At least one description contains a correct em-dash `—` (sanity-guard against empty/changed test data).

## Test plan

- [x] `./gradlew test` passes (all existing tests + new regression test green)
- [x] `./gradlew build` passes
- [ ] Manual: activate guidance on Perilous Moons — step 3 description should show `—` not `â€"`