### PR TITLE
feat(guidance): B4.4 — Top Pick auto-advance carries per-item target ID (#420)

### DIFF
--- a/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
@@ -839,12 +839,21 @@ public class CollectionLogHelperPlugin extends Plugin
 		rankedSourcesDirty = true;
 		if (config.autoAdvanceGuidance())
 		{
-			// Auto-activate guidance for the next top efficiency pick
+			// Auto-activate guidance for the next top efficiency pick.
+			// Pass the best-item target ID (B4.4) so per-item overrides
+			// (perItemRequiredItemIds, perItemStepDescription, perItemNpcId)
+			// activate automatically without the user right-clicking an item.
 			List<ScoredItem> ranked = getRankedSources();
 			ranked.stream()
 				.filter(s -> !s.isLocked())
 				.findFirst()
-				.ifPresent(topPick -> activateGuidance(topPick.getSource()));
+				.ifPresent(topPick ->
+				{
+					Integer targetItemId = topPick.getBestItem() != null
+						? topPick.getBestItem().getItemId()
+						: null;
+					activateGuidance(topPick.getSource(), targetItemId);
+				});
 		}
 	}
 

--- a/src/test/java/com/collectionloghelper/OnSequenceCompletePerItemTest.java
+++ b/src/test/java/com/collectionloghelper/OnSequenceCompletePerItemTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper;
+
+import com.collectionloghelper.data.CollectionLogCategory;
+import com.collectionloghelper.data.CollectionLogItem;
+import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.efficiency.EfficiencyCalculator;
+import com.collectionloghelper.efficiency.ScoredItem;
+import com.collectionloghelper.guidance.GuidanceOverlayCoordinator;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for B4.4: {@code onSequenceComplete()} must pass the best-item target ID
+ * from the top-ranked {@link ScoredItem} to
+ * {@link CollectionLogHelperPlugin#activateGuidance(CollectionLogSource, Integer)}
+ * when auto-advancing guidance after a sequence completes.
+ *
+ * <p>This ensures per-item overrides ({@code perItemRequiredItemIds},
+ * {@code perItemStepDescription}, {@code perItemNpcId}) activate automatically
+ * without the user right-clicking on a specific item.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class OnSequenceCompletePerItemTest
+{
+	private static final int BEST_ITEM_ID = 1234;
+
+	@Mock
+	private net.runelite.client.callback.ClientThread clientThread;
+
+	@Mock
+	private GuidanceOverlayCoordinator guidanceCoordinator;
+
+	@Mock
+	private CollectionLogHelperConfig config;
+
+	@Mock
+	private EfficiencyCalculator calculator;
+
+	private CollectionLogHelperPlugin plugin;
+
+	@Before
+	public void setUp() throws Exception
+	{
+		plugin = new CollectionLogHelperPlugin();
+		injectField("clientThread", clientThread);
+		injectField("guidanceCoordinator", guidanceCoordinator);
+		injectField("config", config);
+		injectField("calculator", calculator);
+
+		// Make clientThread.invokeLater execute the runnable immediately so
+		// coordinator.activateGuidance is reachable within the same test call.
+		doAnswer(inv ->
+		{
+			Runnable r = inv.getArgument(0);
+			r.run();
+			return null;
+		}).when(clientThread).invokeLater(any(Runnable.class));
+
+		when(config.autoAdvanceGuidance()).thenReturn(true);
+	}
+
+	/**
+	 * When the top-ranked {@code ScoredItem} has a non-null {@code bestItem},
+	 * {@code onSequenceComplete} must call
+	 * {@code coordinator.activateGuidance(source, location, bestItem.getItemId())}.
+	 */
+	@Test
+	public void onSequenceComplete_withBestItem_passesBestItemIdToCoordinator() throws Exception
+	{
+		CollectionLogSource source = minimalSource("Test Source");
+		CollectionLogItem bestItem = new CollectionLogItem(
+			BEST_ITEM_ID, "Test Item", 1.0 / 128, false, null, 0, 0, false, false);
+		ScoredItem topPick = new ScoredItem(source, 100.0, 1, "Best", false, 100.0, bestItem, 100.0);
+
+		when(calculator.rankByEfficiency()).thenReturn(Collections.singletonList(topPick));
+
+		invokeOnSequenceComplete();
+
+		ArgumentCaptor<Integer> itemIdCaptor = ArgumentCaptor.forClass(Integer.class);
+		verify(guidanceCoordinator).activateGuidance(eq(source), any(), itemIdCaptor.capture());
+		assertEquals(BEST_ITEM_ID, (int) itemIdCaptor.getValue());
+	}
+
+	/**
+	 * When the top-ranked {@code ScoredItem} has {@code bestItem == null},
+	 * {@code onSequenceComplete} must call
+	 * {@code coordinator.activateGuidance(source, location, null)} and must not throw.
+	 */
+	@Test
+	public void onSequenceComplete_withNullBestItem_passesNullTargetIdToCoordinator() throws Exception
+	{
+		CollectionLogSource source = minimalSource("Null Best Item Source");
+		// bestItem is null — pure-guaranteed source or no specific item identified
+		ScoredItem topPick = new ScoredItem(source, 50.0, 2, "Some reason", false, 50.0, null, 0.0);
+
+		when(calculator.rankByEfficiency()).thenReturn(Collections.singletonList(topPick));
+
+		invokeOnSequenceComplete();
+
+		verify(guidanceCoordinator).activateGuidance(eq(source), any(), isNull());
+	}
+
+	// ── helpers ───────────────────────────────────────────────────────────────
+
+	/**
+	 * Invokes the private {@code onSequenceComplete()} method via reflection.
+	 */
+	private void invokeOnSequenceComplete() throws Exception
+	{
+		Method m = CollectionLogHelperPlugin.class.getDeclaredMethod("onSequenceComplete");
+		m.setAccessible(true);
+		m.invoke(plugin);
+	}
+
+	private void injectField(String fieldName, Object value) throws Exception
+	{
+		Field field = CollectionLogHelperPlugin.class.getDeclaredField(fieldName);
+		field.setAccessible(true);
+		field.set(plugin, value);
+	}
+
+	private static CollectionLogSource minimalSource(String name)
+	{
+		return new CollectionLogSource(
+			name,
+			CollectionLogCategory.BOSSES,
+			0, 0, 0,
+			0, 0,
+			null, null, null, 0.0,
+			null, 0, false, 0,
+			null, 0, null, null,
+			null,
+			null, 0, null, 0,
+			Collections.emptyList()
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Closes the B4.4 milestone: when the panel's auto-advance fires after a guidance sequence completes, the next-source guidance now activates with the per-item target ID set — so per-item overrides (`perItemRequiredItemIds`, `perItemStepDescription`, `perItemNpcId`) light up automatically without the user having to right-click → Guide Me on a specific item.

## Change

**One behavioral change at one site** — `onSequenceComplete()` in `CollectionLogHelperPlugin.java`:

```java
// Before
.ifPresent(topPick -> activateGuidance(topPick.getSource()));

// After (B4.4)
.ifPresent(topPick -> {
    Integer targetItemId = topPick.getBestItem() != null
        ? topPick.getBestItem().getItemId()
        : null;
    activateGuidance(topPick.getSource(), targetItemId);
});
```

`ScoredItem.getBestItem()` already returns "the single most efficient missing item from this source." The 2-arg `activateGuidance(source, targetItemId)` was introduced in an earlier PR and already handles null `targetItemId` by falling back to static guidance behaviour.

## Call-site audit

All callers of `activateGuidance` were reviewed:

| Site | Disposition |
|------|-------------|
| `Plugin.java:847` (Top Pick auto-advance) | **Fixed** — now passes `getBestItem().getItemId()` |
| `Plugin.java:781` (1-arg trampoline overload) | Left as-is — it is the delegation target itself |
| `GuidanceEventRouter.java:402` (right-click NPC "Collection Log Guide" menu) | Left as 1-arg — user clicked a source name, no item context |
| `QuickGuidePanelView.java` ("Guide Me" button) | Already passes `topItemId` via the 2-arg `BiConsumer` — no change needed |
| `ActivateGuidanceClientThreadTest.java` | Test helper calls 1-arg; tests client-thread routing, not per-item — correct as-is |

No other auto-advance-style sites where a `ScoredItem` is in scope were found.

## Tests added

`OnSequenceCompletePerItemTest` (new file):

- **`onSequenceComplete_withBestItem_passesBestItemIdToCoordinator`** — mocks the ranker to return a `ScoredItem` with `bestItem.itemId == 1234`; triggers `onSequenceComplete()` via reflection; asserts `coordinator.activateGuidance` receives `targetItemId == 1234`.
- **`onSequenceComplete_withNullBestItem_passesNullTargetIdToCoordinator`** — same setup with `bestItem == null`; asserts `coordinator.activateGuidance` receives `null` and does not throw.