### PR TITLE
feat(sync): F1 — collectionlog.net profile import

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -598,7 +598,7 @@ Focus: god-object decomposition, build hardening, test expansion. Resulted in th
 
 **Tier F — Social, imports, and long-tail polish**
 
-- [/] F1 — collectionlog.net import                     status: in-progress   owner: cha-ndler  updated: 2026-05-14  note: pr pending
+- [/] F1 — collectionlog.net import                     status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #465
 - [ ] F2 — TempleOSRS KC sync                           status: planned       owner: —          updated: 2026-04-16
 - [ ] F3 — Per-account kill-time learning               status: planned       owner: —          updated: 2026-04-16
 - [ ] F4 — Dry-streak feed                              status: planned       owner: —          updated: 2026-04-16

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -598,7 +598,7 @@ Focus: god-object decomposition, build hardening, test expansion. Resulted in th
 
 **Tier F — Social, imports, and long-tail polish**
 
-- [ ] F1 — collectionlog.net import                     status: planned       owner: —          updated: 2026-04-16
+- [/] F1 — collectionlog.net import                     status: in-progress   owner: cha-ndler  updated: 2026-05-14  note: pr pending
 - [ ] F2 — TempleOSRS KC sync                           status: planned       owner: —          updated: 2026-04-16
 - [ ] F3 — Per-account kill-time learning               status: planned       owner: —          updated: 2026-04-16
 - [ ] F4 — Dry-streak feed                              status: planned       owner: —          updated: 2026-04-16

--- a/src/main/java/com/collectionloghelper/CollectionLogHelperConfig.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperConfig.java
@@ -42,6 +42,26 @@ public interface CollectionLogHelperConfig extends Config
 	String guidanceSection = "guidance";
 
 	@ConfigSection(
+		name = "Sync",
+		description = "External data sync settings",
+		position = 150,
+		closedByDefault = true
+	)
+	String syncSection = "sync";
+
+	@ConfigItem(
+		keyName = "enableCollectionLogNetImport",
+		name = "collectionlog.net import",
+		description = "Show a 'Sync from collectionlog.net' button in the panel to import your obtained items from collectionlog.net",
+		section = syncSection,
+		position = 0
+	)
+	default boolean enableCollectionLogNetImport()
+	{
+		return false;
+	}
+
+	@ConfigSection(
 		name = "Developer",
 		description = "Development tools for authoring guidance sequences",
 		position = 200,

--- a/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
@@ -26,6 +26,8 @@ package com.collectionloghelper;
 
 import com.collectionloghelper.data.CollectionLogItem;
 import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.sync.CollectionLogNetImporter;
+import com.collectionloghelper.sync.ImportResult;
 import com.collectionloghelper.data.DataSyncState;
 import com.collectionloghelper.data.DropRateDatabase;
 import com.collectionloghelper.data.PlayerBankState;
@@ -56,6 +58,8 @@ import java.awt.image.BufferedImage;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
@@ -206,6 +210,8 @@ public class CollectionLogHelperPlugin extends Plugin
 	@Inject
 	private com.collectionloghelper.guidance.GuidanceMovementTracker guidanceMovementTracker;
 
+	@Inject
+	private CollectionLogNetImporter collectionLogNetImporter;
 
 	private CollectionLogHelperPanel panel;
 	private NavigationButton navButton;
@@ -260,6 +266,46 @@ public class CollectionLogHelperPlugin extends Plugin
 			() -> clientThread.invokeLater(guidanceSequencer::restartFromStep0),
 			() -> clientThread.invokeLater(guidanceSequencer::syncToCurrentState)
 		);
+
+		// Wire collectionlog.net import callback — fetches username from the logged-in player.
+		// Called from the EDT; submits async work and posts the result back via the panel method.
+		panel.setCollectionLogNetImportCallback(() ->
+		{
+			String username = client.getLocalPlayer() != null
+				? client.getLocalPlayer().getName()
+				: null;
+			if (username == null || username.isEmpty())
+			{
+				panel.onCollectionLogNetImportComplete("Log in first");
+				return;
+			}
+			Future<ImportResult> future =
+				collectionLogNetImporter.importProfile(username);
+			// Poll the result on a daemon thread so the EDT is not blocked
+			Executors.newSingleThreadExecutor(r ->
+			{
+				Thread t = new Thread(r, "clh-import-result-waiter");
+				t.setDaemon(true);
+				return t;
+			}).submit(() ->
+			{
+				try
+				{
+					ImportResult result = future.get();
+					panel.onCollectionLogNetImportComplete(result.toToastMessage());
+					if (result.isSuccess())
+					{
+						// Trigger a panel rebuild on the EDT
+						panel.rebuild();
+					}
+				}
+				catch (Exception e)
+				{
+					log.warn("collectionlog.net import result waiter failed", e);
+					panel.onCollectionLogNetImportComplete("collectionlog.net: error");
+				}
+			});
+		});
 
 		// Wire coordinator with references it needs from the plugin
 		guidanceCoordinator.setPluginInstance(this);
@@ -331,6 +377,7 @@ public class CollectionLogHelperPlugin extends Plugin
 	{
 		chatCommandManager.unregisterCommand("clh");
 		authoringLogger.close();
+		collectionLogNetImporter.shutdown();
 		if (panel != null)
 		{
 			panel.shutDown();

--- a/src/main/java/com/collectionloghelper/sync/CollectionLogNetImporter.java
+++ b/src/main/java/com/collectionloghelper/sync/CollectionLogNetImporter.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.sync;
+
+import com.collectionloghelper.data.PlayerCollectionState;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.Call;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+/**
+ * Fetches a player's obtained-item list from collectionlog.net and marks
+ * each item as obtained via {@link PlayerCollectionState#markItemObtained}.
+ *
+ * <p>All HTTP work is dispatched on a dedicated single-thread executor so the
+ * game thread and EDT are never blocked.  Every failure mode is caught and
+ * reflected in the returned {@link ImportResult} — this class never throws
+ * to its caller.
+ *
+ * <p>API endpoint:
+ * {@code GET https://api.collectionlog.net/collectionlog/user/{username}}
+ */
+@Slf4j
+@Singleton
+public class CollectionLogNetImporter
+{
+	static final String BASE_URL = "https://api.collectionlog.net/collectionlog/user/";
+
+	private final OkHttpClient httpClient;
+	private final Gson gson;
+	private final PlayerCollectionState collectionState;
+	private final ExecutorService executor;
+
+	@Inject
+	CollectionLogNetImporter(OkHttpClient httpClient, Gson gson, PlayerCollectionState collectionState)
+	{
+		this.httpClient = httpClient;
+		this.gson = gson;
+		this.collectionState = collectionState;
+		this.executor = Executors.newSingleThreadExecutor(r ->
+		{
+			Thread t = new Thread(r, "clh-collectionlog-net-import");
+			t.setDaemon(true);
+			return t;
+		});
+	}
+
+	/**
+	 * Package-private constructor for testing — accepts an injected executor so
+	 * unit tests can use a same-thread executor without spawning real threads.
+	 */
+	CollectionLogNetImporter(OkHttpClient httpClient, Gson gson,
+		PlayerCollectionState collectionState, ExecutorService executor)
+	{
+		this.httpClient = httpClient;
+		this.gson = gson;
+		this.collectionState = collectionState;
+		this.executor = executor;
+	}
+
+	/**
+	 * Submits an import task for the given username.  Returns immediately with a
+	 * {@link Future} that resolves to an {@link ImportResult} describing the
+	 * outcome.  Never throws — all failure modes produce a failure {@link ImportResult}.
+	 *
+	 * @param username the collectionlog.net RSN (URL-encoded by this method)
+	 * @return a {@link Future} resolving to the import result
+	 */
+	public Future<ImportResult> importProfile(String username)
+	{
+		return executor.submit(() -> doImport(username));
+	}
+
+	private ImportResult doImport(String username)
+	{
+		String url = BASE_URL + encodeUsername(username);
+		log.debug("Fetching collectionlog.net profile for '{}' from {}", username, url);
+
+		Request request = new Request.Builder()
+			.url(url)
+			.header("User-Agent", "collection-log-helper-plugin")
+			.build();
+
+		Call call = httpClient.newCall(request);
+		try (Response response = call.execute())
+		{
+			int code = response.code();
+
+			if (code == 404)
+			{
+				log.warn("collectionlog.net: user not found — {}", username);
+				return ImportResult.userNotFound(username);
+			}
+
+			if (!response.isSuccessful())
+			{
+				log.warn("collectionlog.net: HTTP {} for user '{}'", code, username);
+				return ImportResult.serviceUnavailable(code);
+			}
+
+			ResponseBody body = response.body();
+			if (body == null)
+			{
+				log.warn("collectionlog.net: empty response body for user '{}'", username);
+				return ImportResult.serviceUnavailable(code);
+			}
+
+			String json = body.string();
+			return parseAndMark(json, username);
+		}
+		catch (IOException e)
+		{
+			log.warn("collectionlog.net: network error importing profile for '{}'", username, e);
+			return ImportResult.serviceUnavailable(0);
+		}
+	}
+
+	/**
+	 * Parses the JSON response and marks all obtained items.  Returns a failure
+	 * result (not an exception) when the JSON cannot be parsed or is structurally
+	 * invalid.
+	 *
+	 * <p>Expected shape (simplified):
+	 * <pre>{@code
+	 * {
+	 *   "collectionLog": {
+	 *     "tabs": {
+	 *       "TabName": {
+	 *         "SourceName": {
+	 *           "items": [
+	 *             { "id": 12345, "obtained": true, ... },
+	 *             ...
+	 *           ]
+	 *         }
+	 *       }
+	 *     }
+	 *   }
+	 * }
+	 * }</pre>
+	 */
+	ImportResult parseAndMark(String json, String username)
+	{
+		try
+		{
+			JsonObject root = gson.fromJson(json, JsonObject.class);
+			if (root == null)
+			{
+				log.warn("collectionlog.net: null root for user '{}'", username);
+				return ImportResult.malformedResponse();
+			}
+
+			JsonObject collectionLog = getObject(root, "collectionLog");
+			if (collectionLog == null)
+			{
+				log.warn("collectionlog.net: missing 'collectionLog' key for user '{}'", username);
+				return ImportResult.malformedResponse();
+			}
+
+			JsonObject tabs = getObject(collectionLog, "tabs");
+			if (tabs == null)
+			{
+				log.warn("collectionlog.net: missing 'tabs' key for user '{}'", username);
+				return ImportResult.malformedResponse();
+			}
+
+			int marked = 0;
+			int skipped = 0;
+
+			for (String tabName : tabs.keySet())
+			{
+				JsonElement tabEl = tabs.get(tabName);
+				if (!tabEl.isJsonObject())
+				{
+					continue;
+				}
+				JsonObject tab = tabEl.getAsJsonObject();
+
+				for (String sourceName : tab.keySet())
+				{
+					JsonElement sourceEl = tab.get(sourceName);
+					if (!sourceEl.isJsonObject())
+					{
+						continue;
+					}
+					JsonObject source = sourceEl.getAsJsonObject();
+					JsonElement itemsEl = source.get("items");
+					if (itemsEl == null || !itemsEl.isJsonArray())
+					{
+						continue;
+					}
+
+					JsonArray items = itemsEl.getAsJsonArray();
+					for (JsonElement itemEl : items)
+					{
+						if (!itemEl.isJsonObject())
+						{
+							skipped++;
+							continue;
+						}
+						JsonObject item = itemEl.getAsJsonObject();
+						JsonElement obtainedEl = item.get("obtained");
+						if (obtainedEl == null || !obtainedEl.getAsBoolean())
+						{
+							continue;
+						}
+						JsonElement idEl = item.get("id");
+						if (idEl == null || !idEl.isJsonPrimitive())
+						{
+							skipped++;
+							continue;
+						}
+						int itemId = idEl.getAsInt();
+						if (collectionState.markItemObtained(itemId))
+						{
+							marked++;
+						}
+					}
+				}
+			}
+
+			log.info("collectionlog.net import complete for '{}': {} items marked, {} skipped",
+				username, marked, skipped);
+			return ImportResult.success(marked);
+		}
+		catch (JsonParseException | IllegalStateException | NumberFormatException e)
+		{
+			log.warn("collectionlog.net: malformed JSON for user '{}'", username, e);
+			return ImportResult.malformedResponse();
+		}
+	}
+
+	/** URL-encode the username for safe use in a path segment. */
+	private static String encodeUsername(String username)
+	{
+		try
+		{
+			return java.net.URLEncoder.encode(username, "UTF-8").replace("+", "%20");
+		}
+		catch (java.io.UnsupportedEncodingException e)
+		{
+			// UTF-8 is always available
+			return username;
+		}
+	}
+
+	private static JsonObject getObject(JsonObject parent, String key)
+	{
+		JsonElement el = parent.get(key);
+		if (el == null || !el.isJsonObject())
+		{
+			return null;
+		}
+		return el.getAsJsonObject();
+	}
+
+	/**
+	 * Shuts down the background executor.  Safe to call multiple times.
+	 */
+	public void shutdown()
+	{
+		executor.shutdown();
+	}
+}

--- a/src/main/java/com/collectionloghelper/sync/ImportResult.java
+++ b/src/main/java/com/collectionloghelper/sync/ImportResult.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.sync;
+
+/**
+ * Outcome of a {@link CollectionLogNetImporter#importProfile} call.
+ * Immutable value type — use the static factory methods.
+ */
+public final class ImportResult
+{
+	public enum Status
+	{
+		/** Import completed successfully. */
+		SUCCESS,
+		/** The requested username was not found on collectionlog.net (HTTP 404). */
+		USER_NOT_FOUND,
+		/** The service returned a non-404 error or a network error occurred. */
+		SERVICE_UNAVAILABLE,
+		/** The response body could not be parsed as expected JSON. */
+		MALFORMED_RESPONSE
+	}
+
+	private final Status status;
+	private final int itemsMarked;
+	private final String username;
+	private final int httpCode;
+
+	private ImportResult(Status status, int itemsMarked, String username, int httpCode)
+	{
+		this.status = status;
+		this.itemsMarked = itemsMarked;
+		this.username = username;
+		this.httpCode = httpCode;
+	}
+
+	public static ImportResult success(int itemsMarked)
+	{
+		return new ImportResult(Status.SUCCESS, itemsMarked, null, 200);
+	}
+
+	public static ImportResult userNotFound(String username)
+	{
+		return new ImportResult(Status.USER_NOT_FOUND, 0, username, 404);
+	}
+
+	public static ImportResult serviceUnavailable(int httpCode)
+	{
+		return new ImportResult(Status.SERVICE_UNAVAILABLE, 0, null, httpCode);
+	}
+
+	public static ImportResult malformedResponse()
+	{
+		return new ImportResult(Status.MALFORMED_RESPONSE, 0, null, 0);
+	}
+
+	public Status getStatus()
+	{
+		return status;
+	}
+
+	public boolean isSuccess()
+	{
+		return status == Status.SUCCESS;
+	}
+
+	public int getItemsMarked()
+	{
+		return itemsMarked;
+	}
+
+	/** Username associated with a {@link Status#USER_NOT_FOUND} result; {@code null} otherwise. */
+	public String getUsername()
+	{
+		return username;
+	}
+
+	public int getHttpCode()
+	{
+		return httpCode;
+	}
+
+	/** Human-readable toast message suitable for display in the panel. */
+	public String toToastMessage()
+	{
+		switch (status)
+		{
+			case SUCCESS:
+				return "Synced " + itemsMarked + " item" + (itemsMarked == 1 ? "" : "s")
+					+ " from collectionlog.net";
+			case USER_NOT_FOUND:
+				return "collectionlog.net: user not found";
+			case SERVICE_UNAVAILABLE:
+				return "collectionlog.net: service unavailable";
+			case MALFORMED_RESPONSE:
+				return "collectionlog.net: unexpected response format";
+			default:
+				return "collectionlog.net: unknown error";
+		}
+	}
+
+	@Override
+	public String toString()
+	{
+		return "ImportResult{status=" + status
+			+ ", itemsMarked=" + itemsMarked
+			+ ", httpCode=" + httpCode + "}";
+	}
+}

--- a/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
@@ -74,6 +74,7 @@ import java.util.function.Consumer;
 import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
+import javax.swing.JButton;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -138,6 +139,10 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 
 	private final SyncStatusView syncStatusView;
 	private final ClueSummaryView clueSummaryView;
+	private final JButton collectionLogNetSyncButton;
+
+	/** Set by the plugin after construction; called when the sync button is clicked. */
+	private Runnable collectionLogNetImportCallback;
 
 	private final JComboBox<Mode> modeSelector;
 	private final JComboBox<AfkFilter> afkFilterSelector;
@@ -225,6 +230,23 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 		syncStatusView.setAlignmentX(CENTER_ALIGNMENT);
 		syncStatusView.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
 		controlsPanel.add(syncStatusView);
+
+		collectionLogNetSyncButton = new JButton("Sync from collectionlog.net");
+		collectionLogNetSyncButton.setAlignmentX(CENTER_ALIGNMENT);
+		collectionLogNetSyncButton.setMaximumSize(new Dimension(Integer.MAX_VALUE, 26));
+		collectionLogNetSyncButton.setFont(FontManager.getRunescapeSmallFont());
+		collectionLogNetSyncButton.setFocusPainted(false);
+		collectionLogNetSyncButton.setVisible(config.enableCollectionLogNetImport());
+		collectionLogNetSyncButton.addActionListener(e ->
+		{
+			if (collectionLogNetImportCallback != null)
+			{
+				collectionLogNetSyncButton.setEnabled(false);
+				collectionLogNetSyncButton.setText("Syncing...");
+				collectionLogNetImportCallback.run();
+			}
+		});
+		controlsPanel.add(collectionLogNetSyncButton);
 
 		clueSummaryView = new ClueSummaryView();
 		clueSummaryView.setAlignmentX(CENTER_ALIGNMENT);
@@ -434,6 +456,50 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 	public void updateClueSummary(PlayerBankState bankState)
 	{
 		clueSummaryView.updateFromBankState(bankState);
+	}
+
+	/**
+	 * Wires the callback invoked when the "Sync from collectionlog.net" button is clicked.
+	 * Must be called from the EDT or before the panel is shown.
+	 */
+	public void setCollectionLogNetImportCallback(Runnable callback)
+	{
+		this.collectionLogNetImportCallback = callback;
+	}
+
+	/**
+	 * Resets the "Sync from collectionlog.net" button to its ready state and
+	 * shows a brief result message in the button text.  Safe to call from any thread.
+	 *
+	 * @param message short result message, e.g. "Synced 42 items from collectionlog.net"
+	 */
+	public void onCollectionLogNetImportComplete(String message)
+	{
+		SwingUtilities.invokeLater(() ->
+		{
+			collectionLogNetSyncButton.setEnabled(true);
+			collectionLogNetSyncButton.setText(message);
+		});
+	}
+
+	/**
+	 * Shows or hides the collectionlog.net sync button based on the config flag.
+	 * Call when the config section toggle changes.  Safe to call from any thread.
+	 */
+	public void updateCollectionLogNetImportButton()
+	{
+		SwingUtilities.invokeLater(() ->
+		{
+			boolean enabled = config.enableCollectionLogNetImport();
+			collectionLogNetSyncButton.setVisible(enabled);
+			if (enabled)
+			{
+				collectionLogNetSyncButton.setEnabled(true);
+				collectionLogNetSyncButton.setText("Sync from collectionlog.net");
+			}
+			revalidate();
+			repaint();
+		});
 	}
 
 	public void shutDown()

--- a/src/test/java/com/collectionloghelper/sync/CollectionLogNetImporterTest.java
+++ b/src/test/java/com/collectionloghelper/sync/CollectionLogNetImporterTest.java
@@ -1,0 +1,351 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.sync;
+
+import com.collectionloghelper.data.PlayerCollectionState;
+import com.google.gson.Gson;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link CollectionLogNetImporter}.
+ *
+ * HTTP calls are intercepted via a mocked {@link OkHttpClient} — the real
+ * collectionlog.net API is never contacted.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class CollectionLogNetImporterTest
+{
+	private static final MediaType JSON = MediaType.get("application/json; charset=utf-8");
+
+	/** Two-item response: both obtained. */
+	private static final String HAPPY_PATH_JSON = "{"
+		+ "\"collectionLog\":{"
+		+ "  \"tabs\":{"
+		+ "    \"Bosses\":{"
+		+ "      \"Zulrah\":{"
+		+ "        \"items\":["
+		+ "          {\"id\":12932,\"name\":\"Tanzanite fang\",\"obtained\":true,\"quantity\":1},"
+		+ "          {\"id\":12934,\"name\":\"Magic fang\",\"obtained\":true,\"quantity\":2}"
+		+ "        ]"
+		+ "      }"
+		+ "    }"
+		+ "  }"
+		+ "}}";
+
+	/** One obtained, one not. */
+	private static final String PARTIAL_OBTAINED_JSON = "{"
+		+ "\"collectionLog\":{"
+		+ "  \"tabs\":{"
+		+ "    \"Bosses\":{"
+		+ "      \"Vorkath\":{"
+		+ "        \"items\":["
+		+ "          {\"id\":21892,\"name\":\"Dragonbone necklace\",\"obtained\":true,\"quantity\":1},"
+		+ "          {\"id\":21896,\"name\":\"Vorkath's head\",\"obtained\":false,\"quantity\":0}"
+		+ "        ]"
+		+ "      }"
+		+ "    }"
+		+ "  }"
+		+ "}}";
+
+	private static final String NOT_FOUND_BODY = "{\"error\":\"Player not found\"}";
+
+	@Mock
+	private OkHttpClient mockHttpClient;
+
+	@Mock
+	private okhttp3.Call mockCall;
+
+	@Mock
+	private PlayerCollectionState mockCollectionState;
+
+	private final Gson gson = new Gson();
+	private final ExecutorService sameThread = Executors.newSingleThreadExecutor();
+
+	private CollectionLogNetImporter importer;
+
+	@Before
+	public void setUp()
+	{
+		importer = new CollectionLogNetImporter(mockHttpClient, gson, mockCollectionState, sameThread);
+		when(mockHttpClient.newCall(any(Request.class))).thenReturn(mockCall);
+	}
+
+	// ── Happy path ────────────────────────────────────────────────────────────
+
+	@Test
+	public void happyPath_marksObtainedItems() throws Exception
+	{
+		stubResponse(200, HAPPY_PATH_JSON);
+		when(mockCollectionState.markItemObtained(anyInt())).thenReturn(true);
+
+		ImportResult result = get(importer.importProfile("Zezima"));
+
+		assertTrue(result.isSuccess());
+		assertEquals(ImportResult.Status.SUCCESS, result.getStatus());
+		assertEquals(2, result.getItemsMarked());
+
+		ArgumentCaptor<Integer> idCaptor = ArgumentCaptor.forClass(Integer.class);
+		verify(mockCollectionState, atLeastOnce()).markItemObtained(idCaptor.capture());
+		assertTrue(idCaptor.getAllValues().contains(12932));
+		assertTrue(idCaptor.getAllValues().contains(12934));
+	}
+
+	@Test
+	public void happyPath_skipsNonObtainedItems() throws Exception
+	{
+		stubResponse(200, PARTIAL_OBTAINED_JSON);
+		when(mockCollectionState.markItemObtained(21892)).thenReturn(true);
+
+		ImportResult result = get(importer.importProfile("Zezima"));
+
+		assertTrue(result.isSuccess());
+		assertEquals(1, result.getItemsMarked());
+		verify(mockCollectionState).markItemObtained(21892);
+		verify(mockCollectionState, never()).markItemObtained(21896);
+	}
+
+	@Test
+	public void happyPath_toastMessageContainsCount() throws Exception
+	{
+		stubResponse(200, HAPPY_PATH_JSON);
+		when(mockCollectionState.markItemObtained(anyInt())).thenReturn(true);
+
+		ImportResult result = get(importer.importProfile("Zezima"));
+
+		assertTrue(result.toToastMessage().contains("2"));
+		assertTrue(result.toToastMessage().contains("collectionlog.net"));
+	}
+
+	// ── 404 — user not found ─────────────────────────────────────────────────
+
+	@Test
+	public void notFound_returns404Result() throws Exception
+	{
+		stubResponse(404, NOT_FOUND_BODY);
+
+		ImportResult result = get(importer.importProfile("NoSuchPlayer"));
+
+		assertFalse(result.isSuccess());
+		assertEquals(ImportResult.Status.USER_NOT_FOUND, result.getStatus());
+		assertEquals(0, result.getItemsMarked());
+	}
+
+	@Test
+	public void notFound_toastMessageMentionsUserNotFound() throws Exception
+	{
+		stubResponse(404, NOT_FOUND_BODY);
+
+		ImportResult result = get(importer.importProfile("NoSuchPlayer"));
+
+		assertTrue(result.toToastMessage().toLowerCase().contains("not found"));
+	}
+
+	@Test
+	public void notFound_doesNotCallMarkItemObtained() throws Exception
+	{
+		stubResponse(404, NOT_FOUND_BODY);
+
+		get(importer.importProfile("NoSuchPlayer"));
+
+		verify(mockCollectionState, never()).markItemObtained(anyInt());
+	}
+
+	// ── 500 — service error ──────────────────────────────────────────────────
+
+	@Test
+	public void serverError_returnsServiceUnavailable() throws Exception
+	{
+		stubResponse(500, "{\"error\":\"Internal Server Error\"}");
+
+		ImportResult result = get(importer.importProfile("Zezima"));
+
+		assertFalse(result.isSuccess());
+		assertEquals(ImportResult.Status.SERVICE_UNAVAILABLE, result.getStatus());
+	}
+
+	@Test
+	public void serverError_toastMessageMentionsServiceUnavailable() throws Exception
+	{
+		stubResponse(500, "{\"error\":\"Internal Server Error\"}");
+
+		ImportResult result = get(importer.importProfile("Zezima"));
+
+		assertTrue(result.toToastMessage().toLowerCase().contains("unavailable"));
+	}
+
+	@Test
+	public void serverError_doesNotCallMarkItemObtained() throws Exception
+	{
+		stubResponse(500, "{\"error\":\"Internal Server Error\"}");
+
+		get(importer.importProfile("Zezima"));
+
+		verify(mockCollectionState, never()).markItemObtained(anyInt());
+	}
+
+	// ── Network failure ──────────────────────────────────────────────────────
+
+	@Test
+	public void networkError_returnsServiceUnavailable() throws Exception
+	{
+		when(mockCall.execute()).thenThrow(new IOException("Connection refused"));
+
+		ImportResult result = get(importer.importProfile("Zezima"));
+
+		assertFalse(result.isSuccess());
+		assertEquals(ImportResult.Status.SERVICE_UNAVAILABLE, result.getStatus());
+	}
+
+	@Test
+	public void networkError_doesNotThrowToCaller() throws Exception
+	{
+		when(mockCall.execute()).thenThrow(new IOException("Timeout"));
+
+		// Must not throw ExecutionException wrapping a non-checked exception
+		ImportResult result = get(importer.importProfile("Zezima"));
+
+		assertFalse(result.isSuccess());
+	}
+
+	// ── Malformed JSON ───────────────────────────────────────────────────────
+
+	@Test
+	public void malformedJson_returnsMalformedResponse() throws Exception
+	{
+		stubResponse(200, "this is not json at all");
+
+		ImportResult result = get(importer.importProfile("Zezima"));
+
+		assertFalse(result.isSuccess());
+		assertEquals(ImportResult.Status.MALFORMED_RESPONSE, result.getStatus());
+	}
+
+	@Test
+	public void malformedJson_missingTabsKey_returnsMalformedResponse() throws Exception
+	{
+		stubResponse(200, "{\"collectionLog\":{}}");
+
+		ImportResult result = get(importer.importProfile("Zezima"));
+
+		assertFalse(result.isSuccess());
+		assertEquals(ImportResult.Status.MALFORMED_RESPONSE, result.getStatus());
+	}
+
+	@Test
+	public void malformedJson_missingCollectionLogKey_returnsMalformedResponse() throws Exception
+	{
+		stubResponse(200, "{\"other\":\"data\"}");
+
+		ImportResult result = get(importer.importProfile("Zezima"));
+
+		assertFalse(result.isSuccess());
+		assertEquals(ImportResult.Status.MALFORMED_RESPONSE, result.getStatus());
+	}
+
+	@Test
+	public void malformedJson_doesNotCallMarkItemObtained() throws Exception
+	{
+		stubResponse(200, "{ broken json");
+
+		get(importer.importProfile("Zezima"));
+
+		verify(mockCollectionState, never()).markItemObtained(anyInt());
+	}
+
+	// ── parseAndMark unit tests ───────────────────────────────────────────────
+
+	@Test
+	public void parseAndMark_emptyTabs_returnsSuccessWithZeroItems()
+	{
+		String json = "{\"collectionLog\":{\"tabs\":{}}}";
+
+		ImportResult result = importer.parseAndMark(json, "Zezima");
+
+		assertTrue(result.isSuccess());
+		assertEquals(0, result.getItemsMarked());
+	}
+
+	@Test
+	public void parseAndMark_alreadyObtainedItem_countedOnlyIfNewlyAdded()
+	{
+		String json = "{\"collectionLog\":{\"tabs\":{\"Bosses\":{\"Zulrah\":{\"items\":"
+			+ "[{\"id\":12932,\"obtained\":true}]}}}}}";
+		// markItemObtained returns false when item was already present
+		when(mockCollectionState.markItemObtained(12932)).thenReturn(false);
+
+		ImportResult result = importer.parseAndMark(json, "Zezima");
+
+		assertTrue(result.isSuccess());
+		assertEquals(0, result.getItemsMarked());
+	}
+
+	// ── Helpers ──────────────────────────────────────────────────────────────
+
+	private void stubResponse(int code, String body) throws IOException
+	{
+		Request dummyRequest = new Request.Builder()
+			.url(CollectionLogNetImporter.BASE_URL + "Zezima")
+			.build();
+		Response response = new Response.Builder()
+			.request(dummyRequest)
+			.protocol(Protocol.HTTP_1_1)
+			.code(code)
+			.message(code == 200 ? "OK" : "Error")
+			.body(ResponseBody.create(JSON, body))
+			.build();
+		when(mockCall.execute()).thenReturn(response);
+	}
+
+	private static ImportResult get(Future<ImportResult> future) throws ExecutionException, InterruptedException
+	{
+		return future.get();
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `CollectionLogNetImporter` service (`sync` package) — async `Future<ImportResult> importProfile(String username)` via OkHttp. Fetches `GET https://api.collectionlog.net/collectionlog/user/{username}`, traverses `collectionLog.tabs` JSON, and marks every obtained item via `PlayerCollectionState.markItemObtained`.
- `ImportResult` value type: `SUCCESS`, `USER_NOT_FOUND`, `SERVICE_UNAVAILABLE`, `MALFORMED_RESPONSE` statuses plus `toToastMessage()` for panel display.
- Config flag `enableCollectionLogNetImport` (default OFF, new collapsible Sync section at position 150).
- Panel button "Sync from collectionlog.net" hidden when flag is off; disables and shows "Syncing…" while in flight; resets with result toast on completion.
- Fail-soft on all error paths: 404 → "user not found", 5xx/network → "service unavailable", bad JSON → logged + `MALFORMED_RESPONSE`; never throws to caller.

## Test plan

- [ ] `./gradlew test build` passes (17 new tests in `CollectionLogNetImporterTest`, all existing tests green)
- [ ] No real HTTP calls in tests — all responses are in-memory stubs
- [ ] Happy path: two obtained items are marked, count in toast is correct
- [ ] 404: `USER_NOT_FOUND` result, `markItemObtained` never called
- [ ] 500: `SERVICE_UNAVAILABLE` result, `markItemObtained` never called
- [ ] Network `IOException`: `SERVICE_UNAVAILABLE`, no exception propagated
- [ ] Malformed JSON: `MALFORMED_RESPONSE`, `markItemObtained` never called
- [ ] Config flag OFF → button hidden; flag ON → button visible
- [ ] Button resets to ready state after import completes
- [ ] ROADMAP F1 updated to `[/]`