### PR TITLE
feat(overlay): B.5.7 — dialog highlight polish (color/flicker/primary)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -569,7 +569,7 @@ Focus: god-object decomposition, build hardening, test expansion. Resulted in th
 - [ ] B.5.4 — Collapsible step sections                 status: planned       owner: —          updated: 2026-05-10  note: `section` field on step, auto-expand active section; cha-ndler/collection-log-helper#382
 - [ ] B.5.5 — Per-step world map arrow + destination icon  status: planned    owner: —          updated: 2026-05-10  note: Quest-Helper-style arrow + NPC/object icon at step destination; cha-ndler/collection-log-helper#382
 - [ ] B.5.6 — Object/NPC outline-glow highlight style   status: planned       owner: —          updated: 2026-05-10  issue: cha-ndler/collection-log-helper#377
-- [ ] B.5.7 — Dialog choice highlighting polish         status: planned       owner: —          updated: 2026-05-10  note: audit existing `dialogHighlight` overlay; cha-ndler/collection-log-helper#382
+- [/] B.5.7 — Dialog choice highlighting polish         status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #449
 
 **Tier C — Player-aware guidance**
 

--- a/src/main/java/com/collectionloghelper/overlay/DialogHighlightOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/DialogHighlightOverlay.java
@@ -25,10 +25,12 @@
 package com.collectionloghelper.overlay;
 
 import com.collectionloghelper.CollectionLogHelperConfig;
+import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
+import java.awt.RenderingHints;
 import java.util.ArrayList;
 import java.util.List;
 import javax.inject.Inject;
@@ -61,6 +63,14 @@ public class DialogHighlightOverlay extends Overlay
 	private static final int BACKGROUND_PADDING_Y = 2;
 	private static final int BACKGROUND_ALPHA = 50;
 	private static final int BORDER_ALPHA = 120;
+	/** Higher-opacity border for the primary (first-listed) recommended option. */
+	private static final int PRIMARY_BORDER_ALPHA = 220;
+
+	/** Thin border stroke for secondary/additional matched options. */
+	private static final BasicStroke SECONDARY_STROKE = new BasicStroke(1.0f);
+	/** Thicker border stroke for the primary recommended option — visually distinct. */
+	private static final BasicStroke PRIMARY_STROKE = new BasicStroke(2.5f,
+		BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND);
 
 	private final Client client;
 	private final CollectionLogHelperConfig config;
@@ -70,6 +80,7 @@ public class DialogHighlightOverlay extends Overlay
 	private Color cachedHighlightColor;
 	private Color cachedFillColor;
 	private Color cachedBorderColor;
+	private Color cachedPrimaryBorderColor;
 
 	@Inject
 	private DialogHighlightOverlay(Client client, CollectionLogHelperConfig config)
@@ -97,7 +108,11 @@ public class DialogHighlightOverlay extends Overlay
 				highlightColor.getBlue(), BACKGROUND_ALPHA);
 			cachedBorderColor = new Color(highlightColor.getRed(), highlightColor.getGreen(),
 				highlightColor.getBlue(), BORDER_ALPHA);
+			cachedPrimaryBorderColor = new Color(highlightColor.getRed(), highlightColor.getGreen(),
+				highlightColor.getBlue(), PRIMARY_BORDER_ALPHA);
 		}
+
+		graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
 
 		// Highlight matching dialog options and the continue prompt only when a
 		// dialog-choice step is active (targetDialogOptionsLower non-empty).
@@ -127,6 +142,9 @@ public class DialogHighlightOverlay extends Overlay
 		}
 
 		List<String> targets = targetDialogOptionsLower;
+		// primaryTarget is the first entry in the list — it receives a thicker border
+		// and higher-opacity colour so the recommended choice is visually distinct.
+		String primaryTarget = targets.isEmpty() ? null : targets.get(0);
 		for (Widget option : children)
 		{
 			if (option == null || option.getText() == null)
@@ -145,7 +163,8 @@ public class DialogHighlightOverlay extends Overlay
 			{
 				if (optionLower.contains(target))
 				{
-					renderWidgetHighlight(graphics, option, highlightColor);
+					boolean isPrimary = target.equals(primaryTarget);
+					renderWidgetHighlight(graphics, option, highlightColor, isPrimary);
 					break;
 				}
 			}
@@ -162,13 +181,22 @@ public class DialogHighlightOverlay extends Overlay
 
 		String text = continueWidget.getText();
 		// Highlight the continue prompt purely by drawing; do not mutate widget text colour.
+		// The continue prompt is always the sole action available, so it is always primary.
 		if (text != null && text.contains("Click here to continue"))
 		{
-			renderWidgetHighlight(graphics, continueWidget, highlightColor);
+			renderWidgetHighlight(graphics, continueWidget, highlightColor, true);
 		}
 	}
 
-	private void renderWidgetHighlight(Graphics2D graphics, Widget widget, Color highlightColor)
+	/**
+	 * Draws a highlight rectangle for {@code widget}.
+	 *
+	 * @param primary {@code true} for the first/recommended choice — renders with a
+	 *                thicker stroke and higher-opacity border so it stands out from
+	 *                secondary matches. {@code false} for additional matched options.
+	 */
+	private void renderWidgetHighlight(Graphics2D graphics, Widget widget,
+		Color highlightColor, boolean primary)
 	{
 		Rectangle bounds = widget.getBounds();
 		if (bounds == null || bounds.width <= 0 || bounds.height <= 0)
@@ -181,12 +209,14 @@ public class DialogHighlightOverlay extends Overlay
 		int width = bounds.width + BACKGROUND_PADDING_X * 2;
 		int height = bounds.height + BACKGROUND_PADDING_Y * 2;
 
-		// Semi-transparent fill similar to object/NPC highlight overlays
+		// Semi-transparent fill — same intensity for primary and secondary
 		graphics.setColor(cachedFillColor);
 		graphics.fillRect(x, y, width, height);
 
-		// Subtle border
-		graphics.setColor(cachedBorderColor);
+		// Primary choice: thicker stroke + higher-opacity border for clear visual priority.
+		// Secondary choices: thin stroke + normal-opacity border.
+		graphics.setStroke(primary ? PRIMARY_STROKE : SECONDARY_STROKE);
+		graphics.setColor(primary ? cachedPrimaryBorderColor : cachedBorderColor);
 		graphics.drawRect(x, y, width, height);
 	}
 

--- a/src/test/java/com/collectionloghelper/overlay/DialogHighlightOverlayTest.java
+++ b/src/test/java/com/collectionloghelper/overlay/DialogHighlightOverlayTest.java
@@ -25,10 +25,12 @@
 package com.collectionloghelper.overlay;
 
 import com.collectionloghelper.CollectionLogHelperConfig;
+import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
+import java.awt.Stroke;
 import java.util.Arrays;
 import java.util.Collections;
 import net.runelite.api.Client;
@@ -37,10 +39,12 @@ import net.runelite.api.widgets.Widget;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -311,6 +315,81 @@ public class DialogHighlightOverlayTest
 		overlay.render(graphics);
 
 		verify(graphics).fillRect(anyInt(), anyInt(), anyInt(), anyInt());
+	}
+
+	// --- primary vs. secondary stroke ---
+
+	@Test
+	public void render_primaryOption_usesPrimaryStroke()
+	{
+		// The first entry in dialogOptions is primary; its border should use a thicker stroke.
+		overlay.setGuidanceActive(true);
+		overlay.setTargetDialogOptions(Collections.singletonList("yes"));
+
+		Widget option = mockOption("Yes please", new Rectangle(10, 20, 200, 16));
+		Widget container = mockContainer(new Widget[]{option});
+		when(client.getWidget(DIALOG_OPTION_GROUP, DIALOG_OPTION_CHILD)).thenReturn(container);
+		when(client.getWidget(NPC_DIALOG_GROUP, NPC_DIALOG_CONTINUE_CHILD)).thenReturn(null);
+
+		overlay.render(graphics);
+
+		ArgumentCaptor<Stroke> strokeCaptor = ArgumentCaptor.forClass(Stroke.class);
+		verify(graphics).setStroke(strokeCaptor.capture());
+		Stroke usedStroke = strokeCaptor.getValue();
+		assertTrue("Primary option should use a BasicStroke", usedStroke instanceof BasicStroke);
+		assertTrue("Primary stroke width should be > 1.0f",
+			((BasicStroke) usedStroke).getLineWidth() > 1.0f);
+	}
+
+	@Test
+	public void render_secondaryOption_usesSecondaryStroke()
+	{
+		// When both a primary and a secondary option are present, the secondary uses thin stroke.
+		overlay.setGuidanceActive(true);
+		// "bank" is primary, "yes" is secondary
+		overlay.setTargetDialogOptions(Arrays.asList("bank", "yes"));
+
+		Widget optionBank = mockOption("Use the Bank", new Rectangle(10, 20, 200, 16));
+		Widget optionYes  = mockOption("Yes", new Rectangle(10, 40, 200, 16));
+		Widget container  = mockContainer(new Widget[]{optionBank, optionYes});
+		when(client.getWidget(DIALOG_OPTION_GROUP, DIALOG_OPTION_CHILD)).thenReturn(container);
+		when(client.getWidget(NPC_DIALOG_GROUP, NPC_DIALOG_CONTINUE_CHILD)).thenReturn(null);
+
+		overlay.render(graphics);
+
+		ArgumentCaptor<Stroke> strokeCaptor = ArgumentCaptor.forClass(Stroke.class);
+		// Two setStroke calls: one for primary (bank) and one for secondary (yes)
+		verify(graphics, org.mockito.Mockito.times(2)).setStroke(strokeCaptor.capture());
+		java.util.List<Stroke> strokes = strokeCaptor.getAllValues();
+		float primaryWidth   = ((BasicStroke) strokes.get(0)).getLineWidth();
+		float secondaryWidth = ((BasicStroke) strokes.get(1)).getLineWidth();
+		assertTrue("Primary stroke must be thicker than secondary",
+			primaryWidth > secondaryWidth);
+	}
+
+	@Test
+	public void render_continuePrompt_usesPrimaryStroke()
+	{
+		// The continue prompt is the only available action; it is always primary.
+		overlay.setGuidanceActive(true);
+		overlay.setTargetDialogOptions(Collections.singletonList("teleport"));
+
+		when(client.getWidget(DIALOG_OPTION_GROUP, DIALOG_OPTION_CHILD)).thenReturn(null);
+
+		Widget continueWidget = mock(Widget.class);
+		when(continueWidget.isHidden()).thenReturn(false);
+		when(continueWidget.getText()).thenReturn("Click here to continue");
+		when(continueWidget.getBounds()).thenReturn(new Rectangle(50, 400, 300, 20));
+		when(client.getWidget(NPC_DIALOG_GROUP, NPC_DIALOG_CONTINUE_CHILD)).thenReturn(continueWidget);
+
+		overlay.render(graphics);
+
+		ArgumentCaptor<Stroke> strokeCaptor = ArgumentCaptor.forClass(Stroke.class);
+		verify(graphics).setStroke(strokeCaptor.capture());
+		Stroke usedStroke = strokeCaptor.getValue();
+		assertTrue("Continue prompt should use a BasicStroke", usedStroke instanceof BasicStroke);
+		assertTrue("Continue prompt stroke width should be > 1.0f",
+			((BasicStroke) usedStroke).getLineWidth() > 1.0f);
 	}
 
 	// --- helpers ---


### PR DESCRIPTION
## Milestone

B.5.7 — Dialog choice highlighting polish.

## Audit findings (what was wrong before)

Reviewing `DialogHighlightOverlay` against the B.5.7 spec and the `WorldMapDestinationOverlay` / `WidgetHighlightOverlay` baseline:

1. **No BasicStroke constant** — `renderWidgetHighlight` called `graphics.drawRect` using whatever stroke was left on the `Graphics2D` context from the previous overlay pass. Other overlays (e.g. `WidgetHighlightOverlay`) hoist a class-level `STROKE_2` to avoid this; `DialogHighlightOverlay` did not.

2. **No primary-choice indicator** — every matched option and the continue prompt rendered with the same fill + same-alpha border. When a step lists multiple acceptable answers (e.g. `["yes", "continue"]`) there was no visual cue indicating which one is preferred.

3. **No anti-aliasing** — `WorldMapDestinationOverlay` sets `VALUE_ANTIALIAS_ON` in its render path; `DialogHighlightOverlay` did not, producing slightly jagged rect outlines on scaled displays.

4. **`cachedPrimaryBorderColor` missing** — only two color cache slots existed (`cachedFillColor`, `cachedBorderColor`). Adding the primary variant required a third, computed alongside the others.

No flicker source was found: the existing color-equality cache already prevented per-frame `Color` allocation; that aspect required no change.

## Changes made

- `BasicStroke` constants hoisted to class level (`PRIMARY_STROKE` 2.5 px rounded, `SECONDARY_STROKE` 1 px); no stroke is left to chance from a prior overlay pass.
- `PRIMARY_BORDER_ALPHA = 220` added alongside existing `BORDER_ALPHA = 120`; `cachedPrimaryBorderColor` cached and invalidated with the other colors.
- `RenderingHints.VALUE_ANTIALIAS_ON` applied at render entry, consistent with `WorldMapDestinationOverlay`.
- First entry in `dialogOptions` is the primary choice: rendered with `PRIMARY_STROKE` + high-opacity border. Subsequent matches use `SECONDARY_STROKE` + normal-opacity border.
- `Click here to continue` prompt always treated as primary (sole available action in that state).
- Three new unit tests assert primary stroke width > 1, secondary stroke < primary, continue = primary.

Total diff: ~90 lines across `DialogHighlightOverlay.java` and `DialogHighlightOverlayTest.java`.

## In-client validation needed

Swing rendering cannot be asserted headlessly. Confirm in a live RuneLite session:

- [ ] Single `dialogOptions` entry: matching choice shows thick (2.5 px) near-opaque border.
- [ ] Two `dialogOptions` entries: first shows thick border, second shows thin (1 px) border.
- [ ] `Click here to continue` prompt shows thick border.
- [ ] No flicker between frames when dialog is open.
- [ ] Rect outlines appear smoother on scaled (>100%) display scaling.
- [ ] Non-guidance dialogs (guidanceActive = false or empty options) show no highlight.