### PR TITLE
feat(sync): F2 — TempleOSRS KC sync

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -604,7 +604,7 @@ Focus: god-object decomposition, build hardening, test expansion. Resulted in th
 **Tier F — Social, imports, and long-tail polish**
 
 - [/] F1 — collectionlog.net import                     status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #465
-- [ ] F2 — TempleOSRS KC sync                           status: planned       owner: —          updated: 2026-04-16
+- [/] F2 — TempleOSRS KC sync                           status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #468
 - [/] F3 — Per-account kill-time learning               status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #466  note: KillTimeTracker + PersonalizedKillTime, opt-in config flag, 19 tests.
 - [ ] F4 — Dry-streak feed                              status: planned       owner: —          updated: 2026-04-16
 - [/] F5 — JaCoCo + 80% gate                            status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #454  note: gate active at 45% threshold; follow-up to raise to 80% with overlay/UI test additions.

--- a/src/main/java/com/collectionloghelper/CollectionLogHelperConfig.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperConfig.java
@@ -61,6 +61,7 @@ public interface CollectionLogHelperConfig extends Config
 		return false;
 	}
 
+
 	@ConfigSection(
 		name = "Learning",
 		description = "Per-account learning features",
@@ -281,6 +282,20 @@ public interface CollectionLogHelperConfig extends Config
 		position = 0
 	)
 	default boolean learnKillTimes()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "enableTempleOsrsSync",
+		name = "TempleOSRS KC Sync",
+		description = "Enable the 'Sync KC from TempleOSRS' button in the panel. "
+			+ "When clicked the plugin fetches your boss/activity kill counts from "
+			+ "templeosrs.com and stores them locally for use in efficiency scoring.",
+		section = syncSection,
+		position = 1
+	)
+	default boolean enableTempleOsrsSync()
 	{
 		return false;
 	}

--- a/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
@@ -30,6 +30,9 @@ import com.collectionloghelper.sync.CollectionLogNetImporter;
 import com.collectionloghelper.sync.ImportResult;
 import com.collectionloghelper.data.DataSyncState;
 import com.collectionloghelper.data.DropRateDatabase;
+import com.collectionloghelper.sync.SourceKcStore;
+import com.collectionloghelper.sync.SyncResult;
+import com.collectionloghelper.sync.TempleOsrsKcSyncer;
 import com.collectionloghelper.data.PlayerBankState;
 import com.collectionloghelper.data.PlayerCollectionState;
 import com.collectionloghelper.data.PlayerInventoryState;
@@ -56,8 +59,10 @@ import com.collectionloghelper.overlay.ObjectHighlightOverlay;
 import com.collectionloghelper.ui.CollectionLogHelperPanel;
 import com.google.inject.Provides;
 import java.awt.image.BufferedImage;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -217,6 +222,12 @@ public class CollectionLogHelperPlugin extends Plugin
 	@Inject
 	private KillTimeTracker killTimeTracker;
 
+	@Inject
+	private TempleOsrsKcSyncer templeOsrsKcSyncer;
+
+	@Inject
+	private SourceKcStore sourceKcStore;
+
 
 	private CollectionLogHelperPanel panel;
 	private NavigationButton navButton;
@@ -312,6 +323,9 @@ public class CollectionLogHelperPlugin extends Plugin
 			});
 		});
 
+		// Wire TempleOSRS KC sync button callback
+		panel.setTempleSyncCallback(this::onTempleSyncRequested);
+
 		// Wire coordinator with references it needs from the plugin
 		guidanceCoordinator.setPluginInstance(this);
 		guidanceCoordinator.setPanel(panel);
@@ -397,6 +411,8 @@ public class CollectionLogHelperPlugin extends Plugin
 		killTimeTracker.reset();
 		deactivateGuidance();
 		syncStateCoordinator.reset();
+		sourceKcStore.clear();
+		templeOsrsKcSyncer.shutdown();
 		sourcesWithMissingItems.clear();
 		pendingPanelRebuild = false;
 		rankedSourcesDirty = true;
@@ -919,6 +935,98 @@ public class CollectionLogHelperPlugin extends Plugin
 	public void deactivateGuidance()
 	{
 		guidanceCoordinator.deactivateGuidance();
+	}
+
+	/**
+	 * Initiates an asynchronous TempleOSRS KC sync for the current player.
+	 *
+	 * <p>Triggered by the panel "Sync KC from TempleOSRS" button. The sync runs on
+	 * the {@link TempleOsrsKcSyncer} background thread; on completion the result is
+	 * applied on the EDT and the panel button is reset.
+	 *
+	 * <p>Fail-soft: any error is logged and surfaced as a chat message; no exception
+	 * reaches the caller.
+	 */
+	private void onTempleSyncRequested()
+	{
+		if (!config.enableTempleOsrsSync())
+		{
+			return;
+		}
+
+		String playerName = pluginDataManager.getCurrentPlayerName();
+		if (playerName == null || playerName.isEmpty())
+		{
+			log.warn("TempleOSRS sync requested but player name is not available");
+			if (panel != null)
+			{
+				panel.onTempleSyncComplete(false);
+			}
+			return;
+		}
+
+		log.info("Requesting TempleOSRS KC sync for '{}'", playerName);
+
+		java.util.concurrent.Future<SyncResult> future = templeOsrsKcSyncer.syncKc(playerName);
+
+		// Wait for the result on a separate thread so the EDT is not blocked
+		java.util.concurrent.Executors.newSingleThreadExecutor().submit(() ->
+		{
+			SyncResult result;
+			try
+			{
+				result = future.get(30, java.util.concurrent.TimeUnit.SECONDS);
+			}
+			catch (Exception e)
+			{
+				log.warn("TempleOSRS sync future failed for '{}': {}", playerName, e.getMessage());
+				result = SyncResult.failure("Sync timed out or failed: " + e.getMessage());
+			}
+
+			final SyncResult finalResult = result;
+			if (finalResult.isSuccess())
+			{
+				// Validate mapped names against the DB and apply only known sources
+				Map<String, Integer> validated = new java.util.HashMap<>();
+				for (Map.Entry<String, Integer> entry : finalResult.getKcBySource().entrySet())
+				{
+					if (database.getSourceByName(entry.getKey()) != null)
+					{
+						validated.put(entry.getKey(), entry.getValue());
+					}
+					else
+					{
+						log.debug("TempleOSRS KC entry '{}' not found in CLH database — skipping",
+							entry.getKey());
+					}
+				}
+				sourceKcStore.update(validated);
+				log.info("TempleOSRS KC sync complete: {} sources updated, {} skipped",
+					validated.size(), finalResult.getSkippedCount());
+
+				clientThread.invokeLater(() ->
+					client.addChatMessage(
+						net.runelite.api.ChatMessageType.GAMEMESSAGE, "",
+						"<col=00c8c8>[Collection Log Helper]</col> TempleOSRS KC synced: "
+							+ validated.size() + " sources updated.",
+						null));
+			}
+			else
+			{
+				log.warn("TempleOSRS KC sync failed: {}", finalResult.getErrorMessage());
+				clientThread.invokeLater(() ->
+					client.addChatMessage(
+						net.runelite.api.ChatMessageType.GAMEMESSAGE, "",
+						"<col=ff0000>[Collection Log Helper]</col> TempleOSRS KC sync failed: "
+							+ finalResult.getErrorMessage(),
+						null));
+			}
+
+			if (panel != null)
+			{
+				panel.onTempleSyncComplete(finalResult.isSuccess());
+			}
+		});
 	}
 
 	/**

--- a/src/main/java/com/collectionloghelper/sync/SourceKcStore.java
+++ b/src/main/java/com/collectionloghelper/sync/SourceKcStore.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.sync;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Thread-safe in-memory store for per-source kill counts synced from TempleOSRS.
+ *
+ * <p>Keyed by CLH source name (exact match, not lower-cased).
+ * Values are the most recently synced KC for that source.
+ *
+ * <p>Cleared on plugin shutdown or logout so stale data does not persist
+ * across character switches.
+ */
+@Slf4j
+@Singleton
+public class SourceKcStore
+{
+	/** KC map: source name to kill count. */
+	private final ConcurrentHashMap<String, Integer> kcMap = new ConcurrentHashMap<>();
+
+	@Inject
+	SourceKcStore()
+	{
+	}
+
+	/**
+	 * Bulk-update the store with all KC values from a successful sync.
+	 *
+	 * @param kcBySource map from CLH source name to KC (as returned by
+	 *                   {@link SyncResult#getKcBySource()})
+	 */
+	public void update(Map<String, Integer> kcBySource)
+	{
+		kcMap.putAll(kcBySource);
+		log.debug("SourceKcStore updated with {} entries", kcBySource.size());
+	}
+
+	/**
+	 * Returns the synced KC for {@code sourceName}, or {@code 0} if no KC
+	 * has been synced for that source.
+	 */
+	public int getKc(String sourceName)
+	{
+		return kcMap.getOrDefault(sourceName, 0);
+	}
+
+	/**
+	 * Returns a read-only snapshot of the entire KC map.
+	 */
+	public Map<String, Integer> snapshot()
+	{
+		return Collections.unmodifiableMap(new HashMap<>(kcMap));
+	}
+
+	/**
+	 * Returns the number of sources with synced KC data.
+	 */
+	public int size()
+	{
+		return kcMap.size();
+	}
+
+	/**
+	 * Clears all synced KC data. Call on logout or plugin shutdown.
+	 */
+	public void clear()
+	{
+		kcMap.clear();
+		log.debug("SourceKcStore cleared");
+	}
+}

--- a/src/main/java/com/collectionloghelper/sync/SyncResult.java
+++ b/src/main/java/com/collectionloghelper/sync/SyncResult.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.sync;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Result of a TempleOSRS KC sync operation.
+ *
+ * <p>Follows the fail-soft pattern: a failed fetch yields
+ * {@link #failure(String)} so callers need not handle exceptions.
+ */
+public final class SyncResult
+{
+	private final boolean success;
+	private final String errorMessage;
+	/** Map from CLH source name to KC, populated only on success. */
+	private final Map<String, Integer> kcBySource;
+	private final int skippedCount;
+
+	private SyncResult(boolean success, String errorMessage,
+		Map<String, Integer> kcBySource, int skippedCount)
+	{
+		this.success = success;
+		this.errorMessage = errorMessage;
+		this.kcBySource = kcBySource;
+		this.skippedCount = skippedCount;
+	}
+
+	public static SyncResult success(Map<String, Integer> kcBySource, int skippedCount)
+	{
+		return new SyncResult(true, null,
+			Collections.unmodifiableMap(kcBySource), skippedCount);
+	}
+
+	public static SyncResult failure(String errorMessage)
+	{
+		return new SyncResult(false, errorMessage, Collections.emptyMap(), 0);
+	}
+
+	public boolean isSuccess()
+	{
+		return success;
+	}
+
+	public String getErrorMessage()
+	{
+		return errorMessage;
+	}
+
+	/** KC map keyed by CLH source name. Empty on failure. */
+	public Map<String, Integer> getKcBySource()
+	{
+		return kcBySource;
+	}
+
+	/** Number of TempleOSRS activity names with no CLH source mapping (logged, not failed). */
+	public int getSkippedCount()
+	{
+		return skippedCount;
+	}
+
+	@Override
+	public String toString()
+	{
+		if (!success)
+		{
+			return "SyncResult{failure: " + errorMessage + "}";
+		}
+		return "SyncResult{success: " + kcBySource.size() + " sources, skipped=" + skippedCount + "}";
+	}
+}

--- a/src/main/java/com/collectionloghelper/sync/TempleOsrsKcSyncer.java
+++ b/src/main/java/com/collectionloghelper/sync/TempleOsrsKcSyncer.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.sync;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+/**
+ * Fetches boss/activity kill counts from the TempleOSRS API and maps them to
+ * CLH source names.
+ *
+ * <p>API endpoint: {@code GET https://templeosrs.com/api/player_info.php?player={username}}
+ *
+ * <p>Response shape (simplified):
+ * <pre>
+ * {
+ *   "data": {
+ *     "Abyssal Sire": 0,
+ *     "K'ril Tsutsaroth": 100,
+ *     ...
+ *   }
+ * }
+ * </pre>
+ *
+ * <p>Fail-soft: any HTTP error, parse failure, or timeout yields
+ * {@link SyncResult#failure(String)}; no exception propagates to the caller.
+ * Unknown TempleOSRS activity names are logged at DEBUG and skipped; they do not
+ * cause the overall sync to fail.
+ */
+@Slf4j
+@Singleton
+public class TempleOsrsKcSyncer
+{
+	static final String BASE_URL = "https://templeosrs.com/api/player_info.php";
+
+	/**
+	 * Static name mapping from TempleOSRS display name to CLH source name.
+	 *
+	 * <p>Keys are TempleOSRS activity names exactly as returned by the API.
+	 * Values are CLH {@link com.collectionloghelper.data.CollectionLogSource#getName()} strings.
+	 *
+	 * <p>Entries are added only when the names differ; identical names fall through
+	 * to the identity-return path in {@link #resolveClhName}.
+	 */
+	static final Map<String, String> TEMPLE_TO_CLH;
+
+	static
+	{
+		Map<String, String> m = new HashMap<>();
+		// Explicit overrides where TempleOSRS name differs from CLH source name
+		m.put("Barrows Chests", "Barrows");
+		m.put("Leviathan", "The Leviathan");
+		m.put("Mimic", "The Mimic");
+		m.put("Nightmare", "The Nightmare");
+		m.put("Whisperer", "The Whisperer");
+		TEMPLE_TO_CLH = Collections.unmodifiableMap(m);
+	}
+
+	private final OkHttpClient okHttpClient;
+	private final Gson gson;
+	private final ExecutorService executor;
+
+	@Inject
+	TempleOsrsKcSyncer(OkHttpClient okHttpClient, Gson gson)
+	{
+		this.okHttpClient = okHttpClient;
+		this.gson = gson;
+		this.executor = Executors.newSingleThreadExecutor(r ->
+		{
+			Thread t = new Thread(r, "clh-temple-sync");
+			t.setDaemon(true);
+			return t;
+		});
+	}
+
+	/**
+	 * Asynchronously fetches KC data from TempleOSRS for {@code username} and
+	 * maps it to CLH source names.
+	 *
+	 * <p>Never throws; failures are encoded as {@link SyncResult#failure(String)}.
+	 *
+	 * @param username the OSRS display name (spaces allowed; URL-encoded internally)
+	 * @return a Future that resolves to a {@link SyncResult}
+	 */
+	public Future<SyncResult> syncKc(String username)
+	{
+		return executor.submit(() -> doSync(username));
+	}
+
+	/**
+	 * Shuts down the internal executor. Call during plugin shutdown.
+	 */
+	public void shutdown()
+	{
+		executor.shutdownNow();
+	}
+
+	// ---- package-private for testing ----
+
+	/**
+	 * Performs the actual HTTP fetch and parse. Exposed package-private so tests
+	 * can inject a mocked {@link OkHttpClient} and call directly.
+	 */
+	SyncResult doSync(String username)
+	{
+		if (username == null || username.trim().isEmpty())
+		{
+			return SyncResult.failure("Username is empty");
+		}
+
+		String url = BASE_URL + "?player=" + encodeUsername(username.trim());
+		log.debug("Fetching TempleOSRS KC for '{}': {}", username, url);
+
+		Request request = new Request.Builder()
+			.url(url)
+			.header("User-Agent", "collection-log-helper-runelite-plugin")
+			.build();
+
+		try (Response response = okHttpClient.newCall(request).execute())
+		{
+			if (!response.isSuccessful())
+			{
+				String msg = "TempleOSRS returned HTTP " + response.code()
+					+ " for user '" + username + "'";
+				log.warn(msg);
+				return SyncResult.failure(msg);
+			}
+
+			String body = response.body() != null ? response.body().string() : null;
+			if (body == null || body.isEmpty())
+			{
+				return SyncResult.failure("Empty response from TempleOSRS");
+			}
+
+			return parseResponse(body);
+		}
+		catch (IOException e)
+		{
+			log.warn("Network error fetching TempleOSRS KC for '{}': {}",
+				username, e.getMessage());
+			return SyncResult.failure("Network error: " + e.getMessage());
+		}
+		catch (Exception e)
+		{
+			log.warn("Unexpected error fetching TempleOSRS KC for '{}': {}",
+				username, e.getMessage());
+			return SyncResult.failure("Unexpected error: " + e.getMessage());
+		}
+	}
+
+	/**
+	 * Parses the TempleOSRS JSON response into a {@link SyncResult}.
+	 *
+	 * <p>Expected shape: {@code {"data": {"Boss Name": 100, ...}}}
+	 */
+	SyncResult parseResponse(String json)
+	{
+		try
+		{
+			JsonObject root = gson.fromJson(json, JsonObject.class);
+			if (root == null || !root.has("data"))
+			{
+				return SyncResult.failure("TempleOSRS response missing 'data' field");
+			}
+
+			JsonElement dataEl = root.get("data");
+			if (!dataEl.isJsonObject())
+			{
+				return SyncResult.failure("TempleOSRS 'data' field is not an object");
+			}
+
+			return mapActivitiesToSources(dataEl.getAsJsonObject());
+		}
+		catch (JsonSyntaxException e)
+		{
+			log.warn("Failed to parse TempleOSRS response: {}", e.getMessage());
+			return SyncResult.failure("JSON parse error: " + e.getMessage());
+		}
+	}
+
+	/**
+	 * Maps TempleOSRS activity names to CLH source names, skipping unknowns.
+	 *
+	 * <p>Mapping strategy:
+	 * <ol>
+	 *   <li>Explicit override in {@link #TEMPLE_TO_CLH}</li>
+	 *   <li>Identity — return the name as-is (caller validates against the DB)</li>
+	 *   <li>Zero-KC entries are skipped (player has not done that activity)</li>
+	 * </ol>
+	 */
+	SyncResult mapActivitiesToSources(JsonObject data)
+	{
+		Map<String, Integer> result = new HashMap<>();
+		int skipped = 0;
+
+		for (Map.Entry<String, JsonElement> entry : data.entrySet())
+		{
+			String templeName = entry.getKey();
+			JsonElement kcEl = entry.getValue();
+
+			if (!kcEl.isJsonPrimitive())
+			{
+				skipped++;
+				continue;
+			}
+
+			int kc;
+			try
+			{
+				kc = kcEl.getAsInt();
+			}
+			catch (NumberFormatException e)
+			{
+				skipped++;
+				continue;
+			}
+
+			if (kc <= 0)
+			{
+				// Zero KC — player has not completed this activity; skip silently
+				continue;
+			}
+
+			String clhName = resolveClhName(templeName);
+			// Last-write wins if the same CLH name appears under multiple TempleOSRS keys
+			result.merge(clhName, kc, Integer::max);
+		}
+
+		log.debug("TempleOSRS KC mapped {} sources, skipped {} non-numeric entries",
+			result.size(), skipped);
+		return SyncResult.success(result, skipped);
+	}
+
+	/**
+	 * Resolves a TempleOSRS activity name to a CLH-compatible source name.
+	 *
+	 * <p>First checks the explicit override map {@link #TEMPLE_TO_CLH}; if absent,
+	 * returns the name unchanged (identity fallback).  Callers should validate the
+	 * name against {@link com.collectionloghelper.data.DropRateDatabase#getSourceByName}
+	 * to confirm it matches a known CLH source.
+	 *
+	 * @return always non-null
+	 */
+	String resolveClhName(String templeName)
+	{
+		String mapped = TEMPLE_TO_CLH.get(templeName);
+		return mapped != null ? mapped : templeName;
+	}
+
+	/** URL-encode a username for use as a query-parameter value. */
+	private static String encodeUsername(String username)
+	{
+		try
+		{
+			return java.net.URLEncoder.encode(username, "UTF-8").replace("+", "%20");
+		}
+		catch (java.io.UnsupportedEncodingException e)
+		{
+			// UTF-8 is always supported in Java
+			return username;
+		}
+	}
+}

--- a/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
@@ -164,6 +164,9 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 
 	private final Timer searchDebounceTimer;
 
+	/** "Sync KC from TempleOSRS" button; visible only when config.enableTempleOsrsSync() is true. */
+	private final JButton templeSyncButton;
+
 	private final Map<Mode, PanelModeController> modeControllers = new EnumMap<>(Mode.class);
 	private final PanelModeDispatcher<Mode> modeDispatcher = new PanelModeDispatcher<>(modeControllers);
 
@@ -173,6 +176,7 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 	private boolean guidanceActive = false;
 	private CollectionLogSource guidedSource = null;
 	private boolean inDetailView = false;
+	private Runnable templeSyncCallback;
 
 	public CollectionLogHelperPanel(CollectionLogHelperConfig config,
 		DropRateDatabase database, PlayerCollectionState collectionState,
@@ -247,6 +251,23 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 			}
 		});
 		controlsPanel.add(collectionLogNetSyncButton);
+
+		templeSyncButton = new JButton("Sync KC from TempleOSRS");
+		templeSyncButton.setFont(FontManager.getRunescapeSmallFont());
+		templeSyncButton.setAlignmentX(CENTER_ALIGNMENT);
+		templeSyncButton.setMaximumSize(new Dimension(Integer.MAX_VALUE, 28));
+		templeSyncButton.setToolTipText("Fetch your boss/activity kill counts from templeosrs.com");
+		templeSyncButton.setVisible(config.enableTempleOsrsSync());
+		templeSyncButton.addActionListener(e ->
+		{
+			if (templeSyncCallback != null)
+			{
+				templeSyncButton.setEnabled(false);
+				templeSyncButton.setText("Syncing...");
+				templeSyncCallback.run();
+			}
+		});
+		controlsPanel.add(templeSyncButton);
 
 		clueSummaryView = new ClueSummaryView();
 		clueSummaryView.setAlignmentX(CENTER_ALIGNMENT);
@@ -505,6 +526,40 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 	public void shutDown()
 	{
 		searchDebounceTimer.stop();
+	}
+
+	/**
+	 * Registers the callback invoked when the "Sync KC from TempleOSRS" button is clicked.
+	 * Must be called from the EDT or before the panel is shown.
+	 */
+	public void setTempleSyncCallback(Runnable callback)
+	{
+		this.templeSyncCallback = callback;
+	}
+
+	/**
+	 * Refreshes the visibility of the TempleOSRS sync button based on the current config.
+	 * Call after the config value changes.
+	 */
+	public void updateTempleSyncButtonVisibility()
+	{
+		SwingUtilities.invokeLater(() ->
+			templeSyncButton.setVisible(config.enableTempleOsrsSync()));
+	}
+
+	/**
+	 * Resets the TempleOSRS sync button to its idle state after a sync attempt completes.
+	 *
+	 * @param success whether the sync succeeded (affects button label)
+	 */
+	public void onTempleSyncComplete(boolean success)
+	{
+		SwingUtilities.invokeLater(() ->
+		{
+			templeSyncButton.setEnabled(true);
+			templeSyncButton.setText(
+				success ? "Synced KC from TempleOSRS" : "Sync KC from TempleOSRS");
+		});
 	}
 
 	public void rebuild()

--- a/src/test/java/com/collectionloghelper/sync/TempleOsrsKcSyncerTest.java
+++ b/src/test/java/com/collectionloghelper/sync/TempleOsrsKcSyncerTest.java
@@ -1,0 +1,517 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.sync;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import okhttp3.Call;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link TempleOsrsKcSyncer}.
+ *
+ * <p>All tests use mocked HTTP responses — the real TempleOSRS API is never hit.
+ */
+public class TempleOsrsKcSyncerTest
+{
+	private OkHttpClient mockClient;
+	private TempleOsrsKcSyncer syncer;
+	private Gson gson;
+
+	@Before
+	public void setUp()
+	{
+		mockClient = mock(OkHttpClient.class);
+		gson = new Gson();
+		syncer = new TempleOsrsKcSyncer(mockClient, gson);
+	}
+
+	// ========================================================================
+	// parseResponse — valid JSON
+	// ========================================================================
+
+	@Test
+	public void parseResponse_validData_returnsMappedKc()
+	{
+		String json = "{\"data\": {\"Zulrah\": 500, \"Vorkath\": 300}}";
+
+		SyncResult result = syncer.parseResponse(json);
+
+		assertTrue(result.isSuccess());
+		assertEquals(500, (int) result.getKcBySource().get("Zulrah"));
+		assertEquals(300, (int) result.getKcBySource().get("Vorkath"));
+	}
+
+	@Test
+	public void parseResponse_explicitNameOverride_mapsCorrectly()
+	{
+		// "Barrows Chests" in TempleOSRS -> "Barrows" in CLH
+		String json = "{\"data\": {\"Barrows Chests\": 150}}";
+
+		SyncResult result = syncer.parseResponse(json);
+
+		assertTrue(result.isSuccess());
+		assertNotNull(result.getKcBySource().get("Barrows"));
+		assertEquals(150, (int) result.getKcBySource().get("Barrows"));
+		assertNull("Should not contain raw TempleOSRS key",
+			result.getKcBySource().get("Barrows Chests"));
+	}
+
+	@Test
+	public void parseResponse_theNightmare_mapsCorrectly()
+	{
+		String json = "{\"data\": {\"Nightmare\": 75}}";
+
+		SyncResult result = syncer.parseResponse(json);
+
+		assertTrue(result.isSuccess());
+		assertEquals(75, (int) result.getKcBySource().get("The Nightmare"));
+	}
+
+	@Test
+	public void parseResponse_theLeviathan_mapsCorrectly()
+	{
+		String json = "{\"data\": {\"Leviathan\": 42}}";
+
+		SyncResult result = syncer.parseResponse(json);
+
+		assertTrue(result.isSuccess());
+		assertEquals(42, (int) result.getKcBySource().get("The Leviathan"));
+	}
+
+	@Test
+	public void parseResponse_theMimic_mapsCorrectly()
+	{
+		String json = "{\"data\": {\"Mimic\": 3}}";
+
+		SyncResult result = syncer.parseResponse(json);
+
+		assertTrue(result.isSuccess());
+		assertEquals(3, (int) result.getKcBySource().get("The Mimic"));
+	}
+
+	@Test
+	public void parseResponse_theWhisperer_mapsCorrectly()
+	{
+		String json = "{\"data\": {\"Whisperer\": 200}}";
+
+		SyncResult result = syncer.parseResponse(json);
+
+		assertTrue(result.isSuccess());
+		assertEquals(200, (int) result.getKcBySource().get("The Whisperer"));
+	}
+
+	@Test
+	public void parseResponse_krilTsutsaroth_identityMapping()
+	{
+		// K'ril Tsutsaroth name is the same in TempleOSRS and CLH — identity fallback
+		String json = "{\"data\": {\"K'ril Tsutsaroth\": 99}}";
+
+		SyncResult result = syncer.parseResponse(json);
+
+		assertTrue(result.isSuccess());
+		assertEquals(99, (int) result.getKcBySource().get("K'ril Tsutsaroth"));
+	}
+
+	@Test
+	public void parseResponse_zeroKcSkipped()
+	{
+		// Zero KC entries should be silently skipped
+		String json = "{\"data\": {\"Zulrah\": 0, \"Vorkath\": 300}}";
+
+		SyncResult result = syncer.parseResponse(json);
+
+		assertTrue(result.isSuccess());
+		assertNull("Zero KC should not be stored", result.getKcBySource().get("Zulrah"));
+		assertEquals(300, (int) result.getKcBySource().get("Vorkath"));
+	}
+
+	@Test
+	public void parseResponse_multipleEntries_allMapped()
+	{
+		String json = "{\"data\": {"
+			+ "\"Abyssal Sire\": 100,"
+			+ "\"Alchemical Hydra\": 200,"
+			+ "\"Cerberus\": 300,"
+			+ "\"Corporeal Beast\": 50"
+			+ "}}";
+
+		SyncResult result = syncer.parseResponse(json);
+
+		assertTrue(result.isSuccess());
+		assertEquals(4, result.getKcBySource().size());
+		assertEquals(100, (int) result.getKcBySource().get("Abyssal Sire"));
+		assertEquals(200, (int) result.getKcBySource().get("Alchemical Hydra"));
+		assertEquals(300, (int) result.getKcBySource().get("Cerberus"));
+		assertEquals(50, (int) result.getKcBySource().get("Corporeal Beast"));
+	}
+
+	// ========================================================================
+	// parseResponse — failure modes
+	// ========================================================================
+
+	@Test
+	public void parseResponse_missingDataField_returnsFailure()
+	{
+		String json = "{\"error\": \"Player not found\"}";
+
+		SyncResult result = syncer.parseResponse(json);
+
+		assertFalse(result.isSuccess());
+		assertNotNull(result.getErrorMessage());
+		assertTrue(result.getErrorMessage().contains("'data'"));
+	}
+
+	@Test
+	public void parseResponse_invalidJson_returnsFailure()
+	{
+		String json = "not valid json {{{";
+
+		SyncResult result = syncer.parseResponse(json);
+
+		assertFalse(result.isSuccess());
+		assertNotNull(result.getErrorMessage());
+	}
+
+	@Test
+	public void parseResponse_nullJson_returnsFailure()
+	{
+		// Gson returns null object for "null" JSON
+		SyncResult result = syncer.parseResponse("null");
+
+		assertFalse(result.isSuccess());
+		assertNotNull(result.getErrorMessage());
+	}
+
+	@Test
+	public void parseResponse_dataIsArray_returnsFailure()
+	{
+		String json = "{\"data\": [1, 2, 3]}";
+
+		SyncResult result = syncer.parseResponse(json);
+
+		assertFalse(result.isSuccess());
+		assertNotNull(result.getErrorMessage());
+		assertTrue(result.getErrorMessage().contains("not an object"));
+	}
+
+	// ========================================================================
+	// mapActivitiesToSources — non-numeric / skipped entries
+	// ========================================================================
+
+	@Test
+	public void mapActivitiesToSources_nonNumericValue_skipped()
+	{
+		JsonObject data = gson.fromJson("{\"Zulrah\": \"hundred\", \"Vorkath\": 10}", JsonObject.class);
+
+		SyncResult result = syncer.mapActivitiesToSources(data);
+
+		assertTrue(result.isSuccess());
+		assertEquals(1, result.getKcBySource().size());
+		assertEquals(1, result.getSkippedCount());
+	}
+
+	@Test
+	public void mapActivitiesToSources_nonPrimitiveValue_skipped()
+	{
+		JsonObject data = gson.fromJson("{\"Zulrah\": {\"kc\": 100}, \"Vorkath\": 5}", JsonObject.class);
+
+		SyncResult result = syncer.mapActivitiesToSources(data);
+
+		assertTrue(result.isSuccess());
+		assertEquals(1, result.getKcBySource().size());
+		assertEquals(1, result.getSkippedCount());
+		assertEquals(5, (int) result.getKcBySource().get("Vorkath"));
+	}
+
+	@Test
+	public void mapActivitiesToSources_emptyData_returnsEmptySuccess()
+	{
+		JsonObject data = new JsonObject();
+
+		SyncResult result = syncer.mapActivitiesToSources(data);
+
+		assertTrue(result.isSuccess());
+		assertTrue(result.getKcBySource().isEmpty());
+		assertEquals(0, result.getSkippedCount());
+	}
+
+	@Test
+	public void mapActivitiesToSources_phosanis_separateEntry()
+	{
+		// Phosani's Nightmare is a separate CLH source from The Nightmare
+		JsonObject data = gson.fromJson(
+			"{\"Nightmare\": 50, \"Phosani's Nightmare\": 100}", JsonObject.class);
+
+		SyncResult result = syncer.mapActivitiesToSources(data);
+
+		assertTrue(result.isSuccess());
+		assertTrue(result.getKcBySource().containsKey("The Nightmare"));
+		assertTrue(result.getKcBySource().containsKey("Phosani's Nightmare"));
+		assertEquals(50, (int) result.getKcBySource().get("The Nightmare"));
+		assertEquals(100, (int) result.getKcBySource().get("Phosani's Nightmare"));
+	}
+
+	// ========================================================================
+	// resolveClhName
+	// ========================================================================
+
+	@Test
+	public void resolveClhName_explicitOverride_returnsMappedName()
+	{
+		assertEquals("Barrows", syncer.resolveClhName("Barrows Chests"));
+		assertEquals("The Nightmare", syncer.resolveClhName("Nightmare"));
+		assertEquals("The Leviathan", syncer.resolveClhName("Leviathan"));
+		assertEquals("The Mimic", syncer.resolveClhName("Mimic"));
+		assertEquals("The Whisperer", syncer.resolveClhName("Whisperer"));
+	}
+
+	@Test
+	public void resolveClhName_noOverride_returnsIdentity()
+	{
+		assertEquals("Zulrah", syncer.resolveClhName("Zulrah"));
+		assertEquals("K'ril Tsutsaroth", syncer.resolveClhName("K'ril Tsutsaroth"));
+		assertEquals("Chambers of Xeric", syncer.resolveClhName("Chambers of Xeric"));
+		assertEquals("SomeUnknownBoss", syncer.resolveClhName("SomeUnknownBoss"));
+	}
+
+	// ========================================================================
+	// doSync — HTTP-level failure modes (mocked OkHttpClient)
+	// ========================================================================
+
+	@Test
+	public void doSync_emptyUsername_returnsFailure()
+	{
+		SyncResult result = syncer.doSync("");
+
+		assertFalse(result.isSuccess());
+		assertTrue(result.getErrorMessage().contains("empty"));
+	}
+
+	@Test
+	public void doSync_nullUsername_returnsFailure()
+	{
+		SyncResult result = syncer.doSync(null);
+
+		assertFalse(result.isSuccess());
+		assertTrue(result.getErrorMessage().contains("empty"));
+	}
+
+	@Test
+	public void doSync_http404_returnsFailure() throws IOException
+	{
+		mockHttpResponse(404, "");
+
+		SyncResult result = syncer.doSync("PlayerNotFound");
+
+		assertFalse(result.isSuccess());
+		assertTrue(result.getErrorMessage().contains("404"));
+	}
+
+	@Test
+	public void doSync_http500_returnsFailure() throws IOException
+	{
+		mockHttpResponse(500, "Internal Server Error");
+
+		SyncResult result = syncer.doSync("TestPlayer");
+
+		assertFalse(result.isSuccess());
+		assertTrue(result.getErrorMessage().contains("500"));
+	}
+
+	@Test
+	public void doSync_networkException_returnsFailure() throws IOException
+	{
+		Call mockCall = mock(Call.class);
+		when(mockClient.newCall(any(Request.class))).thenReturn(mockCall);
+		when(mockCall.execute()).thenThrow(new IOException("Connection refused"));
+
+		SyncResult result = syncer.doSync("TestPlayer");
+
+		assertFalse(result.isSuccess());
+		assertTrue(result.getErrorMessage().contains("Network error"));
+	}
+
+	@Test
+	public void doSync_validResponse_returnsMappedKc() throws IOException
+	{
+		String json = "{\"data\": {\"Zulrah\": 999, \"Barrows Chests\": 42}}";
+		mockHttpResponse(200, json);
+
+		SyncResult result = syncer.doSync("TestPlayer");
+
+		assertTrue(result.isSuccess());
+		assertEquals(999, (int) result.getKcBySource().get("Zulrah"));
+		assertEquals(42, (int) result.getKcBySource().get("Barrows"));
+	}
+
+	@Test
+	public void doSync_emptyResponseBody_returnsFailure() throws IOException
+	{
+		mockHttpResponse(200, "");
+
+		SyncResult result = syncer.doSync("TestPlayer");
+
+		assertFalse(result.isSuccess());
+	}
+
+	// ========================================================================
+	// SourceKcStore integration
+	// ========================================================================
+
+	@Test
+	public void sourceKcStore_updateAndGet_roundTrip()
+	{
+		SourceKcStore store = new SourceKcStore();
+		Map<String, Integer> kc = new HashMap<>();
+		kc.put("Zulrah", 500);
+		kc.put("Vorkath", 300);
+
+		store.update(kc);
+
+		assertEquals(500, store.getKc("Zulrah"));
+		assertEquals(300, store.getKc("Vorkath"));
+		assertEquals(0, store.getKc("Abyssal Sire")); // not synced
+		assertEquals(2, store.size());
+	}
+
+	@Test
+	public void sourceKcStore_clear_removesAllEntries()
+	{
+		SourceKcStore store = new SourceKcStore();
+		Map<String, Integer> kc = new HashMap<>();
+		kc.put("Zulrah", 500);
+		store.update(kc);
+		assertEquals(1, store.size());
+
+		store.clear();
+
+		assertEquals(0, store.size());
+		assertEquals(0, store.getKc("Zulrah"));
+	}
+
+	@Test
+	public void sourceKcStore_snapshot_isImmutable()
+	{
+		SourceKcStore store = new SourceKcStore();
+		Map<String, Integer> kc = new HashMap<>();
+		kc.put("Vorkath", 100);
+		store.update(kc);
+
+		Map<String, Integer> snapshot = store.snapshot();
+
+		try
+		{
+			snapshot.put("NewEntry", 1);
+			fail("Expected UnsupportedOperationException from immutable snapshot");
+		}
+		catch (UnsupportedOperationException expected)
+		{
+			// expected — snapshot must be immutable
+		}
+	}
+
+	@Test
+	public void sourceKcStore_updateTwice_latestValueWins()
+	{
+		SourceKcStore store = new SourceKcStore();
+		Map<String, Integer> first = new HashMap<>();
+		first.put("Zulrah", 100);
+		store.update(first);
+
+		Map<String, Integer> second = new HashMap<>();
+		second.put("Zulrah", 200);
+		store.update(second);
+
+		assertEquals(200, store.getKc("Zulrah"));
+	}
+
+	// ========================================================================
+	// SyncResult — value object
+	// ========================================================================
+
+	@Test
+	public void syncResult_success_hasCorrectFields()
+	{
+		Map<String, Integer> kc = new HashMap<>();
+		kc.put("Zulrah", 10);
+		SyncResult result = SyncResult.success(kc, 3);
+
+		assertTrue(result.isSuccess());
+		assertNull(result.getErrorMessage());
+		assertEquals(1, result.getKcBySource().size());
+		assertEquals(3, result.getSkippedCount());
+	}
+
+	@Test
+	public void syncResult_failure_hasCorrectFields()
+	{
+		SyncResult result = SyncResult.failure("Connection timed out");
+
+		assertFalse(result.isSuccess());
+		assertEquals("Connection timed out", result.getErrorMessage());
+		assertTrue(result.getKcBySource().isEmpty());
+		assertEquals(0, result.getSkippedCount());
+	}
+
+	// ========================================================================
+	// Helper
+	// ========================================================================
+
+	private void mockHttpResponse(int code, String body) throws IOException
+	{
+		Call mockCall = mock(Call.class);
+		when(mockClient.newCall(any(Request.class))).thenReturn(mockCall);
+
+		Request dummyRequest = new Request.Builder()
+			.url(TempleOsrsKcSyncer.BASE_URL + "?player=test")
+			.build();
+
+		Response response = new Response.Builder()
+			.request(dummyRequest)
+			.protocol(Protocol.HTTP_1_1)
+			.code(code)
+			.message(code == 200 ? "OK" : "Error")
+			.body(ResponseBody.create(MediaType.parse("application/json"), body))
+			.build();
+
+		when(mockCall.execute()).thenReturn(response);
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `TempleOsrsKcSyncer` service that fetches boss/activity kill counts from `GET https://templeosrs.com/api/player_info.php?player={username}` and maps them to CLH source names via a static override map (5 explicit entries: Barrows Chests, Nightmare, Leviathan, Mimic, Whisperer; all others resolved by identity and validated against the drop-rates DB before storage).
- Adds `SourceKcStore` — thread-safe in-memory KC registry keyed by CLH source name; updated on each successful sync, cleared on logout/shutdown.
- Adds `enableTempleOsrsSync` config flag (default OFF, Sync section) and a "Sync KC from TempleOSRS" panel button that is only visible when the flag is enabled.
- Fail-soft: any HTTP error, parse failure, or timeout yields `SyncResult.failure(message)`; errors surface as chat messages, no exception propagates to the UI. Unknown TempleOSRS names are logged at DEBUG and skipped — they do not abort the sync.

## New files

- `src/main/java/com/collectionloghelper/sync/SyncResult.java` — result value object
- `src/main/java/com/collectionloghelper/sync/TempleOsrsKcSyncer.java` — HTTP syncer service
- `src/main/java/com/collectionloghelper/sync/SourceKcStore.java` — KC store
- `src/test/java/com/collectionloghelper/sync/TempleOsrsKcSyncerTest.java` — 30 unit tests

## Test plan

- [ ] `./gradlew test build` passes (verified locally — BUILD SUCCESSFUL)
- [ ] All five explicit name-override mappings tested (Barrows, The Nightmare, The Leviathan, The Mimic, The Whisperer)
- [ ] Identity fallback tested (K'ril Tsutsaroth, Zulrah, Chambers of Xeric)
- [ ] Zero-KC entries are skipped
- [ ] HTTP 404, 500, network exception, empty body all return failure (not throw)
- [ ] `SourceKcStore` update/get/clear/snapshot/immutability round-trips covered
- [ ] Real TempleOSRS API never called in tests (all responses mocked via `OkHttpClient` mock)