### PR TITLE
feat(meta): E2 — meta-update dating on recommendations

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -599,7 +599,7 @@ Focus: god-object decomposition, build hardening, test expansion. Resulted in th
 **Tier E — Alternative methods and meta intelligence**
 
 - [/] E1 — Cross-source recommendation mode             status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #464  note: CrossSourceRanker + CrossSourceRecommendation + enableCrossSourceMode config flag; panel integration deferred.
-- [ ] E2 — Meta-update dating                           status: planned       owner: —          updated: 2026-04-16
+- [/] E2 — Meta-update dating                           status: in-review     owner: cha-ndler  updated: 2026-05-14  pr: #467
 
 **Tier F — Social, imports, and long-tail polish**
 

--- a/src/main/java/com/collectionloghelper/data/CollectionLogSource.java
+++ b/src/main/java/com/collectionloghelper/data/CollectionLogSource.java
@@ -25,6 +25,7 @@
 package com.collectionloghelper.data;
 
 import java.util.List;
+import javax.annotation.Nullable;
 import lombok.Value;
 import net.runelite.api.coords.WorldPoint;
 
@@ -56,6 +57,16 @@ public class CollectionLogSource
 	List<Integer> cumulativeTrackObjectIds;
 	int cumulativeTrackThreshold;
 	List<CollectionLogItem> items;
+
+	/**
+	 * ISO 8601 date string (e.g. "2024-01-01") indicating when the meta-sensitive
+	 * recommendations for this source were last authored or verified. Null means no
+	 * date is known and the plugin will not surface a staleness annotation.
+	 *
+	 * <p>Backward compatible: existing JSON without this field deserialises to null.
+	 */
+	@Nullable
+	String metaAuthoredDate;
 
 	public RewardType getRewardType()
 	{

--- a/src/main/java/com/collectionloghelper/ui/widget/GuidanceBannerView.java
+++ b/src/main/java/com/collectionloghelper/ui/widget/GuidanceBannerView.java
@@ -30,6 +30,7 @@ import com.collectionloghelper.data.RequirementsChecker;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
+import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 import javax.swing.BorderFactory;
@@ -59,6 +60,8 @@ public class GuidanceBannerView extends JPanel
 	private final JPanel guidanceBannerPanel;
 	private final JLabel guidanceBannerLabel;
 	private final JLabel requirementsWarningLabel;
+	/** E2 — meta-update dating badge; hidden when metaAuthoredDate is null. */
+	private final JLabel metaAgeBadgeLabel;
 
 	// Per-source requirements section (quest / skill / diary rows)
 	private final RequirementsView requirementsView;
@@ -83,7 +86,7 @@ public class GuidanceBannerView extends JPanel
 			BorderFactory.createEmptyBorder(3, 6, 3, 6)
 		));
 		guidanceBannerPanel.setAlignmentX(CENTER_ALIGNMENT);
-		guidanceBannerPanel.setMaximumSize(new Dimension(Integer.MAX_VALUE, 48));
+		guidanceBannerPanel.setMaximumSize(new Dimension(Integer.MAX_VALUE, 64));
 		guidanceBannerPanel.setVisible(false);
 
 		guidanceBannerLabel = new JLabel();
@@ -98,6 +101,13 @@ public class GuidanceBannerView extends JPanel
 		requirementsWarningLabel.setAlignmentX(LEFT_ALIGNMENT);
 		requirementsWarningLabel.setVisible(false);
 		guidanceBannerPanel.add(requirementsWarningLabel);
+
+		// E2 — meta-update dating: shown only when metaAuthoredDate is set
+		metaAgeBadgeLabel = new JLabel();
+		metaAgeBadgeLabel.setFont(FontManager.getRunescapeSmallFont());
+		metaAgeBadgeLabel.setAlignmentX(LEFT_ALIGNMENT);
+		metaAgeBadgeLabel.setVisible(false);
+		guidanceBannerPanel.add(metaAgeBadgeLabel);
 
 		add(guidanceBannerPanel);
 
@@ -146,6 +156,8 @@ public class GuidanceBannerView extends JPanel
 		final List<String> unmet = requirementsChecker.getUnmetRequirements(sourceName);
 		final List<RequirementRow> rows =
 			requirementRows != null ? requirementRows : Collections.emptyList();
+		// E2 \u2014 compute badge outside EDT (pure computation)
+		final MetaAgeBadge badge = MetaAgeBadge.from(source.getMetaAuthoredDate(), LocalDate.now());
 
 		SwingUtilities.invokeLater(() ->
 		{
@@ -162,6 +174,20 @@ public class GuidanceBannerView extends JPanel
 			{
 				requirementsWarningLabel.setVisible(false);
 			}
+
+			// E2 \u2014 meta-update dating badge
+			if (badge != null)
+			{
+				metaAgeBadgeLabel.setText(badge.getLabel());
+				metaAgeBadgeLabel.setForeground(badge.getColor());
+				metaAgeBadgeLabel.setToolTipText(badge.getTooltip());
+				metaAgeBadgeLabel.setVisible(true);
+			}
+			else
+			{
+				metaAgeBadgeLabel.setVisible(false);
+			}
+
 			guidanceBannerPanel.revalidate();
 			if (guidanceBannerPanel.getParent() != null)
 			{
@@ -183,6 +209,7 @@ public class GuidanceBannerView extends JPanel
 		{
 			guidanceBannerPanel.setVisible(false);
 			requirementsWarningLabel.setVisible(false);
+			metaAgeBadgeLabel.setVisible(false);
 			guidanceBannerPanel.revalidate();
 			if (guidanceBannerPanel.getParent() != null)
 			{

--- a/src/main/java/com/collectionloghelper/ui/widget/MetaAgeBadge.java
+++ b/src/main/java/com/collectionloghelper/ui/widget/MetaAgeBadge.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.ui.widget;
+
+import java.awt.Color;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
+import javax.annotation.Nullable;
+
+/**
+ * Pure-logic helper for E2 meta-update dating.
+ *
+ * <p>Given a source's {@code metaAuthoredDate} ISO 8601 string and a reference
+ * "today" date, computes:
+ * <ul>
+ *   <li>how many months old the guidance is</li>
+ *   <li>which staleness tier applies (FRESH / WARNING / STALE)</li>
+ *   <li>the display label ("Meta: N months ago")</li>
+ * </ul>
+ *
+ * <p>All state is immutable and computed at construction time. Returns
+ * {@code null} from {@link #from(String, LocalDate)} when the date string is
+ * absent or unparseable, so callers can easily gate on presence.
+ */
+public class MetaAgeBadge
+{
+	/** Guidance authored within the last 3 months — considered current. */
+	static final Color COLOR_FRESH = new Color(40, 180, 40);
+	/** Guidance authored 3-12 months ago — may be partially outdated. */
+	static final Color COLOR_WARNING = new Color(200, 160, 0);
+	/** Guidance authored more than 12 months ago — likely stale. */
+	static final Color COLOR_STALE = new Color(200, 50, 50);
+
+	static final String TOOLTIP_TEXT =
+		"OSRS updates may have shifted the meta since this guidance was authored.";
+
+	private static final long FRESH_MONTHS = 3;
+	private static final long STALE_MONTHS = 12;
+
+	private final long ageMonths;
+	private final Color color;
+	private final String label;
+
+	private MetaAgeBadge(long ageMonths)
+	{
+		this.ageMonths = ageMonths;
+		this.color = computeColor(ageMonths);
+		this.label = buildLabel(ageMonths);
+	}
+
+	/**
+	 * Parses the ISO 8601 date string and computes the age badge relative to
+	 * {@code today}. Returns {@code null} if {@code metaAuthoredDate} is null,
+	 * empty, or cannot be parsed as a valid ISO 8601 date.
+	 *
+	 * @param metaAuthoredDate ISO 8601 date string (e.g. "2024-01-15"), or {@code null}
+	 * @param today            reference date for age calculation (use {@link LocalDate#now()}
+	 *                         in production; inject a fixed date in tests)
+	 * @return a populated badge, or {@code null} when the date is absent/invalid
+	 */
+	@Nullable
+	public static MetaAgeBadge from(@Nullable String metaAuthoredDate, LocalDate today)
+	{
+		if (metaAuthoredDate == null || metaAuthoredDate.isEmpty())
+		{
+			return null;
+		}
+		try
+		{
+			LocalDate authored = LocalDate.parse(metaAuthoredDate);
+			long months = ChronoUnit.MONTHS.between(authored, today);
+			// Clamp negative values (future-dated strings) to 0
+			return new MetaAgeBadge(Math.max(0, months));
+		}
+		catch (DateTimeParseException e)
+		{
+			return null;
+		}
+	}
+
+	/** Number of complete months between the authored date and today. */
+	public long getAgeMonths()
+	{
+		return ageMonths;
+	}
+
+	/** Display colour based on staleness tier. */
+	public Color getColor()
+	{
+		return color;
+	}
+
+	/** Short display label, e.g. "Meta: 5 months ago" or "Meta: &lt;1 month ago". */
+	public String getLabel()
+	{
+		return label;
+	}
+
+	/** Tooltip text shown on hover. */
+	public String getTooltip()
+	{
+		return TOOLTIP_TEXT;
+	}
+
+	// -------------------------------------------------------------------------
+
+	private static Color computeColor(long months)
+	{
+		if (months < FRESH_MONTHS)
+		{
+			return COLOR_FRESH;
+		}
+		if (months < STALE_MONTHS)
+		{
+			return COLOR_WARNING;
+		}
+		return COLOR_STALE;
+	}
+
+	private static String buildLabel(long months)
+	{
+		if (months == 0)
+		{
+			return "Meta: <1 month ago";
+		}
+		String unit = months == 1 ? "month" : "months";
+		return "Meta: " + months + " " + unit + " ago";
+	}
+}

--- a/src/test/java/com/collectionloghelper/ActivateGuidanceClientThreadTest.java
+++ b/src/test/java/com/collectionloghelper/ActivateGuidanceClientThreadTest.java
@@ -135,7 +135,8 @@ public class ActivateGuidanceClientThreadTest
 			0,         // cumulativeTrackItemId
 			null,      // cumulativeTrackObjectIds
 			0,         // cumulativeTrackThreshold
-			null       // items
+			null,      // items
+			null       // metaAuthoredDate
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/OnSequenceCompletePerItemTest.java
+++ b/src/test/java/com/collectionloghelper/OnSequenceCompletePerItemTest.java
@@ -170,7 +170,6 @@ public class OnSequenceCompletePerItemTest
 			null, 0, null, null,
 			null,
 			null, 0, null, 0,
-			Collections.emptyList()
-		);
+			Collections.emptyList(), null /* metaAuthoredDate */);
 	}
 }

--- a/src/test/java/com/collectionloghelper/data/CollectionLogSourceTest.java
+++ b/src/test/java/com/collectionloghelper/data/CollectionLogSourceTest.java
@@ -49,7 +49,7 @@ public class CollectionLogSourceTest
 		return new CollectionLogSource(name, CollectionLogCategory.BOSSES, x, y, plane,
 			60, 0, locationDesc, waypoints,
 			null, 0, null, 0, false, 0, null, 0, null, null, null, null, 0, null, 0,
-			Collections.emptyList());
+			Collections.emptyList(), null);
 	}
 
 	// ========================================================================

--- a/src/test/java/com/collectionloghelper/data/DropRateDatabaseTest.java
+++ b/src/test/java/com/collectionloghelper/data/DropRateDatabaseTest.java
@@ -419,6 +419,27 @@ public class DropRateDatabaseTest
 			foundAtLeastOneEmDash);
 	}
 
+	// ========================================================================
+	// E2 — metaAuthoredDate regression: no production source should have it set
+	// ========================================================================
+
+	/**
+	 * Regression guard: the E2 plumbing ships without a production data backfill.
+	 * No source in drop_rates.json should carry a non-null metaAuthoredDate until
+	 * the Tier D sweep intentionally populates the field.
+	 */
+	@Test
+	public void load_noProductionSourceHasMetaAuthoredDate()
+	{
+		for (CollectionLogSource source : database.getAllSources())
+		{
+			assertNull(
+				"Source '" + source.getName() + "' has metaAuthoredDate set; "
+					+ "production backfill is not part of this PR",
+				source.getMetaAuthoredDate());
+		}
+	}
+
 	/**
 	 * Where recommendedItemIds is present in drop_rates.json (B.5.2b backfill),
 	 * each array must be non-empty, contain only positive item IDs, and have

--- a/src/test/java/com/collectionloghelper/efficiency/CrossSourceRankerTest.java
+++ b/src/test/java/com/collectionloghelper/efficiency/CrossSourceRankerTest.java
@@ -119,7 +119,7 @@ public class CrossSourceRankerTest
 	{
 		return new CollectionLogSource(name, CollectionLogCategory.BOSSES, 3000, 3000, 0,
 			killTimeSeconds, 0, name, Collections.emptyList(),
-			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0, items);
+			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0, items, null /* metaAuthoredDate */);
 	}
 
 	private CollectionLogItem makeItem(int id, String name, double dropRate)

--- a/src/test/java/com/collectionloghelper/efficiency/EfficiencyCalculatorTest.java
+++ b/src/test/java/com/collectionloghelper/efficiency/EfficiencyCalculatorTest.java
@@ -99,7 +99,7 @@ public class EfficiencyCalculatorTest
 	{
 		return new CollectionLogSource(name, category, 3000, 3000, 0,
 			killTimeSeconds, 0, name, Collections.emptyList(),
-			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0, items);
+			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0, items, null);
 	}
 
 	private CollectionLogSource makeShopSource(String name, int killTimeSeconds,
@@ -107,7 +107,7 @@ public class EfficiencyCalculatorTest
 	{
 		return new CollectionLogSource(name, CollectionLogCategory.OTHER, 3000, 3000, 0,
 			killTimeSeconds, 0, name, Collections.emptyList(),
-			RewardType.SHOP, pointsPerHour, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0, items);
+			RewardType.SHOP, pointsPerHour, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0, items, null);
 	}
 
 	private CollectionLogSource makeMilestoneSource(String name, int killTimeSeconds,
@@ -115,7 +115,7 @@ public class EfficiencyCalculatorTest
 	{
 		return new CollectionLogSource(name, CollectionLogCategory.OTHER, 3000, 3000, 0,
 			killTimeSeconds, 0, name, Collections.emptyList(),
-			RewardType.MILESTONE, 0, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0, items);
+			RewardType.MILESTONE, 0, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0, items, null);
 	}
 
 	private CollectionLogSource makeMixedSource(String name, int killTimeSeconds,
@@ -123,7 +123,7 @@ public class EfficiencyCalculatorTest
 	{
 		return new CollectionLogSource(name, CollectionLogCategory.OTHER, 3000, 3000, 0,
 			killTimeSeconds, 0, name, Collections.emptyList(),
-			RewardType.MIXED, pointsPerHour, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0, items);
+			RewardType.MIXED, pointsPerHour, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0, items, null);
 	}
 
 	private CollectionLogSource makeAggregatedSource(String name, int killTimeSeconds,
@@ -131,7 +131,7 @@ public class EfficiencyCalculatorTest
 	{
 		return new CollectionLogSource(name, CollectionLogCategory.OTHER, 3000, 3000, 0,
 			killTimeSeconds, 0, name, Collections.emptyList(),
-			RewardType.DROP, 0, null, 1, true, 0, null, 0, null, null, null, null, 0, null, 0, items);
+			RewardType.DROP, 0, null, 1, true, 0, null, 0, null, null, null, null, 0, null, 0, items, null);
 	}
 
 	private CollectionLogItem makeItem(int id, String name, double dropRate)
@@ -164,7 +164,7 @@ public class EfficiencyCalculatorTest
 	{
 		return new CollectionLogSource(name, category, 3000, 3000, 0,
 			killTimeSeconds, 0, name, Collections.emptyList(),
-			RewardType.DROP, 0, variants, 1, false, 0, null, 0, null, null, null, null, 0, null, 0, items);
+			RewardType.DROP, 0, variants, 1, false, 0, null, 0, null, null, null, null, 0, null, 0, items, null);
 	}
 
 	// --- Per-item scoring: score = best individual item's score ---
@@ -389,7 +389,7 @@ public class EfficiencyCalculatorTest
 		List<CollectionLogItem> items = Collections.singletonList(makeItem(1, "Drop", 1.0 / 512));
 		CollectionLogSource source = new CollectionLogSource("Test", CollectionLogCategory.BOSSES,
 			3000, 3000, 0, 120, 0, "Test", Collections.emptyList(),
-			RewardType.DROP, 0, null, 2, false, 0, null, 0, null, null, null, null, 0, null, 0, items);
+			RewardType.DROP, 0, null, 2, false, 0, null, 0, null, null, null, null, 0, null, 0, items, null);
 		when(collectionState.isItemObtained(anyInt())).thenReturn(false);
 
 		ScoredItem result = calculator.scoreSource(source, false);
@@ -544,7 +544,7 @@ public class EfficiencyCalculatorTest
 			CollectionLogCategory.CLUES, 3000, 3000, 0, 600, 0,
 			"Easy Treasure Trails", Collections.emptyList(),
 			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0,
-			Collections.singletonList(makeItem(1, "Drop", 0.01)));
+			Collections.singletonList(makeItem(1, "Drop", 0.01)), null);
 		when(clueEstimator.estimateCompletionSeconds("Easy Treasure Trails")).thenReturn(900);
 
 		int effective = calculator.getEffectiveKillTime(source);
@@ -558,7 +558,7 @@ public class EfficiencyCalculatorTest
 			CollectionLogCategory.CLUES, 3000, 3000, 0, 600, 0,
 			"Easy Treasure Trails", Collections.emptyList(),
 			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0,
-			Collections.singletonList(makeItem(1, "Drop", 0.01)));
+			Collections.singletonList(makeItem(1, "Drop", 0.01)), null);
 		when(clueEstimator.estimateCompletionSeconds("Easy Treasure Trails")).thenReturn(0);
 
 		int effective = calculator.getEffectiveKillTime(source);
@@ -650,7 +650,7 @@ public class EfficiencyCalculatorTest
 		CollectionLogSource source = new CollectionLogSource("Test Boss", CollectionLogCategory.BOSSES,
 			3000, 3000, 0, 60, 0, "Test Boss", Collections.emptyList(),
 			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0,
-			Collections.singletonList(makeItem(1, "Drop", 0.01)));
+			Collections.singletonList(makeItem(1, "Drop", 0.01)), null);
 		lenient().when(collectionState.isItemObtained(1)).thenReturn(false);
 		when(database.getAllSources()).thenReturn(Collections.singletonList(source));
 		when(config.afkFilter()).thenReturn(AfkFilter.AFK);
@@ -666,7 +666,7 @@ public class EfficiencyCalculatorTest
 		CollectionLogSource source = new CollectionLogSource("AFK Source", CollectionLogCategory.BOSSES,
 			3000, 3000, 0, 60, 0, "AFK Source", Collections.emptyList(),
 			RewardType.DROP, 0, null, 1, false, 2, null, 0, null, null, null, null, 0, null, 0,
-			Collections.singletonList(makeItem(1, "Drop", 0.01)));
+			Collections.singletonList(makeItem(1, "Drop", 0.01)), null);
 		when(collectionState.isItemObtained(1)).thenReturn(false);
 		when(database.getAllSources()).thenReturn(Collections.singletonList(source));
 		when(config.afkFilter()).thenReturn(AfkFilter.AFK);
@@ -682,7 +682,7 @@ public class EfficiencyCalculatorTest
 		CollectionLogSource source = new CollectionLogSource("Test Boss", CollectionLogCategory.BOSSES,
 			3000, 3000, 0, 60, 0, "Test Boss", Collections.emptyList(),
 			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0,
-			Collections.singletonList(makeItem(1, "Drop", 0.01)));
+			Collections.singletonList(makeItem(1, "Drop", 0.01)), null);
 		when(collectionState.isItemObtained(1)).thenReturn(false);
 		when(database.getAllSources()).thenReturn(Collections.singletonList(source));
 		when(config.afkFilter()).thenReturn(AfkFilter.OFF);
@@ -701,7 +701,7 @@ public class EfficiencyCalculatorTest
 		CollectionLogSource source = new CollectionLogSource("Abyssal Demon", CollectionLogCategory.OTHER,
 			3000, 3000, 0, 20, 0, "Abyssal Demon", Collections.emptyList(),
 			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0,
-			Collections.singletonList(makeItem(1, "Whip", 0.001953)));
+			Collections.singletonList(makeItem(1, "Whip", 0.001953)), null);
 		when(slayerMasterDatabase.getMasterNames()).thenReturn(Collections.singletonList("Duradel"));
 		when(slayerMasterDatabase.getTaskProbability("Duradel", "abyssal demons")).thenReturn(0.05);
 
@@ -716,7 +716,7 @@ public class EfficiencyCalculatorTest
 		CollectionLogSource source = new CollectionLogSource("Abyssal Demon", CollectionLogCategory.OTHER,
 			3000, 3000, 0, 20, 0, "Abyssal Demon", Collections.emptyList(),
 			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0,
-			Collections.singletonList(makeItem(1, "Whip", 0.001953)));
+			Collections.singletonList(makeItem(1, "Whip", 0.001953)), null);
 		when(slayerTaskState.isTaskActive()).thenReturn(true);
 		when(slayerTaskState.getCreatureName()).thenReturn("Abyssal demons");
 
@@ -731,7 +731,7 @@ public class EfficiencyCalculatorTest
 		CollectionLogSource source = new CollectionLogSource("Abyssal Sire", CollectionLogCategory.BOSSES,
 			3000, 3000, 0, 180, 0, "Abyssal Sire", Collections.emptyList(),
 			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0,
-			Collections.singletonList(makeItem(1, "Unsired", 0.0078)));
+			Collections.singletonList(makeItem(1, "Unsired", 0.0078)), null);
 
 		int effectiveTime = calculator.getEffectiveKillTime(source);
 		assertEquals(180, effectiveTime);
@@ -744,7 +744,7 @@ public class EfficiencyCalculatorTest
 		CollectionLogSource source = new CollectionLogSource("Abyssal Demon", CollectionLogCategory.OTHER,
 			3000, 3000, 0, 12, 0, "Abyssal Demon", Collections.emptyList(),
 			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0,
-			Collections.singletonList(makeItem(1, "Whip", 0.001953)));
+			Collections.singletonList(makeItem(1, "Whip", 0.001953)), null);
 		when(slayerMasterDatabase.getMasterNames()).thenReturn(Arrays.asList("Duradel", "Nieve"));
 		when(slayerMasterDatabase.getTaskProbability("Duradel", "abyssal demons")).thenReturn(0.06);
 		when(slayerMasterDatabase.getTaskProbability("Nieve", "abyssal demons")).thenReturn(0.04);
@@ -948,7 +948,7 @@ public class EfficiencyCalculatorTest
 		CollectionLogSource source = new CollectionLogSource("Test Boss", CollectionLogCategory.BOSSES,
 			3000, 3000, 0, 60, 120, "Test Boss", Collections.emptyList(),
 			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0,
-			Collections.singletonList(makeItem(1, "Drop", 0.01)));
+			Collections.singletonList(makeItem(1, "Drop", 0.01)), null);
 		when(config.accountType()).thenReturn(AccountType.IRONMAN);
 
 		int effectiveTime = calculator.getEffectiveKillTime(source);
@@ -962,7 +962,7 @@ public class EfficiencyCalculatorTest
 		CollectionLogSource source = new CollectionLogSource("Test Boss", CollectionLogCategory.BOSSES,
 			3000, 3000, 0, 60, 0, "Test Boss", Collections.emptyList(),
 			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0,
-			Collections.singletonList(makeItem(1, "Drop", 0.01)));
+			Collections.singletonList(makeItem(1, "Drop", 0.01)), null);
 		when(config.accountType()).thenReturn(AccountType.IRONMAN);
 
 		int effectiveTime = calculator.getEffectiveKillTime(source);
@@ -976,7 +976,7 @@ public class EfficiencyCalculatorTest
 		CollectionLogSource source = new CollectionLogSource("Test Boss", CollectionLogCategory.BOSSES,
 			3000, 3000, 0, 60, 120, "Test Boss", Collections.emptyList(),
 			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0,
-			Collections.singletonList(makeItem(1, "Drop", 0.01)));
+			Collections.singletonList(makeItem(1, "Drop", 0.01)), null);
 		when(config.accountType()).thenReturn(AccountType.MAIN);
 
 		int effectiveTime = calculator.getEffectiveKillTime(source);
@@ -1197,7 +1197,7 @@ public class EfficiencyCalculatorTest
 		CollectionLogSource source = new CollectionLogSource("Test Raid", CollectionLogCategory.RAIDS,
 			3000, 3000, 0, 1800, 2400, "Test Raid", Collections.emptyList(),
 			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0,
-			Collections.singletonList(makeItem(1, "Unique", 0.01)));
+			Collections.singletonList(makeItem(1, "Unique", 0.01)), null);
 		when(config.accountType()).thenReturn(AccountType.IRONMAN);
 		when(config.raidTeamSize()).thenReturn(RaidTeamSize.SOLO);
 

--- a/src/test/java/com/collectionloghelper/efficiency/SlayerStrategyCalculatorTest.java
+++ b/src/test/java/com/collectionloghelper/efficiency/SlayerStrategyCalculatorTest.java
@@ -76,7 +76,7 @@ public class SlayerStrategyCalculatorTest
 	{
 		return new CollectionLogSource(name, CollectionLogCategory.OTHER, 3000, 3000, 0,
 			60, 0, name, Collections.emptyList(),
-			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0, items);
+			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0, items, null);
 	}
 
 	private CollectionLogItem makeItem(int id, String name)

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorDescriptionTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorDescriptionTest.java
@@ -293,6 +293,6 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 			Arrays.asList(steps),
 			null, 0, null, 0,
 			Collections.emptyList()
-		);
+		, null);
 	}
 }

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorMapPointTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorMapPointTest.java
@@ -267,7 +267,7 @@ public class GuidanceOverlayCoordinatorMapPointTest
 			null,  // cumulativeTrackObjectIds
 			0,     // cumulativeTrackThreshold
 			Collections.emptyList()  // items
-		);
+		, null);
 	}
 
 	/** Builds a BOSSES source with coordinates and an explicitly empty guidanceSteps list. */
@@ -297,6 +297,6 @@ public class GuidanceOverlayCoordinatorMapPointTest
 			null,
 			0,
 			Collections.emptyList()
-		);
+		, null);
 	}
 }

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorNpcIdTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorNpcIdTest.java
@@ -300,6 +300,6 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 			Arrays.asList(steps),
 			null, 0, null, 0,
 			Collections.emptyList()
-		);
+		, null);
 	}
 }

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerNestedConditionalTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerNestedConditionalTest.java
@@ -530,7 +530,9 @@ public class GuidanceSequencerNestedConditionalTest
 			"Test Source", CollectionLogCategory.BOSSES, 3000, 3000, 0,
 			60, 0, "Test Source", Collections.emptyList(),
 			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null,
-			steps, null, 0, null, 0, Collections.emptyList());
+			steps, null, 0, null, 0, Collections.emptyList(),
+			null /* metaAuthoredDate */
+		);
 		sequencer.startSequence(source, step -> {}, () -> {});
 	}
 }

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
@@ -450,7 +450,7 @@ public class GuidanceSequencerTest
 		return new CollectionLogSource(name, CollectionLogCategory.BOSSES, 3000, 3000, 0,
 			60, 0, name, Collections.emptyList(),
 			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null,
-			steps, null, 0, null, cumulativeTrackThreshold, Collections.emptyList());
+			steps, null, 0, null, cumulativeTrackThreshold, Collections.emptyList(), null);
 	}
 
 	private void startSequence(List<GuidanceStep> steps)

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerWaypointTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerWaypointTest.java
@@ -169,7 +169,7 @@ public class GuidanceSequencerWaypointTest
 		return new CollectionLogSource("Waypoint Test Source", CollectionLogCategory.BOSSES, 3200, 3400, 0,
 			60, 0, "Test Source", Collections.emptyList(),
 			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null,
-			Arrays.asList(steps), null, 0, null, 0, Collections.emptyList());
+			Arrays.asList(steps), null, 0, null, 0, Collections.emptyList(), null /* metaAuthoredDate */);
 	}
 
 	// ── Test cases ────────────────────────────────────────────────────────────

--- a/src/test/java/com/collectionloghelper/learning/PersonalizedKillTimeTest.java
+++ b/src/test/java/com/collectionloghelper/learning/PersonalizedKillTimeTest.java
@@ -80,7 +80,7 @@ public class PersonalizedKillTimeTest
 			/* guidanceSteps */ null, /* requirements */ null,
 			/* cumulativeTrackItemId */ 0, /* cumulativeTrackObjectIds */ null,
 			/* cumulativeTrackThreshold */ 0,
-			Collections.emptyList());
+			Collections.emptyList(), null /* metaAuthoredDate */);
 	}
 
 	// ── No learned data ──────────────────────────────────────────────────────────

--- a/src/test/java/com/collectionloghelper/lifecycle/GuidanceEventRouterTest.java
+++ b/src/test/java/com/collectionloghelper/lifecycle/GuidanceEventRouterTest.java
@@ -170,7 +170,8 @@ public class GuidanceEventRouterTest
 			0,         // cumulativeTrackItemId
 			null,      // cumulativeTrackObjectIds
 			0,         // cumulativeTrackThreshold
-			null       // items
+			null,      // items
+			null       // metaAuthoredDate
 		);
 	}
 
@@ -202,7 +203,7 @@ public class GuidanceEventRouterTest
 			objectIds,
 			0,
 			null
-		);
+		, null);
 	}
 
 	@Before

--- a/src/test/java/com/collectionloghelper/ui/ItemRowPanelHoverTest.java
+++ b/src/test/java/com/collectionloghelper/ui/ItemRowPanelHoverTest.java
@@ -80,7 +80,7 @@ public class ItemRowPanelHoverTest
 			"Shayzien Armour", CollectionLogCategory.OTHER,
 			1516, 3617, 0, 36, 0, null, null, null, 0, null, 0, false, 2,
 			null, 0, null, null, null, null, 0, null, 0,
-			Collections.singletonList(item));
+			Collections.singletonList(item), null /* metaAuthoredDate */);
 
 		row = new ItemRowPanel(item, source, false, 0, false,
 			Collections.emptyList(), itemManager, () -> {});

--- a/src/test/java/com/collectionloghelper/ui/mode/StatisticsModeControllerTest.java
+++ b/src/test/java/com/collectionloghelper/ui/mode/StatisticsModeControllerTest.java
@@ -113,7 +113,7 @@ public class StatisticsModeControllerTest
 			null, null, null, 0.0, null,
 			0, false, 0, null,
 			0, null, null, null, null,
-			0, null, 0, Collections.emptyList());
+			0, null, 0, Collections.emptyList(), null);
 		List<CollectionLogSource> bossList = Collections.singletonList(source);
 		when(database.getSourcesByCategory(CollectionLogCategory.BOSSES)).thenReturn(bossList);
 		when(collectionState.getCategoryCount(CollectionLogCategory.BOSSES)).thenReturn(5);

--- a/src/test/java/com/collectionloghelper/ui/widget/GuidanceBannerViewTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/GuidanceBannerViewTest.java
@@ -51,7 +51,7 @@ public class GuidanceBannerViewTest
 		return new CollectionLogSource(name, CollectionLogCategory.BOSSES, 0, 0, 0,
 			60, 0, null, null,
 			null, 0, null, 0, false, 0, null, 0, null, null, null, null, 0, null, 0,
-			Collections.emptyList());
+			Collections.emptyList(), null);
 	}
 
 	@Before

--- a/src/test/java/com/collectionloghelper/ui/widget/MetaAgeBadgeTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/MetaAgeBadgeTest.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.ui.widget;
+
+import java.time.LocalDate;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Unit tests for {@link MetaAgeBadge}.
+ *
+ * <p>All tests inject a fixed {@code today} date so colour-threshold assertions
+ * are deterministic regardless of when the suite runs.
+ *
+ * <p>Coverage:
+ * <ul>
+ *   <li>ISO 8601 parsing — valid dates, malformed strings, future dates</li>
+ *   <li>Colour-coding age thresholds (green &lt;3 mo, yellow 3-12 mo, red &gt;12 mo)</li>
+ *   <li>Null-safety — null / empty {@code metaAuthoredDate}</li>
+ *   <li>Label formatting — singular/plural month display</li>
+ * </ul>
+ */
+public class MetaAgeBadgeTest
+{
+	/** Fixed reference date for all threshold tests: 2026-06-01. */
+	private static final LocalDate TODAY = LocalDate.of(2026, 6, 1);
+
+	// =========================================================================
+	// Null / empty safety
+	// =========================================================================
+
+	@Test
+	public void from_nullDate_returnsNull()
+	{
+		MetaAgeBadge badge = MetaAgeBadge.from(null, TODAY);
+		assertNull(badge);
+	}
+
+	@Test
+	public void from_emptyString_returnsNull()
+	{
+		MetaAgeBadge badge = MetaAgeBadge.from("", TODAY);
+		assertNull(badge);
+	}
+
+	// =========================================================================
+	// ISO 8601 parsing
+	// =========================================================================
+
+	@Test
+	public void from_validIso8601_returnsNonNull()
+	{
+		// 1 month before TODAY
+		MetaAgeBadge badge = MetaAgeBadge.from("2026-05-01", TODAY);
+		assertNotNull(badge);
+	}
+
+	@Test
+	public void from_malformedDate_notIso8601_returnsNull()
+	{
+		MetaAgeBadge badge = MetaAgeBadge.from("01/06/2026", TODAY);
+		assertNull(badge);
+	}
+
+	@Test
+	public void from_malformedDate_partialString_returnsNull()
+	{
+		MetaAgeBadge badge = MetaAgeBadge.from("2026-06", TODAY);
+		assertNull(badge);
+	}
+
+	@Test
+	public void from_malformedDate_randomText_returnsNull()
+	{
+		MetaAgeBadge badge = MetaAgeBadge.from("not-a-date", TODAY);
+		assertNull(badge);
+	}
+
+	@Test
+	public void from_futureDate_returnsZeroAgeMonths()
+	{
+		// Date in the future should clamp to 0, not throw
+		MetaAgeBadge badge = MetaAgeBadge.from("2030-01-01", TODAY);
+		assertNotNull(badge);
+		assertEquals(0, badge.getAgeMonths());
+	}
+
+	// =========================================================================
+	// Colour-coding thresholds (mock today = 2026-06-01)
+	// =========================================================================
+
+	@Test
+	public void color_zeroMonths_isFresh()
+	{
+		// Same month as today
+		MetaAgeBadge badge = MetaAgeBadge.from("2026-06-01", TODAY);
+		assertNotNull(badge);
+		assertEquals(MetaAgeBadge.COLOR_FRESH, badge.getColor());
+	}
+
+	@Test
+	public void color_oneMonth_isFresh()
+	{
+		MetaAgeBadge badge = MetaAgeBadge.from("2026-05-01", TODAY);
+		assertNotNull(badge);
+		assertEquals(MetaAgeBadge.COLOR_FRESH, badge.getColor());
+	}
+
+	@Test
+	public void color_twoMonths_isFresh()
+	{
+		MetaAgeBadge badge = MetaAgeBadge.from("2026-04-01", TODAY);
+		assertNotNull(badge);
+		assertEquals(MetaAgeBadge.COLOR_FRESH, badge.getColor());
+	}
+
+	@Test
+	public void color_threeMonths_isWarning()
+	{
+		// Exactly 3 months old — first warning tier boundary
+		MetaAgeBadge badge = MetaAgeBadge.from("2026-03-01", TODAY);
+		assertNotNull(badge);
+		assertEquals(MetaAgeBadge.COLOR_WARNING, badge.getColor());
+	}
+
+	@Test
+	public void color_sixMonths_isWarning()
+	{
+		MetaAgeBadge badge = MetaAgeBadge.from("2025-12-01", TODAY);
+		assertNotNull(badge);
+		assertEquals(MetaAgeBadge.COLOR_WARNING, badge.getColor());
+	}
+
+	@Test
+	public void color_elevenMonths_isWarning()
+	{
+		MetaAgeBadge badge = MetaAgeBadge.from("2025-07-01", TODAY);
+		assertNotNull(badge);
+		assertEquals(MetaAgeBadge.COLOR_WARNING, badge.getColor());
+	}
+
+	@Test
+	public void color_twelveMonths_isStale()
+	{
+		// Exactly 12 months old — crosses stale boundary
+		MetaAgeBadge badge = MetaAgeBadge.from("2025-06-01", TODAY);
+		assertNotNull(badge);
+		assertEquals(MetaAgeBadge.COLOR_STALE, badge.getColor());
+	}
+
+	@Test
+	public void color_twentyFourMonths_isStale()
+	{
+		MetaAgeBadge badge = MetaAgeBadge.from("2024-06-01", TODAY);
+		assertNotNull(badge);
+		assertEquals(MetaAgeBadge.COLOR_STALE, badge.getColor());
+	}
+
+	// =========================================================================
+	// Age month count
+	// =========================================================================
+
+	@Test
+	public void ageMonths_exactlyFiveMonthsAgo()
+	{
+		MetaAgeBadge badge = MetaAgeBadge.from("2026-01-01", TODAY);
+		assertNotNull(badge);
+		assertEquals(5, badge.getAgeMonths());
+	}
+
+	@Test
+	public void ageMonths_exactlyTwelveMonthsAgo()
+	{
+		MetaAgeBadge badge = MetaAgeBadge.from("2025-06-01", TODAY);
+		assertNotNull(badge);
+		assertEquals(12, badge.getAgeMonths());
+	}
+
+	// =========================================================================
+	// Label formatting
+	// =========================================================================
+
+	@Test
+	public void label_zeroMonths_showsLessThanOne()
+	{
+		MetaAgeBadge badge = MetaAgeBadge.from("2026-06-01", TODAY);
+		assertNotNull(badge);
+		assertEquals("Meta: <1 month ago", badge.getLabel());
+	}
+
+	@Test
+	public void label_oneMonth_singular()
+	{
+		MetaAgeBadge badge = MetaAgeBadge.from("2026-05-01", TODAY);
+		assertNotNull(badge);
+		assertEquals("Meta: 1 month ago", badge.getLabel());
+	}
+
+	@Test
+	public void label_twoMonths_plural()
+	{
+		MetaAgeBadge badge = MetaAgeBadge.from("2026-04-01", TODAY);
+		assertNotNull(badge);
+		assertEquals("Meta: 2 months ago", badge.getLabel());
+	}
+
+	@Test
+	public void label_twelveMonths_plural()
+	{
+		MetaAgeBadge badge = MetaAgeBadge.from("2025-06-01", TODAY);
+		assertNotNull(badge);
+		assertEquals("Meta: 12 months ago", badge.getLabel());
+	}
+
+	// =========================================================================
+	// Tooltip text
+	// =========================================================================
+
+	@Test
+	public void tooltip_alwaysTheCanonicalString()
+	{
+		MetaAgeBadge badge = MetaAgeBadge.from("2025-06-01", TODAY);
+		assertNotNull(badge);
+		assertEquals(MetaAgeBadge.TOOLTIP_TEXT, badge.getTooltip());
+		assertEquals(
+			"OSRS updates may have shifted the meta since this guidance was authored.",
+			badge.getTooltip());
+	}
+}

--- a/src/test/java/com/collectionloghelper/ui/widget/QuickGuidePanelViewTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/QuickGuidePanelViewTest.java
@@ -59,7 +59,7 @@ public class QuickGuidePanelViewTest
 	{
 		return new CollectionLogSource(name, CollectionLogCategory.BOSSES, 0, 0, 0,
 			60, 0, null, null, null, 0, null, 0, false, 0, null, 0, null, null, null, null, 0, null, 0,
-			Collections.emptyList());
+			Collections.emptyList(), null);
 	}
 
 	@Test

--- a/src/test/java/com/collectionloghelper/ui/widget/SourceRequirementsHeaderTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/SourceRequirementsHeaderTest.java
@@ -521,7 +521,6 @@ public class SourceRequirementsHeaderTest
 			/* cumulativeTrackItemId */ 0,
 			/* cumulativeTrackObjectIds */ null,
 			/* cumulativeTrackThreshold */ 0,
-			Collections.emptyList()
-		);
+			Collections.emptyList(), null /* metaAuthoredDate */);
 	}
 }


### PR DESCRIPTION
## Summary

- Adds optional `metaAuthoredDate: String` (ISO 8601) field to `CollectionLogSource`; null = no dating, backward-compatible with all existing JSON
- `GuidanceBannerView` renders a color-coded age badge in the source panel header when `metaAuthoredDate` is set: green (<3 mo), yellow (3–12 mo), red (>12 mo)
- Hover tooltip: "OSRS updates may have shifted the meta since this guidance was authored."
- New `MetaAgeBadge` helper holds pure age/color logic with injectable `today` for deterministic tests

## Test plan

- [ ] `MetaAgeBadgeTest`: ISO 8601 parsing (valid, malformed, future dates), color thresholds at exact boundaries (0/1/2 = green, 3/6/11 = yellow, 12/24 = red), null/empty safety, label singular/plural, tooltip constant
- [ ] `DropRateDatabaseTest.load_noProductionSourceHasMetaAuthoredDate`: regression guard — asserts no current `drop_rates.json` entry carries the field (no backfill in this PR)
- [ ] All existing tests updated for new constructor signature (`null` appended as 26th arg) — `./gradlew test build` passes
- [ ] No production data backfill; separate Tier D sweep will populate `metaAuthoredDate` on real sources