### PR TITLE
feat(panel): B.5.2 — recommended items section (advisory)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -568,10 +568,7 @@ Focus: god-object decomposition, build hardening, test expansion. Resulted in th
 **Tier B.5 — UI parity with Quest Helper**
 
 - [/] B.5.1 — Per-step item requirements panel          status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #452
-- [ ] B.5.2 — Recommended items section                 status: planned       owner: —          updated: 2026-05-10  note: soft-recommended supplies below required; cha-ndler/collection-log-helper#382
-- [ ] B.5.3 — General requirements section              status: planned       owner: —          updated: 2026-05-10  note: surface quest/skill/diary prereqs in panel header (green/red); cha-ndler/collection-log-helper#382
-- [/] B.5.4 — Collapsible step sections                 status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #458
-- [ ] B.5.5 — Per-step world map arrow + destination icon  status: planned    owner: —          updated: 2026-05-10  note: Quest-Helper-style arrow + NPC/object icon at step destination; cha-ndler/collection-log-helper#382
+- [/] B.5.2 — Recommended items section                 status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #472
 - [/] B.5.3 — General requirements section              status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #457
 - [ ] B.5.4 — Collapsible step sections                 status: planned       owner: —          updated: 2026-05-10  note: `section` field on step, auto-expand active section; cha-ndler/collection-log-helper#382
 - [/] B.5.5 — Per-step world map arrow + destination icon  status: partial    owner: cha-ndler  updated: 2026-05-14  note: 5/6 sub-requirements confirmed shipped via #397 + #438 + #423; blocked on #430 (CLH-distinct orange arrow color — pending merge). Sub-reqs: (1) worldmap arrow per step — done (#397, WorldMapDestinationOverlay.setTarget wired in coordinator); (2) chevron shape — done (#397, 4-point notched polygon); (3) CLH-distinct color — pending (#430 adds orange #FF8C00 constant, not yet on master); (4) NPC/object/item icon at destination — done (#397, StepIconType enum + 3 sprite variants + resolveStepIconType); (5) worldmap point + arrow integration — done (#438, setMapPointActive suppresses double arrow); (6) per-item icon retargeting — done (#423, resolveNpcId used in resolveStepIconType).

--- a/src/main/java/com/collectionloghelper/data/GuidanceStep.java
+++ b/src/main/java/com/collectionloghelper/data/GuidanceStep.java
@@ -108,6 +108,18 @@ public class GuidanceStep
 	 */
 	List<Integer> recommendedItemIds;
 
+	/**
+	 * Optional per-item override for recommendedItemIds.  When the active guidance has a
+	 * specific target collection-log item AND this map has an entry for that item, the
+	 * override list is used in place of {@link #recommendedItemIds}.  Falls back to the
+	 * static {@link #recommendedItemIds} when no override applies (null map, null target,
+	 * or target not present in the map).
+	 *
+	 * <p>Null by default — existing JSON without this field deserialises unchanged.
+	 */
+	@Nullable
+	Map<Integer, List<Integer>> perItemRecommendedItemIds;
+
 	/** How the system detects this step is complete. */
 	CompletionCondition completionCondition;
 
@@ -433,6 +445,7 @@ public class GuidanceStep
 			this.requiredItemIds,
 			this.perItemRequiredItemIds,
 			this.recommendedItemIds,
+			this.perItemRecommendedItemIds,
 			alt.getCompletionCondition() != null ? alt.getCompletionCondition() : this.completionCondition,
 			this.completionItemId,
 			this.completionItemCount,

--- a/src/main/java/com/collectionloghelper/guidance/RequiredItemResolver.java
+++ b/src/main/java/com/collectionloghelper/guidance/RequiredItemResolver.java
@@ -133,7 +133,29 @@ public class RequiredItemResolver
 		{
 			return Collections.emptyList();
 		}
-		return resolveIds(step.getRecommendedItemIds());
+		return resolveIds(pickRecommendedItemIds(step));
+	}
+
+	/**
+	 * Selects the effective recommended-item list for a step.  Checks for a
+	 * per-item override via the coordinator's active target item ID before
+	 * falling back to the step's static {@code recommendedItemIds}.
+	 */
+	private List<Integer> pickRecommendedItemIds(GuidanceStep step)
+	{
+		if (step.getPerItemRecommendedItemIds() != null && coordinator != null)
+		{
+			Integer targetItemId = coordinator.getActiveTargetItemId();
+			if (targetItemId != null)
+			{
+				List<Integer> override = step.getPerItemRecommendedItemIds().get(targetItemId);
+				if (override != null)
+				{
+					return override;
+				}
+			}
+		}
+		return step.getRecommendedItemIds();
 	}
 
 	/**

--- a/src/main/java/com/collectionloghelper/ui/widget/RecommendedItemsChipPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/widget/RecommendedItemsChipPanel.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.ui.widget;
+
+import com.collectionloghelper.guidance.RequiredItemDisplay;
+import com.collectionloghelper.guidance.RequiredItemDisplay.Status;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
+import java.util.Collections;
+import java.util.List;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.ImageIcon;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingConstants;
+import javax.swing.SwingUtilities;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.ui.FontManager;
+import net.runelite.client.util.AsyncBufferedImage;
+
+/**
+ * A horizontal strip of item-icon chips for a guidance step's recommended items (B.5.2).
+ *
+ * <p>Mirrors {@link RequiredItemsChipPanel} in layout and three-colour semantics
+ * (green / white / red) but signals advisory — "nice to have" — status via a
+ * thinner 1-pixel border with reduced alpha so it visually recedes behind the
+ * required-items strip above it.
+ *
+ * <ul>
+ *   <li><b>Green</b> — item is held in inventory or equipped.</li>
+ *   <li><b>White</b> — item was seen in the last bank scan but is not currently
+ *       held.</li>
+ *   <li><b>Red</b> — item is not held anywhere known to the plugin.</li>
+ * </ul>
+ *
+ * <p>The section header reads "Recommended:" to distinguish it from the
+ * "Items needed:" heading in the required-items strip.
+ *
+ * <p>The panel hides itself when the supplied item list is null or empty,
+ * preserving the blank-space contract for steps with no recommended items.
+ *
+ * <p>All mutations to Swing state are dispatched on the EDT via
+ * {@link SwingUtilities#invokeLater}.
+ */
+public class RecommendedItemsChipPanel extends JPanel
+{
+	/** Tooltip shown on IN_BANK chips (Quest Helper convention). */
+	static final String IN_BANK_TOOLTIP = "Items can be found in your: Bank";
+
+	/** Muted border alpha applied to all status colours to signal advisory status. */
+	static final int MUTED_ALPHA = 160;
+
+	/** Border width in pixels — thinner than {@link RequiredItemsChipPanel}'s 2px. */
+	private static final int CHIP_BORDER = 1;
+
+	/** Icon size within each chip. */
+	private static final int ICON_SIZE = 28;
+
+	/** Total chip dimension: icon + 2 borders on each side. */
+	private static final int CHIP_SIZE = ICON_SIZE + CHIP_BORDER * 2;
+
+	private static final Color BG = new Color(25, 35, 55);
+
+	/** Muted green for HELD status. */
+	static final Color COLOR_HELD_MUTED = new Color(
+		RequiredItemDisplay.COLOR_HELD.getRed(),
+		RequiredItemDisplay.COLOR_HELD.getGreen(),
+		RequiredItemDisplay.COLOR_HELD.getBlue(),
+		MUTED_ALPHA);
+
+	/** Muted off-white for IN_BANK status. */
+	static final Color COLOR_IN_BANK_MUTED = new Color(220, 220, 220, MUTED_ALPHA);
+
+	/** Muted red for MISSING status. */
+	static final Color COLOR_MISSING_MUTED = new Color(
+		RequiredItemDisplay.COLOR_MISSING.getRed(),
+		RequiredItemDisplay.COLOR_MISSING.getGreen(),
+		RequiredItemDisplay.COLOR_MISSING.getBlue(),
+		MUTED_ALPHA);
+
+	private final ItemManager itemManager;
+
+	/** The horizontal row that holds the heading label and chip labels. */
+	private final JPanel chipRow;
+
+	public RecommendedItemsChipPanel(ItemManager itemManager)
+	{
+		this.itemManager = itemManager;
+
+		setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+		setBackground(BG);
+		setAlignmentX(LEFT_ALIGNMENT);
+		setVisible(false);
+
+		chipRow = new JPanel();
+		chipRow.setLayout(new BoxLayout(chipRow, BoxLayout.X_AXIS));
+		chipRow.setBackground(BG);
+		chipRow.setAlignmentX(LEFT_ALIGNMENT);
+		add(chipRow);
+	}
+
+	/**
+	 * Rebuilds the chip strip from the given display rows and sets visibility.
+	 * Safe to call from any thread; dispatches to the EDT internally.
+	 *
+	 * @param rows pre-resolved display rows from
+	 *             {@link com.collectionloghelper.guidance.RequiredItemResolver#resolveRecommended};
+	 *             {@code null} or empty hides the panel
+	 */
+	public void update(List<RequiredItemDisplay> rows)
+	{
+		final List<RequiredItemDisplay> safeRows =
+			(rows != null) ? rows : Collections.<RequiredItemDisplay>emptyList();
+
+		SwingUtilities.invokeLater(() ->
+		{
+			chipRow.removeAll();
+
+			if (safeRows.isEmpty())
+			{
+				setVisible(false);
+				return;
+			}
+
+			// "Recommended:" heading label
+			JLabel heading = new JLabel("Recommended:");
+			heading.setFont(FontManager.getRunescapeSmallFont());
+			heading.setForeground(new Color(150, 150, 150));
+			heading.setAlignmentX(LEFT_ALIGNMENT);
+			chipRow.add(heading);
+			chipRow.add(Box.createHorizontalStrut(6));
+
+			for (RequiredItemDisplay row : safeRows)
+			{
+				JLabel chip = buildChip(row);
+				chipRow.add(chip);
+				chipRow.add(Box.createHorizontalStrut(3));
+			}
+
+			setVisible(true);
+			chipRow.revalidate();
+			chipRow.repaint();
+			revalidate();
+			if (getParent() != null)
+			{
+				getParent().revalidate();
+			}
+		});
+	}
+
+	/**
+	 * Builds a single chip label: a fixed-size icon placeholder surrounded by a
+	 * 1-pixel muted-colour border. The icon is loaded asynchronously if the item
+	 * manager has an image available; otherwise the chip displays an empty square.
+	 */
+	JLabel buildChip(RequiredItemDisplay row)
+	{
+		Color borderColor = borderColorFor(row.getStatus());
+		String tooltip = tooltipFor(row);
+
+		JLabel chip = new JLabel();
+		chip.setPreferredSize(new Dimension(CHIP_SIZE, CHIP_SIZE));
+		chip.setMinimumSize(new Dimension(CHIP_SIZE, CHIP_SIZE));
+		chip.setMaximumSize(new Dimension(CHIP_SIZE, CHIP_SIZE));
+		chip.setHorizontalAlignment(SwingConstants.CENTER);
+		chip.setVerticalAlignment(SwingConstants.CENTER);
+		chip.setBorder(BorderFactory.createLineBorder(borderColor, CHIP_BORDER));
+		chip.setBackground(BG);
+		chip.setOpaque(true);
+		chip.setToolTipText(tooltip);
+
+		if (row.getItemId() > 0)
+		{
+			loadChipIcon(row.getItemId(), chip);
+		}
+
+		return chip;
+	}
+
+	/**
+	 * Returns the muted border colour for the given status.
+	 * Colours use reduced alpha to signal advisory (not required) status.
+	 * Package-visible for tests.
+	 */
+	static Color borderColorFor(Status status)
+	{
+		switch (status)
+		{
+			case HELD:
+				return COLOR_HELD_MUTED;
+			case IN_BANK:
+				return COLOR_IN_BANK_MUTED;
+			case MISSING:
+			default:
+				return COLOR_MISSING_MUTED;
+		}
+	}
+
+	/**
+	 * Returns the tooltip text for the given display row.
+	 * IN_BANK chips use the Quest Helper "Items can be found in your: Bank" convention;
+	 * all other chips show the item name.
+	 * Package-visible for tests.
+	 */
+	static String tooltipFor(RequiredItemDisplay row)
+	{
+		if (row.getStatus() == Status.IN_BANK)
+		{
+			return IN_BANK_TOOLTIP;
+		}
+		return row.getName();
+	}
+
+	/**
+	 * Loads the item sprite for {@code itemId} into {@code chip} asynchronously.
+	 * The icon is scaled to {@link #ICON_SIZE} x {@link #ICON_SIZE} before being set.
+	 * No-op when the item manager has no image (e.g. in unit tests).
+	 */
+	void loadChipIcon(int itemId, JLabel chip)
+	{
+		AsyncBufferedImage asyncImage = itemManager.getImage(itemId);
+		if (asyncImage == null)
+		{
+			return;
+		}
+
+		Runnable applyIcon = () ->
+		{
+			if (asyncImage.getWidth() > 0)
+			{
+				BufferedImage scaled = scaleImage(asyncImage, ICON_SIZE, ICON_SIZE);
+				chip.setIcon(new ImageIcon(scaled));
+				chip.revalidate();
+				chip.repaint();
+			}
+		};
+
+		asyncImage.onLoaded(applyIcon);
+
+		// Apply synchronously if already loaded (avoids a one-tick blank flash)
+		if (asyncImage.getWidth() > 0)
+		{
+			applyIcon.run();
+		}
+	}
+
+	private static BufferedImage scaleImage(BufferedImage source, int width, int height)
+	{
+		BufferedImage scaled = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+		Graphics2D g = scaled.createGraphics();
+		g.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+			RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+		g.drawImage(source, 0, 0, width, height, null);
+		g.dispose();
+		return scaled;
+	}
+}

--- a/src/main/java/com/collectionloghelper/ui/widget/StepProgressView.java
+++ b/src/main/java/com/collectionloghelper/ui/widget/StepProgressView.java
@@ -104,6 +104,12 @@ public class StepProgressView extends JPanel
 	 * item availability (green/white/red). Hidden when the step has no required items.
 	 */
 	private final RequiredItemsChipPanel chipPanel;
+	/**
+	 * B.5.2 chip strip — rendered directly below the required-items chip strip.
+	 * Uses a thinner 1-pixel muted-alpha border to signal advisory status.
+	 * Hidden when the step has no recommended items.
+	 */
+	private final RecommendedItemsChipPanel recChipPanel;
 	private final JPanel requiredItemsPanel;
 	private final JPanel recommendedItemsPanel;
 	/** Container rendered when the source uses section labels (sectioned mode). */
@@ -148,6 +154,11 @@ public class StepProgressView extends JPanel
 		chipPanel = new RequiredItemsChipPanel(itemManager);
 		chipPanel.setAlignmentX(LEFT_ALIGNMENT);
 		add(chipPanel);
+
+		// B.5.2 chip strip — directly below the required-items chips
+		recChipPanel = new RecommendedItemsChipPanel(itemManager);
+		recChipPanel.setAlignmentX(LEFT_ALIGNMENT);
+		add(recChipPanel);
 		add(Box.createVerticalStrut(2));
 
 		requiredItemsPanel = new JPanel();
@@ -349,6 +360,7 @@ public class StepProgressView extends JPanel
 				// Flat layout — hide sections, show chip strip + required/recommended items inline
 				sectionsPanel.setVisible(false);
 				chipPanel.update(rows);
+				recChipPanel.update(recRows);
 				updateRequiredItemDisplay(rows);
 				updateRecommendedItemDisplay(recRows);
 			}
@@ -356,6 +368,7 @@ public class StepProgressView extends JPanel
 			{
 				// Sectioned layout — hide inline panels (including chip strip), render section blocks
 				chipPanel.update(Collections.<RequiredItemDisplay>emptyList());
+				recChipPanel.update(Collections.<RequiredItemDisplay>emptyList());
 				requiredItemsPanel.removeAll();
 				requiredItemsPanel.setVisible(false);
 				recommendedItemsPanel.removeAll();
@@ -385,6 +398,7 @@ public class StepProgressView extends JPanel
 		SwingUtilities.invokeLater(() ->
 		{
 			chipPanel.update(Collections.<RequiredItemDisplay>emptyList());
+			recChipPanel.update(Collections.<RequiredItemDisplay>emptyList());
 			requiredItemsPanel.removeAll();
 			requiredItemsPanel.setVisible(false);
 			recommendedItemsPanel.removeAll();

--- a/src/test/java/com/collectionloghelper/data/DropRateDatabaseTest.java
+++ b/src/test/java/com/collectionloghelper/data/DropRateDatabaseTest.java
@@ -541,4 +541,35 @@ public class DropRateDatabaseTest
 			}
 		}
 	}
+
+	// ========================================================================
+	// GuidanceStep.perItemRecommendedItemIds — regression (B.5.2)
+	// ========================================================================
+
+	/**
+	 * Regression: as of B.5.2 release, no production step in drop_rates.json uses
+	 * {@code perItemRecommendedItemIds}.  This test enforces the invariant so a
+	 * future data backfill that sets the field is explicit and visible in review.
+	 *
+	 * <p>If this test begins failing intentionally (a data author added the field),
+	 * delete or update it with a comment referencing the PR that introduced the data.
+	 */
+	@Test
+	public void regression_noProductionStepHasPerItemRecommendedItemIds()
+	{
+		for (CollectionLogSource source : database.getAllSources())
+		{
+			if (source.getGuidanceSteps() == null)
+			{
+				continue;
+			}
+			for (GuidanceStep step : source.getGuidanceSteps())
+			{
+				assertNull(
+					"perItemRecommendedItemIds must not be set in production data yet "
+						+ "(source: " + source.getName() + ")",
+					step.getPerItemRecommendedItemIds());
+			}
+		}
+	}
 }

--- a/src/test/java/com/collectionloghelper/data/GuidanceStepSectionTest.java
+++ b/src/test/java/com/collectionloghelper/data/GuidanceStepSectionTest.java
@@ -137,6 +137,7 @@ public class GuidanceStepSectionTest
 			null, null,
 			null,   // perItemRequiredItemIds
 			null,   // recommendedItemIds
+			null, // perItemRecommendedItemIds
 			CompletionCondition.MANUAL,
 			0, 0, 0, 0,
 			null,   // completionNpcIds

--- a/src/test/java/com/collectionloghelper/data/GuidanceStepTest.java
+++ b/src/test/java/com/collectionloghelper/data/GuidanceStepTest.java
@@ -313,6 +313,7 @@ public class GuidanceStepTest
 			null, null,     // travelTip, requiredItemIds
 			null,           // perItemRequiredItemIds
 			null,           // recommendedItemIds
+			null,           // perItemRecommendedItemIds
 			CompletionCondition.MANUAL,
 			0, 0, 0, 0,    // completionItemId, completionItemCount, completionDistance, completionNpcId
 			null,           // completionNpcIds
@@ -346,6 +347,7 @@ public class GuidanceStepTest
 			null, null,     // travelTip, requiredItemIds
 			null,           // perItemRequiredItemIds
 			null,           // recommendedItemIds
+			null,           // perItemRecommendedItemIds
 			CompletionCondition.MANUAL,
 			0, 0, 0, 0,    // completionItemId, completionItemCount, completionDistance, completionNpcId
 			null,           // completionNpcIds

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorDescriptionTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorDescriptionTest.java
@@ -258,6 +258,7 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 			null, null,     // travelTip, requiredItemIds
 			null,           // perItemRequiredItemIds
 			null,           // recommendedItemIds
+			null,           // perItemRecommendedItemIds
 			CompletionCondition.MANUAL,
 			0, 0, 0, 0,    // completionItemId, completionItemCount, completionDistance, completionNpcId
 			null,           // completionNpcIds

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorNpcIdTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorNpcIdTest.java
@@ -265,6 +265,7 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 			null, null,     // travelTip, requiredItemIds
 			null,           // perItemRequiredItemIds
 			null,           // recommendedItemIds
+			null,           // perItemRecommendedItemIds
 			CompletionCondition.ACTOR_DEATH,
 			0, 0, 0, npcId,  // completionItemId, completionItemCount, completionDistance, completionNpcId
 			null,           // completionNpcIds

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerNestedConditionalTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerNestedConditionalTest.java
@@ -469,6 +469,7 @@ public class GuidanceSequencerNestedConditionalTest
 			null, null,
 			null,           // perItemRequiredItemIds
 			null,           // recommendedItemIds
+			null,           // perItemRecommendedItemIds
 			CompletionCondition.MANUAL,
 			0, 0, 0, 0,
 			null,           // completionNpcIds
@@ -502,6 +503,7 @@ public class GuidanceSequencerNestedConditionalTest
 			null, null,
 			null,  // perItemRequiredItemIds
 			null,  // recommendedItemIds
+			null,           // perItemRecommendedItemIds
 			CompletionCondition.ARRIVE_AT_TILE,
 			0, 0, 5, 0,
 			null,  // completionNpcIds

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
@@ -97,6 +97,7 @@ public class GuidanceSequencerTest
 			null, null,     // travelTip, requiredItemIds
 			null,           // perItemRequiredItemIds
 			null,           // recommendedItemIds
+			null,           // perItemRecommendedItemIds
 			CompletionCondition.MANUAL,
 			0, 0, 0, 0,    // completionItemId, completionItemCount, completionDistance, completionNpcId
 			null,           // completionNpcIds
@@ -129,6 +130,7 @@ public class GuidanceSequencerTest
 			null, null,
 			null,  // perItemRequiredItemIds
 			null,  // recommendedItemIds
+			null,  // perItemRecommendedItemIds
 			condition,
 			completionItemId, 0, 0, 0,
 			null,  // completionNpcIds
@@ -161,6 +163,7 @@ public class GuidanceSequencerTest
 			null, null,
 			null,  // perItemRequiredItemIds
 			null,  // recommendedItemIds
+			null,           // perItemRecommendedItemIds
 			CompletionCondition.INVENTORY_HAS_ITEM,
 			itemId, count, 0, 0,
 			null,  // completionNpcIds
@@ -193,6 +196,7 @@ public class GuidanceSequencerTest
 			null, null,
 			null,  // perItemRequiredItemIds
 			null,  // recommendedItemIds
+			null,           // perItemRecommendedItemIds
 			CompletionCondition.ARRIVE_AT_TILE,
 			0, 0, distance, 0,
 			null,  // completionNpcIds
@@ -225,6 +229,7 @@ public class GuidanceSequencerTest
 			null, null,
 			null,  // perItemRequiredItemIds
 			null,  // recommendedItemIds
+			null,           // perItemRecommendedItemIds
 			CompletionCondition.NPC_TALKED_TO,
 			0, 0, 0, npcId,
 			null,  // completionNpcIds
@@ -257,6 +262,7 @@ public class GuidanceSequencerTest
 			null, null,
 			null,  // perItemRequiredItemIds
 			null,  // recommendedItemIds
+			null,           // perItemRecommendedItemIds
 			CompletionCondition.ACTOR_DEATH,
 			0, 0, 0, npcId,
 			null,  // completionNpcIds
@@ -289,6 +295,7 @@ public class GuidanceSequencerTest
 			null, null,
 			null,  // perItemRequiredItemIds
 			null,  // recommendedItemIds
+			null,           // perItemRecommendedItemIds
 			CompletionCondition.CHAT_MESSAGE_RECEIVED,
 			0, 0, 0, 0,
 			null,  // completionNpcIds
@@ -322,6 +329,7 @@ public class GuidanceSequencerTest
 			null, null,
 			null,  // perItemRequiredItemIds
 			null,  // recommendedItemIds
+			null,  // perItemRecommendedItemIds
 			condition,
 			0, 0, 0, completionNpcId,
 			null,  // completionNpcIds
@@ -354,6 +362,7 @@ public class GuidanceSequencerTest
 			null, null,
 			null,  // perItemRequiredItemIds
 			null,  // recommendedItemIds
+			null,           // perItemRecommendedItemIds
 			CompletionCondition.PLAYER_ON_PLANE,
 			0, 0, 0, 0,
 			null,  // completionNpcIds
@@ -386,6 +395,7 @@ public class GuidanceSequencerTest
 			null, null,
 			null,  // perItemRequiredItemIds
 			null,  // recommendedItemIds
+			null,           // perItemRecommendedItemIds
 			CompletionCondition.VARBIT_AT_LEAST,
 			0, 0, 0, 0,
 			null,  // completionNpcIds
@@ -418,6 +428,7 @@ public class GuidanceSequencerTest
 			null, requiredItemIds,
 			null,  // perItemRequiredItemIds
 			null,  // recommendedItemIds
+			null,           // perItemRecommendedItemIds
 			CompletionCondition.MANUAL,
 			0, 0, 0, 0,
 			null,  // completionNpcIds
@@ -792,6 +803,7 @@ public class GuidanceSequencerTest
 			null, null,
 			null,  // perItemRequiredItemIds
 			null,  // recommendedItemIds
+			null,           // perItemRecommendedItemIds
 			CompletionCondition.ACTOR_DEATH,
 			0, 0, 0, 0,
 			Arrays.asList(2042, 2043, 2044),  // completionNpcIds
@@ -1262,6 +1274,7 @@ public class GuidanceSequencerTest
 			travelTip, null,
 			null,  // perItemRequiredItemIds
 			null,  // recommendedItemIds
+			null,           // perItemRecommendedItemIds
 			CompletionCondition.ARRIVE_AT_TILE,
 			0, 0, 5, 0,
 			null,  // completionNpcIds
@@ -1496,6 +1509,7 @@ public class GuidanceSequencerTest
 			null, null,
 			null,  // perItemRequiredItemIds
 			null,  // recommendedItemIds
+			null,           // perItemRecommendedItemIds
 			CompletionCondition.MANUAL,
 			0, 0, 0, 0,
 			null,  // completionNpcIds

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerWaypointTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerWaypointTest.java
@@ -107,6 +107,7 @@ public class GuidanceSequencerWaypointTest
 			null, null,
 			null,  // perItemRequiredItemIds
 			null,  // recommendedItemIds
+			null, // perItemRecommendedItemIds
 			CompletionCondition.ARRIVE_AT_TILE,
 			0, 0, 5, 0,  // completionItemId, completionItemCount, completionDistance, completionNpcId
 			null,  // completionNpcIds
@@ -142,6 +143,7 @@ public class GuidanceSequencerWaypointTest
 			null, null,
 			null,
 			null,
+			null, // perItemRecommendedItemIds
 			CompletionCondition.MANUAL,
 			0, 0, 0, 0,
 			null,
@@ -252,6 +254,7 @@ public class GuidanceSequencerWaypointTest
 			null, null,
 			null,
 			null,
+			null, // perItemRecommendedItemIds
 			CompletionCondition.ARRIVE_AT_TILE,
 			0, 0, 5, 0,
 			null,
@@ -300,6 +303,7 @@ public class GuidanceSequencerWaypointTest
 			null, null,
 			null,
 			null,
+			null, // perItemRecommendedItemIds
 			CompletionCondition.ARRIVE_AT_TILE,
 			0, 0, 5, 0,
 			null,

--- a/src/test/java/com/collectionloghelper/guidance/RequiredItemResolverTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/RequiredItemResolverTest.java
@@ -511,6 +511,92 @@ public class RequiredItemResolverTest
 		assertEquals(TINDERBOX, rows.get(0).getItemId());
 	}
 
+
+	// ── perItemRecommendedItemIds override (B.5.2) ─────────────────────────────
+
+	/**
+	 * When the coordinator has an active target item that is a key in the step's
+	 * perItemRecommendedItemIds map, resolveRecommended uses the override list.
+	 */
+	@Test
+	public void perItemRecommendedOverride_usedWhenTargetMatchesMapKey()
+	{
+		when(coordinator.getActiveTargetItemId()).thenReturn(BRONZE_LOCK);
+
+		Map<Integer, List<Integer>> perItemRecMap = new HashMap<>();
+		perItemRecMap.put(BRONZE_LOCK, Arrays.asList(TINDERBOX, PYRE_LOGS));
+		perItemRecMap.put(GOLD_LOCK, Collections.singletonList(SHADE_REMAINS));
+
+		GuidanceStep step = stepFullWithPerItemRec(
+			null,
+			null,
+			Collections.singletonList(SHADE_REMAINS),  // static fallback
+			perItemRecMap);
+
+		List<RequiredItemDisplay> rows = resolver.resolveRecommended(step);
+
+		assertEquals("Override list must have 2 items for BRONZE_LOCK target", 2, rows.size());
+		assertEquals(TINDERBOX, rows.get(0).getItemId());
+		assertEquals(PYRE_LOGS, rows.get(1).getItemId());
+	}
+
+	/**
+	 * When no active target, resolveRecommended falls back to the static recommendedItemIds.
+	 */
+	@Test
+	public void perItemRecommendedOverride_fallsBackWhenNoActiveTarget()
+	{
+		when(coordinator.getActiveTargetItemId()).thenReturn(null);
+
+		Map<Integer, List<Integer>> perItemRecMap = new HashMap<>();
+		perItemRecMap.put(BRONZE_LOCK, Arrays.asList(TINDERBOX, PYRE_LOGS));
+
+		GuidanceStep step = stepFullWithPerItemRec(
+			null, null, Collections.singletonList(SHADE_REMAINS), perItemRecMap);
+
+		List<RequiredItemDisplay> rows = resolver.resolveRecommended(step);
+
+		assertEquals("Must fall back to static recommended list (1 item)", 1, rows.size());
+		assertEquals(SHADE_REMAINS, rows.get(0).getItemId());
+	}
+
+	/**
+	 * When the target is not in the map, falls back to the static recommendedItemIds.
+	 */
+	@Test
+	public void perItemRecommendedOverride_fallsBackWhenTargetNotInMap()
+	{
+		when(coordinator.getActiveTargetItemId()).thenReturn(99999);
+
+		Map<Integer, List<Integer>> perItemRecMap = new HashMap<>();
+		perItemRecMap.put(BRONZE_LOCK, Arrays.asList(TINDERBOX, PYRE_LOGS));
+
+		GuidanceStep step = stepFullWithPerItemRec(
+			null, null, Collections.singletonList(SHADE_REMAINS), perItemRecMap);
+
+		List<RequiredItemDisplay> rows = resolver.resolveRecommended(step);
+
+		assertEquals("Must fall back to static recommended list when target not in map",
+			1, rows.size());
+		assertEquals(SHADE_REMAINS, rows.get(0).getItemId());
+	}
+
+	/**
+	 * When the step has no perItemRecommendedItemIds map (null), uses the static list.
+	 */
+	@Test
+	public void perItemRecommendedOverride_fallsBackWhenStepHasNoMap()
+	{
+		lenient().when(coordinator.getActiveTargetItemId()).thenReturn(BRONZE_LOCK);
+
+		GuidanceStep step = stepWithRequiredAndRecommendedItems(
+			null, Collections.singletonList(TINDERBOX));
+
+		List<RequiredItemDisplay> rows = resolver.resolveRecommended(step);
+
+		assertEquals("No map on step — must use static recommended list", 1, rows.size());
+		assertEquals(TINDERBOX, rows.get(0).getItemId());
+	}
 	// --- Helpers ---
 
 	private static GuidanceStep stepWithRequiredItems(List<Integer> requiredItemIds)
@@ -544,6 +630,7 @@ public class RequiredItemResolverTest
 			requiredItemIds,
 			perItemRequiredItemIds,
 			recommendedItemIds,
+			null,  // perItemRecommendedItemIds
 			CompletionCondition.MANUAL,
 			0, 0, 0, 0,
 			null,
@@ -564,6 +651,44 @@ public class RequiredItemResolverTest
 			null,  // conditionalAlternatives
 			null,  // section
 			null   // waypoints
+		);
+	}
+
+	private static GuidanceStep stepFullWithPerItemRec(
+		List<Integer> requiredItemIds,
+		Map<Integer, List<Integer>> perItemRequiredItemIds,
+		List<Integer> recommendedItemIds,
+		Map<Integer, List<Integer>> perItemRecommendedItemIds)
+	{
+		return new GuidanceStep(
+			"Test step",
+			null,  // perItemStepDescription
+			0, 0, 0,
+			0, null, null, null,
+			null,
+			requiredItemIds,
+			perItemRequiredItemIds,
+			recommendedItemIds,
+			perItemRecommendedItemIds,
+			CompletionCondition.MANUAL,
+			0, 0, 0, 0,
+			null,
+			null,
+			0, null, null,
+			null,
+			null,
+			null,
+			0, 0,
+			false,
+			0,
+			null,
+			null,
+			0, 0,
+			null,  // skipIfHasAnyItemIds
+			null,  // dynamicItemObjectTiers
+			null,  // completionZone
+			null,  // conditionalAlternatives
+			null   // section
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/guidance/RequiredItemResolverTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/RequiredItemResolverTest.java
@@ -688,7 +688,8 @@ public class RequiredItemResolverTest
 			null,  // dynamicItemObjectTiers
 			null,  // completionZone
 			null,  // conditionalAlternatives
-			null   // section
+			null,  // section
+			null   // waypoints
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/lifecycle/GuidanceEventRouterTest.java
+++ b/src/test/java/com/collectionloghelper/lifecycle/GuidanceEventRouterTest.java
@@ -121,6 +121,7 @@ public class GuidanceEventRouterTest
 			null, null,
 			null,  // perItemRequiredItemIds
 			null,  // recommendedItemIds
+			null,           // perItemRecommendedItemIds
 			CompletionCondition.NPC_TALKED_TO,
 			0, 0, 0, npcId,
 			null,  // completionNpcIds

--- a/src/test/java/com/collectionloghelper/ui/widget/BankScanIntegrationTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/BankScanIntegrationTest.java
@@ -320,8 +320,9 @@ public class BankScanIntegrationTest
 			0, null, null, null,
 			null,
 			requiredItemIds,
-			null,
-			null,
+			null,  // perItemRequiredItemIds
+			null,  // recommendedItemIds
+			null,  // perItemRecommendedItemIds
 			CompletionCondition.MANUAL,
 			0, 0, 0, 0,
 			null,

--- a/src/test/java/com/collectionloghelper/ui/widget/RecommendedItemsChipPanelTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/RecommendedItemsChipPanelTest.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.ui.widget;
+
+import com.collectionloghelper.guidance.RequiredItemDisplay;
+import com.collectionloghelper.guidance.RequiredItemDisplay.Status;
+import java.awt.Color;
+import java.awt.Component;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+import net.runelite.client.game.ItemManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link RecommendedItemsChipPanel} (B.5.2).
+ *
+ * <p>Mirrors {@link RequiredItemsChipPanelTest} in structure. Covers:
+ * <ol>
+ *   <li>Empty / null list yields hidden panel.</li>
+ *   <li>Muted-alpha border colours for all three statuses (HELD/IN_BANK/MISSING).</li>
+ *   <li>Tooltip conventions (item name vs. bank message).</li>
+ *   <li>Round-trip visibility: hidden after construction, visible after non-empty
+ *       update, hidden again after empty update.</li>
+ *   <li>Heading label reads "Recommended:" (not "Items needed:").</li>
+ *   <li>Muted colours have reduced alpha vs. required panel colours.</li>
+ * </ol>
+ */
+public class RecommendedItemsChipPanelTest
+{
+	private static final int TINDERBOX = 590;
+	private static final int PYRE_LOGS = 3438;
+	private static final int SHARK = 385;
+
+	private ItemManager itemManager;
+	private RecommendedItemsChipPanel panel;
+
+	@Before
+	public void setUp()
+	{
+		itemManager = Mockito.mock(ItemManager.class);
+		Mockito.when(itemManager.getImage(Mockito.anyInt())).thenReturn(null);
+		panel = new RecommendedItemsChipPanel(itemManager);
+	}
+
+	// ── Scenario 1: empty / null list → panel hidden ─────────────────────────
+
+	@Test
+	public void update_null_panelHidden() throws Exception
+	{
+		panel.update((List<RequiredItemDisplay>) null);
+		flushEdt();
+		assertFalse("Panel must be hidden for null list", panel.isVisible());
+	}
+
+	@Test
+	public void update_emptyList_panelHidden() throws Exception
+	{
+		panel.update(Collections.<RequiredItemDisplay>emptyList());
+		flushEdt();
+		assertFalse("Panel must be hidden for empty list", panel.isVisible());
+	}
+
+	// ── Scenario 2: HELD → muted green border ────────────────────────────────
+
+	@Test
+	public void borderColorFor_heldStatus_mutedGreen()
+	{
+		Color color = RecommendedItemsChipPanel.borderColorFor(Status.HELD);
+		assertEquals("HELD status must yield muted green border",
+			RecommendedItemsChipPanel.COLOR_HELD_MUTED, color);
+	}
+
+	@Test
+	public void heldMutedColor_hasReducedAlpha()
+	{
+		assertTrue("HELD muted colour must have alpha less than 255",
+			RecommendedItemsChipPanel.COLOR_HELD_MUTED.getAlpha() < 255);
+		assertFalse("Muted HELD colour must differ from required HELD colour",
+			RecommendedItemsChipPanel.COLOR_HELD_MUTED.equals(RequiredItemDisplay.COLOR_HELD));
+	}
+
+	@Test
+	public void tooltipFor_heldStatus_itemName()
+	{
+		RequiredItemDisplay row = new RequiredItemDisplay(TINDERBOX, "Tinderbox", Status.HELD);
+		assertEquals("HELD tooltip must be item name",
+			"Tinderbox", RecommendedItemsChipPanel.tooltipFor(row));
+	}
+
+	// ── Scenario 3: IN_BANK → muted white border + bank tooltip ─────────────
+
+	@Test
+	public void borderColorFor_inBankStatus_mutedWhite()
+	{
+		Color color = RecommendedItemsChipPanel.borderColorFor(Status.IN_BANK);
+		assertEquals("IN_BANK status must yield muted off-white border",
+			RecommendedItemsChipPanel.COLOR_IN_BANK_MUTED, color);
+	}
+
+	@Test
+	public void tooltipFor_inBankStatus_questHelperConvention()
+	{
+		RequiredItemDisplay row = new RequiredItemDisplay(PYRE_LOGS, "Pyre logs", Status.IN_BANK);
+		assertEquals("IN_BANK tooltip must be Quest Helper bank message",
+			RecommendedItemsChipPanel.IN_BANK_TOOLTIP,
+			RecommendedItemsChipPanel.tooltipFor(row));
+	}
+
+	// ── Scenario 4: MISSING → muted red border ───────────────────────────────
+
+	@Test
+	public void borderColorFor_missingStatus_mutedRed()
+	{
+		Color color = RecommendedItemsChipPanel.borderColorFor(Status.MISSING);
+		assertEquals("MISSING status must yield muted red border",
+			RecommendedItemsChipPanel.COLOR_MISSING_MUTED, color);
+	}
+
+	@Test
+	public void missingMutedColor_hasReducedAlpha()
+	{
+		assertTrue("MISSING muted colour must have alpha less than 255",
+			RecommendedItemsChipPanel.COLOR_MISSING_MUTED.getAlpha() < 255);
+		assertFalse("Muted MISSING colour must differ from required MISSING colour",
+			RecommendedItemsChipPanel.COLOR_MISSING_MUTED.equals(RequiredItemDisplay.COLOR_MISSING));
+	}
+
+	@Test
+	public void tooltipFor_missingStatus_itemName()
+	{
+		RequiredItemDisplay row = new RequiredItemDisplay(SHARK, "Shark", Status.MISSING);
+		assertEquals("MISSING tooltip must be item name",
+			"Shark", RecommendedItemsChipPanel.tooltipFor(row));
+	}
+
+	// ── All-statuses coverage ────────────────────────────────────────────────
+
+	@Test
+	public void borderColorFor_allThreeStatuses_correctMutedColors()
+	{
+		assertEquals(RecommendedItemsChipPanel.COLOR_HELD_MUTED,
+			RecommendedItemsChipPanel.borderColorFor(Status.HELD));
+		assertEquals(RecommendedItemsChipPanel.COLOR_IN_BANK_MUTED,
+			RecommendedItemsChipPanel.borderColorFor(Status.IN_BANK));
+		assertEquals(RecommendedItemsChipPanel.COLOR_MISSING_MUTED,
+			RecommendedItemsChipPanel.borderColorFor(Status.MISSING));
+	}
+
+	// ── buildChip ────────────────────────────────────────────────────────────
+
+	@Test
+	public void buildChip_heldItem_itemNameTooltip()
+	{
+		RequiredItemDisplay row = new RequiredItemDisplay(TINDERBOX, "Tinderbox", Status.HELD);
+		JLabel chip = panel.buildChip(row);
+
+		assertNotNull("Chip must not be null", chip);
+		assertEquals("HELD chip tooltip must be item name",
+			"Tinderbox", chip.getToolTipText());
+	}
+
+	@Test
+	public void buildChip_inBankItem_bankTooltip()
+	{
+		RequiredItemDisplay row = new RequiredItemDisplay(PYRE_LOGS, "Pyre logs", Status.IN_BANK);
+		JLabel chip = panel.buildChip(row);
+
+		assertNotNull("Chip must not be null", chip);
+		assertEquals("IN_BANK chip tooltip must be bank message",
+			RecommendedItemsChipPanel.IN_BANK_TOOLTIP, chip.getToolTipText());
+	}
+
+	@Test
+	public void buildChip_threeMixedStatuses_allChipsBuilt()
+	{
+		List<RequiredItemDisplay> rows = Arrays.asList(
+			new RequiredItemDisplay(TINDERBOX, "Tinderbox", Status.HELD),
+			new RequiredItemDisplay(PYRE_LOGS, "Pyre logs", Status.IN_BANK),
+			new RequiredItemDisplay(SHARK, "Shark", Status.MISSING));
+
+		for (RequiredItemDisplay row : rows)
+		{
+			JLabel chip = panel.buildChip(row);
+			assertNotNull("Chip must not be null for status " + row.getStatus(), chip);
+		}
+	}
+
+	// ── Round-trip visibility ────────────────────────────────────────────────
+
+	@Test
+	public void afterConstruction_hidden()
+	{
+		assertFalse("Panel must start hidden", panel.isVisible());
+	}
+
+	@Test
+	public void update_nonEmptyList_panelVisible() throws Exception
+	{
+		List<RequiredItemDisplay> rows = Collections.singletonList(
+			new RequiredItemDisplay(TINDERBOX, "Tinderbox", Status.HELD));
+		panel.update(rows);
+		flushEdt();
+		assertTrue("Panel must be visible after update with non-empty list", panel.isVisible());
+	}
+
+	@Test
+	public void update_emptyAfterNonEmpty_hidesPanel() throws Exception
+	{
+		panel.update(Collections.singletonList(
+			new RequiredItemDisplay(TINDERBOX, "Tinderbox", Status.HELD)));
+		flushEdt();
+		assertTrue("Panel visible after first non-empty update", panel.isVisible());
+
+		panel.update(Collections.<RequiredItemDisplay>emptyList());
+		flushEdt();
+		assertFalse("Panel must be hidden after second empty update", panel.isVisible());
+	}
+
+	// ── Heading text ─────────────────────────────────────────────────────────
+
+	/**
+	 * The chip row must contain a "Recommended:" heading label after a non-empty update.
+	 */
+	@Test
+	public void update_nonEmptyList_headingIsRecommended() throws Exception
+	{
+		panel.update(Collections.singletonList(
+			new RequiredItemDisplay(TINDERBOX, "Tinderbox", Status.HELD)));
+		flushEdt();
+
+		// The chip row is the first (and only) JPanel child of the panel
+		JPanel chipRow = null;
+		for (Component c : panel.getComponents())
+		{
+			if (c instanceof JPanel)
+			{
+				chipRow = (JPanel) c;
+				break;
+			}
+		}
+		assertNotNull("Chip row panel must exist", chipRow);
+
+		boolean foundHeading = false;
+		for (Component c : chipRow.getComponents())
+		{
+			if (c instanceof JLabel && "Recommended:".equals(((JLabel) c).getText()))
+			{
+				foundHeading = true;
+				break;
+			}
+		}
+		assertTrue("Chip row must contain a 'Recommended:' heading label", foundHeading);
+	}
+
+	// ── Helpers ─────────────────────────────────────────────────────────────
+
+	private static void flushEdt() throws Exception
+	{
+		SwingUtilities.invokeAndWait(() -> { /* no-op: drain the EDT queue */ });
+	}
+}

--- a/src/test/java/com/collectionloghelper/ui/widget/StepProgressViewTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/StepProgressViewTest.java
@@ -603,7 +603,7 @@ public class StepProgressViewTest
 			if (c instanceof JPanel)
 			{
 				panelCount++;
-				if (panelCount == 2)
+				if (panelCount == 3)
 				{
 					return (JPanel) c;
 				}
@@ -625,7 +625,7 @@ public class StepProgressViewTest
 			if (c instanceof JPanel)
 			{
 				panelCount++;
-				if (panelCount == 3)
+				if (panelCount == 4)
 				{
 					return (JPanel) c;
 				}
@@ -712,8 +712,9 @@ public class StepProgressViewTest
 	}
 
 	/**
-	 * Finds the sectionsPanel — the fourth {@link JPanel} direct child of the
-	 * StepProgressView (chip panel, required, recommended, then sections).
+	 * Finds the sectionsPanel — the fifth {@link JPanel} direct child of the
+	 * StepProgressView (chipPanel, recChipPanel, requiredItemsPanel,
+	 * recommendedItemsPanel, then sectionsPanel).
 	 */
 	private static JPanel findSectionsPanel(StepProgressView view)
 	{
@@ -723,7 +724,7 @@ public class StepProgressViewTest
 			if (c instanceof JPanel)
 			{
 				panelCount++;
-				if (panelCount == 4)
+				if (panelCount == 5)
 				{
 					return (JPanel) c;
 				}
@@ -929,6 +930,7 @@ public class StepProgressViewTest
 			null, null,
 			null,  // perItemRequiredItemIds
 			null,  // recommendedItemIds
+			null,           // perItemRecommendedItemIds
 			CompletionCondition.MANUAL,
 			0, 0, 0, 0,
 			null, null,
@@ -956,6 +958,7 @@ public class StepProgressViewTest
 			null, null,
 			null,  // perItemRequiredItemIds
 			recommendedItemIds,
+			null,  // perItemRecommendedItemIds
 			CompletionCondition.MANUAL,
 			0, 0, 0, 0,
 			null, null,

--- a/src/test/java/com/collectionloghelper/ui/widget/StepSectionGrouperTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/StepSectionGrouperTest.java
@@ -62,6 +62,7 @@ public class StepSectionGrouperTest
 			null, null,
 			null,  // perItemRequiredItemIds
 			null,  // recommendedItemIds
+			null,           // perItemRecommendedItemIds
 			CompletionCondition.MANUAL,
 			0, 0, 0, 0,
 			null, null,


### PR DESCRIPTION
## Summary

- Adds `RecommendedItemsChipPanel`: a new chip-strip widget parallel to `RequiredItemsChipPanel` (B.5.1), rendered immediately below it in `StepProgressView`. Uses a thinner 1px border with muted alpha (160/255) on all three status colours to signal advisory rather than mandatory status. Section header reads `"Recommended:"`.
- Adds `perItemRecommendedItemIds: Map<Integer, List<Integer>>` schema field on `GuidanceStep` — per-item override matching the `perItemRequiredItemIds` pattern, null by default (fully backwards-compatible).
- Extends `RequiredItemResolver.resolveRecommended()` with per-item override support via `GuidanceOverlayCoordinator.getActiveTargetItemId()`, consistent with the required-items resolver.

## Test plan

- [ ] `RecommendedItemsChipPanelTest` — mirrors `RequiredItemsChipPanelTest`: null/empty list hides panel, muted colour per status, IN_BANK bank tooltip, round-trip visibility, "Recommended:" heading
- [ ] `RequiredItemResolverTest` — new `perItemRecommendedItemIds` override tests: used when target matches map key, falls back when no active target, falls back when target not in map, falls back when step has no map
- [ ] `DropRateDatabaseTest.regression_noProductionStepHasPerItemRecommendedItemIds` — asserts no production step uses the new field yet
- [ ] `./gradlew test build` passes (887+ tests)