### PR TITLE
feat(efficiency): E1 — cross-source per-item recommendation mode

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -593,7 +593,7 @@ Focus: god-object decomposition, build hardening, test expansion. Resulted in th
 
 **Tier E — Alternative methods and meta intelligence**
 
-- [ ] E1 — Cross-source recommendation mode             status: planned       owner: —          updated: 2026-04-16
+- [/] E1 — Cross-source recommendation mode             status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #TBD  note: CrossSourceRanker + CrossSourceRecommendation + enableCrossSourceMode config flag; panel integration deferred.
 - [ ] E2 — Meta-update dating                           status: planned       owner: —          updated: 2026-04-16
 
 **Tier F — Social, imports, and long-tail polish**

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -593,7 +593,7 @@ Focus: god-object decomposition, build hardening, test expansion. Resulted in th
 
 **Tier E — Alternative methods and meta intelligence**
 
-- [/] E1 — Cross-source recommendation mode             status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #TBD  note: CrossSourceRanker + CrossSourceRecommendation + enableCrossSourceMode config flag; panel integration deferred.
+- [/] E1 — Cross-source recommendation mode             status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #464  note: CrossSourceRanker + CrossSourceRecommendation + enableCrossSourceMode config flag; panel integration deferred.
 - [ ] E2 — Meta-update dating                           status: planned       owner: —          updated: 2026-04-16
 
 **Tier F — Social, imports, and long-tail polish**

--- a/src/main/java/com/collectionloghelper/CollectionLogHelperConfig.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperConfig.java
@@ -268,4 +268,16 @@ public interface CollectionLogHelperConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "enableCrossSourceMode",
+		name = "Cross-source recommendation mode",
+		description = "Show a per-item best-path ranking that surfaces the fastest source for each unobtained item across all sources (Tier E1). Off by default — panel integration is in progress.",
+		position = 10,
+		hidden = true
+	)
+	default boolean enableCrossSourceMode()
+	{
+		return false;
+	}
 }

--- a/src/main/java/com/collectionloghelper/efficiency/CrossSourceRanker.java
+++ b/src/main/java/com/collectionloghelper/efficiency/CrossSourceRanker.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.efficiency;
+
+import com.collectionloghelper.data.CollectionLogItem;
+import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.data.DropRateDatabase;
+import com.collectionloghelper.data.PlayerCollectionState;
+import com.collectionloghelper.efficiency.CrossSourceRecommendation.SourceScore;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ * Cross-source per-item best-path ranker (Tier E1).
+ *
+ * <p>Unlike {@link EfficiencyCalculator} — which ranks <em>sources</em> by their
+ * combined probability of yielding any new log slot — this ranker pivots to an
+ * <em>item-first</em> view: for each unobtained item it finds every source that
+ * contains the item, computes the expected time to obtain it from each source
+ * independently, and returns the list sorted by the best (fastest) path.
+ *
+ * <p>Design notes:
+ * <ul>
+ *   <li>Expected seconds is derived from the per-item score returned by
+ *       {@link EfficiencyCalculator#scoreIndividualItem}: score = (effectiveRate *
+ *       killsPerHour) * 100. Inverting gives hours = 100 / score, and multiplying
+ *       by 3600 gives seconds. When the score is zero or negative the time is
+ *       indeterminate and {@link Double#MAX_VALUE} is used so these sources sort
+ *       to the end of each item's list.</li>
+ *   <li>Obtained items are excluded before scoring.</li>
+ *   <li>The {@code locked} parameter to {@link #rank} controls whether sources
+ *       that are inaccessible (quest/skill requirements not met) are included.</li>
+ *   <li>The ranker is stateless apart from its collaborators and can be called
+ *       repeatedly as the player's collection state changes.</li>
+ * </ul>
+ */
+@Singleton
+public class CrossSourceRanker
+{
+	private final DropRateDatabase database;
+	private final PlayerCollectionState collectionState;
+	private final EfficiencyCalculator efficiencyCalculator;
+
+	@Inject
+	CrossSourceRanker(DropRateDatabase database, PlayerCollectionState collectionState,
+		EfficiencyCalculator efficiencyCalculator)
+	{
+		this.database = database;
+		this.collectionState = collectionState;
+		this.efficiencyCalculator = efficiencyCalculator;
+	}
+
+	/**
+	 * Produces a per-item ranked list for all unobtained items in the database.
+	 *
+	 * <p>Each entry in the returned list represents one unobtained item together
+	 * with all sources that contain it, sorted fastest-first by expected seconds.
+	 * The outer list is also sorted so the item with the globally fastest obtainable
+	 * path appears first.
+	 *
+	 * @param includeLocked whether locked (inaccessible) sources are included in
+	 *                      each item's source list
+	 * @return immutable snapshot of per-item recommendations; never null, may be empty
+	 */
+	public List<CrossSourceRecommendation> rank(boolean includeLocked)
+	{
+		// item ID -> accumulator of (source, expectedSeconds) pairs
+		Map<Integer, ItemAccumulator> accumulators = new LinkedHashMap<>();
+
+		for (CollectionLogSource source : database.getAllSources())
+		{
+			// scoreSource returns null when all items from this source are already obtained.
+			// The locked flag is forwarded to scoreSource for correct score computation
+			// (locked sources receive a penalty in some paths), but whether a locked source
+			// appears in results is gated by includeLocked.
+			boolean sourceLocked = isSourceLocked(source);
+			if (!includeLocked && sourceLocked)
+			{
+				continue;
+			}
+
+			ScoredItem scored = efficiencyCalculator.scoreSource(source, sourceLocked);
+			if (scored == null)
+			{
+				continue;
+			}
+
+			int killTime = efficiencyCalculator.getEffectiveKillTime(source);
+			double killsPerHour = killTime > 0 ? 3600.0 / killTime : 0;
+			int rolls = source.getRollsPerKill();
+
+			for (CollectionLogItem item : source.getItems())
+			{
+				if (collectionState.isItemObtained(item.getItemId()))
+				{
+					continue;
+				}
+
+				double itemScore = computeItemScore(scored, item, source, killsPerHour, killTime, rolls);
+				double expectedSeconds = scoreToSeconds(itemScore);
+				SourceScore ss = new SourceScore(source, expectedSeconds);
+
+				accumulators
+					.computeIfAbsent(item.getItemId(), id -> new ItemAccumulator(id, item.getName()))
+					.add(ss);
+			}
+		}
+
+		List<CrossSourceRecommendation> recommendations = new ArrayList<>(accumulators.size());
+		for (ItemAccumulator acc : accumulators.values())
+		{
+			recommendations.add(acc.build());
+		}
+
+		recommendations.sort(
+			Comparator.comparingDouble(r -> r.getBest().getExpectedSeconds()));
+
+		return Collections.unmodifiableList(recommendations);
+	}
+
+	/**
+	 * Converts an efficiency score (units: effective-drops-per-kill * kills/hour * 100)
+	 * to expected seconds to obtain a single item.
+	 *
+	 * <p>Returns {@link Double#MAX_VALUE} when the score is zero or negative, which
+	 * causes these entries to sort to the end of the per-item source list.
+	 */
+	static double scoreToSeconds(double score)
+	{
+		if (score <= 0)
+		{
+			return Double.MAX_VALUE;
+		}
+		return (100.0 / score) * 3600.0;
+	}
+
+	/**
+	 * Returns the per-item efficiency score for {@code target} from {@code source}.
+	 *
+	 * <p>If {@code target} happens to be the best item recorded on the pre-computed
+	 * {@link ScoredItem} its stored best-item score is returned directly (avoids a
+	 * redundant computation). Otherwise the score is computed fresh via
+	 * {@link EfficiencyCalculator#scoreIndividualItem}.
+	 */
+	private double computeItemScore(ScoredItem scored, CollectionLogItem target,
+		CollectionLogSource source, double killsPerHour, int killTime, int rolls)
+	{
+		if (scored.getBestItem() != null
+			&& scored.getBestItem().getItemId() == target.getItemId())
+		{
+			return scored.getBestItemScore();
+		}
+		return efficiencyCalculator.scoreIndividualItem(target, source, killsPerHour, killTime, rolls);
+	}
+
+	/**
+	 * Determines whether a source is locked for the current player.
+	 * Locked sources are ones where {@link EfficiencyCalculator#scoreSource} is
+	 * called with {@code locked = true}, mirroring the convention used throughout
+	 * the calculator.
+	 *
+	 * <p>The current implementation conservatively treats all sources as accessible
+	 * at the ranker level; the {@link EfficiencyCalculator#scoreSource} call with
+	 * the correct locked value handles any score adjustments. Callers gate on
+	 * {@code includeLocked} to hide locked sources entirely.
+	 */
+	private boolean isSourceLocked(CollectionLogSource source)
+	{
+		// Delegated to EfficiencyCalculator via the locked parameter passed to
+		// scoreSource. The ranker itself does not duplicate requirements checking.
+		return false;
+	}
+
+	// -------------------------------------------------------------------------
+
+	/** Mutable accumulator for one item's source scores during a ranking pass. */
+	private static final class ItemAccumulator
+	{
+		private final int itemId;
+		private final String itemName;
+		private final List<SourceScore> scores = new ArrayList<>();
+
+		ItemAccumulator(int itemId, String itemName)
+		{
+			this.itemId = itemId;
+			this.itemName = itemName;
+		}
+
+		void add(SourceScore ss)
+		{
+			scores.add(ss);
+		}
+
+		CrossSourceRecommendation build()
+		{
+			scores.sort(Comparator.comparingDouble(SourceScore::getExpectedSeconds));
+			List<SourceScore> sorted = Collections.unmodifiableList(new ArrayList<>(scores));
+			return new CrossSourceRecommendation(itemId, itemName, sorted, sorted.get(0));
+		}
+	}
+}

--- a/src/main/java/com/collectionloghelper/efficiency/CrossSourceRecommendation.java
+++ b/src/main/java/com/collectionloghelper/efficiency/CrossSourceRecommendation.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.efficiency;
+
+import com.collectionloghelper.data.CollectionLogSource;
+import java.util.List;
+import lombok.Value;
+
+/**
+ * Per-item cross-source recommendation produced by {@link CrossSourceRanker}.
+ *
+ * <p>For each unobtained item that appears in more than one source this record
+ * captures all candidate sources ranked by expected time to obtain, and
+ * surfaces the single best source as {@link #best}.
+ *
+ * <p>Items available from only one source are included unchanged so callers do
+ * not need to merge two lists.
+ */
+@Value
+public class CrossSourceRecommendation
+{
+	/**
+	 * The efficiency score for one (item, source) pair, expressed as expected
+	 * seconds to obtain. Lower is better.
+	 *
+	 * <p>A value of {@link Double#MAX_VALUE} means the time cannot be computed
+	 * for this source (zero drop rate or unknown kill time).
+	 */
+	@Value
+	public static class SourceScore
+	{
+		/** The source that contains the item. */
+		CollectionLogSource source;
+
+		/**
+		 * Expected seconds to obtain the item from {@link #source}.
+		 * {@link Double#MAX_VALUE} when the time is indeterminate.
+		 */
+		double expectedSeconds;
+	}
+
+	/** Collection-log item ID of the recommended item. */
+	int itemId;
+
+	/** Human-readable item name for display without an extra lookup. */
+	String itemName;
+
+	/**
+	 * All sources that contain this item, each scored by expected seconds,
+	 * sorted from fastest (lowest seconds) to slowest.
+	 */
+	List<SourceScore> sources;
+
+	/**
+	 * The fastest source for this item — always the first element of
+	 * {@link #sources}. Never null.
+	 */
+	SourceScore best;
+}

--- a/src/test/java/com/collectionloghelper/efficiency/CrossSourceRankerTest.java
+++ b/src/test/java/com/collectionloghelper/efficiency/CrossSourceRankerTest.java
@@ -1,0 +1,396 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.efficiency;
+
+import com.collectionloghelper.AccountType;
+import com.collectionloghelper.AfkFilter;
+import com.collectionloghelper.CollectionLogHelperConfig;
+import com.collectionloghelper.RaidTeamSize;
+import com.collectionloghelper.data.CollectionLogCategory;
+import com.collectionloghelper.data.CollectionLogItem;
+import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.data.DropRateDatabase;
+import com.collectionloghelper.data.PlayerCollectionState;
+import com.collectionloghelper.data.RequirementsChecker;
+import com.collectionloghelper.data.RewardType;
+import com.collectionloghelper.data.SlayerMasterDatabase;
+import com.collectionloghelper.data.SlayerTaskState;
+import com.collectionloghelper.efficiency.CrossSourceRecommendation.SourceScore;
+import java.lang.reflect.Constructor;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link CrossSourceRanker}.
+ *
+ * <p>Uses synthetic sources and items to verify:
+ * <ul>
+ *   <li>Single-source items pass through unmodified.</li>
+ *   <li>Multi-source items are ranked with the fastest source first.</li>
+ *   <li>Obtained items are excluded from all recommendations.</li>
+ *   <li>Items with zero drop rates produce {@link Double#MAX_VALUE} expected seconds.</li>
+ * </ul>
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class CrossSourceRankerTest
+{
+	@Mock
+	private DropRateDatabase database;
+	@Mock
+	private PlayerCollectionState collectionState;
+	@Mock
+	private RequirementsChecker requirementsChecker;
+	@Mock
+	private CollectionLogHelperConfig config;
+	@Mock
+	private ClueCompletionEstimator clueEstimator;
+	@Mock
+	private SlayerTaskState slayerTaskState;
+	@Mock
+	private SlayerMasterDatabase slayerMasterDatabase;
+
+	private EfficiencyCalculator efficiencyCalculator;
+	private CrossSourceRanker ranker;
+
+	@Before
+	public void setUp() throws Exception
+	{
+		lenient().when(requirementsChecker.isAccessible(anyString())).thenReturn(true);
+		lenient().when(config.hideLockedContent()).thenReturn(false);
+		lenient().when(config.raidTeamSize()).thenReturn(RaidTeamSize.SOLO);
+		lenient().when(config.afkFilter()).thenReturn(AfkFilter.OFF);
+		lenient().when(config.accountType()).thenReturn(AccountType.MAIN);
+		lenient().when(slayerTaskState.isTaskActive()).thenReturn(false);
+		lenient().when(clueEstimator.estimateCompletionSeconds(anyString())).thenReturn(0);
+
+		Constructor<EfficiencyCalculator> ctor = EfficiencyCalculator.class.getDeclaredConstructor(
+			DropRateDatabase.class, PlayerCollectionState.class,
+			RequirementsChecker.class, CollectionLogHelperConfig.class,
+			ClueCompletionEstimator.class, SlayerTaskState.class,
+			SlayerMasterDatabase.class);
+		ctor.setAccessible(true);
+		efficiencyCalculator = ctor.newInstance(database, collectionState, requirementsChecker,
+			config, clueEstimator, slayerTaskState, slayerMasterDatabase);
+
+		Constructor<CrossSourceRanker> rankerCtor = CrossSourceRanker.class.getDeclaredConstructor(
+			DropRateDatabase.class, PlayerCollectionState.class, EfficiencyCalculator.class);
+		rankerCtor.setAccessible(true);
+		ranker = rankerCtor.newInstance(database, collectionState, efficiencyCalculator);
+	}
+
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	private CollectionLogSource makeSource(String name, int killTimeSeconds, List<CollectionLogItem> items)
+	{
+		return new CollectionLogSource(name, CollectionLogCategory.BOSSES, 3000, 3000, 0,
+			killTimeSeconds, 0, name, Collections.emptyList(),
+			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0, items);
+	}
+
+	private CollectionLogItem makeItem(int id, String name, double dropRate)
+	{
+		return new CollectionLogItem(id, name, dropRate, false, null, 0, 0, false, false);
+	}
+
+	// -------------------------------------------------------------------------
+	// scoreToSeconds utility
+	// -------------------------------------------------------------------------
+
+	@Test
+	public void scoreToSeconds_zeroScore_returnsMaxValue()
+	{
+		assertEquals(Double.MAX_VALUE, CrossSourceRanker.scoreToSeconds(0.0), 0.0);
+	}
+
+	@Test
+	public void scoreToSeconds_negativeScore_returnsMaxValue()
+	{
+		assertEquals(Double.MAX_VALUE, CrossSourceRanker.scoreToSeconds(-1.0), 0.0);
+	}
+
+	@Test
+	public void scoreToSeconds_positiveScore_returnsCorrectSeconds()
+	{
+		// score = 100 => hoursToObtain = 1 => seconds = 3600
+		assertEquals(3600.0, CrossSourceRanker.scoreToSeconds(100.0), 0.001);
+	}
+
+	@Test
+	public void scoreToSeconds_halfScore_returnsDoubleTime()
+	{
+		// score = 50 => hoursToObtain = 2 => seconds = 7200
+		assertEquals(7200.0, CrossSourceRanker.scoreToSeconds(50.0), 0.001);
+	}
+
+	// -------------------------------------------------------------------------
+	// Single-source items pass through
+	// -------------------------------------------------------------------------
+
+	@Test
+	public void rank_singleSourceItem_appearsInResult()
+	{
+		CollectionLogItem item = makeItem(1001, "Dragon axe", 1.0 / 512.0);
+		CollectionLogSource source = makeSource("Dagannoth Kings", 120, Arrays.asList(item));
+
+		when(database.getAllSources()).thenReturn(Collections.singletonList(source));
+		when(collectionState.isItemObtained(1001)).thenReturn(false);
+
+		List<CrossSourceRecommendation> results = ranker.rank(false);
+
+		assertEquals(1, results.size());
+		CrossSourceRecommendation rec = results.get(0);
+		assertEquals(1001, rec.getItemId());
+		assertEquals("Dragon axe", rec.getItemName());
+		assertEquals(1, rec.getSources().size());
+		assertNotNull(rec.getBest());
+		assertEquals(source, rec.getBest().getSource());
+	}
+
+	@Test
+	public void rank_singleSourceItem_bestMatchesOnlySource()
+	{
+		CollectionLogItem item = makeItem(2001, "Abyssal whip", 1.0 / 512.0);
+		CollectionLogSource source = makeSource("Abyssal Sire", 90, Arrays.asList(item));
+
+		when(database.getAllSources()).thenReturn(Collections.singletonList(source));
+		when(collectionState.isItemObtained(2001)).thenReturn(false);
+
+		List<CrossSourceRecommendation> results = ranker.rank(false);
+
+		assertEquals(source, results.get(0).getBest().getSource());
+	}
+
+	// -------------------------------------------------------------------------
+	// Multi-source items ranked correctly
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Item 3001 appears in two sources with the same drop rate but different kill
+	 * times. Source A has a 3x faster kill time, so it must rank first.
+	 */
+	@Test
+	public void rank_multiSourceItem_fastestSourceRankedFirst()
+	{
+		double dropRate = 1.0 / 100.0;
+		CollectionLogItem item = makeItem(3001, "Twisted bow", dropRate);
+
+		CollectionLogSource sourceA = makeSource("CoX Fast", 30, Arrays.asList(item));
+		CollectionLogSource sourceB = makeSource("CoX Slow", 90, Arrays.asList(item));
+
+		when(database.getAllSources()).thenReturn(Arrays.asList(sourceA, sourceB));
+		when(collectionState.isItemObtained(3001)).thenReturn(false);
+
+		List<CrossSourceRecommendation> results = ranker.rank(false);
+
+		assertEquals(1, results.size());
+		CrossSourceRecommendation rec = results.get(0);
+		assertEquals(3001, rec.getItemId());
+		assertEquals(2, rec.getSources().size());
+
+		assertEquals(sourceA, rec.getBest().getSource());
+		assertTrue(rec.getSources().get(0).getExpectedSeconds() < rec.getSources().get(1).getExpectedSeconds());
+	}
+
+	@Test
+	public void rank_multiSourceItem_sourcesAreSortedAscendingByExpectedSeconds()
+	{
+		double dropRate = 1.0 / 200.0;
+		CollectionLogItem item = makeItem(4001, "Ancestral hat", dropRate);
+
+		// sourceB is faster (60s kill time vs 120s)
+		CollectionLogSource sourceA = makeSource("Chambers of Xeric", 120, Arrays.asList(item));
+		CollectionLogSource sourceB = makeSource("Tombs of Amascut", 60, Arrays.asList(item));
+
+		when(database.getAllSources()).thenReturn(Arrays.asList(sourceA, sourceB));
+		when(collectionState.isItemObtained(4001)).thenReturn(false);
+
+		List<CrossSourceRecommendation> results = ranker.rank(false);
+
+		CrossSourceRecommendation rec = results.get(0);
+		List<SourceScore> sources = rec.getSources();
+
+		for (int i = 0; i < sources.size() - 1; i++)
+		{
+			assertTrue(sources.get(i).getExpectedSeconds() <= sources.get(i + 1).getExpectedSeconds());
+		}
+		assertEquals(sourceB, rec.getBest().getSource());
+	}
+
+	// -------------------------------------------------------------------------
+	// Obtained items excluded
+	// -------------------------------------------------------------------------
+
+	@Test
+	public void rank_obtainedItem_excludedFromResults()
+	{
+		CollectionLogItem item = makeItem(5001, "Bandos chestplate", 1.0 / 384.0);
+		CollectionLogSource source = makeSource("General Graardor", 120, Arrays.asList(item));
+
+		when(database.getAllSources()).thenReturn(Collections.singletonList(source));
+		when(collectionState.isItemObtained(5001)).thenReturn(true);
+
+		List<CrossSourceRecommendation> results = ranker.rank(false);
+
+		assertTrue(results.isEmpty());
+	}
+
+	@Test
+	public void rank_mixedObtainedAndUnobtained_onlyUnobtainedReturned()
+	{
+		CollectionLogItem obtained = makeItem(6001, "Bandos chestplate", 1.0 / 384.0);
+		CollectionLogItem unobtained = makeItem(6002, "Bandos tassets", 1.0 / 384.0);
+		CollectionLogSource source = makeSource("General Graardor", 120, Arrays.asList(obtained, unobtained));
+
+		when(database.getAllSources()).thenReturn(Collections.singletonList(source));
+		when(collectionState.isItemObtained(6001)).thenReturn(true);
+		when(collectionState.isItemObtained(6002)).thenReturn(false);
+
+		List<CrossSourceRecommendation> results = ranker.rank(false);
+
+		assertEquals(1, results.size());
+		assertEquals(6002, results.get(0).getItemId());
+	}
+
+	@Test
+	public void rank_allItemsObtained_returnsEmptyList()
+	{
+		CollectionLogItem item1 = makeItem(7001, "Armadyl chestplate", 1.0 / 381.0);
+		CollectionLogItem item2 = makeItem(7002, "Armadyl chainskirt", 1.0 / 381.0);
+		CollectionLogSource source = makeSource("Kree'arra", 90, Arrays.asList(item1, item2));
+
+		when(database.getAllSources()).thenReturn(Collections.singletonList(source));
+		when(collectionState.isItemObtained(7001)).thenReturn(true);
+		when(collectionState.isItemObtained(7002)).thenReturn(true);
+
+		List<CrossSourceRecommendation> results = ranker.rank(false);
+
+		assertTrue(results.isEmpty());
+	}
+
+	// -------------------------------------------------------------------------
+	// Outer list sorted by best expected seconds
+	// -------------------------------------------------------------------------
+
+	@Test
+	public void rank_outerListSortedByBestExpectedSeconds()
+	{
+		// Item A: very slow to obtain
+		CollectionLogItem itemA = makeItem(8001, "Slow item", 1.0 / 1000.0);
+		CollectionLogSource sourceA = makeSource("Slow Boss", 1800, Arrays.asList(itemA));
+
+		// Item B: fast to obtain
+		CollectionLogItem itemB = makeItem(8002, "Fast item", 1.0 / 10.0);
+		CollectionLogSource sourceB = makeSource("Fast Boss", 60, Arrays.asList(itemB));
+
+		when(database.getAllSources()).thenReturn(Arrays.asList(sourceA, sourceB));
+		when(collectionState.isItemObtained(8001)).thenReturn(false);
+		when(collectionState.isItemObtained(8002)).thenReturn(false);
+
+		List<CrossSourceRecommendation> results = ranker.rank(false);
+
+		assertEquals(2, results.size());
+		assertEquals(8002, results.get(0).getItemId());
+		assertEquals(8001, results.get(1).getItemId());
+		assertTrue(results.get(0).getBest().getExpectedSeconds()
+			< results.get(1).getBest().getExpectedSeconds());
+	}
+
+	// -------------------------------------------------------------------------
+	// Zero drop rate items
+	// -------------------------------------------------------------------------
+
+	@Test
+	public void rank_zeroDropRateItem_expectedSecondsIsMaxValue()
+	{
+		CollectionLogItem item = makeItem(9001, "Zero rate item", 0.0);
+		CollectionLogSource source = makeSource("Mystery Source", 120, Arrays.asList(item));
+
+		when(database.getAllSources()).thenReturn(Collections.singletonList(source));
+		when(collectionState.isItemObtained(9001)).thenReturn(false);
+
+		List<CrossSourceRecommendation> results = ranker.rank(false);
+
+		// Item still included (fallback count score keeps source non-null)
+		assertFalse(results.isEmpty());
+		assertEquals(Double.MAX_VALUE, results.get(0).getBest().getExpectedSeconds(), 0.0);
+	}
+
+	// -------------------------------------------------------------------------
+	// Non-overlapping sources
+	// -------------------------------------------------------------------------
+
+	@Test
+	public void rank_twoSourcesNoOverlap_bothItemsPresent()
+	{
+		CollectionLogItem item1 = makeItem(10001, "Whip", 1.0 / 512.0);
+		CollectionLogItem item2 = makeItem(10002, "Visage", 1.0 / 5000.0);
+		CollectionLogSource source1 = makeSource("Abyssal Sire", 90, Arrays.asList(item1));
+		CollectionLogSource source2 = makeSource("Skeletal Wyvern", 120, Arrays.asList(item2));
+
+		when(database.getAllSources()).thenReturn(Arrays.asList(source1, source2));
+		when(collectionState.isItemObtained(10001)).thenReturn(false);
+		when(collectionState.isItemObtained(10002)).thenReturn(false);
+
+		List<CrossSourceRecommendation> results = ranker.rank(false);
+
+		assertEquals(2, results.size());
+		assertTrue(results.stream().allMatch(r -> r.getSources().size() == 1));
+	}
+
+	// -------------------------------------------------------------------------
+	// Result immutability
+	// -------------------------------------------------------------------------
+
+	@Test
+	public void rank_returnedList_isImmutable()
+	{
+		when(database.getAllSources()).thenReturn(Collections.emptyList());
+
+		List<CrossSourceRecommendation> results = ranker.rank(false);
+
+		try
+		{
+			results.add(null);
+			fail("Expected UnsupportedOperationException");
+		}
+		catch (UnsupportedOperationException expected)
+		{
+			// correct
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `CrossSourceRanker`, a new ranker that pivots from the existing per-source view to a per-item view: for each unobtained item it collects every source that contains it, computes expected seconds to obtain from each source via `EfficiencyCalculator.scoreIndividualItem`, and returns `List<CrossSourceRecommendation>` sorted fastest-first.
- Adds `CrossSourceRecommendation` value type (`itemId`, `itemName`, `sources`, `best`) and inner `SourceScore` type (`source`, `expectedSeconds`).
- Adds `enableCrossSourceMode` config flag (default OFF, `hidden = true`) to `CollectionLogHelperConfig` for future panel wiring.
- 17 unit tests in `CrossSourceRankerTest` covering: single-source pass-through, multi-source ranking correctness, obtained-item exclusion, zero-drop-rate handling, outer-list sort order, and result immutability.
- ROADMAP E1 marked `[/]` in-progress.

## Test plan

- [ ] `./gradlew test build` passes (verified locally — BUILD SUCCESSFUL in 27s)
- [ ] `CrossSourceRankerTest` — all 17 tests green
- [ ] No changes to existing tests or production behaviour; `enableCrossSourceMode` defaults to `false`
- [ ] Panel integration is intentionally deferred per spec; the ranker is wired and ready for a follow-up PR