### PR TITLE
data(auto-completion): Tier 3 CHAT_MESSAGE_RECEIVED backfill for 2 sources (#306)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -11308,7 +11308,8 @@
         "worldX": 2809,
         "worldY": 3194,
         "worldPlane": 0,
-        "completionCondition": "MANUAL"
+        "completionCondition": "CHAT_MESSAGE_RECEIVED",
+        "completionChatPattern": "You have received an Agility Arena Ticket"
       }
     ],
     "rewardType": "SHOP",
@@ -11579,7 +11580,8 @@
           "Intermediate",
           "Veteran"
         ],
-        "completionCondition": "MANUAL"
+        "completionCondition": "CHAT_MESSAGE_RECEIVED",
+        "completionChatPattern": "You have successfully defended the island!"
       }
     ],
     "rewardType": "SHOP",

--- a/src/test/java/com/collectionloghelper/data/DropRateDatabaseTest.java
+++ b/src/test/java/com/collectionloghelper/data/DropRateDatabaseTest.java
@@ -385,4 +385,93 @@ public class DropRateDatabaseTest
 			}
 		}
 	}
+
+	// ========================================================================
+	// Issue #306 Tier 3 backfill — CHAT_MESSAGE_RECEIVED upgrades
+	// ========================================================================
+
+	/**
+	 * Brimhaven Agility Arena final step must use CHAT_MESSAGE_RECEIVED with the
+	 * confirmed per-ticket award message (OSRS Wiki: Ticket_Dispenser).
+	 */
+	@Test
+	public void spotCheck_brimhavenAgilityArena_finalStep_isChatMessageReceived()
+	{
+		CollectionLogSource source = database.getSourceByName("Brimhaven Agility Arena");
+		assertNotNull("Brimhaven Agility Arena source must exist", source);
+
+		List<GuidanceStep> steps = source.getGuidanceSteps();
+		assertNotNull("Brimhaven Agility Arena must have guidance steps", steps);
+		assertFalse("Brimhaven Agility Arena must have at least one step", steps.isEmpty());
+
+		GuidanceStep finalStep = steps.get(steps.size() - 1);
+		assertEquals(
+			"Brimhaven Agility Arena final step must use CHAT_MESSAGE_RECEIVED",
+			CompletionCondition.CHAT_MESSAGE_RECEIVED,
+			finalStep.getCompletionCondition());
+		assertNotNull(
+			"Brimhaven Agility Arena final step must have a completionChatPattern",
+			finalStep.getCompletionChatPattern());
+		assertTrue(
+			"Brimhaven Agility Arena chat pattern must match ticket award message",
+			"You have received an Agility Arena Ticket and Brimhaven Voucher!"
+				.contains(finalStep.getCompletionChatPattern()));
+	}
+
+	/**
+	 * Pest Control final step must use CHAT_MESSAGE_RECEIVED with the confirmed
+	 * game-win message (OSRS Wiki: Pest_Control).
+	 */
+	@Test
+	public void spotCheck_pestControl_finalStep_isChatMessageReceived()
+	{
+		CollectionLogSource source = database.getSourceByName("Pest Control");
+		assertNotNull("Pest Control source must exist", source);
+
+		List<GuidanceStep> steps = source.getGuidanceSteps();
+		assertNotNull("Pest Control must have guidance steps", steps);
+		assertFalse("Pest Control must have at least one step", steps.isEmpty());
+
+		GuidanceStep finalStep = steps.get(steps.size() - 1);
+		assertEquals(
+			"Pest Control final step must use CHAT_MESSAGE_RECEIVED",
+			CompletionCondition.CHAT_MESSAGE_RECEIVED,
+			finalStep.getCompletionCondition());
+		assertNotNull(
+			"Pest Control final step must have a completionChatPattern",
+			finalStep.getCompletionChatPattern());
+		assertEquals(
+			"Pest Control chat pattern must match game-win message exactly",
+			"You have successfully defended the island!",
+			finalStep.getCompletionChatPattern());
+	}
+
+	/**
+	 * Every CHAT_MESSAGE_RECEIVED step in the database must have a non-null,
+	 * non-empty completionChatPattern (schema invariant).
+	 */
+	@Test
+	public void load_allChatMessageReceivedSteps_haveNonEmptyPattern()
+	{
+		for (CollectionLogSource source : database.getAllSources())
+		{
+			if (source.getGuidanceSteps() == null)
+			{
+				continue;
+			}
+			for (GuidanceStep step : source.getGuidanceSteps())
+			{
+				if (step.getCompletionCondition() == CompletionCondition.CHAT_MESSAGE_RECEIVED)
+				{
+					String ctx = source.getName() + " / " + step.getDescription();
+					assertNotNull(
+						"CHAT_MESSAGE_RECEIVED step must have completionChatPattern: " + ctx,
+						step.getCompletionChatPattern());
+					assertFalse(
+						"CHAT_MESSAGE_RECEIVED step must have non-empty completionChatPattern: " + ctx,
+						step.getCompletionChatPattern().isEmpty());
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
## Summary

Partial fix for #306. Upgrades 2 of 8 Tier 3 MANUAL final steps to `CHAT_MESSAGE_RECEIVED` using patterns verified against the OSRS Wiki.

## Sources shipped

| Source | Condition | Pattern | Wiki source |
|---|---|---|---|
| Pest Control | `CHAT_MESSAGE_RECEIVED` | `You have successfully defended the island!` | [wiki/Pest_Control](https://oldschool.runescape.wiki/w/Pest_Control) |
| Brimhaven Agility Arena | `CHAT_MESSAGE_RECEIVED` | `You have received an Agility Arena Ticket` | [wiki/Ticket_Dispenser](https://oldschool.runescape.wiki/w/Ticket_Dispenser) |

Both patterns are `GAMEMESSAGE`-type messages listed verbatim on the OSRS Wiki. The sequencer uses `Pattern.compile(pattern).matcher(message).find()` so these are substring-match patterns (no special regex chars needed).

## Sources left as MANUAL (with reason)

| Source | Reason |
|---|---|
| Soul Wars | No game-end chat message documented on wiki; issue owner confirmed these don't send KC-style messages |
| Fishing Trawler | No round-complete message documented on wiki |
| Volcanic Mine | No round-end message documented on wiki |
| Pyramid Plunder | No chest loot / run-end message documented on wiki |
| Rogues' Den | No maze completion message documented on wiki |
| Trouble Brewing | No game-end message documented on wiki |

All 6 require in-game authoring-log capture (per issue label `needs-in-game-capture`).

## Tier 2 status (ACTOR_DEATH)

All 3 Tier 2 sources were already patched before this branch:
- Armoured Zombie — `ACTOR_DEATH` npcId 14113
- Ogress Shaman — `ACTOR_DEATH` npcId 7991
- Prifddinas Rabbit — `ACTOR_DEATH` npcId 9118

No changes made to these.

## Em-dash check

No em-dashes or en-dashes found in `drop_rates.json` (verified via Python check).

## Tests added

- `spotCheck_brimhavenAgilityArena_finalStep_isChatMessageReceived` — asserts condition + pattern substring match
- `spotCheck_pestControl_finalStep_isChatMessageReceived` — asserts condition + exact pattern string
- `load_allChatMessageReceivedSteps_haveNonEmptyPattern` — schema invariant: every `CHAT_MESSAGE_RECEIVED` step must have a non-null, non-empty pattern

## Test plan

- [x] `./gradlew test` passes (BUILD SUCCESSFUL)
- [x] `./gradlew build` passes (BUILD SUCCESSFUL)
- [x] JSON parses cleanly (225 sources loaded)
- [x] Em-dash check clean
- [x] All 3 new tests pass

Fixes #306 (partial — 2 of 8 Tier 3 sources shipped)