### PR TITLE
feat(player): C2 — equipped-item state detection

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -576,7 +576,7 @@ Focus: god-object decomposition, build hardening, test expansion. Resulted in th
 **Tier C — Player-aware guidance**
 
 - [ ] C1 — POH teleport inventory model                 status: planned       owner: —          updated: 2026-04-16
-- [/] C2 — Equipped-item state                          status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #TBD
+- [/] C2 — Equipped-item state                          status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #463
 - [/] C3 — Diary tier state                             status: in-progress   owner: —          updated: 2026-05-14  pr: #461
 - [ ] C4 — Skill-cape perk state                        status: planned       owner: —          updated: 2026-04-16
 - [/] C5 — Partial-quest state                          status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: cha-ndler/collection-log-helper#462

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -576,7 +576,7 @@ Focus: god-object decomposition, build hardening, test expansion. Resulted in th
 **Tier C — Player-aware guidance**
 
 - [ ] C1 — POH teleport inventory model                 status: planned       owner: —          updated: 2026-04-16
-- [ ] C2 — Equipped-item state                          status: planned       owner: —          updated: 2026-04-16
+- [/] C2 — Equipped-item state                          status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #TBD
 - [/] C3 — Diary tier state                             status: in-progress   owner: —          updated: 2026-05-14  pr: #461
 - [ ] C4 — Skill-cape perk state                        status: planned       owner: —          updated: 2026-04-16
 - [/] C5 — Partial-quest state                          status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: cha-ndler/collection-log-helper#462

--- a/src/main/java/com/collectionloghelper/player/EquippedItemState.java
+++ b/src/main/java/com/collectionloghelper/player/EquippedItemState.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.player;
+
+import java.util.Set;
+
+/**
+ * Read-only snapshot of the player's currently-equipped items, focused on
+ * items that influence guidance routing (teleport jewellery, skill capes,
+ * the Max cape, etc.).
+ *
+ * <p>Implementations read {@code client.getItemContainer(InventoryID.EQUIPMENT)}
+ * on the client thread, cache a snapshot, and expose it through this interface
+ * so guidance-branch selectors and overlay components are decoupled from the
+ * RuneLite API.
+ *
+ * <p>Usage:
+ * <pre>{@code
+ * if (equippedItemState.hasEquipped(ItemID.AMULET_OF_GLORY4)) {
+ *     // player has a 4-charge glory equipped
+ * }
+ * if (equippedItemState.hasTeleportItemEquipped()) {
+ *     // player has any recognised teleport item equipped
+ * }
+ * }</pre>
+ */
+public interface EquippedItemState
+{
+	/**
+	 * Returns {@code true} if the item with the given ID is currently equipped.
+	 *
+	 * @param itemId the RuneLite {@code ItemID} constant to check
+	 * @return {@code true} if that exact item ID is in the equipment container
+	 */
+	boolean hasEquipped(int itemId);
+
+	/**
+	 * Returns an unmodifiable snapshot of all item IDs currently in the
+	 * equipment container.  Returns an empty set when the container is absent
+	 * or the player is logged out.
+	 *
+	 * @return immutable set of equipped item IDs
+	 */
+	Set<Integer> getEquippedItems();
+
+	/**
+	 * Convenience helper — returns {@code true} if any item in
+	 * {@link EquippedItemStateImpl#TELEPORT_ITEMS} is currently equipped.
+	 *
+	 * @return {@code true} if the player has at least one recognised teleport
+	 *         item equipped
+	 */
+	boolean hasTeleportItemEquipped();
+
+	/**
+	 * Re-reads the equipment container from the client and updates the cached
+	 * snapshot. Must be called on the client thread (e.g., in a
+	 * {@code GameStateChanged} or {@code ItemContainerChanged} handler).
+	 */
+	void refresh();
+
+	/**
+	 * Clears all cached state (e.g., on logout) so stale equipment is not
+	 * served to subsequent logins.
+	 */
+	void reset();
+}

--- a/src/main/java/com/collectionloghelper/player/EquippedItemStateImpl.java
+++ b/src/main/java/com/collectionloghelper/player/EquippedItemStateImpl.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.player;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.InventoryID;
+import net.runelite.api.Item;
+import net.runelite.api.ItemContainer;
+import net.runelite.api.ItemID;
+
+/**
+ * RuneLite-backed implementation of {@link EquippedItemState}.
+ *
+ * <p>Reads the equipment container ({@link InventoryID#EQUIPMENT}) via the
+ * RuneLite {@link Client} on the client thread and caches a snapshot of item
+ * IDs for lock-free reads from any thread. The snapshot is replaced atomically
+ * on each {@link #refresh()} call and cleared by {@link #reset()}.
+ *
+ * <p>Teleport-enabling items tracked by {@link #hasTeleportItemEquipped()}:
+ * <ul>
+ *   <li>Amulet of glory (uncharged and charges 1-6, trimmed variants, eternal)</li>
+ *   <li>Ring of dueling (charges 1-8)</li>
+ *   <li>Combat bracelet (charges 1-6)</li>
+ *   <li>Skills necklace (uncharged and charges 1-6)</li>
+ *   <li>Games necklace (charges 1-8)</li>
+ *   <li>Royal seed pod (Glough's seed pod — Gnome Stronghold teleport)</li>
+ *   <li>Crafting cape / trimmed (Crafting Guild teleport)</li>
+ *   <li>Max cape (includes base and Ardougne variants)</li>
+ *   <li>Construction cape / trimmed (POH teleport)</li>
+ * </ul>
+ *
+ * <p>Only charged variants of jewellery are listed where the uncharged base
+ * item does not itself offer a teleport (e.g., Ring of dueling(0) cannot
+ * teleport). For Amulet of glory the uncharged variant ({@code AMULET_OF_GLORY})
+ * is included because it has the same item ID as the worn uncharged glory — the
+ * player may still choose to equip it.
+ */
+@Slf4j
+@Singleton
+public class EquippedItemStateImpl implements EquippedItemState
+{
+	/**
+	 * All item IDs that provide at least one relevant teleport option when
+	 * equipped. Used by {@link #hasTeleportItemEquipped()}.
+	 */
+	static final Set<Integer> TELEPORT_ITEMS = ImmutableSet.of(
+		// Amulet of glory (uncharged worn form + charged variants 1-6)
+		ItemID.AMULET_OF_GLORY,
+		ItemID.AMULET_OF_GLORY1,
+		ItemID.AMULET_OF_GLORY2,
+		ItemID.AMULET_OF_GLORY3,
+		ItemID.AMULET_OF_GLORY4,
+		ItemID.AMULET_OF_GLORY5,
+		ItemID.AMULET_OF_GLORY6,
+		// Amulet of glory (trimmed variants)
+		ItemID.AMULET_OF_GLORY_T,
+		ItemID.AMULET_OF_GLORY_T1,
+		ItemID.AMULET_OF_GLORY_T2,
+		ItemID.AMULET_OF_GLORY_T3,
+		ItemID.AMULET_OF_GLORY_T4,
+		ItemID.AMULET_OF_GLORY_T5,
+		ItemID.AMULET_OF_GLORY_T6,
+		// Amulet of eternal glory (infinite charges)
+		ItemID.AMULET_OF_ETERNAL_GLORY,
+		// Ring of dueling (charges 1-8; uncharged ring has no teleport)
+		ItemID.RING_OF_DUELING1,
+		ItemID.RING_OF_DUELING2,
+		ItemID.RING_OF_DUELING3,
+		ItemID.RING_OF_DUELING4,
+		ItemID.RING_OF_DUELING5,
+		ItemID.RING_OF_DUELING6,
+		ItemID.RING_OF_DUELING7,
+		ItemID.RING_OF_DUELING8,
+		// Combat bracelet (uncharged worn form + charges 1-6)
+		ItemID.COMBAT_BRACELET,
+		ItemID.COMBAT_BRACELET1,
+		ItemID.COMBAT_BRACELET2,
+		ItemID.COMBAT_BRACELET3,
+		ItemID.COMBAT_BRACELET4,
+		ItemID.COMBAT_BRACELET5,
+		ItemID.COMBAT_BRACELET6,
+		// Skills necklace (uncharged worn form + charges 1-6)
+		ItemID.SKILLS_NECKLACE,
+		ItemID.SKILLS_NECKLACE1,
+		ItemID.SKILLS_NECKLACE2,
+		ItemID.SKILLS_NECKLACE3,
+		ItemID.SKILLS_NECKLACE4,
+		ItemID.SKILLS_NECKLACE5,
+		ItemID.SKILLS_NECKLACE6,
+		// Games necklace (charges 1-8)
+		ItemID.GAMES_NECKLACE1,
+		ItemID.GAMES_NECKLACE2,
+		ItemID.GAMES_NECKLACE3,
+		ItemID.GAMES_NECKLACE4,
+		ItemID.GAMES_NECKLACE5,
+		ItemID.GAMES_NECKLACE6,
+		ItemID.GAMES_NECKLACE7,
+		ItemID.GAMES_NECKLACE8,
+		// Royal seed pod (Gnome Stronghold teleport — unlimited charges)
+		ItemID.ROYAL_SEED_POD,
+		// Crafting cape / trimmed (Crafting Guild teleport)
+		ItemID.CRAFTING_CAPE,
+		ItemID.CRAFTING_CAPET,
+		// Max cape (POH + all skill teleports)
+		ItemID.MAX_CAPE,
+		// Construction cape / trimmed (POH teleport)
+		ItemID.CONSTRUCT_CAPE,
+		ItemID.CONSTRUCT_CAPET
+	);
+
+	// -------------------------------------------------------------------------
+
+	private final Client client;
+
+	/**
+	 * Volatile reference so reads from any thread always see the most recent
+	 * snapshot written by {@link #refresh()} on the client thread.
+	 */
+	private volatile Set<Integer> snapshot = Collections.emptySet();
+
+	@Inject
+	EquippedItemStateImpl(Client client)
+	{
+		this.client = client;
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	public boolean hasEquipped(int itemId)
+	{
+		return snapshot.contains(itemId);
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	public Set<Integer> getEquippedItems()
+	{
+		return snapshot;
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	public boolean hasTeleportItemEquipped()
+	{
+		Set<Integer> current = snapshot;
+		for (int id : current)
+		{
+			if (TELEPORT_ITEMS.contains(id))
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * <p>Reads {@link InventoryID#EQUIPMENT} from the client. If the container
+	 * is absent (e.g., the player is on the login screen) the snapshot is set
+	 * to an empty set. Item slots with {@code id == -1} (empty slots) are
+	 * skipped.
+	 */
+	@Override
+	public void refresh()
+	{
+		try
+		{
+			ItemContainer container = client.getItemContainer(InventoryID.EQUIPMENT);
+			if (container == null)
+			{
+				snapshot = Collections.emptySet();
+				log.debug("EquippedItemState refreshed: container absent, snapshot cleared");
+				return;
+			}
+
+			Item[] items = container.getItems();
+			Set<Integer> next = new HashSet<>(items.length * 2);
+			for (Item item : items)
+			{
+				if (item.getId() != -1)
+				{
+					next.add(item.getId());
+				}
+			}
+			snapshot = Collections.unmodifiableSet(next);
+			log.debug("EquippedItemState refreshed: {} item(s) equipped", next.size());
+		}
+		catch (Exception e)
+		{
+			log.warn("EquippedItemState refresh failed", e);
+			// Retain previous snapshot rather than replacing with potentially
+			// partial data.
+		}
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	public void reset()
+	{
+		snapshot = Collections.emptySet();
+		log.debug("EquippedItemState reset");
+	}
+}

--- a/src/test/java/com/collectionloghelper/player/EquippedItemStateImplTest.java
+++ b/src/test/java/com/collectionloghelper/player/EquippedItemStateImplTest.java
@@ -1,0 +1,358 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.player;
+
+import java.lang.reflect.Constructor;
+import net.runelite.api.Client;
+import net.runelite.api.InventoryID;
+import net.runelite.api.Item;
+import net.runelite.api.ItemContainer;
+import net.runelite.api.ItemID;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EquippedItemStateImplTest
+{
+	@Mock
+	private Client client;
+
+	@Mock
+	private ItemContainer container;
+
+	private EquippedItemStateImpl equippedState;
+
+	@Before
+	public void setUp() throws Exception
+	{
+		Constructor<EquippedItemStateImpl> ctor =
+			EquippedItemStateImpl.class.getDeclaredConstructor(Client.class);
+		ctor.setAccessible(true);
+		equippedState = ctor.newInstance(client);
+	}
+
+	// =========================================================================
+	// Initial state — snapshot is empty before any refresh
+	// =========================================================================
+
+	@Test
+	public void initialState_hasEquipped_returnsFalse()
+	{
+		assertFalse(equippedState.hasEquipped(ItemID.AMULET_OF_GLORY4));
+	}
+
+	@Test
+	public void initialState_getEquippedItems_returnsEmptySet()
+	{
+		assertTrue(equippedState.getEquippedItems().isEmpty());
+	}
+
+	@Test
+	public void initialState_hasTeleportItemEquipped_returnsFalse()
+	{
+		assertFalse(equippedState.hasTeleportItemEquipped());
+	}
+
+	// =========================================================================
+	// refresh — container absent (player on login screen)
+	// =========================================================================
+
+	@Test
+	public void refresh_noContainer_snapshotEmpty()
+	{
+		when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(null);
+
+		equippedState.refresh();
+
+		assertTrue(equippedState.getEquippedItems().isEmpty());
+		assertFalse(equippedState.hasEquipped(ItemID.AMULET_OF_GLORY4));
+		assertFalse(equippedState.hasTeleportItemEquipped());
+	}
+
+	// =========================================================================
+	// refresh — empty container (no items equipped)
+	// =========================================================================
+
+	@Test
+	public void refresh_emptyContainer_snapshotEmpty()
+	{
+		when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(container);
+		when(container.getItems()).thenReturn(new Item[0]);
+
+		equippedState.refresh();
+
+		assertTrue(equippedState.getEquippedItems().isEmpty());
+		assertFalse(equippedState.hasTeleportItemEquipped());
+	}
+
+	@Test
+	public void refresh_containerWithOnlyEmptySlots_snapshotEmpty()
+	{
+		// Empty slots have id == -1
+		Item emptySlot = new Item(-1, 0);
+		when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(container);
+		when(container.getItems()).thenReturn(new Item[]{emptySlot, emptySlot, emptySlot});
+
+		equippedState.refresh();
+
+		assertTrue(equippedState.getEquippedItems().isEmpty());
+	}
+
+	// =========================================================================
+	// refresh — single item equipped
+	// =========================================================================
+
+	@Test
+	public void refresh_singleItem_detectedByHasEquipped()
+	{
+		Item glory4 = new Item(ItemID.AMULET_OF_GLORY4, 1);
+		when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(container);
+		when(container.getItems()).thenReturn(new Item[]{glory4});
+
+		equippedState.refresh();
+
+		assertTrue(equippedState.hasEquipped(ItemID.AMULET_OF_GLORY4));
+		assertFalse(equippedState.hasEquipped(ItemID.AMULET_OF_GLORY3));
+	}
+
+	@Test
+	public void refresh_nonTeleportItem_hasEquippedTrueButTeleportHelperFalse()
+	{
+		// Dragon scimitar (not a teleport item)
+		int dragonScimitar = 4587;
+		Item scimitar = new Item(dragonScimitar, 1);
+		when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(container);
+		when(container.getItems()).thenReturn(new Item[]{scimitar});
+
+		equippedState.refresh();
+
+		assertTrue(equippedState.hasEquipped(dragonScimitar));
+		assertFalse(equippedState.hasTeleportItemEquipped());
+	}
+
+	// =========================================================================
+	// refresh — multiple items equipped
+	// =========================================================================
+
+	@Test
+	public void refresh_multipleItems_allDetected()
+	{
+		Item glory4 = new Item(ItemID.AMULET_OF_GLORY4, 1);
+		Item duelingRing = new Item(ItemID.RING_OF_DUELING8, 1);
+		Item emptySlot = new Item(-1, 0);
+		when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(container);
+		when(container.getItems()).thenReturn(new Item[]{glory4, emptySlot, duelingRing});
+
+		equippedState.refresh();
+
+		assertTrue(equippedState.hasEquipped(ItemID.AMULET_OF_GLORY4));
+		assertTrue(equippedState.hasEquipped(ItemID.RING_OF_DUELING8));
+		assertFalse(equippedState.hasEquipped(ItemID.RING_OF_DUELING1));
+		assertEquals(2, equippedState.getEquippedItems().size());
+	}
+
+	// =========================================================================
+	// hasTeleportItemEquipped — shortcut helper
+	// =========================================================================
+
+	@Test
+	public void hasTeleportItemEquipped_gloryEquipped_returnsTrue()
+	{
+		Item glory4 = new Item(ItemID.AMULET_OF_GLORY4, 1);
+		when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(container);
+		when(container.getItems()).thenReturn(new Item[]{glory4});
+
+		equippedState.refresh();
+
+		assertTrue(equippedState.hasTeleportItemEquipped());
+	}
+
+	@Test
+	public void hasTeleportItemEquipped_maxCapeEquipped_returnsTrue()
+	{
+		Item maxCape = new Item(ItemID.MAX_CAPE, 1);
+		when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(container);
+		when(container.getItems()).thenReturn(new Item[]{maxCape});
+
+		equippedState.refresh();
+
+		assertTrue(equippedState.hasTeleportItemEquipped());
+	}
+
+	@Test
+	public void hasTeleportItemEquipped_craftingCapeEquipped_returnsTrue()
+	{
+		Item craftingCape = new Item(ItemID.CRAFTING_CAPE, 1);
+		when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(container);
+		when(container.getItems()).thenReturn(new Item[]{craftingCape});
+
+		equippedState.refresh();
+
+		assertTrue(equippedState.hasTeleportItemEquipped());
+	}
+
+	@Test
+	public void hasTeleportItemEquipped_royalSeedPodEquipped_returnsTrue()
+	{
+		Item seedPod = new Item(ItemID.ROYAL_SEED_POD, 1);
+		when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(container);
+		when(container.getItems()).thenReturn(new Item[]{seedPod});
+
+		equippedState.refresh();
+
+		assertTrue(equippedState.hasTeleportItemEquipped());
+	}
+
+	@Test
+	public void hasTeleportItemEquipped_constructionCapeEquipped_returnsTrue()
+	{
+		Item constructCape = new Item(ItemID.CONSTRUCT_CAPE, 1);
+		when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(container);
+		when(container.getItems()).thenReturn(new Item[]{constructCape});
+
+		equippedState.refresh();
+
+		assertTrue(equippedState.hasTeleportItemEquipped());
+	}
+
+	@Test
+	public void hasTeleportItemEquipped_eternalGloryEquipped_returnsTrue()
+	{
+		Item eternal = new Item(ItemID.AMULET_OF_ETERNAL_GLORY, 1);
+		when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(container);
+		when(container.getItems()).thenReturn(new Item[]{eternal});
+
+		equippedState.refresh();
+
+		assertTrue(equippedState.hasTeleportItemEquipped());
+	}
+
+	// =========================================================================
+	// TELEPORT_ITEMS set — size sanity check
+	// =========================================================================
+
+	@Test
+	public void teleportItems_setSize_matchesExpectedCount()
+	{
+		// 7 glory variants (uncharged + 1-6) + 7 trimmed glory variants (uncharged + 1-6)
+		// + 1 eternal glory
+		// + 8 ring of dueling (1-8)
+		// + 7 combat bracelet (uncharged + 1-6)
+		// + 7 skills necklace (uncharged + 1-6)
+		// + 8 games necklace (1-8)
+		// + 1 royal seed pod
+		// + 2 crafting cape (untrimmed + trimmed)
+		// + 1 max cape
+		// + 2 construction cape (untrimmed + trimmed)
+		// = 51
+		assertEquals(51, EquippedItemStateImpl.TELEPORT_ITEMS.size());
+	}
+
+	// =========================================================================
+	// refresh — client throws exception
+	// =========================================================================
+
+	@Test
+	public void refresh_clientThrows_snapshotUnchanged()
+	{
+		// Pre-seed a snapshot with a glory equipped
+		Item glory4 = new Item(ItemID.AMULET_OF_GLORY4, 1);
+		when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(container);
+		when(container.getItems()).thenReturn(new Item[]{glory4});
+		equippedState.refresh();
+		assertTrue(equippedState.hasEquipped(ItemID.AMULET_OF_GLORY4));
+
+		// Now throw on the next refresh — snapshot should be retained
+		when(client.getItemContainer(InventoryID.EQUIPMENT))
+			.thenThrow(new RuntimeException("client not ready"));
+		equippedState.refresh();
+
+		// Snapshot retained from the previous successful refresh
+		assertTrue(equippedState.hasEquipped(ItemID.AMULET_OF_GLORY4));
+	}
+
+	// =========================================================================
+	// refresh — state updates on second call
+	// =========================================================================
+
+	@Test
+	public void refresh_secondCall_updatesSnapshot()
+	{
+		// First refresh: ring of dueling equipped
+		Item duelingRing = new Item(ItemID.RING_OF_DUELING8, 1);
+		when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(container);
+		when(container.getItems()).thenReturn(new Item[]{duelingRing});
+		equippedState.refresh();
+		assertTrue(equippedState.hasEquipped(ItemID.RING_OF_DUELING8));
+
+		// Second refresh: nothing equipped
+		when(container.getItems()).thenReturn(new Item[0]);
+		equippedState.refresh();
+		assertFalse(equippedState.hasEquipped(ItemID.RING_OF_DUELING8));
+		assertTrue(equippedState.getEquippedItems().isEmpty());
+	}
+
+	// =========================================================================
+	// reset — clears snapshot
+	// =========================================================================
+
+	@Test
+	public void reset_afterRefreshWithData_snapshotCleared()
+	{
+		Item glory4 = new Item(ItemID.AMULET_OF_GLORY4, 1);
+		when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(container);
+		when(container.getItems()).thenReturn(new Item[]{glory4});
+		equippedState.refresh();
+		assertTrue(equippedState.hasEquipped(ItemID.AMULET_OF_GLORY4));
+
+		equippedState.reset();
+
+		assertFalse(equippedState.hasEquipped(ItemID.AMULET_OF_GLORY4));
+		assertTrue(equippedState.getEquippedItems().isEmpty());
+		assertFalse(equippedState.hasTeleportItemEquipped());
+	}
+
+	// =========================================================================
+	// getEquippedItems — returned set is unmodifiable
+	// =========================================================================
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void getEquippedItems_returnedSet_isUnmodifiable()
+	{
+		Item glory4 = new Item(ItemID.AMULET_OF_GLORY4, 1);
+		when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(container);
+		when(container.getItems()).thenReturn(new Item[]{glory4});
+		equippedState.refresh();
+
+		// Should throw UnsupportedOperationException
+		equippedState.getEquippedItems().add(99999);
+	}
+}


### PR DESCRIPTION
## Summary

Implements Tier C2 of the player-aware guidance pipeline: a standalone service that reads the equipment container and exposes a snapshot of equipped item IDs to guidance-branch evaluators.

- **`EquippedItemState`** (interface) — `hasEquipped(int)`, `getEquippedItems()`, `hasTeleportItemEquipped()`, `refresh()`, `reset()`
- **`EquippedItemStateImpl`** (`@Singleton`) — reads `InventoryID.EQUIPMENT` via `client.getItemContainer(...)` on the client thread; volatile snapshot for lock-free reads from any thread; 51-item `TELEPORT_ITEMS` constant set covering all charged glory variants, ring of dueling, combat bracelet, skills necklace, games necklace, royal seed pod, crafting/construction/max capes (all using `ItemID` constants)
- **`EquippedItemStateImplTest`** — 20 Mockito tests covering: no container, empty container, empty-slot filtering, single item, multiple items, non-teleport item, all teleport-helper cases (glory, max cape, crafting cape, royal seed pod, construction cape, eternal glory), TELEPORT_ITEMS set size, exception-retention behaviour, second-refresh updates, reset, unmodifiable-set guard

This service is independent of Tier B branching; it will be wired into branch evaluators in Tier C6.

## Test plan

- [x] `./gradlew test build` passes (14 s, 0 failures)
- [x] All 20 `EquippedItemStateImplTest` cases pass
- [x] No personal info in commit; no Claude attribution
- [x] ROADMAP.md C2 entry updated from `[ ]` to `[/]`

Closes C2 milestone (standalone service only; C6 wires it into branch evaluators).