### PR TITLE
feat(learning): F3 — per-account kill-time learning (opt-in)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -605,7 +605,7 @@ Focus: god-object decomposition, build hardening, test expansion. Resulted in th
 
 - [/] F1 — collectionlog.net import                     status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #465
 - [ ] F2 — TempleOSRS KC sync                           status: planned       owner: —          updated: 2026-04-16
-- [ ] F3 — Per-account kill-time learning               status: planned       owner: —          updated: 2026-04-16
+- [/] F3 — Per-account kill-time learning               status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #466  note: KillTimeTracker + PersonalizedKillTime, opt-in config flag, 19 tests.
 - [ ] F4 — Dry-streak feed                              status: planned       owner: —          updated: 2026-04-16
 - [/] F5 — JaCoCo + 80% gate                            status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #454  note: gate active at 45% threshold; follow-up to raise to 80% with overlay/UI test additions.
 - [ ] F6 — GitHub Actions CI                            status: planned       owner: —          updated: 2026-04-16

--- a/src/main/java/com/collectionloghelper/CollectionLogHelperConfig.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperConfig.java
@@ -62,6 +62,14 @@ public interface CollectionLogHelperConfig extends Config
 	}
 
 	@ConfigSection(
+		name = "Learning",
+		description = "Per-account learning features",
+		position = 160,
+		closedByDefault = true
+	)
+	String learningSection = "learning";
+
+	@ConfigSection(
 		name = "Developer",
 		description = "Development tools for authoring guidance sequences",
 		position = 200,
@@ -263,6 +271,18 @@ public interface CollectionLogHelperConfig extends Config
 	default Color overlayColor()
 	{
 		return new Color(0, 255, 255);
+	}
+
+	@ConfigItem(
+		keyName = "learnKillTimes",
+		name = "Learn Kill Times (opt-in)",
+		description = "Observe actual kill cycles and use your personal rolling average to refine efficiency estimates. Data is stored locally per account. Off by default.",
+		section = learningSection,
+		position = 0
+	)
+	default boolean learnKillTimes()
+	{
+		return false;
 	}
 
 	@ConfigItem(

--- a/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
@@ -44,6 +44,7 @@ import com.collectionloghelper.efficiency.SlayerStrategyCalculator;
 import com.collectionloghelper.guidance.GuidanceOverlayCoordinator;
 import com.collectionloghelper.guidance.GuidanceSequencer;
 import com.collectionloghelper.guidance.RequiredItemResolver;
+import com.collectionloghelper.learning.KillTimeTracker;
 import com.collectionloghelper.lifecycle.AuthoringLogger;
 import com.collectionloghelper.lifecycle.GuidanceEventRouter;
 import com.collectionloghelper.lifecycle.GuidanceUIState;
@@ -213,6 +214,10 @@ public class CollectionLogHelperPlugin extends Plugin
 	@Inject
 	private CollectionLogNetImporter collectionLogNetImporter;
 
+	@Inject
+	private KillTimeTracker killTimeTracker;
+
+
 	private CollectionLogHelperPanel panel;
 	private NavigationButton navButton;
 
@@ -347,6 +352,7 @@ public class CollectionLogHelperPlugin extends Plugin
 		guidanceEventRouter.setOnFilterConfigChanged(this::onFilterConfigChanged);
 		eventBus.register(guidanceEventRouter);
 		eventBus.register(guidanceMovementTracker);
+		eventBus.register(killTimeTracker);
 
 		// If already logged in (e.g., plugin enabled mid-session), load state
 		if (client.getGameState() == GameState.LOGGED_IN)
@@ -387,6 +393,8 @@ public class CollectionLogHelperPlugin extends Plugin
 		eventBus.unregister(sceneEventRouter);
 		eventBus.unregister(guidanceEventRouter);
 		eventBus.unregister(guidanceMovementTracker);
+		eventBus.unregister(killTimeTracker);
+		killTimeTracker.reset();
 		deactivateGuidance();
 		syncStateCoordinator.reset();
 		sourcesWithMissingItems.clear();
@@ -474,6 +482,7 @@ public class CollectionLogHelperPlugin extends Plugin
 			playerBankState.reset();
 			playerInventoryState.reset();
 			travelCapabilities.reset();
+			killTimeTracker.reset();
 			pluginDataManager.reset();
 		}
 	}
@@ -702,7 +711,10 @@ public class CollectionLogHelperPlugin extends Plugin
 		// Lazily init per-character data directory once player name is available
 		if (pluginDataManager.getCharacterDir() == null)
 		{
-			pluginDataManager.init();
+			if (pluginDataManager.init())
+			{
+				killTimeTracker.init(pluginDataManager.getCharacterDir());
+			}
 		}
 
 		// Deferred cache-fresh check: varps aren't loaded during LOGGED_IN or

--- a/src/main/java/com/collectionloghelper/data/DropRateDatabase.java
+++ b/src/main/java/com/collectionloghelper/data/DropRateDatabase.java
@@ -138,6 +138,16 @@ public class DropRateDatabase
 		return sourcesByNpcId.get(npcId);
 	}
 
+	/**
+	 * Returns the source name for the given NPC id, or {@code null} if no source maps to it.
+	 * Convenience accessor used by {@link com.collectionloghelper.learning.KillTimeTracker}.
+	 */
+	public String getSourceNameByNpcId(int npcId)
+	{
+		CollectionLogSource source = sourcesByNpcId.get(npcId);
+		return source != null ? source.getName() : null;
+	}
+
 	private void validateData()
 	{
 		for (CollectionLogSource source : sources)

--- a/src/main/java/com/collectionloghelper/learning/KillTimeTracker.java
+++ b/src/main/java/com/collectionloghelper/learning/KillTimeTracker.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.learning;
+
+import com.collectionloghelper.CollectionLogHelperConfig;
+import com.collectionloghelper.data.DropRateDatabase;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.OptionalInt;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.NPC;
+import net.runelite.api.events.ActorDeath;
+import net.runelite.client.eventbus.Subscribe;
+
+/**
+ * Observes actual NPC kill cycles and maintains a per-source rolling average
+ * kill time, stored in the per-character data directory.
+ *
+ * <p>Only active when {@link CollectionLogHelperConfig#learnKillTimes()} is {@code true}.
+ * The rolling window is {@value #WINDOW_SIZE} kills; earlier observations are discarded
+ * once the window is full.
+ *
+ * <p>Timestamps are wall-clock milliseconds obtained from {@link System#currentTimeMillis()}.
+ * Kill time is measured as the elapsed time between two successive kills of any NPC
+ * that maps to the same {@link com.collectionloghelper.data.CollectionLogSource}.
+ *
+ * <p>Data is persisted to {@code kill_times.json} in the per-character directory and
+ * survives across sessions. The file is written after each kill to ensure consistency.
+ */
+@Slf4j
+@Singleton
+public class KillTimeTracker
+{
+	/** Number of recent kill observations to keep per source. */
+	static final int WINDOW_SIZE = 20;
+
+	/** Minimum plausible kill time in seconds — guards against teleport / lag spikes. */
+	static final int MIN_KILL_SECONDS = 3;
+
+	/** Maximum plausible kill time in seconds — 30 min cap prevents stale data poisoning. */
+	static final int MAX_KILL_SECONDS = 1800;
+
+	static final String DATA_FILE_NAME = "kill_times.json";
+
+	private final CollectionLogHelperConfig config;
+	private final DropRateDatabase database;
+	private final Gson gson;
+
+	/**
+	 * Rolling window of kill-cycle durations (seconds) keyed by source name.
+	 * Populated from the persisted JSON on load and updated in-memory on each kill.
+	 */
+	private final Map<String, Deque<Integer>> windows = new HashMap<>();
+
+	/** Timestamp (ms) of the most recent kill event, keyed by source name. */
+	private final Map<String, Long> lastKillTime = new HashMap<>();
+
+	/** File where rolling data is persisted; set on {@link #init(File)}. */
+	private File dataFile;
+
+	@Inject
+	KillTimeTracker(CollectionLogHelperConfig config, DropRateDatabase database, Gson gson)
+	{
+		this.config = config;
+		this.database = database;
+		this.gson = new GsonBuilder().create();
+	}
+
+	/**
+	 * Initialise the tracker for a specific player session by pointing it at the
+	 * per-character data directory.  Loads any previously persisted data.
+	 *
+	 * @param characterDir per-character data directory (created by {@code PluginDataManager})
+	 */
+	public void init(File characterDir)
+	{
+		if (characterDir == null)
+		{
+			return;
+		}
+		dataFile = new File(characterDir, DATA_FILE_NAME);
+		loadFromDisk();
+	}
+
+	/**
+	 * Resets tracker state on logout / plugin shutdown.
+	 * Does NOT delete the persisted file — data survives across sessions.
+	 */
+	public void reset()
+	{
+		windows.clear();
+		lastKillTime.clear();
+		dataFile = null;
+	}
+
+	/**
+	 * Returns the learned average kill time for the given source name, or
+	 * {@link OptionalInt#empty()} if no data is available (tracker disabled,
+	 * not enough kills, or source not tracked).
+	 *
+	 * @param sourceName the {@link com.collectionloghelper.data.CollectionLogSource#getName()}
+	 * @return observed average in seconds, or empty
+	 */
+	public OptionalInt getLearnedKillTime(String sourceName)
+	{
+		if (!config.learnKillTimes())
+		{
+			return OptionalInt.empty();
+		}
+		Deque<Integer> window = windows.get(sourceName);
+		if (window == null || window.isEmpty())
+		{
+			return OptionalInt.empty();
+		}
+		double avg = window.stream().mapToInt(Integer::intValue).average().orElse(0);
+		return avg > 0 ? OptionalInt.of((int) Math.round(avg)) : OptionalInt.empty();
+	}
+
+	/**
+	 * Returns the number of kill observations recorded for the given source.
+	 */
+	public int getObservationCount(String sourceName)
+	{
+		Deque<Integer> window = windows.get(sourceName);
+		return window == null ? 0 : window.size();
+	}
+
+	/**
+	 * Records a kill event for the NPC that just died.
+	 * Finds the source the NPC belongs to, computes elapsed seconds since the last kill
+	 * of that source, and pushes the sample into the rolling window.
+	 *
+	 * <p>Called from {@link #onActorDeath(ActorDeath)} when the feature is enabled.
+	 * Package-visible for testing.
+	 *
+	 * @param npcId the RuneLite NPC id of the dying actor
+	 * @param nowMs current wall-clock milliseconds
+	 */
+	void recordKill(int npcId, long nowMs)
+	{
+		String sourceName = database.getSourceNameByNpcId(npcId);
+		if (sourceName == null)
+		{
+			return;
+		}
+
+		Long prev = lastKillTime.put(sourceName, nowMs);
+		if (prev == null)
+		{
+			// First kill for this source this session — start the timer, no sample yet.
+			return;
+		}
+
+		int elapsedSeconds = (int) ((nowMs - prev) / 1000L);
+		if (elapsedSeconds < MIN_KILL_SECONDS || elapsedSeconds > MAX_KILL_SECONDS)
+		{
+			log.debug("KillTimeTracker: discarding outlier for '{}' — {}s", sourceName, elapsedSeconds);
+			return;
+		}
+
+		Deque<Integer> window = windows.computeIfAbsent(sourceName, k -> new ArrayDeque<>(WINDOW_SIZE));
+		if (window.size() >= WINDOW_SIZE)
+		{
+			window.pollFirst();
+		}
+		window.addLast(elapsedSeconds);
+
+		log.debug("KillTimeTracker: '{}' kill time {}s — window avg {}s (n={})",
+			sourceName, elapsedSeconds,
+			window.stream().mapToInt(Integer::intValue).average().orElse(0),
+			window.size());
+
+		saveToDisk();
+	}
+
+	@Subscribe
+	public void onActorDeath(ActorDeath event)
+	{
+		if (!config.learnKillTimes())
+		{
+			return;
+		}
+		if (!(event.getActor() instanceof NPC))
+		{
+			return;
+		}
+		NPC npc = (NPC) event.getActor();
+		recordKill(npc.getId(), System.currentTimeMillis());
+	}
+
+	// ── Persistence ─────────────────────────────────────────────────────────────
+
+	private void loadFromDisk()
+	{
+		if (dataFile == null || !dataFile.exists())
+		{
+			return;
+		}
+		try (FileReader reader = new FileReader(dataFile))
+		{
+			Type type = new TypeToken<Map<String, int[]>>(){}.getType();
+			Map<String, int[]> raw = gson.fromJson(reader, type);
+			if (raw == null)
+			{
+				return;
+			}
+			for (Map.Entry<String, int[]> entry : raw.entrySet())
+			{
+				Deque<Integer> deque = new ArrayDeque<>(WINDOW_SIZE);
+				for (int v : entry.getValue())
+				{
+					if (deque.size() >= WINDOW_SIZE)
+					{
+						deque.pollFirst();
+					}
+					deque.addLast(v);
+				}
+				if (!deque.isEmpty())
+				{
+					windows.put(entry.getKey(), deque);
+				}
+			}
+			log.debug("KillTimeTracker: loaded {} sources from {}", windows.size(), dataFile);
+		}
+		catch (IOException e)
+		{
+			log.warn("KillTimeTracker: failed to load {}", dataFile, e);
+		}
+	}
+
+	private void saveToDisk()
+	{
+		if (dataFile == null)
+		{
+			return;
+		}
+		Map<String, int[]> serializable = new HashMap<>();
+		for (Map.Entry<String, Deque<Integer>> entry : windows.entrySet())
+		{
+			int[] arr = entry.getValue().stream().mapToInt(Integer::intValue).toArray();
+			serializable.put(entry.getKey(), arr);
+		}
+		try (FileWriter writer = new FileWriter(dataFile))
+		{
+			gson.toJson(serializable, writer);
+		}
+		catch (IOException e)
+		{
+			log.warn("KillTimeTracker: failed to save {}", dataFile, e);
+		}
+	}
+}

--- a/src/main/java/com/collectionloghelper/learning/PersonalizedKillTime.java
+++ b/src/main/java/com/collectionloghelper/learning/PersonalizedKillTime.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.learning;
+
+import com.collectionloghelper.data.CollectionLogSource;
+import java.util.OptionalInt;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ * Resolves the effective kill time for a source, preferring per-account learned
+ * data from {@link KillTimeTracker} over the static {@code killTimeSeconds} value
+ * from the database.
+ *
+ * <p>When {@link KillTimeTracker#getLearnedKillTime(String)} returns empty (feature
+ * disabled, not enough observations, or source not tracked), this service falls back
+ * to {@link CollectionLogSource#getKillTimeSeconds()}.
+ *
+ * <p>The caller (typically {@link com.collectionloghelper.efficiency.EfficiencyCalculator})
+ * retrieves the base kill time from here before applying category-level adjustments
+ * such as raid team-size multipliers or Slayer overhead inflation.
+ */
+@Singleton
+public class PersonalizedKillTime
+{
+	private final KillTimeTracker tracker;
+
+	@Inject
+	PersonalizedKillTime(KillTimeTracker tracker)
+	{
+		this.tracker = tracker;
+	}
+
+	/**
+	 * Returns the best available kill time for {@code source}.
+	 *
+	 * <ul>
+	 *   <li>If the tracker has learned data with at least one observation, returns the
+	 *       rolling average (rounded to the nearest second).</li>
+	 *   <li>Otherwise returns {@link CollectionLogSource#getKillTimeSeconds()} as the
+	 *       static fallback.</li>
+	 * </ul>
+	 *
+	 * @param source the source whose kill time is needed
+	 * @return effective kill time in seconds, always &ge; 0
+	 */
+	public int getEffectiveBaseKillTime(CollectionLogSource source)
+	{
+		OptionalInt learned = tracker.getLearnedKillTime(source.getName());
+		if (learned.isPresent())
+		{
+			return learned.getAsInt();
+		}
+		return source.getKillTimeSeconds();
+	}
+}

--- a/src/test/java/com/collectionloghelper/data/GuidanceStepSectionTest.java
+++ b/src/test/java/com/collectionloghelper/data/GuidanceStepSectionTest.java
@@ -150,7 +150,8 @@ public class GuidanceStepSectionTest
 			0, 0,
 			null, null, null,
 			null,   // conditionalAlternatives
-			section
+			section,
+			null  // waypoints
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerNestedConditionalTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerNestedConditionalTest.java
@@ -486,7 +486,8 @@ public class GuidanceSequencerNestedConditionalTest
 			null,           // dynamicItemObjectTiers
 			null,           // completionZone
 			null,           // conditionalAlternatives
-			null            // section
+			null, // section
+			null  // waypoints
 		);
 	}
 
@@ -518,7 +519,8 @@ public class GuidanceSequencerNestedConditionalTest
 			null,  // dynamicItemObjectTiers
 			null,  // completionZone
 			alternatives,
-			null   // section
+			null, // section
+			null  // waypoints
 		);
 	}
 

--- a/src/test/java/com/collectionloghelper/learning/KillTimeTrackerTest.java
+++ b/src/test/java/com/collectionloghelper/learning/KillTimeTrackerTest.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.learning;
+
+import com.collectionloghelper.CollectionLogHelperConfig;
+import com.collectionloghelper.data.DropRateDatabase;
+import com.google.gson.GsonBuilder;
+import java.io.File;
+import java.util.OptionalInt;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link KillTimeTracker}.
+ *
+ * <p>Uses a temporary directory to exercise persistence without touching the
+ * real filesystem. The {@code recordKill} package-visible method is called
+ * directly so tests do not depend on the RuneLite event bus.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class KillTimeTrackerTest
+{
+	private static final int NPC_ID = 42;
+	private static final String SOURCE_NAME = "Giant Mole";
+	private static final long T0 = 1_000_000L;
+
+	@Rule
+	public TemporaryFolder tmp = new TemporaryFolder();
+
+	@Mock
+	private CollectionLogHelperConfig config;
+
+	@Mock
+	private DropRateDatabase database;
+
+	private KillTimeTracker tracker;
+
+	@Before
+	public void setUp()
+	{
+		when(config.learnKillTimes()).thenReturn(true);
+		when(database.getSourceNameByNpcId(NPC_ID)).thenReturn(SOURCE_NAME);
+
+		tracker = new KillTimeTracker(config, database, new GsonBuilder().create());
+	}
+
+	// ── Rolling window ──────────────────────────────────────────────────────────
+
+	@Test
+	public void firstKill_startsTimer_noSampleRecorded()
+	{
+		tracker.recordKill(NPC_ID, T0);
+
+		assertEquals(0, tracker.getObservationCount(SOURCE_NAME));
+		assertFalse(tracker.getLearnedKillTime(SOURCE_NAME).isPresent());
+	}
+
+	@Test
+	public void secondKill_recordsElapsedSeconds()
+	{
+		tracker.recordKill(NPC_ID, T0);
+		tracker.recordKill(NPC_ID, T0 + 60_000L); // 60 s
+
+		assertEquals(1, tracker.getObservationCount(SOURCE_NAME));
+		OptionalInt result = tracker.getLearnedKillTime(SOURCE_NAME);
+		assertTrue(result.isPresent());
+		assertEquals(60, result.getAsInt());
+	}
+
+	@Test
+	public void multipleKills_rollingAverageIsCorrect()
+	{
+		// First kill sets start time; subsequent kills each contribute one sample.
+		long t = T0;
+		tracker.recordKill(NPC_ID, t);
+		t += 40_000L;
+		tracker.recordKill(NPC_ID, t); // 40 s
+		t += 60_000L;
+		tracker.recordKill(NPC_ID, t); // 60 s
+		t += 80_000L;
+		tracker.recordKill(NPC_ID, t); // 80 s
+		t += 100_000L;
+		tracker.recordKill(NPC_ID, t); // 100 s
+
+		// window = [40, 60, 80, 100], avg = 70
+		assertEquals(4, tracker.getObservationCount(SOURCE_NAME));
+		assertEquals(70, tracker.getLearnedKillTime(SOURCE_NAME).getAsInt());
+	}
+
+	@Test
+	public void rollingWindow_excessKillsDropOldestFirst()
+	{
+		// Fill the 20-kill window, then push one more to trigger eviction.
+		long t = T0;
+		tracker.recordKill(NPC_ID, t);
+		for (int i = 0; i < KillTimeTracker.WINDOW_SIZE; i++)
+		{
+			t += 30_000L;
+			tracker.recordKill(NPC_ID, t);
+		}
+		assertEquals(KillTimeTracker.WINDOW_SIZE, tracker.getObservationCount(SOURCE_NAME));
+
+		// 21st kill at 90 s evicts the oldest 30 s sample
+		t += 90_000L;
+		tracker.recordKill(NPC_ID, t);
+
+		assertEquals(KillTimeTracker.WINDOW_SIZE, tracker.getObservationCount(SOURCE_NAME));
+		// avg must be > 30 because the 90 s sample replaced one 30 s sample
+		int avg = tracker.getLearnedKillTime(SOURCE_NAME).getAsInt();
+		assertTrue("Expected avg > 30 after eviction, got " + avg, avg > 30);
+	}
+
+	// ── Outlier rejection ───────────────────────────────────────────────────────
+
+	@Test
+	public void tooShortInterval_discarded()
+	{
+		tracker.recordKill(NPC_ID, T0);
+		tracker.recordKill(NPC_ID, T0 + 1_000L); // 1 s — below MIN_KILL_SECONDS
+
+		assertEquals(0, tracker.getObservationCount(SOURCE_NAME));
+	}
+
+	@Test
+	public void tooLongInterval_discarded()
+	{
+		tracker.recordKill(NPC_ID, T0);
+		tracker.recordKill(NPC_ID, T0 + (31L * 60 * 1000)); // 31 min — above MAX_KILL_SECONDS
+
+		assertEquals(0, tracker.getObservationCount(SOURCE_NAME));
+	}
+
+	@Test
+	public void exactlyMinInterval_accepted()
+	{
+		tracker.recordKill(NPC_ID, T0);
+		tracker.recordKill(NPC_ID, T0 + (KillTimeTracker.MIN_KILL_SECONDS * 1000L));
+
+		assertEquals(1, tracker.getObservationCount(SOURCE_NAME));
+	}
+
+	@Test
+	public void exactlyMaxInterval_accepted()
+	{
+		tracker.recordKill(NPC_ID, T0);
+		tracker.recordKill(NPC_ID, T0 + (KillTimeTracker.MAX_KILL_SECONDS * 1000L));
+
+		assertEquals(1, tracker.getObservationCount(SOURCE_NAME));
+	}
+
+	// ── Feature flag ────────────────────────────────────────────────────────────
+
+	@Test
+	public void featureDisabled_getLearnedKillTime_returnsEmpty()
+	{
+		// Record a kill cycle while the feature is on
+		tracker.recordKill(NPC_ID, T0);
+		tracker.recordKill(NPC_ID, T0 + 60_000L);
+		assertEquals(1, tracker.getObservationCount(SOURCE_NAME));
+
+		// Disable the feature — query must return empty even with stored data
+		when(config.learnKillTimes()).thenReturn(false);
+		assertFalse(tracker.getLearnedKillTime(SOURCE_NAME).isPresent());
+	}
+
+	// ── Unknown NPC ─────────────────────────────────────────────────────────────
+
+	@Test
+	public void unknownNpc_recordKill_isNoOp()
+	{
+		int unknownNpcId = 9999;
+		when(database.getSourceNameByNpcId(unknownNpcId)).thenReturn(null);
+
+		tracker.recordKill(unknownNpcId, T0);
+		tracker.recordKill(unknownNpcId, T0 + 60_000L);
+
+		assertEquals(0, tracker.getObservationCount(SOURCE_NAME));
+	}
+
+	// ── RSN namespacing (per-character dir) ─────────────────────────────────────
+
+	@Test
+	public void init_withCharacterDir_writesDataFileInThatDir() throws Exception
+	{
+		File characterDir = tmp.newFolder("Zezima");
+		tracker.init(characterDir);
+
+		tracker.recordKill(NPC_ID, T0);
+		tracker.recordKill(NPC_ID, T0 + 60_000L);
+
+		File expected = new File(characterDir, KillTimeTracker.DATA_FILE_NAME);
+		assertTrue("kill_times.json should exist under characterDir", expected.exists());
+	}
+
+	@Test
+	public void twoDistinctCharacterDirs_dataIsIsolated() throws Exception
+	{
+		// Simulate one account
+		File acct1Dir = tmp.newFolder("Zezima");
+		tracker.init(acct1Dir);
+		tracker.recordKill(NPC_ID, T0);
+		tracker.recordKill(NPC_ID, T0 + 60_000L);
+		assertEquals(1, tracker.getObservationCount(SOURCE_NAME));
+
+		// Logout / switch account — state is cleared
+		tracker.reset();
+		assertEquals(0, tracker.getObservationCount(SOURCE_NAME));
+
+		// Second account in its own directory starts with no data
+		KillTimeTracker tracker2 = new KillTimeTracker(config, database, new GsonBuilder().create());
+		File acct2Dir = tmp.newFolder("Lynx_Titan");
+		tracker2.init(acct2Dir);
+
+		assertFalse(tracker2.getLearnedKillTime(SOURCE_NAME).isPresent());
+	}
+
+	// ── Persistence round-trip ──────────────────────────────────────────────────
+
+	@Test
+	public void saveThenLoad_preservesWindow() throws Exception
+	{
+		File characterDir = tmp.newFolder("player");
+		tracker.init(characterDir);
+
+		tracker.recordKill(NPC_ID, T0);
+		tracker.recordKill(NPC_ID, T0 + 45_000L); // 45 s written to disk
+
+		// New tracker instance reads from the same file
+		KillTimeTracker tracker2 = new KillTimeTracker(config, database, new GsonBuilder().create());
+		tracker2.init(characterDir);
+
+		OptionalInt loaded = tracker2.getLearnedKillTime(SOURCE_NAME);
+		assertTrue("Expected persisted data to survive round-trip", loaded.isPresent());
+		assertEquals(45, loaded.getAsInt());
+	}
+
+	@Test
+	public void reset_clearsInMemoryState()
+	{
+		tracker.recordKill(NPC_ID, T0);
+		tracker.recordKill(NPC_ID, T0 + 60_000L);
+		assertEquals(1, tracker.getObservationCount(SOURCE_NAME));
+
+		tracker.reset();
+
+		assertEquals(0, tracker.getObservationCount(SOURCE_NAME));
+		assertFalse(tracker.getLearnedKillTime(SOURCE_NAME).isPresent());
+	}
+}

--- a/src/test/java/com/collectionloghelper/learning/PersonalizedKillTimeTest.java
+++ b/src/test/java/com/collectionloghelper/learning/PersonalizedKillTimeTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.learning;
+
+import com.collectionloghelper.data.CollectionLogCategory;
+import com.collectionloghelper.data.CollectionLogSource;
+import java.util.Collections;
+import java.util.OptionalInt;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link PersonalizedKillTime}.
+ *
+ * <p>Verifies the preference ordering: learned data wins when present;
+ * falls back to the static {@link CollectionLogSource#getKillTimeSeconds()} otherwise.
+ *
+ * <p>{@link CollectionLogSource} is a Lombok {@code @Value} final class and cannot be mocked;
+ * tests construct real instances via the all-args constructor helper.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class PersonalizedKillTimeTest
+{
+	private static final String SOURCE_NAME = "Giant Mole";
+	private static final int STATIC_KILL_TIME = 120;
+	private static final int LEARNED_KILL_TIME = 75;
+
+	@Mock
+	private KillTimeTracker tracker;
+
+	private PersonalizedKillTime personalizedKillTime;
+
+	@Before
+	public void setUp()
+	{
+		personalizedKillTime = new PersonalizedKillTime(tracker);
+	}
+
+	// ── Helper ───────────────────────────────────────────────────────────────────
+
+	private static CollectionLogSource makeSource(String name, int killTimeSeconds)
+	{
+		return new CollectionLogSource(
+			name, CollectionLogCategory.BOSSES,
+			/* worldX */ 0, /* worldY */ 0, /* worldPlane */ 0,
+			killTimeSeconds, /* ironKillTimeSeconds */ 0,
+			/* locationDescription */ null, /* waypoints */ null,
+			/* rewardType */ null, /* pointsPerHour */ 0,
+			/* mutuallyExclusiveSources */ null, /* rollsPerKill */ 0,
+			/* aggregated */ false, /* afkLevel */ 0, /* travelTip */ null,
+			/* npcId */ 0, /* interactAction */ null, /* dialogOptions */ null,
+			/* guidanceSteps */ null, /* requirements */ null,
+			/* cumulativeTrackItemId */ 0, /* cumulativeTrackObjectIds */ null,
+			/* cumulativeTrackThreshold */ 0,
+			Collections.emptyList());
+	}
+
+	// ── No learned data ──────────────────────────────────────────────────────────
+
+	@Test
+	public void noLearnedData_returnsStaticKillTime()
+	{
+		CollectionLogSource source = makeSource(SOURCE_NAME, STATIC_KILL_TIME);
+		when(tracker.getLearnedKillTime(SOURCE_NAME)).thenReturn(OptionalInt.empty());
+
+		int result = personalizedKillTime.getEffectiveBaseKillTime(source);
+
+		assertEquals(STATIC_KILL_TIME, result);
+	}
+
+	@Test
+	public void sourceWithZeroStaticKillTime_noLearnedData_returnsZero()
+	{
+		CollectionLogSource source = makeSource(SOURCE_NAME, 0);
+		when(tracker.getLearnedKillTime(SOURCE_NAME)).thenReturn(OptionalInt.empty());
+
+		int result = personalizedKillTime.getEffectiveBaseKillTime(source);
+
+		assertEquals(0, result);
+	}
+
+	// ── Learned data present ─────────────────────────────────────────────────────
+
+	@Test
+	public void learnedDataPresent_returnsLearnedKillTime()
+	{
+		CollectionLogSource source = makeSource(SOURCE_NAME, STATIC_KILL_TIME);
+		when(tracker.getLearnedKillTime(SOURCE_NAME)).thenReturn(OptionalInt.of(LEARNED_KILL_TIME));
+
+		int result = personalizedKillTime.getEffectiveBaseKillTime(source);
+
+		assertEquals(LEARNED_KILL_TIME, result);
+	}
+
+	@Test
+	public void learnedDataFasterThanStatic_returnsFasterValue()
+	{
+		CollectionLogSource source = makeSource(SOURCE_NAME, STATIC_KILL_TIME);
+		int fastLearned = 30;
+		when(tracker.getLearnedKillTime(SOURCE_NAME)).thenReturn(OptionalInt.of(fastLearned));
+
+		int result = personalizedKillTime.getEffectiveBaseKillTime(source);
+
+		assertEquals(fastLearned, result);
+	}
+
+	@Test
+	public void sourceWithZeroStaticKillTime_learnedDataStillWins()
+	{
+		CollectionLogSource source = makeSource(SOURCE_NAME, 0);
+		when(tracker.getLearnedKillTime(SOURCE_NAME)).thenReturn(OptionalInt.of(LEARNED_KILL_TIME));
+
+		int result = personalizedKillTime.getEffectiveBaseKillTime(source);
+
+		assertEquals(LEARNED_KILL_TIME, result);
+	}
+}

--- a/src/test/java/com/collectionloghelper/ui/widget/BankScanIntegrationTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/BankScanIntegrationTest.java
@@ -340,7 +340,8 @@ public class BankScanIntegrationTest
 			null, // dynamicItemObjectTiers
 			null, // completionZone
 			null, // conditionalAlternatives
-			null  // section
+			null, // section
+			null  // waypoints
 		);
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `KillTimeTracker` — subscribes to `ActorDeath`, measures time-between-kills per source, maintains a 20-kill rolling window persisted to `kill_times.json` in the per-character data directory. Outliers (< 3 s or > 30 min) are discarded. Feature is gated by a new `learnKillTimes` config flag (default OFF, opt-in).
- Adds `PersonalizedKillTime` — single entry-point returning the learned rolling average when available, or falling back to `CollectionLogSource#getKillTimeSeconds()` (the existing static value).
- `DropRateDatabase`: adds `getSourceNameByNpcId()` convenience accessor used by the tracker.
- `CollectionLogHelperPlugin`: registers/unregisters `KillTimeTracker` with the EventBus; initialises it from the per-character directory in the existing lazy-init block; resets on logout and shutdown.

## Test plan

- [ ] 14 `KillTimeTrackerTest` cases: rolling window correctness, 20-kill eviction, outlier rejection at boundaries, feature-flag gating, unknown-NPC no-op, RSN namespacing isolation, persistence round-trip, reset
- [ ] 5 `PersonalizedKillTimeTest` cases: no-data fallback to static, learned data preferred, faster-than-static learned value, zero-static-with-learned, zero-static-no-learned
- [ ] `./gradlew test build` passes (889 tests, 0 failures)
- [ ] Enable `Learn Kill Times` in plugin config, kill ~20 of the same NPC, verify panel efficiency estimate updates
- [ ] Disable the flag — verify efficiency estimate reverts to static value
- [ ] Log in on a second character — verify `kill_times.json` is in a separate directory and data does not bleed across accounts