### PR TITLE
ci: F6 — GitHub Actions build + test workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: Build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: 'gradle'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build
+        run: ./gradlew build --no-daemon
+
+      - name: Run tests
+        run: ./gradlew test --no-daemon
+
+      - name: Upload test report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report
+          path: build/reports/tests/test/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Collection Log Helper
 
+[![Build](https://github.com/cha-ndler/collection-log-helper/actions/workflows/build.yml/badge.svg)](https://github.com/cha-ndler/collection-log-helper/actions/workflows/build.yml)
+
 Ranks every collection log source by efficiency and guides you there step-by-step — like Quest Helper, but for the collection log.
 
 2,109 items across 225 sources. Drop rates wiki-verified. Kill times aligned with TempleOSRS EHB rates.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -601,5 +601,5 @@ Focus: god-object decomposition, build hardening, test expansion. Resulted in th
 - [ ] F3 — Per-account kill-time learning               status: planned       owner: —          updated: 2026-04-16
 - [ ] F4 — Dry-streak feed                              status: planned       owner: —          updated: 2026-04-16
 - [ ] F5 — JaCoCo + 80% gate                            status: planned       owner: —          updated: 2026-04-16
-- [ ] F6 — GitHub Actions CI                            status: planned       owner: —          updated: 2026-04-16
+- [/] F6 — GitHub Actions CI                            status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #451  note: build+test workflow on PR/push; verify first CI run is green before moving to [x].
 - [ ] F7 — Issue #134 account-specific calcs            status: planned       owner: —          updated: 2026-04-16


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/build.yml` — F6 milestone from the project roadmap
- Workflow runs on every push to `master` and every PR targeting `master`
- Steps: checkout, set up JDK 11 (Temurin, matching `options.release.set(11)` in `build.gradle`), Gradle cache, `./gradlew build --no-daemon`, `./gradlew test --no-daemon`
- On failure, the HTML test report (`build/reports/tests/test/`) is uploaded as a GitHub Actions artifact for diagnosis
- Adds a build-status badge to README.md pointing at this workflow

## Verification

- Local `./gradlew build` passes (BUILD SUCCESSFUL, 6 tasks executed)
- Verify the first CI run on this PR is green before moving F6 to `[x]` in the roadmap

## Test plan

- [ ] Open this PR and confirm the Actions run triggers automatically
- [ ] Confirm the `Build` job completes green (all steps pass)
- [ ] Confirm the badge renders correctly in README.md on the PR preview
- [ ] Merge and confirm the push-to-master trigger also fires green