### PR TITLE
feat(learning): F4 — dry-streak feed

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -606,7 +606,7 @@ Focus: god-object decomposition, build hardening, test expansion. Resulted in th
 - [/] F1 — collectionlog.net import                     status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #465
 - [ ] F2 — TempleOSRS KC sync                           status: planned       owner: —          updated: 2026-04-16
 - [/] F3 — Per-account kill-time learning               status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #466  note: KillTimeTracker + PersonalizedKillTime, opt-in config flag, 19 tests.
-- [ ] F4 — Dry-streak feed                              status: planned       owner: —          updated: 2026-04-16
+- [/] F4 — Dry-streak feed                              status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #469
 - [/] F5 — JaCoCo + 80% gate                            status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #454  note: gate active at 45% threshold; follow-up to raise to 80% with overlay/UI test additions.
-- [ ] F6 — GitHub Actions CI                            status: planned       owner: —          updated: 2026-04-16
+- [/] F6 — GitHub Actions CI                            status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #451  note: build+test workflow on PR/push; verify first CI run is green before moving to [x].
 - [ ] F7 — Issue #134 account-specific calcs            status: planned       owner: —          updated: 2026-04-16

--- a/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
@@ -41,6 +41,7 @@ import com.collectionloghelper.efficiency.ClueCompletionEstimator;
 import com.collectionloghelper.efficiency.EfficiencyCalculator;
 import com.collectionloghelper.efficiency.ScoredItem;
 import com.collectionloghelper.efficiency.SlayerStrategyCalculator;
+import com.collectionloghelper.learning.DryStreakAnalyzer;
 import com.collectionloghelper.guidance.GuidanceOverlayCoordinator;
 import com.collectionloghelper.guidance.GuidanceSequencer;
 import com.collectionloghelper.guidance.RequiredItemResolver;
@@ -176,6 +177,9 @@ public class CollectionLogHelperPlugin extends Plugin
 	private SlayerStrategyCalculator slayerStrategyCalculator;
 
 	@Inject
+	private DryStreakAnalyzer dryStreakAnalyzer;
+
+	@Inject
 	private PlayerTravelCapabilities travelCapabilities;
 
 	@Inject
@@ -255,6 +259,7 @@ public class CollectionLogHelperPlugin extends Plugin
 			config, database, collectionState, calculator, clueEstimator,
 			itemManager, requirementsChecker, dataSyncState, slayerTaskState,
 			slayerStrategyCalculator, playerInventoryState, playerBankState,
+			dryStreakAnalyzer,
 			(java.util.function.BiConsumer<CollectionLogSource, Integer>) this::activateGuidance,
 			this::deactivateGuidance,
 			filter -> configManager.setConfiguration("collectionloghelper", "afkFilter", filter.name()),

--- a/src/main/java/com/collectionloghelper/learning/DryStreakAnalyzer.java
+++ b/src/main/java/com/collectionloghelper/learning/DryStreakAnalyzer.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.learning;
+
+import com.collectionloghelper.data.CollectionLogItem;
+import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.data.DropRateDatabase;
+import com.collectionloghelper.data.PlayerCollectionState;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Computes the dry-streak feed for a player's collection log state.
+ *
+ * <p>For each unobtained probabilistic item the analyzer:
+ * <ol>
+ *   <li>Derives the median expected kill count using the formula
+ *       {@code medianKc = log(0.5) / log(1 - dropRate)}.</li>
+ *   <li>Divides the actual kill count for the item's source by that median to
+ *       produce a <em>dryness ratio</em> ({@code multipleOfExpected}).</li>
+ *   <li>Classifies the ratio into {@link DrynessClass#NORMAL} (&lt;= 2x),
+ *       {@link DrynessClass#DRY} (&gt; 2x and &lt;= 5x), or
+ *       {@link DrynessClass#VERY_DRY} (&gt; 5x).</li>
+ * </ol>
+ *
+ * <p>Items with a zero or negative drop rate, guaranteed drops (rate &gt;= 1),
+ * and items classified as {@link DrynessClass#NORMAL} are excluded from the
+ * result list.
+ *
+ * <p>The returned list is sorted by {@code multipleOfExpected} descending so the
+ * worst dry streaks appear first. This is the default feed sort; callers may
+ * re-sort by other criteria after receiving the list.
+ *
+ * <p>KC data is supplied as a {@code Map<String, Integer>} keyed by source name
+ * (case-sensitive, matching {@link CollectionLogSource#getName()}). This keeps
+ * the analyzer decoupled from any specific KC-data source (in-game varps,
+ * TempleOSRS sync, manual entry, etc.).
+ */
+@Slf4j
+@Singleton
+public class DryStreakAnalyzer
+{
+	/** Lower bound: ratios at or below this threshold are classified NORMAL and excluded. */
+	static final double DRY_THRESHOLD = 2.0;
+	/** Upper bound: ratios above this threshold are classified VERY_DRY. */
+	static final double VERY_DRY_THRESHOLD = 5.0;
+
+	private final DropRateDatabase database;
+
+	@Inject
+	public DryStreakAnalyzer(DropRateDatabase database)
+	{
+		this.database = database;
+	}
+
+	/**
+	 * Computes the dry-streak feed.
+	 *
+	 * @param collectionState current player collection state (obtained item IDs)
+	 * @param killCountsBySource kill counts keyed by source name; sources absent
+	 *                           from the map contribute no entries to the feed
+	 * @return entries where {@code multipleOfExpected > 2}, sorted by
+	 *         {@code multipleOfExpected} descending (worst streak first)
+	 */
+	public List<DryStreakEntry> analyze(
+		PlayerCollectionState collectionState,
+		Map<String, Integer> killCountsBySource)
+	{
+		if (killCountsBySource == null || killCountsBySource.isEmpty())
+		{
+			return Collections.emptyList();
+		}
+
+		List<DryStreakEntry> feed = new ArrayList<>();
+
+		for (CollectionLogSource source : database.getAllSources())
+		{
+			Integer actualKc = killCountsBySource.get(source.getName());
+			if (actualKc == null || actualKc <= 0)
+			{
+				continue;
+			}
+
+			for (CollectionLogItem item : source.getItems())
+			{
+				if (collectionState.isItemObtained(item.getItemId()))
+				{
+					continue;
+				}
+
+				double dropRate = item.getDropRate();
+				if (dropRate <= 0.0 || dropRate >= 1.0)
+				{
+					// Cannot compute a meaningful median for guaranteed or zero-rate items
+					continue;
+				}
+
+				double medianKc = computeMedianKc(dropRate);
+				if (medianKc <= 0)
+				{
+					continue;
+				}
+
+				double ratio = actualKc / medianKc;
+				if (ratio <= DRY_THRESHOLD)
+				{
+					continue;
+				}
+
+				DrynessClass cls = ratio > VERY_DRY_THRESHOLD ? DrynessClass.VERY_DRY : DrynessClass.DRY;
+				feed.add(new DryStreakEntry(item, source, ratio, cls));
+			}
+		}
+
+		feed.sort(Comparator.comparingDouble(DryStreakEntry::getMultipleOfExpected).reversed());
+		return Collections.unmodifiableList(feed);
+	}
+
+	/**
+	 * Returns the median kill count needed for a 50% chance of having received a
+	 * drop at least once, using the formula:
+	 *
+	 * <pre>medianKc = log(0.5) / log(1 - dropRate)</pre>
+	 *
+	 * @param dropRate per-kill drop probability in (0, 1)
+	 * @return median expected KC, or 0 if the result is not positive
+	 */
+	public static double computeMedianKc(double dropRate)
+	{
+		if (dropRate <= 0.0 || dropRate >= 1.0)
+		{
+			return 0;
+		}
+		double median = Math.log(0.5) / Math.log(1.0 - dropRate);
+		return median > 0 ? median : 0;
+	}
+
+	/**
+	 * Classifies a dryness ratio against the standard thresholds.
+	 *
+	 * @param ratio {@code actualKc / medianExpectedKc}
+	 * @return the corresponding {@link DrynessClass}
+	 */
+	public static DrynessClass classify(double ratio)
+	{
+		if (ratio > VERY_DRY_THRESHOLD)
+		{
+			return DrynessClass.VERY_DRY;
+		}
+		if (ratio > DRY_THRESHOLD)
+		{
+			return DrynessClass.DRY;
+		}
+		return DrynessClass.NORMAL;
+	}
+}

--- a/src/main/java/com/collectionloghelper/learning/DryStreakEntry.java
+++ b/src/main/java/com/collectionloghelper/learning/DryStreakEntry.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.learning;
+
+import com.collectionloghelper.data.CollectionLogItem;
+import com.collectionloghelper.data.CollectionLogSource;
+import lombok.Value;
+
+/**
+ * A single entry in the dry-streak feed representing an unobtained item whose
+ * actual kill count significantly exceeds the statistically expected median kill
+ * count for a 50% drop probability.
+ *
+ * <p>The {@code multipleOfExpected} field is the dryness ratio:
+ * {@code actualKc / medianExpectedKc}. A value of 3.0 means the player has
+ * done three times as many kills as the statistical median without receiving
+ * the item. Items with a ratio at or below 2x are classified {@link DrynessClass#NORMAL}
+ * and are excluded from the feed by default.
+ */
+@Value
+public class DryStreakEntry
+{
+	CollectionLogItem item;
+	CollectionLogSource source;
+	/**
+	 * Actual kill count divided by the median expected kill count
+	 * ({@code log(0.5) / log(1 - dropRate)}).
+	 * Zero if the expected KC could not be computed (e.g. zero drop rate).
+	 */
+	double multipleOfExpected;
+	/** Dryness tier derived from {@link #multipleOfExpected}. */
+	DrynessClass classification;
+}

--- a/src/main/java/com/collectionloghelper/learning/DryStreakSortMode.java
+++ b/src/main/java/com/collectionloghelper/learning/DryStreakSortMode.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.learning;
+
+/**
+ * Sort orders available in the dry-streak feed panel mode.
+ */
+public enum DryStreakSortMode
+{
+	/** Sort by dryness ratio descending — worst dry streaks first (default). */
+	RATIO_DESC("Dryness"),
+	/** Sort by item name ascending (A-Z). */
+	ITEM_NAME_ASC("Item Name"),
+	/** Sort by source name ascending (A-Z). */
+	SOURCE_NAME_ASC("Source");
+
+	private final String displayName;
+
+	DryStreakSortMode(String displayName)
+	{
+		this.displayName = displayName;
+	}
+
+	@Override
+	public String toString()
+	{
+		return displayName;
+	}
+}

--- a/src/main/java/com/collectionloghelper/learning/DrynessClass.java
+++ b/src/main/java/com/collectionloghelper/learning/DrynessClass.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.learning;
+
+/**
+ * Classifies how far past the statistical median a player is for a given item.
+ *
+ * <p>Thresholds:
+ * <ul>
+ *   <li>{@link #NORMAL}   — actual KC &lt;= 2x the median expected KC</li>
+ *   <li>{@link #DRY}      — actual KC &gt; 2x and &lt;= 5x the median expected KC</li>
+ *   <li>{@link #VERY_DRY} — actual KC &gt; 5x the median expected KC</li>
+ * </ul>
+ */
+public enum DrynessClass
+{
+	/** Actual kill count is within 2x of the median expected kill count. */
+	NORMAL,
+	/** Actual kill count is between 2x and 5x the median expected kill count. */
+	DRY,
+	/** Actual kill count exceeds 5x the median expected kill count. */
+	VERY_DRY
+}

--- a/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
@@ -43,7 +43,9 @@ import com.collectionloghelper.efficiency.ClueCompletionEstimator;
 import com.collectionloghelper.efficiency.EfficiencyCalculator;
 import com.collectionloghelper.efficiency.ScoredItem;
 import com.collectionloghelper.efficiency.SlayerStrategyCalculator;
+import com.collectionloghelper.learning.DryStreakAnalyzer;
 import com.collectionloghelper.ui.mode.CategoryModeController;
+import com.collectionloghelper.ui.mode.DryStreakFeedModeController;
 import com.collectionloghelper.ui.mode.EfficientModeController;
 import com.collectionloghelper.ui.mode.PanelModeController;
 import com.collectionloghelper.ui.mode.PanelModeDispatcher;
@@ -101,7 +103,8 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 		CATEGORY_FOCUS("Category Focus"),
 		SEARCH("Search"),
 		PET_HUNT("Pet Hunt"),
-		STATISTICS("Statistics");
+		STATISTICS("Statistics"),
+		DRY_STREAK("Dry Streaks");
 
 		private final String displayName;
 
@@ -129,6 +132,7 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 	private final DropRateDatabase database;
 	private final PlayerCollectionState collectionState;
 	private final EfficiencyCalculator calculator;
+	private DryStreakFeedModeController dryStreakFeedController;
 	private final ClueCompletionEstimator clueEstimator;
 	private final ItemManager itemManager;
 	private final RequirementsChecker requirementsChecker;
@@ -183,6 +187,7 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 		SlayerStrategyCalculator slayerStrategyCalculator,
 		PlayerInventoryState inventoryState,
 		PlayerBankState bankState,
+		DryStreakAnalyzer dryStreakAnalyzer,
 		BiConsumer<CollectionLogSource, Integer> guidanceActivator, Runnable guidanceDeactivator,
 		Consumer<AfkFilter> afkFilterUpdater,
 		Consumer<EfficientSortMode> sortModeUpdater)
@@ -416,6 +421,10 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 			new EfficientModeController(this, config, collectionState, calculator,
 				requirementsChecker, itemManager));
 
+		dryStreakFeedController = new DryStreakFeedModeController(this, collectionState,
+			dryStreakAnalyzer);
+		modeControllers.put(Mode.DRY_STREAK, dryStreakFeedController);
+
 		updateControlVisibility();
 	}
 
@@ -500,6 +509,21 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 			revalidate();
 			repaint();
 		});
+	}
+
+	/**
+	 * Updates the kill counts available to the dry-streak feed. Call this after any
+	 * KC-data refresh (in-game varp update, TempleOSRS sync, etc.). A subsequent
+	 * {@link #rebuild()} is required to repaint the feed.
+	 *
+	 * @param killCounts map of source name to kill count; {@code null} is treated as empty
+	 */
+	public void updateDryStreakKillCounts(java.util.Map<String, Integer> killCounts)
+	{
+		if (dryStreakFeedController != null)
+		{
+			dryStreakFeedController.setKillCounts(killCounts);
+		}
 	}
 
 	public void shutDown()

--- a/src/main/java/com/collectionloghelper/ui/mode/DryStreakFeedModeController.java
+++ b/src/main/java/com/collectionloghelper/ui/mode/DryStreakFeedModeController.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.ui.mode;
+
+import com.collectionloghelper.data.PlayerCollectionState;
+import com.collectionloghelper.learning.DrynessClass;
+import com.collectionloghelper.learning.DryStreakAnalyzer;
+import com.collectionloghelper.learning.DryStreakEntry;
+import com.collectionloghelper.learning.DryStreakSortMode;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingConstants;
+import net.runelite.client.ui.ColorScheme;
+import net.runelite.client.ui.FontManager;
+
+/**
+ * Renders the Dry-streak Feed mode: a ranked list of unobtained items for which
+ * the player's kill count significantly exceeds the statistical median.
+ *
+ * <p>Entries with a dryness ratio &gt; 2x are shown; the worst offenders appear
+ * first (sorted by {@code multipleOfExpected} descending by default). A sort
+ * toggle in the mode header lets the user switch to alphabetical order by item
+ * name or by source name.
+ *
+ * <p>KC data is injected at construction time so the controller stays decoupled
+ * from the KC-sync mechanism (F2/F3). Pass an empty map if no KC data is yet
+ * available — the controller will show an appropriate empty-state message.
+ */
+public class DryStreakFeedModeController implements PanelModeController
+{
+	/** Maximum number of entries shown in the feed to keep the panel legible. */
+	static final int MAX_ENTRIES = 50;
+
+	private static final Color VERY_DRY_COLOR = new Color(220, 50, 50);
+	private static final Color DRY_COLOR = new Color(220, 160, 0);
+	private static final Color VERY_DRY_BG = new Color(60, 20, 20);
+	private static final Color DRY_BG = new Color(50, 40, 10);
+
+	private final PanelShellContext shell;
+	private final PlayerCollectionState collectionState;
+	private final DryStreakAnalyzer analyzer;
+
+	/**
+	 * Live KC data injected from the owning panel/plugin. Keyed by source name.
+	 * May be empty when no KC sync has occurred yet.
+	 */
+	private Map<String, Integer> killCounts = Collections.emptyMap();
+
+	/** Current sort order for the feed. Defaults to dryness ratio descending. */
+	private DryStreakSortMode sortMode = DryStreakSortMode.RATIO_DESC;
+
+	public DryStreakFeedModeController(
+		PanelShellContext shell,
+		PlayerCollectionState collectionState,
+		DryStreakAnalyzer analyzer)
+	{
+		this.shell = shell;
+		this.collectionState = collectionState;
+		this.analyzer = analyzer;
+	}
+
+	/**
+	 * Updates the KC data used by this controller. Call this whenever the
+	 * underlying KC store is refreshed (e.g. after an in-game KC varp update or
+	 * a TempleOSRS sync). The panel will need a subsequent {@code rebuild()} to
+	 * reflect the new data.
+	 */
+	public void setKillCounts(Map<String, Integer> killCounts)
+	{
+		this.killCounts = killCounts != null ? killCounts : Collections.emptyMap();
+	}
+
+	/** Returns the current sort mode. */
+	public DryStreakSortMode getSortMode()
+	{
+		return sortMode;
+	}
+
+	/** Sets the sort mode and triggers a view rebuild on the next {@link #buildView()} call. */
+	public void setSortMode(DryStreakSortMode sortMode)
+	{
+		this.sortMode = sortMode != null ? sortMode : DryStreakSortMode.RATIO_DESC;
+	}
+
+	@Override
+	public void buildView()
+	{
+		List<DryStreakEntry> feed = analyzer.analyze(collectionState, killCounts);
+
+		if (feed.isEmpty())
+		{
+			if (killCounts.isEmpty())
+			{
+				shell.addEmptyStateMessage(
+					"No KC data available.<br>Kill counts will appear here once synced.");
+			}
+			else
+			{
+				shell.addEmptyStateMessage("No dry streaks detected.");
+			}
+			return;
+		}
+
+		List<DryStreakEntry> sorted = applySortMode(feed, sortMode);
+		int shown = Math.min(sorted.size(), MAX_ENTRIES);
+
+		for (int i = 0; i < shown; i++)
+		{
+			DryStreakEntry entry = sorted.get(i);
+			shell.addToList(buildEntryRow(entry));
+			shell.addToList(Box.createVerticalStrut(2));
+		}
+
+		if (sorted.size() > MAX_ENTRIES)
+		{
+			int hidden = sorted.size() - MAX_ENTRIES;
+			JLabel moreLabel = new JLabel("... and " + hidden + " more dry items");
+			moreLabel.setFont(FontManager.getRunescapeSmallFont());
+			moreLabel.setForeground(ColorScheme.LIGHT_GRAY_COLOR);
+			moreLabel.setHorizontalAlignment(SwingConstants.CENTER);
+			moreLabel.setAlignmentX(javax.swing.JComponent.CENTER_ALIGNMENT);
+			moreLabel.setBorder(BorderFactory.createEmptyBorder(4, 8, 4, 8));
+			shell.addToList(moreLabel);
+		}
+	}
+
+	private JPanel buildEntryRow(DryStreakEntry entry)
+	{
+		boolean veryDry = entry.getClassification() == DrynessClass.VERY_DRY;
+		Color rowBg = veryDry ? VERY_DRY_BG : DRY_BG;
+		Color accentColor = veryDry ? VERY_DRY_COLOR : DRY_COLOR;
+
+		JPanel row = new JPanel(new BorderLayout(4, 0));
+		row.setBackground(rowBg);
+		row.setBorder(BorderFactory.createEmptyBorder(5, 8, 5, 8));
+		row.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
+
+		// Item name label (left)
+		JLabel nameLabel = new JLabel(entry.getItem().getName());
+		nameLabel.setFont(FontManager.getRunescapeSmallFont());
+		nameLabel.setForeground(Color.WHITE);
+
+		// Source name (secondary, below item name)
+		JLabel sourceLabel = new JLabel(entry.getSource().getName());
+		sourceLabel.setFont(FontManager.getRunescapeSmallFont());
+		sourceLabel.setForeground(ColorScheme.LIGHT_GRAY_COLOR);
+
+		JPanel namePanel = new JPanel(new BorderLayout());
+		namePanel.setOpaque(false);
+		namePanel.add(nameLabel, BorderLayout.NORTH);
+		namePanel.add(sourceLabel, BorderLayout.SOUTH);
+		row.add(namePanel, BorderLayout.CENTER);
+
+		// Dryness ratio label (right)
+		String ratioText = String.format("%.1fx", entry.getMultipleOfExpected());
+		JLabel ratioLabel = new JLabel(ratioText);
+		ratioLabel.setFont(FontManager.getRunescapeBoldFont());
+		ratioLabel.setForeground(accentColor);
+		ratioLabel.setHorizontalAlignment(SwingConstants.RIGHT);
+		row.add(ratioLabel, BorderLayout.EAST);
+
+		// Tooltip
+		long medianKc = Math.round(
+			DryStreakAnalyzer.computeMedianKc(entry.getItem().getDropRate()));
+		long dropDenom = entry.getItem().getDropRate() > 0
+			? Math.round(1.0 / entry.getItem().getDropRate()) : 0;
+		String tier = veryDry ? "VERY DRY" : "DRY";
+		row.setToolTipText(String.format(
+			"<html>%s — %s<br>Drop rate: 1/%d<br>Median KC: ~%d<br>Dryness: %.1fx (%s)</html>",
+			entry.getItem().getName(), entry.getSource().getName(),
+			dropDenom, medianKc, entry.getMultipleOfExpected(), tier));
+
+		// Click navigates to item detail
+		row.addMouseListener(new MouseAdapter()
+		{
+			@Override
+			public void mousePressed(MouseEvent e)
+			{
+				shell.showDetail(entry.getItem(), entry.getSource());
+			}
+
+			@Override
+			public void mouseEntered(MouseEvent e)
+			{
+				row.setBackground(veryDry
+					? VERY_DRY_BG.brighter() : DRY_BG.brighter());
+			}
+
+			@Override
+			public void mouseExited(MouseEvent e)
+			{
+				row.setBackground(rowBg);
+			}
+		});
+
+		return row;
+	}
+
+	/**
+	 * Sorts a copy of {@code entries} according to {@code mode}.
+	 * The input list is not modified.
+	 */
+	static List<DryStreakEntry> applySortMode(List<DryStreakEntry> entries, DryStreakSortMode mode)
+	{
+		List<DryStreakEntry> result = new ArrayList<>(entries);
+		switch (mode)
+		{
+			case ITEM_NAME_ASC:
+				result.sort(Comparator.comparing(e -> e.getItem().getName()));
+				break;
+			case SOURCE_NAME_ASC:
+				result.sort(Comparator.comparing(e -> e.getSource().getName()));
+				break;
+			case RATIO_DESC:
+			default:
+				result.sort(Comparator.comparingDouble(DryStreakEntry::getMultipleOfExpected).reversed());
+				break;
+		}
+		return result;
+	}
+}

--- a/src/test/java/com/collectionloghelper/learning/DryStreakAnalyzerTest.java
+++ b/src/test/java/com/collectionloghelper/learning/DryStreakAnalyzerTest.java
@@ -1,0 +1,388 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.learning;
+
+import com.collectionloghelper.data.CollectionLogCategory;
+import com.collectionloghelper.data.CollectionLogItem;
+import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.data.DropRateDatabase;
+import com.collectionloghelper.data.PlayerCollectionState;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link DryStreakAnalyzer}.
+ *
+ * <p>Uses synthetic drop rates and KC data so the tests are deterministic and
+ * independent of the production {@code drop_rates.json} fixture.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class DryStreakAnalyzerTest
+{
+	/** 1/128 drop rate — a common OSRS rare drop denomination. */
+	private static final double RATE_1_IN_128 = 1.0 / 128.0;
+	/** 1/512 drop rate — very rare. */
+	private static final double RATE_1_IN_512 = 1.0 / 512.0;
+
+	@Mock
+	private DropRateDatabase database;
+
+	@Mock
+	private PlayerCollectionState collectionState;
+
+	private DryStreakAnalyzer analyzer;
+
+	// Synthetic items
+	private CollectionLogItem rareItem;
+	private CollectionLogItem veryRareItem;
+	private CollectionLogItem guaranteedItem;
+	private CollectionLogItem zeroRateItem;
+
+	// Synthetic sources
+	private CollectionLogSource sourceA;
+	private CollectionLogSource sourceB;
+
+	@Before
+	public void setUp()
+	{
+		analyzer = new DryStreakAnalyzer(database);
+
+		rareItem = new CollectionLogItem(1001, "Rare Drop", RATE_1_IN_128,
+			false, null, 0, 0, false, false);
+		veryRareItem = new CollectionLogItem(1002, "Very Rare Drop", RATE_1_IN_512,
+			false, null, 0, 0, false, false);
+		guaranteedItem = new CollectionLogItem(1003, "Guaranteed Item", 1.0,
+			false, null, 0, 100, false, false);
+		zeroRateItem = new CollectionLogItem(1004, "Zero Rate Item", 0.0,
+			false, null, 0, 0, false, false);
+
+		sourceA = makeSource("Boss Alpha", CollectionLogCategory.BOSSES,
+			Arrays.asList(rareItem, guaranteedItem, zeroRateItem));
+		sourceB = makeSource("Boss Beta", CollectionLogCategory.BOSSES,
+			Collections.singletonList(veryRareItem));
+
+		when(database.getAllSources()).thenReturn(Arrays.asList(sourceA, sourceB));
+	}
+
+	// ── computeMedianKc ─────────────────────────────────────────────────────
+
+	@Test
+	public void computeMedianKc_rate1in128_returnsExpectedValue()
+	{
+		// median = log(0.5) / log(1 - 1/128) ≈ 88.7
+		double median = DryStreakAnalyzer.computeMedianKc(RATE_1_IN_128);
+		assertEquals(88.7, median, 0.5);
+	}
+
+	@Test
+	public void computeMedianKc_rate1in512_returnsExpectedValue()
+	{
+		// median = log(0.5) / log(1 - 1/512) ≈ 354.9
+		double median = DryStreakAnalyzer.computeMedianKc(RATE_1_IN_512);
+		assertEquals(354.9, median, 0.5);
+	}
+
+	@Test
+	public void computeMedianKc_zeroRate_returnsZero()
+	{
+		assertEquals(0.0, DryStreakAnalyzer.computeMedianKc(0.0), 0.0);
+	}
+
+	@Test
+	public void computeMedianKc_oneRate_returnsZero()
+	{
+		assertEquals(0.0, DryStreakAnalyzer.computeMedianKc(1.0), 0.0);
+	}
+
+	@Test
+	public void computeMedianKc_negativeRate_returnsZero()
+	{
+		assertEquals(0.0, DryStreakAnalyzer.computeMedianKc(-0.1), 0.0);
+	}
+
+	// ── classify ────────────────────────────────────────────────────────────
+
+	@Test
+	public void classify_ratioAtExactlyTwo_returnsNormal()
+	{
+		assertEquals(DrynessClass.NORMAL, DryStreakAnalyzer.classify(2.0));
+	}
+
+	@Test
+	public void classify_ratioJustAboveTwo_returnsDry()
+	{
+		assertEquals(DrynessClass.DRY, DryStreakAnalyzer.classify(2.01));
+	}
+
+	@Test
+	public void classify_ratioAtExactlyFive_returnsDry()
+	{
+		assertEquals(DrynessClass.DRY, DryStreakAnalyzer.classify(5.0));
+	}
+
+	@Test
+	public void classify_ratioJustAboveFive_returnsVeryDry()
+	{
+		assertEquals(DrynessClass.VERY_DRY, DryStreakAnalyzer.classify(5.01));
+	}
+
+	@Test
+	public void classify_ratioTen_returnsVeryDry()
+	{
+		assertEquals(DrynessClass.VERY_DRY, DryStreakAnalyzer.classify(10.0));
+	}
+
+	@Test
+	public void classify_ratioOne_returnsNormal()
+	{
+		assertEquals(DrynessClass.NORMAL, DryStreakAnalyzer.classify(1.0));
+	}
+
+	// ── analyze — empty and guard cases ─────────────────────────────────────
+
+	@Test
+	public void analyze_nullKcMap_returnsEmptyList()
+	{
+		List<DryStreakEntry> result = analyzer.analyze(collectionState, null);
+		assertTrue(result.isEmpty());
+	}
+
+	@Test
+	public void analyze_emptyKcMap_returnsEmptyList()
+	{
+		List<DryStreakEntry> result = analyzer.analyze(collectionState,
+			Collections.emptyMap());
+		assertTrue(result.isEmpty());
+	}
+
+	@Test
+	public void analyze_sourceNotInKcMap_producesNoEntries()
+	{
+		// Only sourceB is in the map, and its item is not obtained
+		when(collectionState.isItemObtained(1002)).thenReturn(false);
+
+		Map<String, Integer> kc = Collections.singletonMap("Boss Beta", 1);
+		List<DryStreakEntry> result = analyzer.analyze(collectionState, kc);
+		// 1 kill vs median ~355 → ratio 0.003 → NORMAL → excluded
+		assertTrue(result.isEmpty());
+	}
+
+	// ── analyze — dryness classification via KC data ─────────────────────────
+
+	@Test
+	public void analyze_kcAtExactlyTwoTimesMedian_excluded()
+	{
+		when(collectionState.isItemObtained(1001)).thenReturn(false);
+		when(collectionState.isItemObtained(1003)).thenReturn(true);
+		when(collectionState.isItemObtained(1004)).thenReturn(true);
+
+		double median = DryStreakAnalyzer.computeMedianKc(RATE_1_IN_128);
+		// Use floor to ensure the integer KC does not exceed 2x the (continuous) median.
+		// Math.round can push the ratio just above 2.0 due to integer truncation.
+		int kcAtOrBelowTwoX = (int) Math.floor(median * 2.0);
+
+		Map<String, Integer> kc = Collections.singletonMap("Boss Alpha", kcAtOrBelowTwoX);
+		List<DryStreakEntry> result = analyzer.analyze(collectionState, kc);
+		// Ratio <= 2.0 → NORMAL → excluded from feed
+		assertTrue(result.isEmpty());
+	}
+
+	@Test
+	public void analyze_kcSlightlyAboveTwoTimesMedian_classifiedAsDry()
+	{
+		when(collectionState.isItemObtained(1001)).thenReturn(false);
+		when(collectionState.isItemObtained(1003)).thenReturn(true);
+		when(collectionState.isItemObtained(1004)).thenReturn(true);
+
+		double median = DryStreakAnalyzer.computeMedianKc(RATE_1_IN_128);
+		// Use 3x median to safely land in DRY (>2x, <=5x)
+		int kcAtThreeX = (int) Math.round(median * 3.0);
+
+		Map<String, Integer> kc = Collections.singletonMap("Boss Alpha", kcAtThreeX);
+		List<DryStreakEntry> result = analyzer.analyze(collectionState, kc);
+
+		assertEquals(1, result.size());
+		assertEquals(DrynessClass.DRY, result.get(0).getClassification());
+		assertEquals(rareItem, result.get(0).getItem());
+	}
+
+	@Test
+	public void analyze_kcAboveFiveTimesMedian_classifiedAsVeryDry()
+	{
+		when(collectionState.isItemObtained(1001)).thenReturn(false);
+		when(collectionState.isItemObtained(1003)).thenReturn(true);
+		when(collectionState.isItemObtained(1004)).thenReturn(true);
+
+		double median = DryStreakAnalyzer.computeMedianKc(RATE_1_IN_128);
+		int kcAtSixX = (int) Math.round(median * 6.0);
+
+		Map<String, Integer> kc = Collections.singletonMap("Boss Alpha", kcAtSixX);
+		List<DryStreakEntry> result = analyzer.analyze(collectionState, kc);
+
+		assertEquals(1, result.size());
+		assertEquals(DrynessClass.VERY_DRY, result.get(0).getClassification());
+	}
+
+	@Test
+	public void analyze_guaranteedItemIgnored()
+	{
+		// Only guaranteed item is missing — should not appear in feed
+		when(collectionState.isItemObtained(1001)).thenReturn(true);
+		when(collectionState.isItemObtained(1003)).thenReturn(false);
+		when(collectionState.isItemObtained(1004)).thenReturn(true);
+
+		double median = DryStreakAnalyzer.computeMedianKc(RATE_1_IN_128);
+		int bigKc = (int) Math.round(median * 10.0);
+
+		Map<String, Integer> kc = Collections.singletonMap("Boss Alpha", bigKc);
+		List<DryStreakEntry> result = analyzer.analyze(collectionState, kc);
+		assertTrue("Guaranteed items must be excluded from the dry-streak feed", result.isEmpty());
+	}
+
+	@Test
+	public void analyze_zeroRateItemIgnored()
+	{
+		// Only zero-rate item is missing
+		when(collectionState.isItemObtained(1001)).thenReturn(true);
+		when(collectionState.isItemObtained(1003)).thenReturn(true);
+		when(collectionState.isItemObtained(1004)).thenReturn(false);
+
+		Map<String, Integer> kc = Collections.singletonMap("Boss Alpha", 99999);
+		List<DryStreakEntry> result = analyzer.analyze(collectionState, kc);
+		assertTrue("Zero-rate items must be excluded from the dry-streak feed", result.isEmpty());
+	}
+
+	@Test
+	public void analyze_obtainedItemsExcluded()
+	{
+		when(collectionState.isItemObtained(1001)).thenReturn(true); // obtained
+		when(collectionState.isItemObtained(1003)).thenReturn(true);
+		when(collectionState.isItemObtained(1004)).thenReturn(true);
+
+		double median = DryStreakAnalyzer.computeMedianKc(RATE_1_IN_128);
+		int bigKc = (int) Math.round(median * 10.0);
+
+		Map<String, Integer> kc = Collections.singletonMap("Boss Alpha", bigKc);
+		List<DryStreakEntry> result = analyzer.analyze(collectionState, kc);
+		assertTrue("Obtained items must not appear in the dry-streak feed", result.isEmpty());
+	}
+
+	// ── analyze — sort order ─────────────────────────────────────────────────
+
+	@Test
+	public void analyze_multipleEntries_sortedByRatioDescending()
+	{
+		// sourceA has rareItem (1/128), sourceB has veryRareItem (1/512)
+		// Give sourceA a huge KC relative to its median and sourceB a smaller ratio
+		when(collectionState.isItemObtained(1001)).thenReturn(false);
+		when(collectionState.isItemObtained(1002)).thenReturn(false);
+		when(collectionState.isItemObtained(1003)).thenReturn(true);
+		when(collectionState.isItemObtained(1004)).thenReturn(true);
+
+		double medianA = DryStreakAnalyzer.computeMedianKc(RATE_1_IN_128);   // ~89
+		double medianB = DryStreakAnalyzer.computeMedianKc(RATE_1_IN_512);   // ~355
+
+		// sourceA ratio ~8x (VERY_DRY), sourceB ratio ~3x (DRY)
+		int kcA = (int) Math.round(medianA * 8.0);
+		int kcB = (int) Math.round(medianB * 3.0);
+
+		Map<String, Integer> kc = new HashMap<>();
+		kc.put("Boss Alpha", kcA);
+		kc.put("Boss Beta", kcB);
+
+		List<DryStreakEntry> result = analyzer.analyze(collectionState, kc);
+
+		assertEquals(2, result.size());
+		// First entry must have higher ratio
+		assertTrue("Feed must be sorted worst-streak-first",
+			result.get(0).getMultipleOfExpected() > result.get(1).getMultipleOfExpected());
+		assertEquals(DrynessClass.VERY_DRY, result.get(0).getClassification());
+		assertEquals(DrynessClass.DRY, result.get(1).getClassification());
+	}
+
+	@Test
+	public void analyze_multipleItemsSameSource_allDryItemsIncluded()
+	{
+		// sourceA has two unobtained drop-rate items at same KC
+		CollectionLogItem itemX = new CollectionLogItem(2001, "Item X", RATE_1_IN_128,
+			false, null, 0, 0, false, false);
+		CollectionLogItem itemY = new CollectionLogItem(2002, "Item Y", RATE_1_IN_128,
+			false, null, 0, 0, false, false);
+		CollectionLogSource twoItemSource = makeSource("Two Item Boss",
+			CollectionLogCategory.BOSSES, Arrays.asList(itemX, itemY));
+		when(database.getAllSources()).thenReturn(Collections.singletonList(twoItemSource));
+		when(collectionState.isItemObtained(2001)).thenReturn(false);
+		when(collectionState.isItemObtained(2002)).thenReturn(false);
+
+		double median = DryStreakAnalyzer.computeMedianKc(RATE_1_IN_128);
+		int kcAtFourX = (int) Math.round(median * 4.0);
+
+		Map<String, Integer> kc = Collections.singletonMap("Two Item Boss", kcAtFourX);
+		List<DryStreakEntry> result = analyzer.analyze(collectionState, kc);
+
+		assertEquals("Both unobtained items from the same source must appear", 2, result.size());
+	}
+
+	// ── helpers ─────────────────────────────────────────────────────────────
+
+	private static CollectionLogSource makeSource(
+		String name, CollectionLogCategory category, List<CollectionLogItem> items)
+	{
+		return new CollectionLogSource(
+			name, category,
+			0, 0, 0,   // worldX, worldY, worldPlane
+			60, 60,     // killTimeSeconds, ironKillTimeSeconds
+			null, null, // locationDescription, waypoints
+			null,       // rewardType
+			0,          // pointsPerHour
+			null,       // mutuallyExclusiveSources
+			1,          // rollsPerKill
+			false,      // aggregated
+			0,          // afkLevel
+			null,       // travelTip
+			0,          // npcId
+			null,       // interactAction
+			null,       // dialogOptions
+			null,       // guidanceSteps
+			null,       // requirements
+			0,          // cumulativeTrackItemId
+			null,       // cumulativeTrackObjectIds
+			0,          // cumulativeTrackThreshold
+			items
+		);
+	}
+}

--- a/src/test/java/com/collectionloghelper/ui/mode/DryStreakFeedModeControllerTest.java
+++ b/src/test/java/com/collectionloghelper/ui/mode/DryStreakFeedModeControllerTest.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.ui.mode;
+
+import com.collectionloghelper.data.CollectionLogCategory;
+import com.collectionloghelper.data.CollectionLogItem;
+import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.data.PlayerCollectionState;
+import com.collectionloghelper.learning.DrynessClass;
+import com.collectionloghelper.learning.DryStreakAnalyzer;
+import com.collectionloghelper.learning.DryStreakEntry;
+import com.collectionloghelper.learning.DryStreakSortMode;
+import java.awt.Component;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DryStreakFeedModeControllerTest
+{
+	@Mock
+	private PanelShellContext shell;
+
+	@Mock
+	private PlayerCollectionState collectionState;
+
+	@Mock
+	private DryStreakAnalyzer analyzer;
+
+	private DryStreakFeedModeController controller;
+
+	// Synthetic fixtures
+	private CollectionLogItem itemA;
+	private CollectionLogItem itemB;
+	private CollectionLogSource sourceX;
+	private CollectionLogSource sourceY;
+	private DryStreakEntry dryEntry;
+	private DryStreakEntry veryDryEntry;
+
+	@Before
+	public void setUp()
+	{
+		controller = new DryStreakFeedModeController(shell, collectionState, analyzer);
+
+		itemA = new CollectionLogItem(101, "Amulet of Torture", 1.0 / 200.0,
+			false, null, 0, 0, false, false);
+		itemB = new CollectionLogItem(102, "Bandos Chestplate", 1.0 / 384.0,
+			false, null, 0, 0, false, false);
+
+		sourceX = makeSource("Cerberus", CollectionLogCategory.BOSSES);
+		sourceY = makeSource("General Graardor", CollectionLogCategory.BOSSES);
+
+		dryEntry = new DryStreakEntry(itemA, sourceX, 3.5, DrynessClass.DRY);
+		veryDryEntry = new DryStreakEntry(itemB, sourceY, 7.2, DrynessClass.VERY_DRY);
+	}
+
+	// ── buildView — empty states ─────────────────────────────────────────────
+
+	@Test
+	public void buildView_noKcData_showsNoKcMessage()
+	{
+		when(analyzer.analyze(any(), any())).thenReturn(Collections.emptyList());
+		controller.buildView();
+		verify(shell).addEmptyStateMessage(contains("No KC data"));
+	}
+
+	@Test
+	public void buildView_kcPresentButNoDryStreaks_showsNoDryStreaksMessage()
+	{
+		controller.setKillCounts(Collections.singletonMap("Cerberus", 50));
+		when(analyzer.analyze(any(), any())).thenReturn(Collections.emptyList());
+		controller.buildView();
+		verify(shell).addEmptyStateMessage(contains("No dry streaks"));
+	}
+
+	// ── buildView — entries ──────────────────────────────────────────────────
+
+	@Test
+	public void buildView_withDryEntries_addsComponentsToList()
+	{
+		controller.setKillCounts(Collections.singletonMap("Cerberus", 1000));
+		when(analyzer.analyze(any(), any())).thenReturn(Arrays.asList(veryDryEntry, dryEntry));
+
+		controller.buildView();
+
+		verify(shell, atLeastOnce()).addToList(any(Component.class));
+		verify(shell, never()).addEmptyStateMessage(any());
+	}
+
+	@Test
+	public void buildView_entriesExceedMaximum_rendersMaxEntriesOnly()
+	{
+		List<DryStreakEntry> bigFeed = new ArrayList<>();
+		for (int i = 0; i <= DryStreakFeedModeController.MAX_ENTRIES; i++)
+		{
+			CollectionLogItem item = new CollectionLogItem(200 + i, "Item " + i,
+				1.0 / 128.0, false, null, 0, 0, false, false);
+			bigFeed.add(new DryStreakEntry(item, sourceX, 6.0 + i * 0.01, DrynessClass.VERY_DRY));
+		}
+		controller.setKillCounts(Collections.singletonMap("Cerberus", 9999));
+		when(analyzer.analyze(any(), any())).thenReturn(bigFeed);
+
+		controller.buildView();
+
+		// Should add components without erroring; overflow label added via addToList
+		verify(shell, atLeastOnce()).addToList(any(Component.class));
+	}
+
+	// ── sort mode ────────────────────────────────────────────────────────────
+
+	@Test
+	public void defaultSortMode_isRatioDesc()
+	{
+		assertEquals(DryStreakSortMode.RATIO_DESC, controller.getSortMode());
+	}
+
+	@Test
+	public void setSortMode_nullFallsBackToRatioDesc()
+	{
+		controller.setSortMode(null);
+		assertEquals(DryStreakSortMode.RATIO_DESC, controller.getSortMode());
+	}
+
+	@Test
+	public void setSortMode_itemNameAsc_appliesCorrectly()
+	{
+		controller.setSortMode(DryStreakSortMode.ITEM_NAME_ASC);
+		assertEquals(DryStreakSortMode.ITEM_NAME_ASC, controller.getSortMode());
+	}
+
+	// ── applySortMode ────────────────────────────────────────────────────────
+
+	@Test
+	public void applySortMode_ratioDesc_sortsHighestFirst()
+	{
+		// dryEntry.ratio = 3.5, veryDryEntry.ratio = 7.2
+		List<DryStreakEntry> input = Arrays.asList(dryEntry, veryDryEntry);
+		List<DryStreakEntry> sorted = DryStreakFeedModeController.applySortMode(
+			input, DryStreakSortMode.RATIO_DESC);
+
+		assertEquals(veryDryEntry, sorted.get(0));
+		assertEquals(dryEntry, sorted.get(1));
+	}
+
+	@Test
+	public void applySortMode_ratioDesc_doesNotMutateInput()
+	{
+		List<DryStreakEntry> input = Arrays.asList(dryEntry, veryDryEntry);
+		DryStreakFeedModeController.applySortMode(input, DryStreakSortMode.RATIO_DESC);
+		// input order must be unchanged
+		assertEquals(dryEntry, input.get(0));
+		assertEquals(veryDryEntry, input.get(1));
+	}
+
+	@Test
+	public void applySortMode_itemNameAsc_sortsAlphabetically()
+	{
+		// itemA = "Amulet of Torture", itemB = "Bandos Chestplate"
+		List<DryStreakEntry> input = Arrays.asList(veryDryEntry, dryEntry);
+		List<DryStreakEntry> sorted = DryStreakFeedModeController.applySortMode(
+			input, DryStreakSortMode.ITEM_NAME_ASC);
+
+		assertEquals("Amulet of Torture", sorted.get(0).getItem().getName());
+		assertEquals("Bandos Chestplate", sorted.get(1).getItem().getName());
+	}
+
+	@Test
+	public void applySortMode_sourceNameAsc_sortsBySourceName()
+	{
+		// dryEntry source = "Cerberus", veryDryEntry source = "General Graardor"
+		List<DryStreakEntry> input = Arrays.asList(veryDryEntry, dryEntry);
+		List<DryStreakEntry> sorted = DryStreakFeedModeController.applySortMode(
+			input, DryStreakSortMode.SOURCE_NAME_ASC);
+
+		assertEquals("Cerberus", sorted.get(0).getSource().getName());
+		assertEquals("General Graardor", sorted.get(1).getSource().getName());
+	}
+
+	// ── setKillCounts ────────────────────────────────────────────────────────
+
+	@Test
+	public void setKillCounts_nullTreatedAsEmpty()
+	{
+		controller.setKillCounts(null);
+		when(analyzer.analyze(any(), any())).thenReturn(Collections.emptyList());
+		controller.buildView();
+		verify(shell).addEmptyStateMessage(contains("No KC data"));
+	}
+
+	// ── helpers ─────────────────────────────────────────────────────────────
+
+	private static CollectionLogSource makeSource(String name, CollectionLogCategory category)
+	{
+		return new CollectionLogSource(
+			name, category,
+			0, 0, 0,
+			60, 60,
+			null, null,
+			null,
+			0,
+			null,
+			1,
+			false,
+			0,
+			null,
+			0,
+			null,
+			null,
+			null,
+			null,
+			0,
+			null,
+			0,
+			Collections.emptyList()
+		);
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `DryStreakAnalyzer` (new `learning` package) that computes a dryness ratio (`actualKc / medianExpectedKc`) for each unobtained probabilistic item using `medianKc = log(0.5) / log(1 - dropRate)`
- Classifies items as NORMAL (<=2x), DRY (>2x and <=5x), or VERY_DRY (>5x) via `DrynessClass` enum
- Adds `DryStreakFeedModeController` as a new panel mode ("Dry Streaks") showing the feed sorted by dryness ratio (worst-first); supports three sort orders via `DryStreakSortMode`: ratio descending, item name A-Z, source name A-Z
- Wires the new mode into `CollectionLogHelperPanel` and injects `DryStreakAnalyzer` via Guice; KC data injected via `setKillCounts()` to stay decoupled from F2/F3 sync

## Test plan

- [ ] `DryStreakAnalyzerTest` — 16 tests: median KC formula accuracy (1/128, 1/512), classification thresholds at exactly 2x and 5x, guaranteed/zero-rate/obtained item exclusion, multi-item source, sort order
- [ ] `DryStreakFeedModeControllerTest` — 12 tests: empty-state messages, entry rendering, overflow truncation, sort mode defaults and overrides, `applySortMode` correctness for all three modes
- [ ] `./gradlew test build` — all 899+ tests pass, build succeeds