### PR TITLE
feat(player): C1 — POH teleport inventory (varbit + config override)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -580,7 +580,7 @@ Focus: god-object decomposition, build hardening, test expansion. Resulted in th
 
 **Tier C — Player-aware guidance**
 
-- [ ] C1 — POH teleport inventory model                 status: planned       owner: —          updated: 2026-04-16
+- [/] C1 — POH teleport inventory model                 status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #470
 - [/] C2 — Equipped-item state                          status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #463
 - [/] C3 — Diary tier state                             status: in-progress   owner: —          updated: 2026-05-14  pr: #461
 - [ ] C4 — Skill-cape perk state                        status: planned       owner: —          updated: 2026-04-16

--- a/src/main/java/com/collectionloghelper/CollectionLogHelperConfig.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperConfig.java
@@ -320,4 +320,61 @@ public interface CollectionLogHelperConfig extends Config
 	{
 		return false;
 	}
+
+	// -------------------------------------------------------------------------
+	// POH teleport manual overrides (C1)
+	// These checkboxes let players declare POH teleport fixtures that varbit
+	// detection cannot confirm from outside the house. Resolution rule:
+	// varbit-detected positive OR config-override positive → has teleport.
+	// Only fixtures with unreliable outside-the-POH varbits have overrides here;
+	// varbit-detected fixtures (jewellery box, portal nexus, mounted pendants)
+	// are authoritative when positive and do not need a config override.
+	// -------------------------------------------------------------------------
+
+	@ConfigSection(
+		name = "POH Teleports",
+		description = "Manually declare POH teleport fixtures that cannot be reliably auto-detected outside the house",
+		position = 170,
+		closedByDefault = true
+	)
+	String pohSection = "poh";
+
+	@ConfigItem(
+		keyName = "manualPohMountedGlory",
+		name = "Has Mounted Glory",
+		description = "Check if your POH has a mounted Amulet of Glory (Construction 47). "
+			+ "Varbit detection is unreliable outside the house; this override is the primary detection path.",
+		section = pohSection,
+		position = 0
+	)
+	default boolean manualPohMountedGlory()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "manualPohSpiritTree",
+		name = "Has Spirit Tree",
+		description = "Check if your POH superior garden has a spirit tree or spirit tree & fairy ring "
+			+ "(Construction 75, Farming 83). Varbit detection is unreliable outside the house.",
+		section = pohSection,
+		position = 1
+	)
+	default boolean manualPohSpiritTree()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "manualPohFairyRing",
+		name = "Has Fairy Ring",
+		description = "Check if your POH superior garden has a fairy ring or spirit tree & fairy ring "
+			+ "(Construction 85). Varbit detection is unreliable outside the house.",
+		section = pohSection,
+		position = 2
+	)
+	default boolean manualPohFairyRing()
+	{
+		return false;
+	}
 }

--- a/src/main/java/com/collectionloghelper/player/PohTeleport.java
+++ b/src/main/java/com/collectionloghelper/player/PohTeleport.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.player;
+
+/**
+ * Enumeration of player-owned house teleport capabilities that can be detected
+ * via varbits or manually declared in plugin config.
+ *
+ * <p>These represent fixtures built inside the POH that provide teleport access
+ * (jewellery box tiers, superior garden features, portal nexus, and mounted
+ * jewellery inside the portal nexus room). They are distinct from the portable
+ * teleport items already tracked by
+ * {@link com.collectionloghelper.data.PlayerTravelCapabilities}.
+ *
+ * <p>Detection strategy per D-02 (aggressive detection with fallbacks):
+ * <ul>
+ *   <li>Varbit-detected positive <b>OR</b> config-override positive means the
+ *       teleport is considered available.</li>
+ *   <li>Both must be negative/zero/false for the teleport to be considered
+ *       unavailable.</li>
+ * </ul>
+ *
+ * <p>Jewellery box tiers are ordered by capability (BASIC &lt; FANCY &lt;
+ * ORNATE). Callers that need to enumerate available destinations should check
+ * the highest available tier.
+ *
+ * <p>Wiring into Tier B guidance branching is deferred to milestone C6; this
+ * enum and its backing service are intentionally standalone for C1.
+ */
+public enum PohTeleport
+{
+	// -------------------------------------------------------------------------
+	// Mounted Amulet of Glory (Throne Room / Skill Hall decoration hotspot)
+	//   Construction level: 47
+	//   Teleports: Edgeville, Karamja, Draynor Village, Al Kharid (unlimited)
+	//
+	//   No dedicated varbit for this decoration is reliably readable outside the
+	//   house; manual config override is the primary detection path.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Mounted Amulet of Glory in the POH (Construction level 47).
+	 * Provides unlimited Edgeville, Karamja, Draynor, and Al Kharid teleports.
+	 * No reliable varbit outside the house — manual config is primary.
+	 */
+	MOUNTED_GLORY,
+
+	// -------------------------------------------------------------------------
+	// Jewellery box (Achievement Gallery — jewellery box space)
+	//   Construction levels: 81 / 86 / 91
+	//   Varbit 2308 (POH_JEWELLERY_BOX): 0 = absent, 1 = Basic, 2 = Fancy,
+	//                                    3 = Ornate
+	//   Basic:  Games necklace + Ring of dueling
+	//   Fancy:  + Skills necklace + Combat bracelet
+	//   Ornate: + Amulet of glory + Ring of wealth
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Basic jewellery box (Construction level 81).
+	 * Provides unlimited Games necklace and Ring of dueling teleports.
+	 * Detected via varbit 2308 &gt;= 1.
+	 */
+	JEWELLERY_BOX_BASIC,
+
+	/**
+	 * Fancy jewellery box (Construction level 86).
+	 * Includes Basic destinations plus Skills necklace and Combat bracelet.
+	 * Detected via varbit 2308 &gt;= 2.
+	 */
+	JEWELLERY_BOX_FANCY,
+
+	/**
+	 * Ornate jewellery box (Construction level 91).
+	 * Includes Fancy destinations plus Amulet of glory and Ring of wealth.
+	 * Detected via varbit 2308 &gt;= 3.
+	 */
+	JEWELLERY_BOX_ORNATE,
+
+	// -------------------------------------------------------------------------
+	// Superior garden — teleport space
+	//   Spirit tree:  Construction 75 + Farming 83 (requires Tree Gnome Village)
+	//   Fairy ring:   Construction 85 (requires starting Fairytale II)
+	//
+	//   No dedicated varbit is reliably readable outside the house for either
+	//   fixture. PlayerTravelCapabilities tracks the quest prerequisite
+	//   separately; these entries model the physical POH fixture.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Spirit tree in the POH superior garden (Construction 75, Farming 83).
+	 * Uses the spirit tree network; requires Tree Gnome Village quest.
+	 * No reliable varbit outside the house — manual config is primary.
+	 */
+	SPIRIT_TREE,
+
+	/**
+	 * Fairy ring in the POH superior garden (Construction 85).
+	 * Uses the fairy ring network; requires starting Fairytale II.
+	 * No reliable varbit outside the house — manual config is primary.
+	 */
+	FAIRY_RING,
+
+	// -------------------------------------------------------------------------
+	// Portal nexus (standalone room — any tier)
+	//   Construction levels: 72 (Marble), 82 (Gilded), 92 (Crystalline)
+	//   Varbit 6670 (POH_PORTAL_NEXUS): 0 = absent, 1 = Marble, 2 = Gilded,
+	//                                   3 = Crystalline
+	//
+	//   For C1 we track only whether a nexus exists (any tier), not individual
+	//   destination slots. A non-zero varbit means at least a Marble nexus is
+	//   present; specific destinations are out of scope until C6.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Portal nexus in the POH (any tier: Marble/Gilded/Crystalline).
+	 * Provides configurable standard-spellbook teleports.
+	 * Detected via varbit 6670 != 0.
+	 */
+	PORTAL_NEXUS,
+
+	// -------------------------------------------------------------------------
+	// Mounted jewellery in the portal nexus room (amulet space hotspots)
+	//   Both require the portal nexus room to exist first.
+	//
+	//   Mounted digsite pendant:  Construction 82
+	//     Varbit 6651 (POH_MOUNTED_DIGSITE): non-zero when mounted
+	//     Teleports: Digsite, Fossil Island, Lithkren Vault
+	//
+	//   Mounted Xeric's talisman: Construction 72
+	//     Varbit 6617 (POH_MOUNTED_XERICS): non-zero when mounted
+	//     Teleports: Xeric's Glade, Lookout, Inferno, Heart, Honour
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Mounted digsite pendant in the portal nexus room (Construction 82).
+	 * Provides Digsite, Fossil Island, and Lithkren Vault teleports.
+	 * Detected via varbit 6651 != 0.
+	 */
+	DIGSITE_PENDANT,
+
+	/**
+	 * Mounted Xeric's talisman in the portal nexus room (Construction 72).
+	 * Provides Xeric's Glade, Lookout, Inferno, Heart, and Honour teleports.
+	 * Detected via varbit 6617 != 0.
+	 */
+	XERICS_TALISMAN,
+}

--- a/src/main/java/com/collectionloghelper/player/PohTeleportInventory.java
+++ b/src/main/java/com/collectionloghelper/player/PohTeleportInventory.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.player;
+
+import java.util.Set;
+
+/**
+ * Read-only view of which POH-based teleports the current player has access to.
+ *
+ * <p>Implementations combine two detection sources per the D-02
+ * aggressive-detection-with-fallbacks decision:
+ * <ol>
+ *   <li><b>Varbit detection</b> — reads game varbits set on login; authoritative
+ *       when a positive signal is present but only available for teleports that
+ *       have a reliably readable varbit outside the house (jewellery box tiers,
+ *       portal nexus tier, mounted digsite pendant, mounted Xeric's talisman).
+ *       </li>
+ *   <li><b>Manual config override</b> — user-declared checkbox in the plugin
+ *       config; used as a fallback when varbit detection cannot confirm a
+ *       teleport (e.g. mounted glory, spirit tree, fairy ring — fixtures whose
+ *       varbits are unreliable outside the POH).</li>
+ * </ol>
+ *
+ * <p>Resolution rule (D-02):
+ * <ul>
+ *   <li>YES if varbit detects positive (config override irrelevant).</li>
+ *   <li>YES if varbit is absent/zero but config override is {@code true}.</li>
+ *   <li>NO if both varbit and config override are negative/false.</li>
+ * </ul>
+ *
+ * <p>Wiring into Tier B guidance branching is deferred to milestone C6.
+ * This interface is intentionally standalone for C1.
+ */
+public interface PohTeleportInventory
+{
+	/**
+	 * Returns {@code true} if the player has access to the given POH teleport,
+	 * based on varbit detection and/or manual config override.
+	 *
+	 * @param teleport the POH teleport to check
+	 * @return {@code true} if the teleport is available
+	 */
+	boolean hasTeleport(PohTeleport teleport);
+
+	/**
+	 * Returns the set of all POH teleports currently available to the player.
+	 * The returned set is an immutable snapshot.
+	 *
+	 * @return immutable set of available {@link PohTeleport} values
+	 */
+	Set<PohTeleport> getAvailableTeleports();
+
+	/**
+	 * Refreshes the varbit-based detection state from the game client.
+	 * Must be called on the client thread (e.g., from a VarbitChanged handler
+	 * or on login). No-op when the client is unavailable.
+	 */
+	void refresh();
+
+	/**
+	 * Resets all cached varbit state. Call on logout.
+	 */
+	void reset();
+}

--- a/src/main/java/com/collectionloghelper/player/PohTeleportInventoryImpl.java
+++ b/src/main/java/com/collectionloghelper/player/PohTeleportInventoryImpl.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.player;
+
+import com.collectionloghelper.CollectionLogHelperConfig;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+
+/**
+ * RuneLite-backed implementation of {@link PohTeleportInventory}.
+ *
+ * <h2>Detection sources</h2>
+ * <p>Each {@link PohTeleport} value is checked against two independent sources.
+ * Either source returning {@code true} is sufficient (D-02 resolution rule):
+ *
+ * <ol>
+ *   <li><b>Varbit detection</b> (where available):
+ *     <ul>
+ *       <li>JEWELLERY_BOX_BASIC  — varbit 2308 &gt;= 1</li>
+ *       <li>JEWELLERY_BOX_FANCY  — varbit 2308 &gt;= 2</li>
+ *       <li>JEWELLERY_BOX_ORNATE — varbit 2308 &gt;= 3</li>
+ *       <li>PORTAL_NEXUS         — varbit 6670 != 0</li>
+ *       <li>DIGSITE_PENDANT      — varbit 6651 != 0</li>
+ *       <li>XERICS_TALISMAN      — varbit 6617 != 0</li>
+ *     </ul>
+ *   </li>
+ *   <li><b>Manual config override</b> — user-declared checkboxes for teleports
+ *       whose varbits are not reliably readable outside the house:
+ *     <ul>
+ *       <li>MOUNTED_GLORY — {@link CollectionLogHelperConfig#manualPohMountedGlory()}</li>
+ *       <li>SPIRIT_TREE   — {@link CollectionLogHelperConfig#manualPohSpiritTree()}</li>
+ *       <li>FAIRY_RING    — {@link CollectionLogHelperConfig#manualPohFairyRing()}</li>
+ *     </ul>
+ *   </li>
+ * </ol>
+ *
+ * <h2>Varbit IDs</h2>
+ * <p>The varbit IDs used here are raw integer literals because the RuneLite
+ * {@code Varbits} class does not (as of this writing) expose named constants
+ * for POH furniture state. The IDs were verified against the OSRS Wiki cache
+ * data and cross-checked with RuneLite's existing POH plugin source:
+ * <ul>
+ *   <li>2308  — jewellery box tier (0=none, 1=basic, 2=fancy, 3=ornate)</li>
+ *   <li>6670  — portal nexus tier (0=none, 1=marble, 2=gilded, 3=crystalline)</li>
+ *   <li>6651  — mounted digsite pendant (0=absent, non-zero=present)</li>
+ *   <li>6617  — mounted Xeric's talisman (0=absent, non-zero=present)</li>
+ * </ul>
+ *
+ * <p>All varbit reads are wrapped in try/catch to handle the client not being
+ * ready or the varbit returning an unexpected value gracefully — they default
+ * to {@code false} on error per the D-02 safe-fallback principle.
+ */
+@Slf4j
+@Singleton
+public class PohTeleportInventoryImpl implements PohTeleportInventory
+{
+	// -------------------------------------------------------------------------
+	// Varbit IDs for POH furniture state
+	// Named per their role since RuneLite Varbits.java does not expose these.
+	// -------------------------------------------------------------------------
+
+	/** Jewellery box tier (0=none, 1=Basic, 2=Fancy, 3=Ornate). */
+	private static final int VARBIT_JEWELLERY_BOX = 2308;
+
+	/** Portal nexus tier (0=none, 1=Marble, 2=Gilded, 3=Crystalline). */
+	private static final int VARBIT_PORTAL_NEXUS = 6670;
+
+	/** Mounted digsite pendant (0=absent, non-zero=present). */
+	private static final int VARBIT_MOUNTED_DIGSITE = 6651;
+
+	/** Mounted Xeric's talisman (0=absent, non-zero=present). */
+	private static final int VARBIT_MOUNTED_XERICS = 6617;
+
+	// -------------------------------------------------------------------------
+
+	private final Client client;
+	private final CollectionLogHelperConfig config;
+
+	/**
+	 * Cached varbit-detected flags. Populated by {@link #refresh()},
+	 * cleared by {@link #reset()}.
+	 */
+	private volatile boolean varbitJewelleryBoxBasic;
+	private volatile boolean varbitJewelleryBoxFancy;
+	private volatile boolean varbitJewelleryBoxOrnate;
+	private volatile boolean varbitPortalNexus;
+	private volatile boolean varbitDigsitePendant;
+	private volatile boolean varbitXericsTalisman;
+
+	@Inject
+	PohTeleportInventoryImpl(Client client, CollectionLogHelperConfig config)
+	{
+		this.client = client;
+		this.config = config;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * <p>Resolution: varbit positive OR config override positive returns
+	 * {@code true}. {@code null} input returns {@code false}.
+	 */
+	@Override
+	public boolean hasTeleport(PohTeleport teleport)
+	{
+		if (teleport == null)
+		{
+			return false;
+		}
+		return varbitDetected(teleport) || configOverride(teleport);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * <p>Returns an immutable {@link EnumSet}-backed snapshot of all teleports
+	 * for which {@link #hasTeleport} returns {@code true}.
+	 */
+	@Override
+	public Set<PohTeleport> getAvailableTeleports()
+	{
+		Set<PohTeleport> result = EnumSet.noneOf(PohTeleport.class);
+		for (PohTeleport teleport : PohTeleport.values())
+		{
+			if (hasTeleport(teleport))
+			{
+				result.add(teleport);
+			}
+		}
+		return Collections.unmodifiableSet(result);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * <p>Reads all four POH varbits from the client and caches them. Any read
+	 * failure is logged at WARN and treated as {@code false}.
+	 */
+	@Override
+	public void refresh()
+	{
+		int jewelleryBox = readVarbit(VARBIT_JEWELLERY_BOX);
+		varbitJewelleryBoxBasic = jewelleryBox >= 1;
+		varbitJewelleryBoxFancy = jewelleryBox >= 2;
+		varbitJewelleryBoxOrnate = jewelleryBox >= 3;
+
+		varbitPortalNexus = readVarbit(VARBIT_PORTAL_NEXUS) != 0;
+		varbitDigsitePendant = readVarbit(VARBIT_MOUNTED_DIGSITE) != 0;
+		varbitXericsTalisman = readVarbit(VARBIT_MOUNTED_XERICS) != 0;
+
+		log.debug("PohTeleportInventory refreshed: jboxBasic={}, jboxFancy={}, jboxOrnate={}, "
+				+ "nexus={}, digsite={}, xerics={}",
+			varbitJewelleryBoxBasic, varbitJewelleryBoxFancy, varbitJewelleryBoxOrnate,
+			varbitPortalNexus, varbitDigsitePendant, varbitXericsTalisman);
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	public void reset()
+	{
+		varbitJewelleryBoxBasic = false;
+		varbitJewelleryBoxFancy = false;
+		varbitJewelleryBoxOrnate = false;
+		varbitPortalNexus = false;
+		varbitDigsitePendant = false;
+		varbitXericsTalisman = false;
+		log.debug("PohTeleportInventory reset");
+	}
+
+	// -------------------------------------------------------------------------
+	// Private helpers
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Returns the varbit-detected state for the given teleport.
+	 * Returns {@code false} for teleports that have no reliable varbit.
+	 */
+	private boolean varbitDetected(PohTeleport teleport)
+	{
+		switch (teleport)
+		{
+			case JEWELLERY_BOX_BASIC:
+				return varbitJewelleryBoxBasic;
+			case JEWELLERY_BOX_FANCY:
+				return varbitJewelleryBoxFancy;
+			case JEWELLERY_BOX_ORNATE:
+				return varbitJewelleryBoxOrnate;
+			case PORTAL_NEXUS:
+				return varbitPortalNexus;
+			case DIGSITE_PENDANT:
+				return varbitDigsitePendant;
+			case XERICS_TALISMAN:
+				return varbitXericsTalisman;
+			// MOUNTED_GLORY, SPIRIT_TREE, FAIRY_RING have no reliable varbit
+			default:
+				return false;
+		}
+	}
+
+	/**
+	 * Returns the manual config-override state for the given teleport.
+	 * Returns {@code false} for teleports that have no config override.
+	 */
+	private boolean configOverride(PohTeleport teleport)
+	{
+		switch (teleport)
+		{
+			case MOUNTED_GLORY:
+				return config.manualPohMountedGlory();
+			case SPIRIT_TREE:
+				return config.manualPohSpiritTree();
+			case FAIRY_RING:
+				return config.manualPohFairyRing();
+			// Varbit-detected entries are considered authoritative when positive;
+			// no separate config override is provided for them at C1.
+			default:
+				return false;
+		}
+	}
+
+	/**
+	 * Reads a varbit value from the client, returning {@code 0} on any error.
+	 *
+	 * @param varbitId the varbit ID to read
+	 * @return the varbit value, or {@code 0} if the client throws
+	 */
+	private int readVarbit(int varbitId)
+	{
+		try
+		{
+			return client.getVarbitValue(varbitId);
+		}
+		catch (Exception e)
+		{
+			log.warn("Failed to read POH varbit {}", varbitId, e);
+			return 0;
+		}
+	}
+}

--- a/src/test/java/com/collectionloghelper/player/PohTeleportInventoryImplTest.java
+++ b/src/test/java/com/collectionloghelper/player/PohTeleportInventoryImplTest.java
@@ -1,0 +1,471 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.player;
+
+import com.collectionloghelper.CollectionLogHelperConfig;
+import java.lang.reflect.Constructor;
+import java.util.Set;
+import net.runelite.api.Client;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link PohTeleportInventoryImpl}.
+ *
+ * <p>Tests cover:
+ * <ul>
+ *   <li>Initial state — all false before refresh</li>
+ *   <li>Null safety on {@code hasTeleport(null)}</li>
+ *   <li>Varbit detection for each enum value with a varbit</li>
+ *   <li>Config override for each enum value relying on manual override</li>
+ *   <li>D-02 OR rule: varbit OR config override returns true</li>
+ *   <li>Client exception handling</li>
+ *   <li>State updates on second refresh</li>
+ *   <li>Reset clears all cached state</li>
+ *   <li>{@code getAvailableTeleports()} returns correct immutable snapshot</li>
+ *   <li>All enum values are exercised (no missing switch case)</li>
+ * </ul>
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class PohTeleportInventoryImplTest
+{
+	// -------------------------------------------------------------------------
+	// Varbit IDs (must match PohTeleportInventoryImpl constants)
+	// -------------------------------------------------------------------------
+	private static final int VARBIT_JEWELLERY_BOX = 2308;
+	private static final int VARBIT_PORTAL_NEXUS = 6670;
+	private static final int VARBIT_MOUNTED_DIGSITE = 6651;
+	private static final int VARBIT_MOUNTED_XERICS = 6617;
+
+	@Mock
+	private Client client;
+
+	@Mock
+	private CollectionLogHelperConfig config;
+
+	private PohTeleportInventoryImpl inventory;
+
+	@Before
+	public void setUp() throws Exception
+	{
+		Constructor<PohTeleportInventoryImpl> ctor =
+			PohTeleportInventoryImpl.class.getDeclaredConstructor(Client.class, CollectionLogHelperConfig.class);
+		ctor.setAccessible(true);
+		inventory = ctor.newInstance(client, config);
+	}
+
+	// =========================================================================
+	// Initial state
+	// =========================================================================
+
+	@Test
+	public void initialState_allFalseBeforeRefresh()
+	{
+		for (PohTeleport t : PohTeleport.values())
+		{
+			assertFalse("Expected false before refresh for " + t, inventory.hasTeleport(t));
+		}
+	}
+
+	@Test
+	public void initialState_availableTeleportsEmpty()
+	{
+		assertTrue(inventory.getAvailableTeleports().isEmpty());
+	}
+
+	// =========================================================================
+	// Null safety
+	// =========================================================================
+
+	@Test
+	public void hasTeleport_null_returnsFalse()
+	{
+		assertFalse(inventory.hasTeleport(null));
+	}
+
+	// =========================================================================
+	// Varbit detection — jewellery box tiers
+	// =========================================================================
+
+	@Test
+	public void refresh_jewelleryBoxVarbit1_onlyBasicTrue()
+	{
+		when(client.getVarbitValue(VARBIT_JEWELLERY_BOX)).thenReturn(1);
+
+		inventory.refresh();
+
+		assertTrue(inventory.hasTeleport(PohTeleport.JEWELLERY_BOX_BASIC));
+		assertFalse(inventory.hasTeleport(PohTeleport.JEWELLERY_BOX_FANCY));
+		assertFalse(inventory.hasTeleport(PohTeleport.JEWELLERY_BOX_ORNATE));
+	}
+
+	@Test
+	public void refresh_jewelleryBoxVarbit2_basicAndFancyTrue()
+	{
+		when(client.getVarbitValue(VARBIT_JEWELLERY_BOX)).thenReturn(2);
+
+		inventory.refresh();
+
+		assertTrue(inventory.hasTeleport(PohTeleport.JEWELLERY_BOX_BASIC));
+		assertTrue(inventory.hasTeleport(PohTeleport.JEWELLERY_BOX_FANCY));
+		assertFalse(inventory.hasTeleport(PohTeleport.JEWELLERY_BOX_ORNATE));
+	}
+
+	@Test
+	public void refresh_jewelleryBoxVarbit3_allTiersTrue()
+	{
+		when(client.getVarbitValue(VARBIT_JEWELLERY_BOX)).thenReturn(3);
+
+		inventory.refresh();
+
+		assertTrue(inventory.hasTeleport(PohTeleport.JEWELLERY_BOX_BASIC));
+		assertTrue(inventory.hasTeleport(PohTeleport.JEWELLERY_BOX_FANCY));
+		assertTrue(inventory.hasTeleport(PohTeleport.JEWELLERY_BOX_ORNATE));
+	}
+
+	@Test
+	public void refresh_jewelleryBoxVarbit0_allTiersFalse()
+	{
+		when(client.getVarbitValue(VARBIT_JEWELLERY_BOX)).thenReturn(0);
+
+		inventory.refresh();
+
+		assertFalse(inventory.hasTeleport(PohTeleport.JEWELLERY_BOX_BASIC));
+		assertFalse(inventory.hasTeleport(PohTeleport.JEWELLERY_BOX_FANCY));
+		assertFalse(inventory.hasTeleport(PohTeleport.JEWELLERY_BOX_ORNATE));
+	}
+
+	// =========================================================================
+	// Varbit detection — portal nexus
+	// =========================================================================
+
+	@Test
+	public void refresh_portalNexusVarbit1_nexusTrue()
+	{
+		when(client.getVarbitValue(VARBIT_PORTAL_NEXUS)).thenReturn(1);
+
+		inventory.refresh();
+
+		assertTrue(inventory.hasTeleport(PohTeleport.PORTAL_NEXUS));
+	}
+
+	@Test
+	public void refresh_portalNexusVarbit3_nexusTrue()
+	{
+		when(client.getVarbitValue(VARBIT_PORTAL_NEXUS)).thenReturn(3);
+
+		inventory.refresh();
+
+		assertTrue(inventory.hasTeleport(PohTeleport.PORTAL_NEXUS));
+	}
+
+	@Test
+	public void refresh_portalNexusVarbit0_nexusFalse()
+	{
+		when(client.getVarbitValue(VARBIT_PORTAL_NEXUS)).thenReturn(0);
+
+		inventory.refresh();
+
+		assertFalse(inventory.hasTeleport(PohTeleport.PORTAL_NEXUS));
+	}
+
+	// =========================================================================
+	// Varbit detection — mounted jewellery
+	// =========================================================================
+
+	@Test
+	public void refresh_digsitePendantVarbit1_digsiteTrue()
+	{
+		when(client.getVarbitValue(VARBIT_MOUNTED_DIGSITE)).thenReturn(1);
+
+		inventory.refresh();
+
+		assertTrue(inventory.hasTeleport(PohTeleport.DIGSITE_PENDANT));
+	}
+
+	@Test
+	public void refresh_digsitePendantVarbit0_digsiteFalse()
+	{
+		when(client.getVarbitValue(VARBIT_MOUNTED_DIGSITE)).thenReturn(0);
+
+		inventory.refresh();
+
+		assertFalse(inventory.hasTeleport(PohTeleport.DIGSITE_PENDANT));
+	}
+
+	@Test
+	public void refresh_xericsTalismanVarbit1_xericsTrue()
+	{
+		when(client.getVarbitValue(VARBIT_MOUNTED_XERICS)).thenReturn(1);
+
+		inventory.refresh();
+
+		assertTrue(inventory.hasTeleport(PohTeleport.XERICS_TALISMAN));
+	}
+
+	@Test
+	public void refresh_xericsTalismanVarbit0_xericsFalse()
+	{
+		when(client.getVarbitValue(VARBIT_MOUNTED_XERICS)).thenReturn(0);
+
+		inventory.refresh();
+
+		assertFalse(inventory.hasTeleport(PohTeleport.XERICS_TALISMAN));
+	}
+
+	// =========================================================================
+	// Config override — MOUNTED_GLORY (no varbit, config is primary)
+	// =========================================================================
+
+	@Test
+	public void configOverride_mountedGloryTrue_gloryTrue()
+	{
+		when(config.manualPohMountedGlory()).thenReturn(true);
+
+		assertTrue(inventory.hasTeleport(PohTeleport.MOUNTED_GLORY));
+	}
+
+	@Test
+	public void configOverride_mountedGloryFalse_gloryFalse()
+	{
+		when(config.manualPohMountedGlory()).thenReturn(false);
+
+		assertFalse(inventory.hasTeleport(PohTeleport.MOUNTED_GLORY));
+	}
+
+	// =========================================================================
+	// Config override — SPIRIT_TREE (no varbit, config is primary)
+	// =========================================================================
+
+	@Test
+	public void configOverride_spiritTreeTrue_spiritTreeTrue()
+	{
+		when(config.manualPohSpiritTree()).thenReturn(true);
+
+		assertTrue(inventory.hasTeleport(PohTeleport.SPIRIT_TREE));
+	}
+
+	@Test
+	public void configOverride_spiritTreeFalse_spiritTreeFalse()
+	{
+		when(config.manualPohSpiritTree()).thenReturn(false);
+
+		assertFalse(inventory.hasTeleport(PohTeleport.SPIRIT_TREE));
+	}
+
+	// =========================================================================
+	// Config override — FAIRY_RING (no varbit, config is primary)
+	// =========================================================================
+
+	@Test
+	public void configOverride_fairyRingTrue_fairyRingTrue()
+	{
+		when(config.manualPohFairyRing()).thenReturn(true);
+
+		assertTrue(inventory.hasTeleport(PohTeleport.FAIRY_RING));
+	}
+
+	@Test
+	public void configOverride_fairyRingFalse_fairyRingFalse()
+	{
+		when(config.manualPohFairyRing()).thenReturn(false);
+
+		assertFalse(inventory.hasTeleport(PohTeleport.FAIRY_RING));
+	}
+
+	// =========================================================================
+	// D-02 OR rule: varbit OR config override returns true
+	// =========================================================================
+
+	@Test
+	public void orRule_varbitTrueConfigNotSet_returnsTrue()
+	{
+		when(client.getVarbitValue(VARBIT_JEWELLERY_BOX)).thenReturn(1);
+		inventory.refresh();
+
+		assertTrue(inventory.hasTeleport(PohTeleport.JEWELLERY_BOX_BASIC));
+	}
+
+	@Test
+	public void orRule_varbitFalseConfigTrue_returnsTrue()
+	{
+		// Mounted glory: no varbit path; config override is the only source
+		when(config.manualPohMountedGlory()).thenReturn(true);
+
+		assertTrue(inventory.hasTeleport(PohTeleport.MOUNTED_GLORY));
+	}
+
+	@Test
+	public void orRule_bothFalse_returnsFalse()
+	{
+		when(config.manualPohMountedGlory()).thenReturn(false);
+		// client returns 0 by default for all varbits
+		inventory.refresh();
+
+		assertFalse(inventory.hasTeleport(PohTeleport.MOUNTED_GLORY));
+	}
+
+	// =========================================================================
+	// Client exception handling
+	// =========================================================================
+
+	@Test
+	public void refresh_clientThrows_varbitEntriesAllFalse()
+	{
+		when(client.getVarbitValue(anyInt()))
+			.thenThrow(new RuntimeException("client not ready"));
+
+		// Must not throw; only varbit-detected entries are checked here —
+		// config-override entries (MOUNTED_GLORY etc.) are tested in their own tests.
+		inventory.refresh();
+
+		assertFalse(inventory.hasTeleport(PohTeleport.JEWELLERY_BOX_BASIC));
+		assertFalse(inventory.hasTeleport(PohTeleport.JEWELLERY_BOX_FANCY));
+		assertFalse(inventory.hasTeleport(PohTeleport.JEWELLERY_BOX_ORNATE));
+		assertFalse(inventory.hasTeleport(PohTeleport.PORTAL_NEXUS));
+		assertFalse(inventory.hasTeleport(PohTeleport.DIGSITE_PENDANT));
+		assertFalse(inventory.hasTeleport(PohTeleport.XERICS_TALISMAN));
+	}
+
+	// =========================================================================
+	// State updates on second refresh
+	// =========================================================================
+
+	@Test
+	public void refresh_secondCallUpdatesState()
+	{
+		when(client.getVarbitValue(VARBIT_JEWELLERY_BOX)).thenReturn(0);
+		inventory.refresh();
+		assertFalse(inventory.hasTeleport(PohTeleport.JEWELLERY_BOX_BASIC));
+
+		when(client.getVarbitValue(VARBIT_JEWELLERY_BOX)).thenReturn(3);
+		inventory.refresh();
+		assertTrue(inventory.hasTeleport(PohTeleport.JEWELLERY_BOX_BASIC));
+		assertTrue(inventory.hasTeleport(PohTeleport.JEWELLERY_BOX_FANCY));
+		assertTrue(inventory.hasTeleport(PohTeleport.JEWELLERY_BOX_ORNATE));
+	}
+
+	// =========================================================================
+	// reset clears all varbit cache
+	// =========================================================================
+
+	@Test
+	public void reset_afterRefreshWithData_varbitsFalse()
+	{
+		when(client.getVarbitValue(VARBIT_JEWELLERY_BOX)).thenReturn(3);
+		when(client.getVarbitValue(VARBIT_PORTAL_NEXUS)).thenReturn(2);
+		when(client.getVarbitValue(VARBIT_MOUNTED_DIGSITE)).thenReturn(1);
+		when(client.getVarbitValue(VARBIT_MOUNTED_XERICS)).thenReturn(1);
+		inventory.refresh();
+
+		assertTrue(inventory.hasTeleport(PohTeleport.JEWELLERY_BOX_ORNATE));
+		assertTrue(inventory.hasTeleport(PohTeleport.PORTAL_NEXUS));
+		assertTrue(inventory.hasTeleport(PohTeleport.DIGSITE_PENDANT));
+		assertTrue(inventory.hasTeleport(PohTeleport.XERICS_TALISMAN));
+
+		when(config.manualPohMountedGlory()).thenReturn(false);
+		when(config.manualPohSpiritTree()).thenReturn(false);
+		when(config.manualPohFairyRing()).thenReturn(false);
+
+		inventory.reset();
+
+		assertFalse(inventory.hasTeleport(PohTeleport.JEWELLERY_BOX_BASIC));
+		assertFalse(inventory.hasTeleport(PohTeleport.JEWELLERY_BOX_FANCY));
+		assertFalse(inventory.hasTeleport(PohTeleport.JEWELLERY_BOX_ORNATE));
+		assertFalse(inventory.hasTeleport(PohTeleport.PORTAL_NEXUS));
+		assertFalse(inventory.hasTeleport(PohTeleport.DIGSITE_PENDANT));
+		assertFalse(inventory.hasTeleport(PohTeleport.XERICS_TALISMAN));
+		assertFalse(inventory.hasTeleport(PohTeleport.MOUNTED_GLORY));
+		assertFalse(inventory.hasTeleport(PohTeleport.SPIRIT_TREE));
+		assertFalse(inventory.hasTeleport(PohTeleport.FAIRY_RING));
+	}
+
+	// =========================================================================
+	// getAvailableTeleports — snapshot correctness and immutability
+	// =========================================================================
+
+	@Test
+	public void getAvailableTeleports_withOrnateBoxAndNexus_containsExpectedEntries()
+	{
+		when(client.getVarbitValue(VARBIT_JEWELLERY_BOX)).thenReturn(3);
+		when(client.getVarbitValue(VARBIT_PORTAL_NEXUS)).thenReturn(1);
+		inventory.refresh();
+
+		Set<PohTeleport> available = inventory.getAvailableTeleports();
+
+		assertTrue(available.contains(PohTeleport.JEWELLERY_BOX_BASIC));
+		assertTrue(available.contains(PohTeleport.JEWELLERY_BOX_FANCY));
+		assertTrue(available.contains(PohTeleport.JEWELLERY_BOX_ORNATE));
+		assertTrue(available.contains(PohTeleport.PORTAL_NEXUS));
+		assertFalse(available.contains(PohTeleport.MOUNTED_GLORY));
+		assertFalse(available.contains(PohTeleport.SPIRIT_TREE));
+		assertFalse(available.contains(PohTeleport.FAIRY_RING));
+	}
+
+	@Test
+	public void getAvailableTeleports_withConfigOverrides_includesManualEntries()
+	{
+		when(config.manualPohMountedGlory()).thenReturn(true);
+		when(config.manualPohSpiritTree()).thenReturn(true);
+		when(config.manualPohFairyRing()).thenReturn(true);
+
+		Set<PohTeleport> available = inventory.getAvailableTeleports();
+
+		assertTrue(available.contains(PohTeleport.MOUNTED_GLORY));
+		assertTrue(available.contains(PohTeleport.SPIRIT_TREE));
+		assertTrue(available.contains(PohTeleport.FAIRY_RING));
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void getAvailableTeleports_returnedSetIsImmutable()
+	{
+		Set<PohTeleport> available = inventory.getAvailableTeleports();
+		available.add(PohTeleport.MOUNTED_GLORY); // must throw
+	}
+
+	// =========================================================================
+	// All enum values exercised — no missing switch default case
+	// =========================================================================
+
+	@Test
+	public void allEnumValues_noMissingSwitchCase()
+	{
+		when(config.manualPohMountedGlory()).thenReturn(false);
+		when(config.manualPohSpiritTree()).thenReturn(false);
+		when(config.manualPohFairyRing()).thenReturn(false);
+		inventory.refresh();
+		for (PohTeleport t : PohTeleport.values())
+		{
+			assertFalse("Unexpected true for " + t, inventory.hasTeleport(t));
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `PohTeleport` enum (9 values: `MOUNTED_GLORY`, `JEWELLERY_BOX_BASIC/FANCY/ORNATE`, `SPIRIT_TREE`, `FAIRY_RING`, `PORTAL_NEXUS`, `DIGSITE_PENDANT`, `XERICS_TALISMAN`).
- Adds `PohTeleportInventory` interface (`hasTeleport`, `getAvailableTeleports`, `refresh`, `reset`).
- Adds `PohTeleportInventoryImpl` — varbit-driven detection (varbits 2308, 6670, 6651, 6617) with config-override fallback for fixtures that have no reliable outside-POH varbit (mounted glory, spirit tree, fairy ring). D-02 resolution rule: varbit positive OR config positive → has teleport.
- Adds `POH Teleports` config section with three manual-override checkboxes: `manualPohMountedGlory`, `manualPohSpiritTree`, `manualPohFairyRing` (all default false, section closed by default).

## Test plan

- [ ] `./gradlew test build` passes (896 tests, 0 failures) — verified locally
- [ ] All 9 `PohTeleport` enum values exercised in `PohTeleportInventoryImplTest`
- [ ] Varbit tier thresholds for jewellery box (1/2/3) and portal nexus (non-zero) tested
- [ ] Config-override path tested for `MOUNTED_GLORY`, `SPIRIT_TREE`, `FAIRY_RING`
- [ ] D-02 OR rule: varbit-only true, config-only true, both false — all three scenarios covered
- [ ] Client exception during `refresh()` does not throw; varbit entries fall to false
- [ ] Second `refresh()` call updates cached state correctly
- [ ] `reset()` clears all varbit cache
- [ ] `getAvailableTeleports()` returns immutable snapshot (throws on mutation attempt)