### PR TITLE
data(cyclopes): per-defender step descriptions (B4.3.3 / #420)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -18093,6 +18093,16 @@
       },
       {
         "description": "Kill Cyclopes for defender drops. Each kill costs 10 warrior guild tokens",
+        "perItemStepDescription": {
+          "8844": "Kill Cyclopes (no prerequisite) to receive a Bronze defender and start the chain.",
+          "8845": "Kill Cyclopes while holding a Bronze defender in inventory to receive an Iron defender.",
+          "8846": "Kill Cyclopes while holding an Iron defender in inventory to receive a Steel defender.",
+          "8847": "Kill Cyclopes while holding a Steel defender in inventory to receive a Black defender.",
+          "8848": "Kill Cyclopes while holding a Black defender in inventory to receive a Mithril defender.",
+          "8849": "Kill Cyclopes while holding a Mithril defender in inventory to receive an Adamant defender.",
+          "8850": "Kill Cyclopes while holding an Adamant defender in inventory to receive a Rune defender.",
+          "12954": "Kill Cyclopes while holding a Rune defender in inventory to receive the Dragon defender."
+        },
         "worldX": 2849,
         "worldY": 3543,
         "worldPlane": 2,

--- a/src/test/java/com/collectionloghelper/data/GuidanceStepTest.java
+++ b/src/test/java/com/collectionloghelper/data/GuidanceStepTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Unit tests for {@link GuidanceStep#resolveDescription(Integer)},
@@ -163,6 +164,83 @@ public class GuidanceStepTest
 		assertEquals("Tier 5 override", map.get(1005));
 		assertEquals("Kill soldiers", step.resolveDescription(9999));
 		assertEquals("Tier 1 override", step.resolveDescription(1001));
+	}
+
+	// ── Cyclopes defender tier chain (B4.3.3) ────────────────────────────────
+
+	/** Item IDs for the Warriors' Guild defender tier chain. */
+	private static final int BRONZE_DEFENDER = 8844;
+	private static final int IRON_DEFENDER   = 8845;
+	private static final int RUNE_DEFENDER   = 8850;
+	private static final int DRAGON_DEFENDER = 12954;
+
+	private static final String CYCLOPES_STATIC_DESC =
+		"Kill Cyclopes for defender drops. Each kill costs 10 warrior guild tokens";
+
+	/**
+	 * Verifies that resolveDescription returns the Iron defender override text
+	 * (containing both "Iron" and "Bronze") when targeted at the Iron defender item.
+	 * This exercises the mid-chain scenario where the player holds the previous tier.
+	 */
+	@Test
+	public void cyclopes_resolveDescription_ironDefender_mentionsBronzeHolding()
+	{
+		Map<Integer, String> overrides = new HashMap<>();
+		overrides.put(BRONZE_DEFENDER,
+			"Kill Cyclopes (no prerequisite) to receive a Bronze defender and start the chain.");
+		overrides.put(IRON_DEFENDER,
+			"Kill Cyclopes while holding a Bronze defender in inventory to receive an Iron defender.");
+		overrides.put(RUNE_DEFENDER,
+			"Kill Cyclopes while holding an Adamant defender in inventory to receive a Rune defender.");
+		overrides.put(DRAGON_DEFENDER,
+			"Kill Cyclopes while holding a Rune defender in inventory to receive the Dragon defender.");
+
+		GuidanceStep step = stepWithOverrides(CYCLOPES_STATIC_DESC, overrides);
+
+		String resolved = step.resolveDescription(IRON_DEFENDER);
+		assertTrue("Override for Iron defender must mention 'Iron'",
+			resolved.contains("Iron"));
+		assertTrue("Override for Iron defender must mention 'Bronze' (what to hold)",
+			resolved.contains("Bronze"));
+	}
+
+	/**
+	 * Verifies that the Dragon defender entry (the terminal tier) resolves
+	 * correctly and references the Rune defender as the required held item.
+	 */
+	@Test
+	public void cyclopes_resolveDescription_dragonDefender_mentionsRuneHolding()
+	{
+		Map<Integer, String> overrides = new HashMap<>();
+		overrides.put(DRAGON_DEFENDER,
+			"Kill Cyclopes while holding a Rune defender in inventory to receive the Dragon defender.");
+
+		GuidanceStep step = stepWithOverrides(CYCLOPES_STATIC_DESC, overrides);
+
+		String resolved = step.resolveDescription(DRAGON_DEFENDER);
+		assertTrue("Dragon defender override must mention 'Dragon'",
+			resolved.contains("Dragon"));
+		assertTrue("Dragon defender override must mention 'Rune' (what to hold)",
+			resolved.contains("Rune"));
+	}
+
+	/**
+	 * When no targetItemId is supplied the coordinator has no active item in context
+	 * (e.g. the source has multiple uncollected tiers). The static generic description
+	 * should be returned unchanged.
+	 */
+	@Test
+	public void cyclopes_resolveDescription_noTarget_returnsStaticDescription()
+	{
+		Map<Integer, String> overrides = new HashMap<>();
+		overrides.put(BRONZE_DEFENDER,
+			"Kill Cyclopes (no prerequisite) to receive a Bronze defender and start the chain.");
+		overrides.put(IRON_DEFENDER,
+			"Kill Cyclopes while holding a Bronze defender in inventory to receive an Iron defender.");
+
+		GuidanceStep step = stepWithOverrides(CYCLOPES_STATIC_DESC, overrides);
+
+		assertEquals(CYCLOPES_STATIC_DESC, step.resolveDescription(null));
 	}
 
 	// ── resolveNpcId constants ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Backfills `perItemStepDescription` for the Cyclopes kill step (step 2) in the Warriors' Guild source, closing out B4.3.3 from the #420 per-item differentiation survey (Phase 3, P3 candidate #5).

### Defender tier mapping (8 items)

| Item ID | Defender | Held prerequisite |
|---------|----------|-------------------|
| 8844 | Bronze defender | None (chain start) |
| 8845 | Iron defender | Bronze defender |
| 8846 | Steel defender | Iron defender |
| 8847 | Black defender | Steel defender |
| 8848 | Mithril defender | Black defender |
| 8849 | Adamant defender | Mithril defender |
| 8850 | Rune defender | Adamant defender |
| 12954 | Dragon defender | Rune defender |

Each override description names both the tier being targeted and the defender that must be held in inventory for the drop to land. The static fallback ("Kill Cyclopes for defender drops...") is preserved for null-target resolution when multiple tiers are still uncollected.

## Data hygiene

- JSON validates cleanly (`json.load` passes, 225 sources).
- Em-dash check: no mojibake (`â` byte) found in the file.
- No changes to `requiresPrevious: true` flags or item IDs — data only.

## Tests added

Three new cases in `GuidanceStepTest` (B4.3.3 section):

- `cyclopes_resolveDescription_ironDefender_mentionsBronzeHolding` — mid-chain scenario; override contains both "Iron" and "Bronze".
- `cyclopes_resolveDescription_dragonDefender_mentionsRuneHolding` — terminal tier; override contains "Dragon" and "Rune".
- `cyclopes_resolveDescription_noTarget_returnsStaticDescription` — null targetItemId returns the generic static description.

## Verification

- `./gradlew test` — BUILD SUCCESSFUL
- `./gradlew build` — BUILD SUCCESSFUL

Closes #420 (B4.3.3 sub-item)