### PR TITLE
feat(player): C3 — diary tier state model

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -575,7 +575,7 @@ Focus: god-object decomposition, build hardening, test expansion. Resulted in th
 
 - [ ] C1 — POH teleport inventory model                 status: planned       owner: —          updated: 2026-04-16
 - [ ] C2 — Equipped-item state                          status: planned       owner: —          updated: 2026-04-16
-- [ ] C3 — Diary tier state                             status: planned       owner: —          updated: 2026-04-16
+- [/] C3 — Diary tier state                             status: in-progress   owner: —          updated: 2026-05-14  pr: #461
 - [ ] C4 — Skill-cape perk state                        status: planned       owner: —          updated: 2026-04-16
 - [ ] C5 — Partial-quest state                          status: planned       owner: —          updated: 2026-04-16
 - [ ] C6 — Wire into top-20 sources                     status: planned       owner: —          updated: 2026-04-16

--- a/src/main/java/com/collectionloghelper/player/DiaryRegion.java
+++ b/src/main/java/com/collectionloghelper/player/DiaryRegion.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.player;
+
+/**
+ * The twelve Achievement Diary regions in Old School RuneScape.
+ * <p>
+ * The {@link #varbitPrefix} matches the {@code DIARY_<PREFIX>_<TIER>} naming
+ * convention used in RuneLite's {@code Varbits} class, allowing compile-time
+ * constant references to be looked up by name at runtime if needed.
+ */
+public enum DiaryRegion
+{
+	ARDOUGNE("ARDOUGNE"),
+	DESERT("DESERT"),
+	FALADOR("FALADOR"),
+	FREMENNIK("FREMENNIK"),
+	KANDARIN("KANDARIN"),
+	KARAMJA("KARAMJA"),
+	KOUREND("KOUREND"),
+	LUMBRIDGE("LUMBRIDGE"),
+	MORYTANIA("MORYTANIA"),
+	VARROCK("VARROCK"),
+	WESTERN("WESTERN"),
+	WILDERNESS("WILDERNESS");
+
+	/** Segment of the Varbits constant name: {@code DIARY_<varbitPrefix>_<tier>}. */
+	private final String varbitPrefix;
+
+	DiaryRegion(String varbitPrefix)
+	{
+		this.varbitPrefix = varbitPrefix;
+	}
+
+	public String getVarbitPrefix()
+	{
+		return varbitPrefix;
+	}
+}

--- a/src/main/java/com/collectionloghelper/player/DiaryTier.java
+++ b/src/main/java/com/collectionloghelper/player/DiaryTier.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.player;
+
+/**
+ * The four completion tiers for an Achievement Diary region, ordered by
+ * ascending difficulty.
+ * <p>
+ * The {@link #varbitSuffix} matches the suffix used in RuneLite's
+ * {@code Varbits} constant names: {@code DIARY_<REGION>_<varbitSuffix>}.
+ */
+public enum DiaryTier
+{
+	EASY("EASY"),
+	MEDIUM("MEDIUM"),
+	HARD("HARD"),
+	ELITE("ELITE");
+
+	/** Suffix of the Varbits constant name: {@code DIARY_<region>_<varbitSuffix>}. */
+	private final String varbitSuffix;
+
+	DiaryTier(String varbitSuffix)
+	{
+		this.varbitSuffix = varbitSuffix;
+	}
+
+	public String getVarbitSuffix()
+	{
+		return varbitSuffix;
+	}
+}

--- a/src/main/java/com/collectionloghelper/player/DiaryTierState.java
+++ b/src/main/java/com/collectionloghelper/player/DiaryTierState.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.player;
+
+/**
+ * Read-only view of a player's Achievement Diary completion state.
+ * <p>
+ * Implementations cache the varbit values read from the RuneLite client and
+ * expose them through this interface so callers (branch selectors, requirement
+ * checkers, UI components) are decoupled from the RuneLite API.
+ *
+ * <p>Usage:
+ * <pre>{@code
+ * if (diaryTierState.hasDiary(DiaryRegion.KARAMJA, DiaryTier.HARD)) {
+ *     // player has Karamja Hard diary complete
+ * }
+ * }</pre>
+ */
+public interface DiaryTierState
+{
+	/**
+	 * Returns {@code true} if the player has completed the given diary tier for
+	 * the given region.
+	 *
+	 * @param region the diary region (e.g. {@link DiaryRegion#KARAMJA})
+	 * @param tier   the difficulty tier (e.g. {@link DiaryTier#HARD})
+	 * @return {@code true} if the diary is complete, {@code false} otherwise
+	 */
+	boolean hasDiary(DiaryRegion region, DiaryTier tier);
+
+	/**
+	 * Refreshes all cached varbit values from the RuneLite client.
+	 * Must be called on the client thread (e.g. in a {@code VarbitChanged}
+	 * event handler or after login).
+	 */
+	void refresh();
+
+	/**
+	 * Resets all cached state to {@code false} (e.g. on logout).
+	 */
+	void reset();
+}

--- a/src/main/java/com/collectionloghelper/player/DiaryTierStateImpl.java
+++ b/src/main/java/com/collectionloghelper/player/DiaryTierStateImpl.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.player;
+
+import java.util.EnumMap;
+import java.util.Map;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.Varbits;
+
+/**
+ * RuneLite-backed implementation of {@link DiaryTierState}.
+ * <p>
+ * Reads the canonical Achievement Diary completion varbits (one per
+ * region-tier pair) via the RuneLite {@link Client} and caches them in an
+ * in-memory map. The map is populated once per {@link #refresh()} call and
+ * cleared on {@link #reset()}.
+ * <p>
+ * Varbit IDs are sourced from {@link Varbits} using the
+ * {@code DIARY_<REGION>_<TIER>} naming convention. All 48 region-tier
+ * combinations are wired explicitly so the compiler catches any future
+ * constant renames.
+ * <p>
+ * Varbit values observed:
+ * <ul>
+ *   <li>Ardougne:  Easy=4458, Medium=4459, Hard=4460, Elite=4461</li>
+ *   <li>Desert:    Easy=4483, Medium=4484, Hard=4485, Elite=4486</li>
+ *   <li>Falador:   Easy=4462, Medium=4463, Hard=4464, Elite=4465</li>
+ *   <li>Fremennik: Easy=4491, Medium=4492, Hard=4493, Elite=4494</li>
+ *   <li>Kandarin:  Easy=4475, Medium=4476, Hard=4477, Elite=4478</li>
+ *   <li>Karamja:   Easy=3578, Medium=3599, Hard=3611, Elite=4566</li>
+ *   <li>Kourend:   Easy=7925, Medium=7926, Hard=7927, Elite=7928</li>
+ *   <li>Lumbridge: Easy=4495, Medium=4496, Hard=4497, Elite=4498</li>
+ *   <li>Morytania: Easy=4487, Medium=4488, Hard=4489, Elite=4490</li>
+ *   <li>Varrock:   Easy=4479, Medium=4480, Hard=4481, Elite=4482</li>
+ *   <li>Western:   Easy=4471, Medium=4472, Hard=4473, Elite=4474</li>
+ *   <li>Wilderness:Easy=4466, Medium=4467, Hard=4468, Elite=4469</li>
+ * </ul>
+ * <p>
+ * Reference: RuneLite AchievementDiaryPlugin.java
+ * https://github.com/runelite/runelite/blob/master/runelite-client/src/main/java/net/runelite/client/plugins/achievementdiary/AchievementDiaryPlugin.java
+ */
+@Slf4j
+@Singleton
+public class DiaryTierStateImpl implements DiaryTierState
+{
+	/**
+	 * Static lookup: region -> tier -> varbit ID.
+	 * Two-level EnumMap avoids boxing and provides O(1) access.
+	 */
+	private static final Map<DiaryRegion, Map<DiaryTier, Integer>> VARBIT_IDS;
+
+	static
+	{
+		VARBIT_IDS = new EnumMap<>(DiaryRegion.class);
+
+		addRegion(DiaryRegion.ARDOUGNE,
+			Varbits.DIARY_ARDOUGNE_EASY,
+			Varbits.DIARY_ARDOUGNE_MEDIUM,
+			Varbits.DIARY_ARDOUGNE_HARD,
+			Varbits.DIARY_ARDOUGNE_ELITE);
+
+		addRegion(DiaryRegion.DESERT,
+			Varbits.DIARY_DESERT_EASY,
+			Varbits.DIARY_DESERT_MEDIUM,
+			Varbits.DIARY_DESERT_HARD,
+			Varbits.DIARY_DESERT_ELITE);
+
+		addRegion(DiaryRegion.FALADOR,
+			Varbits.DIARY_FALADOR_EASY,
+			Varbits.DIARY_FALADOR_MEDIUM,
+			Varbits.DIARY_FALADOR_HARD,
+			Varbits.DIARY_FALADOR_ELITE);
+
+		addRegion(DiaryRegion.FREMENNIK,
+			Varbits.DIARY_FREMENNIK_EASY,
+			Varbits.DIARY_FREMENNIK_MEDIUM,
+			Varbits.DIARY_FREMENNIK_HARD,
+			Varbits.DIARY_FREMENNIK_ELITE);
+
+		addRegion(DiaryRegion.KANDARIN,
+			Varbits.DIARY_KANDARIN_EASY,
+			Varbits.DIARY_KANDARIN_MEDIUM,
+			Varbits.DIARY_KANDARIN_HARD,
+			Varbits.DIARY_KANDARIN_ELITE);
+
+		addRegion(DiaryRegion.KARAMJA,
+			Varbits.DIARY_KARAMJA_EASY,
+			Varbits.DIARY_KARAMJA_MEDIUM,
+			Varbits.DIARY_KARAMJA_HARD,
+			Varbits.DIARY_KARAMJA_ELITE);
+
+		addRegion(DiaryRegion.KOUREND,
+			Varbits.DIARY_KOUREND_EASY,
+			Varbits.DIARY_KOUREND_MEDIUM,
+			Varbits.DIARY_KOUREND_HARD,
+			Varbits.DIARY_KOUREND_ELITE);
+
+		addRegion(DiaryRegion.LUMBRIDGE,
+			Varbits.DIARY_LUMBRIDGE_EASY,
+			Varbits.DIARY_LUMBRIDGE_MEDIUM,
+			Varbits.DIARY_LUMBRIDGE_HARD,
+			Varbits.DIARY_LUMBRIDGE_ELITE);
+
+		addRegion(DiaryRegion.MORYTANIA,
+			Varbits.DIARY_MORYTANIA_EASY,
+			Varbits.DIARY_MORYTANIA_MEDIUM,
+			Varbits.DIARY_MORYTANIA_HARD,
+			Varbits.DIARY_MORYTANIA_ELITE);
+
+		addRegion(DiaryRegion.VARROCK,
+			Varbits.DIARY_VARROCK_EASY,
+			Varbits.DIARY_VARROCK_MEDIUM,
+			Varbits.DIARY_VARROCK_HARD,
+			Varbits.DIARY_VARROCK_ELITE);
+
+		addRegion(DiaryRegion.WESTERN,
+			Varbits.DIARY_WESTERN_EASY,
+			Varbits.DIARY_WESTERN_MEDIUM,
+			Varbits.DIARY_WESTERN_HARD,
+			Varbits.DIARY_WESTERN_ELITE);
+
+		addRegion(DiaryRegion.WILDERNESS,
+			Varbits.DIARY_WILDERNESS_EASY,
+			Varbits.DIARY_WILDERNESS_MEDIUM,
+			Varbits.DIARY_WILDERNESS_HARD,
+			Varbits.DIARY_WILDERNESS_ELITE);
+	}
+
+	private static void addRegion(DiaryRegion region, int easy, int medium, int hard, int elite)
+	{
+		Map<DiaryTier, Integer> tiers = new EnumMap<>(DiaryTier.class);
+		tiers.put(DiaryTier.EASY, easy);
+		tiers.put(DiaryTier.MEDIUM, medium);
+		tiers.put(DiaryTier.HARD, hard);
+		tiers.put(DiaryTier.ELITE, elite);
+		VARBIT_IDS.put(region, tiers);
+	}
+
+	// -------------------------------------------------------------------------
+
+	private final Client client;
+
+	/** Cached completion flags — populated by refresh(), cleared by reset(). */
+	private final Map<DiaryRegion, Map<DiaryTier, Boolean>> cache;
+
+	@Inject
+	DiaryTierStateImpl(Client client)
+	{
+		this.client = client;
+		this.cache = new EnumMap<>(DiaryRegion.class);
+		for (DiaryRegion region : DiaryRegion.values())
+		{
+			Map<DiaryTier, Boolean> tierMap = new EnumMap<>(DiaryTier.class);
+			for (DiaryTier tier : DiaryTier.values())
+			{
+				tierMap.put(tier, false);
+			}
+			cache.put(region, tierMap);
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * <p>
+	 * A varbit value of {@code 1} indicates completion, matching the convention
+	 * used by the game and RuneLite's AchievementDiaryPlugin.
+	 */
+	@Override
+	public boolean hasDiary(DiaryRegion region, DiaryTier tier)
+	{
+		if (region == null || tier == null)
+		{
+			return false;
+		}
+		Map<DiaryTier, Boolean> tierMap = cache.get(region);
+		if (tierMap == null)
+		{
+			return false;
+		}
+		Boolean value = tierMap.get(tier);
+		return value != null && value;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * <p>
+	 * Reads all 48 diary varbits from the client in a single pass. Must be
+	 * called on the client thread.
+	 */
+	@Override
+	public void refresh()
+	{
+		for (DiaryRegion region : DiaryRegion.values())
+		{
+			Map<DiaryTier, Integer> varbitMap = VARBIT_IDS.get(region);
+			Map<DiaryTier, Boolean> tierCache = cache.get(region);
+			for (DiaryTier tier : DiaryTier.values())
+			{
+				int varbitId = varbitMap.get(tier);
+				boolean complete;
+				try
+				{
+					complete = client.getVarbitValue(varbitId) == 1;
+				}
+				catch (Exception e)
+				{
+					log.warn("Failed to read diary varbit {} ({} {})", varbitId, region, tier, e);
+					complete = false;
+				}
+				tierCache.put(tier, complete);
+			}
+		}
+		log.debug("DiaryTierState refreshed");
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	public void reset()
+	{
+		for (Map<DiaryTier, Boolean> tierMap : cache.values())
+		{
+			for (DiaryTier tier : DiaryTier.values())
+			{
+				tierMap.put(tier, false);
+			}
+		}
+		log.debug("DiaryTierState reset");
+	}
+}

--- a/src/test/java/com/collectionloghelper/player/DiaryTierStateImplTest.java
+++ b/src/test/java/com/collectionloghelper/player/DiaryTierStateImplTest.java
@@ -1,0 +1,318 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.player;
+
+import java.lang.reflect.Constructor;
+import net.runelite.api.Client;
+import net.runelite.api.Varbits;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DiaryTierStateImplTest
+{
+	@Mock
+	private Client client;
+
+	private DiaryTierStateImpl diaryState;
+
+	@Before
+	public void setUp() throws Exception
+	{
+		Constructor<DiaryTierStateImpl> ctor =
+			DiaryTierStateImpl.class.getDeclaredConstructor(Client.class);
+		ctor.setAccessible(true);
+		diaryState = ctor.newInstance(client);
+	}
+
+	// =========================================================================
+	// Initial state — all false before any refresh
+	// =========================================================================
+
+	@Test
+	public void initialState_allFalse()
+	{
+		for (DiaryRegion region : DiaryRegion.values())
+		{
+			for (DiaryTier tier : DiaryTier.values())
+			{
+				assertFalse("Expected false before refresh for " + region + " " + tier,
+					diaryState.hasDiary(region, tier));
+			}
+		}
+	}
+
+	// =========================================================================
+	// hasDiary — null guards
+	// =========================================================================
+
+	@Test
+	public void hasDiary_nullRegion_returnsFalse()
+	{
+		assertFalse(diaryState.hasDiary(null, DiaryTier.HARD));
+	}
+
+	@Test
+	public void hasDiary_nullTier_returnsFalse()
+	{
+		assertFalse(diaryState.hasDiary(DiaryRegion.KARAMJA, null));
+	}
+
+	@Test
+	public void hasDiary_bothNull_returnsFalse()
+	{
+		assertFalse(diaryState.hasDiary(null, null));
+	}
+
+	// =========================================================================
+	// refresh — single tier complete
+	// =========================================================================
+
+	@Test
+	public void refresh_karamjaHardComplete_returnsTrue()
+	{
+		when(client.getVarbitValue(Varbits.DIARY_KARAMJA_HARD)).thenReturn(1);
+
+		diaryState.refresh();
+
+		assertTrue(diaryState.hasDiary(DiaryRegion.KARAMJA, DiaryTier.HARD));
+	}
+
+	@Test
+	public void refresh_karamjaHardNotComplete_returnsFalse()
+	{
+		when(client.getVarbitValue(Varbits.DIARY_KARAMJA_HARD)).thenReturn(0);
+
+		diaryState.refresh();
+
+		assertFalse(diaryState.hasDiary(DiaryRegion.KARAMJA, DiaryTier.HARD));
+	}
+
+	@Test
+	public void refresh_ardougneEliteComplete_returnsTrue()
+	{
+		when(client.getVarbitValue(Varbits.DIARY_ARDOUGNE_ELITE)).thenReturn(1);
+
+		diaryState.refresh();
+
+		assertTrue(diaryState.hasDiary(DiaryRegion.ARDOUGNE, DiaryTier.ELITE));
+	}
+
+	@Test
+	public void refresh_lumbridgeMediumComplete_returnsTrue()
+	{
+		when(client.getVarbitValue(Varbits.DIARY_LUMBRIDGE_MEDIUM)).thenReturn(1);
+
+		diaryState.refresh();
+
+		assertTrue(diaryState.hasDiary(DiaryRegion.LUMBRIDGE, DiaryTier.MEDIUM));
+	}
+
+	@Test
+	public void refresh_morytaniaEasyComplete_returnsTrue()
+	{
+		when(client.getVarbitValue(Varbits.DIARY_MORYTANIA_EASY)).thenReturn(1);
+
+		diaryState.refresh();
+
+		assertTrue(diaryState.hasDiary(DiaryRegion.MORYTANIA, DiaryTier.EASY));
+	}
+
+	// =========================================================================
+	// refresh — multiple tiers/regions independently tracked
+	// =========================================================================
+
+	@Test
+	public void refresh_onlySelectedTiersComplete_othersRemainFalse()
+	{
+		when(client.getVarbitValue(Varbits.DIARY_VARROCK_HARD)).thenReturn(1);
+		when(client.getVarbitValue(Varbits.DIARY_WILDERNESS_ELITE)).thenReturn(1);
+
+		diaryState.refresh();
+
+		assertTrue(diaryState.hasDiary(DiaryRegion.VARROCK, DiaryTier.HARD));
+		assertTrue(diaryState.hasDiary(DiaryRegion.WILDERNESS, DiaryTier.ELITE));
+
+		// Tiers not set should still be false
+		assertFalse(diaryState.hasDiary(DiaryRegion.VARROCK, DiaryTier.ELITE));
+		assertFalse(diaryState.hasDiary(DiaryRegion.WILDERNESS, DiaryTier.EASY));
+		assertFalse(diaryState.hasDiary(DiaryRegion.KARAMJA, DiaryTier.HARD));
+	}
+
+	@Test
+	public void refresh_allForOneRegion_allTiersDetected()
+	{
+		when(client.getVarbitValue(Varbits.DIARY_KANDARIN_EASY)).thenReturn(1);
+		when(client.getVarbitValue(Varbits.DIARY_KANDARIN_MEDIUM)).thenReturn(1);
+		when(client.getVarbitValue(Varbits.DIARY_KANDARIN_HARD)).thenReturn(1);
+		when(client.getVarbitValue(Varbits.DIARY_KANDARIN_ELITE)).thenReturn(1);
+
+		diaryState.refresh();
+
+		assertTrue(diaryState.hasDiary(DiaryRegion.KANDARIN, DiaryTier.EASY));
+		assertTrue(diaryState.hasDiary(DiaryRegion.KANDARIN, DiaryTier.MEDIUM));
+		assertTrue(diaryState.hasDiary(DiaryRegion.KANDARIN, DiaryTier.HARD));
+		assertTrue(diaryState.hasDiary(DiaryRegion.KANDARIN, DiaryTier.ELITE));
+	}
+
+	// =========================================================================
+	// refresh — all 12 regions have distinct varbit IDs (coverage check)
+	// =========================================================================
+
+	@Test
+	public void refresh_eachRegionEasyTierRead_usesDistinctVarbits()
+	{
+		// Stub each region's Easy varbit to return 1
+		when(client.getVarbitValue(Varbits.DIARY_ARDOUGNE_EASY)).thenReturn(1);
+		when(client.getVarbitValue(Varbits.DIARY_DESERT_EASY)).thenReturn(1);
+		when(client.getVarbitValue(Varbits.DIARY_FALADOR_EASY)).thenReturn(1);
+		when(client.getVarbitValue(Varbits.DIARY_FREMENNIK_EASY)).thenReturn(1);
+		when(client.getVarbitValue(Varbits.DIARY_KANDARIN_EASY)).thenReturn(1);
+		when(client.getVarbitValue(Varbits.DIARY_KARAMJA_EASY)).thenReturn(1);
+		when(client.getVarbitValue(Varbits.DIARY_KOUREND_EASY)).thenReturn(1);
+		when(client.getVarbitValue(Varbits.DIARY_LUMBRIDGE_EASY)).thenReturn(1);
+		when(client.getVarbitValue(Varbits.DIARY_MORYTANIA_EASY)).thenReturn(1);
+		when(client.getVarbitValue(Varbits.DIARY_VARROCK_EASY)).thenReturn(1);
+		when(client.getVarbitValue(Varbits.DIARY_WESTERN_EASY)).thenReturn(1);
+		when(client.getVarbitValue(Varbits.DIARY_WILDERNESS_EASY)).thenReturn(1);
+
+		diaryState.refresh();
+
+		for (DiaryRegion region : DiaryRegion.values())
+		{
+			assertTrue("Expected EASY true for " + region,
+				diaryState.hasDiary(region, DiaryTier.EASY));
+		}
+	}
+
+	// =========================================================================
+	// refresh — client exception is handled gracefully
+	// =========================================================================
+
+	@Test
+	public void refresh_clientThrows_treatedAsNotComplete()
+	{
+		when(client.getVarbitValue(anyInt()))
+			.thenThrow(new RuntimeException("client not ready"));
+
+		// Must not throw; all entries should remain false
+		diaryState.refresh();
+
+		for (DiaryRegion region : DiaryRegion.values())
+		{
+			for (DiaryTier tier : DiaryTier.values())
+			{
+				assertFalse("Expected false when client throws for " + region + " " + tier,
+					diaryState.hasDiary(region, tier));
+			}
+		}
+	}
+
+	// =========================================================================
+	// refresh — state updates on second call
+	// =========================================================================
+
+	@Test
+	public void refresh_secondCallUpdatesState()
+	{
+		// First refresh: Fremennik Hard not complete
+		when(client.getVarbitValue(Varbits.DIARY_FREMENNIK_HARD)).thenReturn(0);
+		diaryState.refresh();
+		assertFalse(diaryState.hasDiary(DiaryRegion.FREMENNIK, DiaryTier.HARD));
+
+		// Second refresh: Fremennik Hard now complete
+		when(client.getVarbitValue(Varbits.DIARY_FREMENNIK_HARD)).thenReturn(1);
+		diaryState.refresh();
+		assertTrue(diaryState.hasDiary(DiaryRegion.FREMENNIK, DiaryTier.HARD));
+	}
+
+	// =========================================================================
+	// reset — clears all cached state
+	// =========================================================================
+
+	@Test
+	public void reset_afterRefreshWithData_allFalse()
+	{
+		when(client.getVarbitValue(Varbits.DIARY_DESERT_ELITE)).thenReturn(1);
+		when(client.getVarbitValue(Varbits.DIARY_KARAMJA_HARD)).thenReturn(1);
+		diaryState.refresh();
+
+		assertTrue(diaryState.hasDiary(DiaryRegion.DESERT, DiaryTier.ELITE));
+		assertTrue(diaryState.hasDiary(DiaryRegion.KARAMJA, DiaryTier.HARD));
+
+		diaryState.reset();
+
+		for (DiaryRegion region : DiaryRegion.values())
+		{
+			for (DiaryTier tier : DiaryTier.values())
+			{
+				assertFalse("Expected false after reset for " + region + " " + tier,
+					diaryState.hasDiary(region, tier));
+			}
+		}
+	}
+
+	// =========================================================================
+	// refresh — Kourend (highest varbit IDs ~7925-7928) and Karamja (non-sequential
+	// IDs 3578/3599/3611/4566) work correctly
+	// =========================================================================
+
+	@Test
+	public void refresh_kourendAllTiers_allDetected()
+	{
+		when(client.getVarbitValue(Varbits.DIARY_KOUREND_EASY)).thenReturn(1);
+		when(client.getVarbitValue(Varbits.DIARY_KOUREND_MEDIUM)).thenReturn(1);
+		when(client.getVarbitValue(Varbits.DIARY_KOUREND_HARD)).thenReturn(1);
+		when(client.getVarbitValue(Varbits.DIARY_KOUREND_ELITE)).thenReturn(1);
+
+		diaryState.refresh();
+
+		assertTrue(diaryState.hasDiary(DiaryRegion.KOUREND, DiaryTier.EASY));
+		assertTrue(diaryState.hasDiary(DiaryRegion.KOUREND, DiaryTier.MEDIUM));
+		assertTrue(diaryState.hasDiary(DiaryRegion.KOUREND, DiaryTier.HARD));
+		assertTrue(diaryState.hasDiary(DiaryRegion.KOUREND, DiaryTier.ELITE));
+	}
+
+	@Test
+	public void refresh_karamjaElite_usesCorrectVarbit()
+	{
+		// Karamja Elite is varbit 4566, non-sequential with Easy/Medium/Hard (3578/3599/3611)
+		when(client.getVarbitValue(Varbits.DIARY_KARAMJA_ELITE)).thenReturn(1);
+
+		diaryState.refresh();
+
+		assertTrue(diaryState.hasDiary(DiaryRegion.KARAMJA, DiaryTier.ELITE));
+		// Lower tiers not set should remain false
+		assertFalse(diaryState.hasDiary(DiaryRegion.KARAMJA, DiaryTier.EASY));
+		assertFalse(diaryState.hasDiary(DiaryRegion.KARAMJA, DiaryTier.MEDIUM));
+		assertFalse(diaryState.hasDiary(DiaryRegion.KARAMJA, DiaryTier.HARD));
+	}
+}


### PR DESCRIPTION
## Summary

- Introduces `DiaryTierState` interface and `DiaryTierStateImpl` singleton in the new `player` package
- Adds `DiaryRegion` enum (12 regions: Ardougne, Desert, Falador, Fremennik, Kandarin, Karamja, Kourend, Lumbridge, Morytania, Varrock, Western, Wilderness) and `DiaryTier` enum (Easy/Medium/Hard/Elite)
- All 48 region-tier combinations wired to canonical `Varbits.DIARY_<REGION>_<TIER>` constants; varbit IDs confirmed against RuneLite master (Ardougne 4458–4461, Karamja 3578/3599/3611/4566, Kourend 7925–7928, etc.)
- Client-side varbit reads cached in two-level `EnumMap`; `refresh()` reads all 48 in one pass, `reset()` clears on logout
- Closes Tier C3 in the roadmap

## Test plan

- [x] `DiaryTierStateImplTest` — Mockito unit tests: initial state, null guards, per-tier/region detection, exception resilience, state update on second refresh, reset semantics, Karamja Elite non-sequential varbit, all 12 EASY varbits distinct
- [x] `./gradlew test build` passes