### PR TITLE
feat(guidance): B5 — puzzle/dynamic step type with Wintertodt pilot

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -562,7 +562,7 @@ Focus: god-object decomposition, build hardening, test expansion. Resulted in th
 - [ ] B4.3.4 — Barrows per-brother targeting  status: deferred  owner: —  updated: 2026-05-14  note: Flagged in #420 for human design review — `perItemRequiredItemIds` may not suffice; needs `perItemCompletionNpcId` or guidance-step redesign for the VARBIT-based kill-progress interaction.
 - [ ] B4.3.5 — Barracuda Trials per-trial mapping  status: deferred  owner: —  updated: 2026-05-14  note: Flagged in #420 — re-audit after Sailing mechanics stabilize before scoping.
 - [ ] B4.4 — Top Pick auto-drives per-item method choice (North Star UI alignment)  status: planned  owner: —  updated: 2026-05-13
-- [ ] B5 — Puzzle/dynamic step type                     status: planned       owner: —          updated: 2026-04-16
+- [/] B5 — Puzzle/dynamic step type                     status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #TBD  note: DynamicTargetEvaluator interface + registry + WintertodtBrazierEvaluator pilot. Coordinator tick() dispatches per-tick; regression guard ensures no production step carries the field.
 - [ ] B6 — Decision D-01 pilot (hybrid Java helper)     status: planned       owner: —          updated: 2026-04-16
 
 **Tier B.5 — UI parity with Quest Helper**

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -562,7 +562,7 @@ Focus: god-object decomposition, build hardening, test expansion. Resulted in th
 - [ ] B4.3.4 — Barrows per-brother targeting  status: deferred  owner: —  updated: 2026-05-14  note: Flagged in #420 for human design review — `perItemRequiredItemIds` may not suffice; needs `perItemCompletionNpcId` or guidance-step redesign for the VARBIT-based kill-progress interaction.
 - [ ] B4.3.5 — Barracuda Trials per-trial mapping  status: deferred  owner: —  updated: 2026-05-14  note: Flagged in #420 — re-audit after Sailing mechanics stabilize before scoping.
 - [ ] B4.4 — Top Pick auto-drives per-item method choice (North Star UI alignment)  status: planned  owner: —  updated: 2026-05-13
-- [/] B5 — Puzzle/dynamic step type                     status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #TBD  note: DynamicTargetEvaluator interface + registry + WintertodtBrazierEvaluator pilot. Coordinator tick() dispatches per-tick; regression guard ensures no production step carries the field.
+- [/] B5 — Puzzle/dynamic step type                     status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #473  note: DynamicTargetEvaluator interface + registry + WintertodtBrazierEvaluator pilot. Coordinator tick() dispatches per-tick; regression guard ensures no production step carries the field.
 - [ ] B6 — Decision D-01 pilot (hybrid Java helper)     status: planned       owner: —          updated: 2026-04-16
 
 **Tier B.5 — UI parity with Quest Helper**

--- a/src/main/java/com/collectionloghelper/data/GuidanceStep.java
+++ b/src/main/java/com/collectionloghelper/data/GuidanceStep.java
@@ -235,6 +235,23 @@ public class GuidanceStep
 	@Nullable
 	List<StepWaypoint> waypoints;
 
+	/**
+	 * Optional key that activates per-tick dynamic target evaluation for this step.
+	 * When non-null, {@link com.collectionloghelper.guidance.GuidanceOverlayCoordinator}
+	 * looks up the corresponding
+	 * {@link com.collectionloghelper.guidance.DynamicTargetEvaluator} in the
+	 * {@link com.collectionloghelper.guidance.dynamic.DynamicTargetEvaluatorRegistry}
+	 * and calls it once per game tick.  The returned
+	 * {@link net.runelite.api.coords.WorldPoint} overrides the step's static
+	 * {@link #worldX}/{@link #worldY}/{@link #worldPlane} for that tick's overlay update.
+	 *
+	 * <p>Null by default — existing JSON without this field deserialises unchanged.
+	 * Production steps must NOT set this field; it is reserved for puzzle/dynamic
+	 * content authored specifically for dynamic evaluators (e.g. Wintertodt braziers).
+	 */
+	@Nullable
+	String dynamicTargetEvaluator;
+
 	public int getCompletionDistance()
 	{
 		return completionDistance > 0 ? completionDistance : 5;
@@ -459,7 +476,8 @@ public class GuidanceStep
 			this.completionZone,
 			null, // merged steps don't carry alternatives (already resolved)
 			this.section,
-			null  // waypoints: merged steps inherit null; authors set waypoints on the base step
+			null, // waypoints: merged steps inherit null; authors set waypoints on the base step
+			this.dynamicTargetEvaluator
 		);
 	}
 }

--- a/src/main/java/com/collectionloghelper/guidance/DynamicTargetEvaluator.java
+++ b/src/main/java/com/collectionloghelper/guidance/DynamicTargetEvaluator.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.guidance;
+
+import com.collectionloghelper.data.GuidanceStep;
+import javax.annotation.Nullable;
+import net.runelite.api.Client;
+import net.runelite.api.coords.WorldPoint;
+
+/**
+ * Pluggable per-tick target resolver for puzzle/dynamic guidance steps.
+ *
+ * <p>When a {@link GuidanceStep} carries a non-null
+ * {@link GuidanceStep#getDynamicTargetEvaluator()} key, the
+ * {@link com.collectionloghelper.guidance.dynamic.DynamicTargetEvaluatorRegistry}
+ * looks up the registered evaluator by that key and calls
+ * {@link #evaluate(Client, GuidanceStep)} once per game tick.  The returned
+ * {@link WorldPoint} replaces the step's static {@code worldX/worldY/worldPlane}
+ * for that tick's overlay update.
+ *
+ * <p>Evaluators run on the client thread (called from the game-tick handler).
+ * Implementations may freely call any {@link Client} API without thread-safety
+ * concerns.  Return {@code null} to signal that no dynamic target is available
+ * for the current tick; the coordinator falls back to the step's static
+ * coordinates (or no target when those are also absent).
+ *
+ * <p>Implementations must be stateless or externally thread-safe if shared
+ * across multiple simultaneous guidance sessions (unlikely in practice, but
+ * the registry stores one instance per key).
+ */
+public interface DynamicTargetEvaluator
+{
+	/**
+	 * Computes the current target {@link WorldPoint} for the given guidance step.
+	 *
+	 * <p>Called once per game tick while the step is active.  Must complete
+	 * quickly — no blocking I/O, no heavy computation.
+	 *
+	 * @param client the RuneLite {@link Client}, available for NPC/varbit queries
+	 * @param step   the currently active guidance step (read-only)
+	 * @return the computed target, or {@code null} when no dynamic target applies
+	 */
+	@Nullable
+	WorldPoint evaluate(Client client, GuidanceStep step);
+}

--- a/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
@@ -37,6 +37,8 @@ import com.collectionloghelper.data.PlayerInventoryState;
 import com.collectionloghelper.data.PlayerTravelCapabilities;
 import com.collectionloghelper.data.RequirementRow;
 import com.collectionloghelper.data.RequirementsChecker;
+import com.collectionloghelper.guidance.DynamicTargetEvaluator;
+import com.collectionloghelper.guidance.dynamic.DynamicTargetEvaluatorRegistry;
 import com.collectionloghelper.overlay.CollectionLogWorldMapPoint;
 import com.collectionloghelper.overlay.DialogHighlightOverlay;
 import com.collectionloghelper.overlay.GroundItemHighlightOverlay;
@@ -95,6 +97,7 @@ public class GuidanceOverlayCoordinator
 	private final EventBus eventBus;
 	private final CollectionLogHelperConfig config;
 	private final GuidanceSequencer guidanceSequencer;
+	private final DynamicTargetEvaluatorRegistry dynamicTargetEvaluatorRegistry;
 	private final RequirementsChecker requirementsChecker;
 	private final PlayerTravelCapabilities travelCapabilities;
 	private final PlayerInventoryState playerInventoryState;
@@ -168,6 +171,7 @@ public class GuidanceOverlayCoordinator
 		EventBus eventBus,
 		CollectionLogHelperConfig config,
 		GuidanceSequencer guidanceSequencer,
+		DynamicTargetEvaluatorRegistry dynamicTargetEvaluatorRegistry,
 		RequirementsChecker requirementsChecker,
 		PlayerTravelCapabilities travelCapabilities,
 		PlayerInventoryState playerInventoryState,
@@ -190,6 +194,7 @@ public class GuidanceOverlayCoordinator
 		this.eventBus = eventBus;
 		this.config = config;
 		this.guidanceSequencer = guidanceSequencer;
+		this.dynamicTargetEvaluatorRegistry = dynamicTargetEvaluatorRegistry;
 		this.requirementsChecker = requirementsChecker;
 		this.travelCapabilities = travelCapabilities;
 		this.playerInventoryState = playerInventoryState;
@@ -400,8 +405,10 @@ public class GuidanceOverlayCoordinator
 	}
 
 	/**
-	 * Called from the plugin's onGameTick. Handles world map arrow rotation
-	 * and dispatches the deferred ShortestPath "path" message.
+	 * Called from the plugin's onGameTick. Handles world map arrow rotation,
+	 * dispatches the deferred ShortestPath "path" message, and updates
+	 * dynamic target overlays for steps that carry a
+	 * {@link com.collectionloghelper.data.GuidanceStep#getDynamicTargetEvaluator()} key.
 	 */
 	public void tick()
 	{
@@ -420,8 +427,63 @@ public class GuidanceOverlayCoordinator
 			eventBus.post(new PluginMessage("shortestpath", "path", data));
 		}
 
+		// Dynamic target evaluator dispatch: update overlays each tick when the
+		// active step has a dynamicTargetEvaluator key.
+		tickDynamicTargetEvaluator();
+
 		// World map arrow rotation
 		updateWorldMapArrow();
+	}
+
+	/**
+	 * If the currently active guidance step has a non-null
+	 * {@link com.collectionloghelper.data.GuidanceStep#getDynamicTargetEvaluator()}
+	 * key, looks up the evaluator in the registry and calls it to obtain the
+	 * current target {@link WorldPoint}.  When the evaluator returns a non-null
+	 * point, pushes it to all location-sensitive overlays (minimap, world map,
+	 * overlay, hint arrow).  Returns silently when guidance is inactive, the
+	 * step carries no evaluator key, the key is unknown, or the evaluator
+	 * returns {@code null}.
+	 *
+	 * <p>Called on the client thread once per game tick via {@link #tick()}.
+	 */
+	private void tickDynamicTargetEvaluator()
+	{
+		if (!guidanceSequencer.isActive())
+		{
+			return;
+		}
+		GuidanceStep step = guidanceSequencer.getRawCurrentStep();
+		if (step == null || step.getDynamicTargetEvaluator() == null)
+		{
+			return;
+		}
+		DynamicTargetEvaluator evaluator = dynamicTargetEvaluatorRegistry.get(step.getDynamicTargetEvaluator());
+		if (evaluator == null)
+		{
+			return;
+		}
+		WorldPoint dynamicPoint = evaluator.evaluate(client, step);
+		if (dynamicPoint == null)
+		{
+			return;
+		}
+		guidanceOverlay.setTargetPoint(dynamicPoint);
+		guidanceMinimapOverlay.setTargetPoint(dynamicPoint);
+		worldMapRouteOverlay.setTargetPoint(dynamicPoint);
+		worldMapDestinationOverlay.setTarget(dynamicPoint, resolveStepIconType(step));
+		if (activeMapPoint != null)
+		{
+			worldMapPointManager.remove(activeMapPoint);
+		}
+		activeMapPoint = new CollectionLogWorldMapPoint(dynamicPoint,
+			step.resolveDescription(activeTargetItemId), collectionLogIcon);
+		worldMapPointManager.add(activeMapPoint);
+		worldMapDestinationOverlay.setMapPointActive(true);
+		if (shouldSetHintArrowTo(dynamicPoint))
+		{
+			client.setHintArrow(dynamicPoint);
+		}
 	}
 
 	/**

--- a/src/main/java/com/collectionloghelper/guidance/dynamic/DynamicTargetEvaluatorRegistry.java
+++ b/src/main/java/com/collectionloghelper/guidance/dynamic/DynamicTargetEvaluatorRegistry.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.guidance.dynamic;
+
+import com.collectionloghelper.guidance.DynamicTargetEvaluator;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ * Registry mapping evaluator key strings to {@link DynamicTargetEvaluator} instances.
+ *
+ * <p>When a {@link com.collectionloghelper.data.GuidanceStep} has a non-null
+ * {@code dynamicTargetEvaluator} field, {@link com.collectionloghelper.guidance.GuidanceOverlayCoordinator}
+ * calls {@link #get(String)} with that key and invokes the returned evaluator
+ * once per game tick to obtain the current target {@link net.runelite.api.coords.WorldPoint}.
+ *
+ * <p>New evaluators are registered here by name.  Keys are lowercase, using
+ * underscores as separators, and should be unique across the plugin
+ * (e.g. {@code "wintertodt_active_brazier"}, {@code "barbarian_assault_role"}).
+ *
+ * <p>The registry is a singleton; Guice injects it into
+ * {@link com.collectionloghelper.guidance.GuidanceOverlayCoordinator}.
+ */
+@Singleton
+public class DynamicTargetEvaluatorRegistry
+{
+	/** Key for the Wintertodt nearest-active-brazier evaluator. */
+	public static final String WINTERTODT_ACTIVE_BRAZIER = "wintertodt_active_brazier";
+
+	private final Map<String, DynamicTargetEvaluator> registry;
+
+	@Inject
+	public DynamicTargetEvaluatorRegistry()
+	{
+		registry = new HashMap<>();
+		register(WINTERTODT_ACTIVE_BRAZIER, new WintertodtBrazierEvaluator());
+	}
+
+	/**
+	 * Registers an evaluator under the given key.  Replaces any existing
+	 * registration for that key.
+	 *
+	 * @param key       the evaluator key used in guidance step JSON
+	 * @param evaluator the evaluator instance
+	 */
+	public void register(String key, DynamicTargetEvaluator evaluator)
+	{
+		registry.put(key, evaluator);
+	}
+
+	/**
+	 * Returns the evaluator registered under {@code key}, or {@code null} if
+	 * no evaluator has been registered for that key.
+	 *
+	 * @param key the evaluator key from a guidance step's {@code dynamicTargetEvaluator} field
+	 * @return the evaluator, or {@code null}
+	 */
+	@Nullable
+	public DynamicTargetEvaluator get(String key)
+	{
+		if (key == null)
+		{
+			return null;
+		}
+		return registry.get(key);
+	}
+}

--- a/src/main/java/com/collectionloghelper/guidance/dynamic/WintertodtBrazierEvaluator.java
+++ b/src/main/java/com/collectionloghelper/guidance/dynamic/WintertodtBrazierEvaluator.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.guidance.dynamic;
+
+import com.collectionloghelper.data.GuidanceStep;
+import com.collectionloghelper.guidance.DynamicTargetEvaluator;
+import javax.annotation.Nullable;
+import net.runelite.api.Client;
+import net.runelite.api.NPC;
+import net.runelite.api.WorldView;
+import net.runelite.api.coords.WorldPoint;
+
+/**
+ * Dynamic target evaluator for the Wintertodt minigame.
+ *
+ * <p>Returns the world location of the nearest active (lit) brazier NPC each
+ * game tick.  Active braziers are identified by NPC IDs 29312 and 29313
+ * (the lit states observed in the Wintertodt Prison region per the OSRS Wiki
+ * <a href="https://oldschool.runescape.wiki/w/Brazier">Brazier</a> page).
+ * Broken/unlit brazier IDs (29314, 31926) are intentionally excluded so that
+ * the overlay only points players toward braziers they should be tending.
+ *
+ * <p>When no active brazier is visible in the current WorldView, {@code null}
+ * is returned and the coordinator falls back to the step's static coordinates
+ * (if any).
+ *
+ * <p>Registered in {@link DynamicTargetEvaluatorRegistry} under the key
+ * {@code "wintertodt_active_brazier"}.
+ */
+public class WintertodtBrazierEvaluator implements DynamicTargetEvaluator
+{
+	/**
+	 * NPC ID for a lit (active) brazier — standard form.
+	 * Source: https://oldschool.runescape.wiki/w/Brazier
+	 */
+	static final int BRAZIER_LIT_1 = 29312;
+
+	/**
+	 * NPC ID for a lit (active) brazier — alternate/damaged-but-burning form.
+	 * Source: https://oldschool.runescape.wiki/w/Brazier
+	 */
+	static final int BRAZIER_LIT_2 = 29313;
+
+	@Override
+	@Nullable
+	public WorldPoint evaluate(Client client, GuidanceStep step)
+	{
+		WorldView wv = client.getTopLevelWorldView();
+		if (wv == null)
+		{
+			return null;
+		}
+
+		NPC nearest = null;
+		int nearestDist = Integer.MAX_VALUE;
+
+		WorldPoint playerLocation = null;
+		net.runelite.api.Player lp = client.getLocalPlayer();
+		if (lp != null)
+		{
+			playerLocation = lp.getWorldLocation();
+		}
+
+		for (NPC npc : wv.npcs())
+		{
+			if (npc == null)
+			{
+				continue;
+			}
+			int id = npc.getId();
+			if (id != BRAZIER_LIT_1 && id != BRAZIER_LIT_2)
+			{
+				continue;
+			}
+			if (playerLocation != null)
+			{
+				WorldPoint loc = npc.getWorldLocation();
+				if (loc != null)
+				{
+					int dist = playerLocation.distanceTo2D(loc);
+					if (dist < nearestDist)
+					{
+						nearestDist = dist;
+						nearest = npc;
+					}
+				}
+			}
+			else
+			{
+				// No player location — just return the first active brazier found
+				nearest = npc;
+				break;
+			}
+		}
+
+		return nearest != null ? nearest.getWorldLocation() : null;
+	}
+}

--- a/src/test/java/com/collectionloghelper/data/B5RegressionTest.java
+++ b/src/test/java/com/collectionloghelper/data/B5RegressionTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * B5 regression guard — asserts that no entry in the production
+ * {@code drop_rates.json} has a non-null
+ * {@link GuidanceStep#getDynamicTargetEvaluator()} field.
+ *
+ * <p>The {@code dynamicTargetEvaluator} field is reserved for puzzle/dynamic
+ * content authored specifically against a registered evaluator.  Production
+ * sources must not set it until a deliberate B5 data PR introduces Wintertodt
+ * (or other puzzle) steps.  This guard fires if such a field appears in the
+ * data before the corresponding evaluator plumbing is reviewed.
+ *
+ * <p>Pattern mirrors the regression guards used in B3 (nestedAlternatives),
+ * B4.1 (perItemRequiredItemIds), and B4.3.0b (perItemNpcId).
+ */
+public class B5RegressionTest
+{
+	private DropRateDatabase database;
+
+	@Before
+	public void setUp() throws Exception
+	{
+		database = new DropRateDatabase();
+
+		Gson gson = new GsonBuilder().create();
+		Field gsonField = DropRateDatabase.class.getDeclaredField("gson");
+		gsonField.setAccessible(true);
+		gsonField.set(database, gson);
+
+		database.load();
+	}
+
+	@Test
+	public void noProductionStepHasDynamicTargetEvaluatorSet()
+	{
+		List<String> violations = new ArrayList<>();
+
+		for (CollectionLogSource source : database.getAllSources())
+		{
+			if (source.getGuidanceSteps() == null)
+			{
+				continue;
+			}
+			for (int i = 0; i < source.getGuidanceSteps().size(); i++)
+			{
+				GuidanceStep step = source.getGuidanceSteps().get(i);
+				if (step.getDynamicTargetEvaluator() != null)
+				{
+					violations.add(source.getName() + " step " + (i + 1)
+						+ ": dynamicTargetEvaluator=\"" + step.getDynamicTargetEvaluator() + "\"");
+				}
+			}
+		}
+
+		assertTrue(
+			"No production step should carry dynamicTargetEvaluator — this field is reserved "
+				+ "for deliberate B5 puzzle/dynamic data PRs. Violations:\n"
+				+ String.join("\n", violations),
+			violations.isEmpty());
+	}
+}

--- a/src/test/java/com/collectionloghelper/data/GuidanceStepSectionTest.java
+++ b/src/test/java/com/collectionloghelper/data/GuidanceStepSectionTest.java
@@ -151,7 +151,8 @@ public class GuidanceStepSectionTest
 			null, null, null,
 			null,   // conditionalAlternatives
 			section,
-			null  // waypoints
+			null, // waypoints
+			null  // dynamicTargetEvaluator
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/data/GuidanceStepTest.java
+++ b/src/test/java/com/collectionloghelper/data/GuidanceStepTest.java
@@ -330,8 +330,9 @@ public class GuidanceStepTest
 			null,           // dynamicItemObjectTiers
 			null,           // completionZone
 			null,           // conditionalAlternatives
-			null,           // section
-			null            // waypoints
+			null, // section
+			null, // waypoints
+			null  // dynamicTargetEvaluator
 		);
 	}
 
@@ -363,8 +364,9 @@ public class GuidanceStepTest
 			null,           // dynamicItemObjectTiers
 			null,           // completionZone
 			null,           // conditionalAlternatives
-			null,           // section
-			null            // waypoints
+			null, // section
+			null, // waypoints
+			null  // dynamicTargetEvaluator
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/guidance/DynamicTargetEvaluatorDispatchTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/DynamicTargetEvaluatorDispatchTest.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.guidance;
+
+import com.collectionloghelper.CollectionLogHelperConfig;
+import com.collectionloghelper.data.CompletionCondition;
+import com.collectionloghelper.data.GuidanceStep;
+import com.collectionloghelper.data.PlayerInventoryState;
+import com.collectionloghelper.data.PlayerTravelCapabilities;
+import com.collectionloghelper.data.RequirementsChecker;
+import com.collectionloghelper.guidance.dynamic.DynamicTargetEvaluatorRegistry;
+import com.collectionloghelper.overlay.DialogHighlightOverlay;
+import com.collectionloghelper.overlay.GroundItemHighlightOverlay;
+import com.collectionloghelper.overlay.GuidanceMinimapOverlay;
+import com.collectionloghelper.overlay.GuidanceOverlay;
+import com.collectionloghelper.overlay.ItemHighlightOverlay;
+import com.collectionloghelper.overlay.ObjectHighlightOverlay;
+import com.collectionloghelper.overlay.WidgetHighlightOverlay;
+import com.collectionloghelper.overlay.WorldMapDestinationOverlay;
+import com.collectionloghelper.overlay.WorldMapRouteOverlay;
+import java.lang.reflect.Constructor;
+import net.runelite.api.Client;
+import net.runelite.api.Player;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.eventbus.EventBus;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
+import net.runelite.client.ui.overlay.worldmap.WorldMapPointManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests the sequencer-dispatch path for dynamic target evaluators.
+ *
+ * <p>Verifies that {@link GuidanceOverlayCoordinator#tick()} invokes the
+ * registered {@link DynamicTargetEvaluator} when the active guidance step
+ * has a non-null {@code dynamicTargetEvaluator} key, and pushes the returned
+ * {@link WorldPoint} to the overlay.
+ *
+ * <p>Acceptance criteria:
+ * <ul>
+ *   <li>When the active step has a registered evaluator key and the evaluator
+ *       returns a non-null point, {@code guidanceOverlay.setTargetPoint} is
+ *       called with that point.</li>
+ *   <li>When the active step has no {@code dynamicTargetEvaluator} key (null),
+ *       the evaluator is never invoked and {@code setTargetPoint} is not called
+ *       via the tick path.</li>
+ *   <li>When the evaluator key is unknown (not registered), the tick path is a
+ *       no-op for overlay updates.</li>
+ *   <li>When the evaluator returns null, the tick path is a no-op.</li>
+ * </ul>
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class DynamicTargetEvaluatorDispatchTest
+{
+	private static final WorldPoint DYNAMIC_POINT = new WorldPoint(1641, 4000, 0);
+
+	@Mock
+	private Client client;
+	@Mock
+	private ClientThread clientThread;
+	@Mock
+	private EventBus eventBus;
+	@Mock
+	private CollectionLogHelperConfig config;
+	@Mock
+	private GuidanceSequencer guidanceSequencer;
+	@Mock
+	private RequirementsChecker requirementsChecker;
+	@Mock
+	private PlayerTravelCapabilities travelCapabilities;
+	@Mock
+	private PlayerInventoryState playerInventoryState;
+	@Mock
+	private ItemManager itemManager;
+	@Mock
+	private RequiredItemResolver requiredItemResolver;
+	@Mock
+	private WorldMapPointManager worldMapPointManager;
+	@Mock
+	private InfoBoxManager infoBoxManager;
+	@Mock
+	private GuidanceOverlay guidanceOverlay;
+	@Mock
+	private GuidanceMinimapOverlay guidanceMinimapOverlay;
+	@Mock
+	private DialogHighlightOverlay dialogHighlightOverlay;
+	@Mock
+	private ObjectHighlightOverlay objectHighlightOverlay;
+	@Mock
+	private ItemHighlightOverlay itemHighlightOverlay;
+	@Mock
+	private WorldMapRouteOverlay worldMapRouteOverlay;
+	@Mock
+	private WorldMapDestinationOverlay worldMapDestinationOverlay;
+	@Mock
+	private GroundItemHighlightOverlay groundItemHighlightOverlay;
+	@Mock
+	private WidgetHighlightOverlay widgetHighlightOverlay;
+	@Mock
+	private Player localPlayer;
+
+	/** Registry with one stub evaluator that always returns {@link #DYNAMIC_POINT}. */
+	private DynamicTargetEvaluatorRegistry registry;
+	private GuidanceOverlayCoordinator coordinator;
+
+	private static final String STUB_KEY = "test_stub_evaluator";
+
+	@Before
+	public void setUp() throws Exception
+	{
+		registry = new DynamicTargetEvaluatorRegistry();
+		// Register a predictable stub evaluator
+		registry.register(STUB_KEY, (c, step) -> DYNAMIC_POINT);
+
+		Constructor<GuidanceOverlayCoordinator> ctor =
+			GuidanceOverlayCoordinator.class.getDeclaredConstructor(
+				Client.class,
+				ClientThread.class,
+				EventBus.class,
+				CollectionLogHelperConfig.class,
+				GuidanceSequencer.class,
+				DynamicTargetEvaluatorRegistry.class,
+				RequirementsChecker.class,
+				PlayerTravelCapabilities.class,
+				PlayerInventoryState.class,
+				ItemManager.class,
+				RequiredItemResolver.class,
+				WorldMapPointManager.class,
+				InfoBoxManager.class,
+				GuidanceOverlay.class,
+				GuidanceMinimapOverlay.class,
+				DialogHighlightOverlay.class,
+				ObjectHighlightOverlay.class,
+				ItemHighlightOverlay.class,
+				WorldMapRouteOverlay.class,
+				WorldMapDestinationOverlay.class,
+				GroundItemHighlightOverlay.class,
+				WidgetHighlightOverlay.class);
+		ctor.setAccessible(true);
+		coordinator = ctor.newInstance(
+			client, clientThread, eventBus, config,
+			guidanceSequencer, registry, requirementsChecker, travelCapabilities,
+			playerInventoryState, itemManager, requiredItemResolver,
+			worldMapPointManager, infoBoxManager,
+			guidanceOverlay, guidanceMinimapOverlay, dialogHighlightOverlay,
+			objectHighlightOverlay, itemHighlightOverlay,
+			worldMapRouteOverlay, worldMapDestinationOverlay,
+			groundItemHighlightOverlay, widgetHighlightOverlay);
+
+		lenient().when(client.getLocalPlayer()).thenReturn(localPlayer);
+		lenient().when(localPlayer.getWorldLocation()).thenReturn(new WorldPoint(3200, 3200, 0));
+		lenient().when(localPlayer.getWorldView()).thenReturn(null);
+		lenient().when(config.showHintArrow()).thenReturn(false);
+	}
+
+	/**
+	 * When the active step has a registered evaluator key, tick() must call the
+	 * evaluator and push its result to guidanceOverlay.setTargetPoint.
+	 */
+	@Test
+	public void tick_stepWithRegisteredEvaluatorKey_pushesDynamicPointToOverlay()
+	{
+		GuidanceStep step = stepWithEvaluator(STUB_KEY);
+		when(guidanceSequencer.isActive()).thenReturn(true);
+		when(guidanceSequencer.getRawCurrentStep()).thenReturn(step);
+
+		coordinator.tick();
+
+		ArgumentCaptor<WorldPoint> pointCaptor = ArgumentCaptor.forClass(WorldPoint.class);
+		verify(guidanceOverlay, atLeastOnce()).setTargetPoint(pointCaptor.capture());
+		assertEquals(DYNAMIC_POINT, pointCaptor.getValue());
+	}
+
+	/**
+	 * When the active step has no dynamicTargetEvaluator (null key), tick() must
+	 * not call setTargetPoint on the overlay via the dynamic path.
+	 */
+	@Test
+	public void tick_stepWithNullEvaluatorKey_doesNotPushDynamicPoint()
+	{
+		GuidanceStep step = stepWithEvaluator(null);
+		when(guidanceSequencer.isActive()).thenReturn(true);
+		when(guidanceSequencer.getRawCurrentStep()).thenReturn(step);
+
+		coordinator.tick();
+
+		verify(guidanceOverlay, never()).setTargetPoint(any());
+	}
+
+	/**
+	 * When the evaluator key is not registered, tick() is a no-op for overlay
+	 * updates (registry returns null, code path short-circuits).
+	 */
+	@Test
+	public void tick_stepWithUnknownEvaluatorKey_doesNotPushDynamicPoint()
+	{
+		GuidanceStep step = stepWithEvaluator("unknown_evaluator_key");
+		when(guidanceSequencer.isActive()).thenReturn(true);
+		when(guidanceSequencer.getRawCurrentStep()).thenReturn(step);
+
+		coordinator.tick();
+
+		verify(guidanceOverlay, never()).setTargetPoint(any());
+	}
+
+	/**
+	 * When the evaluator returns null, tick() must not push anything to the overlay.
+	 */
+	@Test
+	public void tick_evaluatorReturnsNull_doesNotPushDynamicPoint()
+	{
+		registry.register(STUB_KEY, (c, step) -> null);
+
+		GuidanceStep step = stepWithEvaluator(STUB_KEY);
+		when(guidanceSequencer.isActive()).thenReturn(true);
+		when(guidanceSequencer.getRawCurrentStep()).thenReturn(step);
+
+		coordinator.tick();
+
+		verify(guidanceOverlay, never()).setTargetPoint(any());
+	}
+
+	/**
+	 * When guidance is not active, tick() must not call any evaluator.
+	 */
+	@Test
+	public void tick_guidanceNotActive_doesNotPushDynamicPoint()
+	{
+		when(guidanceSequencer.isActive()).thenReturn(false);
+
+		coordinator.tick();
+
+		verify(guidanceOverlay, never()).setTargetPoint(any());
+	}
+
+	// ── Helper ────────────────────────────────────────────────────────────────
+
+	private static GuidanceStep stepWithEvaluator(String evaluatorKey)
+	{
+		return new GuidanceStep(
+			"Dynamic step",
+			null,  // perItemStepDescription
+			0, 0, 0,
+			0, null, null, null,
+			null, null,
+			null,  // perItemRequiredItemIds
+			null,  // recommendedItemIds
+			CompletionCondition.MANUAL,
+			0, 0, 0, 0,
+			null,  // completionNpcIds
+			null,  // worldMessage
+			0, null, null,
+			null, null,
+			null,
+			0, 0,
+			false,
+			0,     // objectMaxDistance
+			null,  // objectFilterTiles
+			null,  // highlightWidgetIds
+			0, 0,  // loopBackToStep, loopCount
+			null,  // skipIfHasAnyItemIds
+			null,  // dynamicItemObjectTiers
+			null,  // completionZone
+			null,  // conditionalAlternatives
+			null,  // section
+			null,  // waypoints
+			evaluatorKey  // dynamicTargetEvaluator
+		);
+	}
+}

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorDescriptionTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorDescriptionTest.java
@@ -39,6 +39,7 @@ import com.collectionloghelper.overlay.GuidanceOverlay;
 import com.collectionloghelper.overlay.ItemHighlightOverlay;
 import com.collectionloghelper.overlay.ObjectHighlightOverlay;
 import com.collectionloghelper.overlay.WidgetHighlightOverlay;
+import com.collectionloghelper.guidance.dynamic.DynamicTargetEvaluatorRegistry;
 import com.collectionloghelper.overlay.WorldMapDestinationOverlay;
 import com.collectionloghelper.overlay.WorldMapRouteOverlay;
 import com.collectionloghelper.ui.CollectionLogHelperPanel;
@@ -101,6 +102,8 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 	@Mock
 	private GuidanceSequencer guidanceSequencer;
 	@Mock
+	private com.collectionloghelper.guidance.dynamic.DynamicTargetEvaluatorRegistry dynamicTargetEvaluatorRegistry;
+	@Mock
 	private RequirementsChecker requirementsChecker;
 	@Mock
 	private PlayerTravelCapabilities travelCapabilities;
@@ -147,6 +150,7 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 				EventBus.class,
 				CollectionLogHelperConfig.class,
 				GuidanceSequencer.class,
+				DynamicTargetEvaluatorRegistry.class,
 				RequirementsChecker.class,
 				PlayerTravelCapabilities.class,
 				PlayerInventoryState.class,
@@ -166,7 +170,7 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 		ctor.setAccessible(true);
 		coordinator = ctor.newInstance(
 			client, clientThread, eventBus, config,
-			guidanceSequencer, requirementsChecker, travelCapabilities,
+			guidanceSequencer, dynamicTargetEvaluatorRegistry, requirementsChecker, travelCapabilities,
 			playerInventoryState, itemManager, requiredItemResolver,
 			worldMapPointManager, infoBoxManager,
 			guidanceOverlay, guidanceMinimapOverlay, dialogHighlightOverlay,
@@ -275,8 +279,9 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 			null,           // dynamicItemObjectTiers
 			null,           // completionZone
 			null,           // conditionalAlternatives
-			null,           // section
-			null            // waypoints
+			null, // section
+			null, // waypoints
+			null  // dynamicTargetEvaluator
 		);
 	}
 

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorMapPointTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorMapPointTest.java
@@ -38,6 +38,7 @@ import com.collectionloghelper.overlay.GuidanceOverlay;
 import com.collectionloghelper.overlay.ItemHighlightOverlay;
 import com.collectionloghelper.overlay.ObjectHighlightOverlay;
 import com.collectionloghelper.overlay.WidgetHighlightOverlay;
+import com.collectionloghelper.guidance.dynamic.DynamicTargetEvaluatorRegistry;
 import com.collectionloghelper.overlay.WorldMapDestinationOverlay;
 import com.collectionloghelper.overlay.WorldMapRouteOverlay;
 import java.lang.reflect.Constructor;
@@ -89,6 +90,8 @@ public class GuidanceOverlayCoordinatorMapPointTest
 	@Mock
 	private GuidanceSequencer guidanceSequencer;
 	@Mock
+	private com.collectionloghelper.guidance.dynamic.DynamicTargetEvaluatorRegistry dynamicTargetEvaluatorRegistry;
+	@Mock
 	private RequirementsChecker requirementsChecker;
 	@Mock
 	private PlayerTravelCapabilities travelCapabilities;
@@ -133,6 +136,7 @@ public class GuidanceOverlayCoordinatorMapPointTest
 				EventBus.class,
 				CollectionLogHelperConfig.class,
 				GuidanceSequencer.class,
+				DynamicTargetEvaluatorRegistry.class,
 				RequirementsChecker.class,
 				PlayerTravelCapabilities.class,
 				PlayerInventoryState.class,
@@ -152,7 +156,7 @@ public class GuidanceOverlayCoordinatorMapPointTest
 		ctor.setAccessible(true);
 		coordinator = ctor.newInstance(
 			client, clientThread, eventBus, config,
-			guidanceSequencer, requirementsChecker, travelCapabilities,
+			guidanceSequencer, dynamicTargetEvaluatorRegistry, requirementsChecker, travelCapabilities,
 			playerInventoryState, itemManager, requiredItemResolver,
 			worldMapPointManager, infoBoxManager,
 			guidanceOverlay, guidanceMinimapOverlay, dialogHighlightOverlay,

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorNpcIdTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorNpcIdTest.java
@@ -39,6 +39,7 @@ import com.collectionloghelper.overlay.GuidanceOverlay;
 import com.collectionloghelper.overlay.ItemHighlightOverlay;
 import com.collectionloghelper.overlay.ObjectHighlightOverlay;
 import com.collectionloghelper.overlay.WidgetHighlightOverlay;
+import com.collectionloghelper.guidance.dynamic.DynamicTargetEvaluatorRegistry;
 import com.collectionloghelper.overlay.WorldMapDestinationOverlay;
 import com.collectionloghelper.overlay.WorldMapRouteOverlay;
 import java.lang.reflect.Constructor;
@@ -100,6 +101,8 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 	@Mock
 	private GuidanceSequencer guidanceSequencer;
 	@Mock
+	private com.collectionloghelper.guidance.dynamic.DynamicTargetEvaluatorRegistry dynamicTargetEvaluatorRegistry;
+	@Mock
 	private RequirementsChecker requirementsChecker;
 	@Mock
 	private PlayerTravelCapabilities travelCapabilities;
@@ -144,6 +147,7 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 				EventBus.class,
 				CollectionLogHelperConfig.class,
 				GuidanceSequencer.class,
+				DynamicTargetEvaluatorRegistry.class,
 				RequirementsChecker.class,
 				PlayerTravelCapabilities.class,
 				PlayerInventoryState.class,
@@ -163,7 +167,7 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 		ctor.setAccessible(true);
 		coordinator = ctor.newInstance(
 			client, clientThread, eventBus, config,
-			guidanceSequencer, requirementsChecker, travelCapabilities,
+			guidanceSequencer, dynamicTargetEvaluatorRegistry, requirementsChecker, travelCapabilities,
 			playerInventoryState, itemManager, requiredItemResolver,
 			worldMapPointManager, infoBoxManager,
 			guidanceOverlay, guidanceMinimapOverlay, dialogHighlightOverlay,
@@ -282,8 +286,9 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 			null,           // dynamicItemObjectTiers
 			null,           // completionZone
 			null,           // conditionalAlternatives
-			null,           // section
-			null            // waypoints
+			null, // section
+			null, // waypoints
+			null  // dynamicTargetEvaluator
 		);
 	}
 

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerNestedConditionalTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerNestedConditionalTest.java
@@ -487,7 +487,8 @@ public class GuidanceSequencerNestedConditionalTest
 			null,           // completionZone
 			null,           // conditionalAlternatives
 			null, // section
-			null  // waypoints
+			null, // waypoints
+			null  // dynamicTargetEvaluator
 		);
 	}
 
@@ -520,7 +521,8 @@ public class GuidanceSequencerNestedConditionalTest
 			null,  // completionZone
 			alternatives,
 			null, // section
-			null  // waypoints
+			null, // waypoints
+			null  // dynamicTargetEvaluator
 		);
 	}
 

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
@@ -114,8 +114,9 @@ public class GuidanceSequencerTest
 			null,           // dynamicItemObjectTiers
 			null,           // completionZone
 			null,           // conditionalAlternatives
-			null,           // section
-			null            // waypoints
+			null, // section
+			null, // waypoints
+			null  // dynamicTargetEvaluator
 		);
 	}
 
@@ -146,8 +147,9 @@ public class GuidanceSequencerTest
 			null,  // dynamicItemObjectTiers
 			null,  // completionZone
 			null,  // conditionalAlternatives
-			null,  // section
-			null   // waypoints
+			null, // section
+			null, // waypoints
+			null  // dynamicTargetEvaluator
 		);
 	}
 
@@ -178,8 +180,9 @@ public class GuidanceSequencerTest
 			null,  // dynamicItemObjectTiers
 			null,  // completionZone
 			null,  // conditionalAlternatives
-			null,  // section
-			null   // waypoints
+			null, // section
+			null, // waypoints
+			null  // dynamicTargetEvaluator
 		);
 	}
 
@@ -210,8 +213,9 @@ public class GuidanceSequencerTest
 			null,  // dynamicItemObjectTiers
 			null,  // completionZone
 			null,  // conditionalAlternatives
-			null,  // section
-			null   // waypoints
+			null, // section
+			null, // waypoints
+			null  // dynamicTargetEvaluator
 		);
 	}
 
@@ -242,8 +246,9 @@ public class GuidanceSequencerTest
 			null,  // dynamicItemObjectTiers
 			null,  // completionZone
 			null,  // conditionalAlternatives
-			null,  // section
-			null   // waypoints
+			null, // section
+			null, // waypoints
+			null  // dynamicTargetEvaluator
 		);
 	}
 
@@ -274,8 +279,9 @@ public class GuidanceSequencerTest
 			null,  // dynamicItemObjectTiers
 			null,  // completionZone
 			null,  // conditionalAlternatives
-			null,  // section
-			null   // waypoints
+			null, // section
+			null, // waypoints
+			null  // dynamicTargetEvaluator
 		);
 	}
 
@@ -306,8 +312,9 @@ public class GuidanceSequencerTest
 			null,  // dynamicItemObjectTiers
 			null,  // completionZone
 			null,  // conditionalAlternatives
-			null,  // section
-			null   // waypoints
+			null, // section
+			null, // waypoints
+			null  // dynamicTargetEvaluator
 		);
 	}
 
@@ -339,8 +346,9 @@ public class GuidanceSequencerTest
 			null,  // dynamicItemObjectTiers
 			null,  // completionZone
 			null,  // conditionalAlternatives
-			null,  // section
-			null   // waypoints
+			null, // section
+			null, // waypoints
+			null  // dynamicTargetEvaluator
 		);
 	}
 
@@ -371,8 +379,9 @@ public class GuidanceSequencerTest
 			null,  // dynamicItemObjectTiers
 			null,  // completionZone
 			null,  // conditionalAlternatives
-			null,  // section
-			null   // waypoints
+			null, // section
+			null, // waypoints
+			null  // dynamicTargetEvaluator
 		);
 	}
 
@@ -403,8 +412,9 @@ public class GuidanceSequencerTest
 			null,  // dynamicItemObjectTiers
 			null,  // completionZone
 			null,  // conditionalAlternatives
-			null,  // section
-			null   // waypoints
+			null, // section
+			null, // waypoints
+			null  // dynamicTargetEvaluator
 		);
 	}
 
@@ -435,8 +445,9 @@ public class GuidanceSequencerTest
 			null,  // dynamicItemObjectTiers
 			null,  // completionZone
 			null,  // conditionalAlternatives
-			null,  // section
-			null   // waypoints
+			null, // section
+			null, // waypoints
+			null  // dynamicTargetEvaluator
 		);
 	}
 
@@ -807,8 +818,9 @@ public class GuidanceSequencerTest
 			null,  // dynamicItemObjectTiers
 			null,  // completionZone
 			null,  // conditionalAlternatives
-			null,  // section
-			null   // waypoints
+			null, // section
+			null, // waypoints
+			null  // dynamicTargetEvaluator
 		);
 
 		List<GuidanceStep> steps = Arrays.asList(
@@ -1279,8 +1291,9 @@ public class GuidanceSequencerTest
 			null,  // dynamicItemObjectTiers
 			null,  // completionZone
 			alternatives,
-			null,  // section
-			null   // waypoints
+			null, // section
+			null, // waypoints
+			null  // dynamicTargetEvaluator
 		);
 	}
 
@@ -1513,8 +1526,9 @@ public class GuidanceSequencerTest
 			null,  // dynamicItemObjectTiers
 			null,  // completionZone
 			Collections.emptyList(),  // empty list of alternatives
-			null,  // section
-			null   // waypoints
+			null, // section
+			null, // waypoints
+			null  // dynamicTargetEvaluator
 		);
 
 		List<GuidanceStep> steps = Arrays.asList(step);

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerWaypointTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerWaypointTest.java
@@ -125,7 +125,8 @@ public class GuidanceSequencerWaypointTest
 			null, // completionZone
 			null, // conditionalAlternatives
 			null, // section
-			waypoints
+			waypoints,
+			null  // dynamicTargetEvaluator
 		);
 	}
 
@@ -160,7 +161,8 @@ public class GuidanceSequencerWaypointTest
 			null,
 			null,
 			null,
-			null
+			null, // waypoints
+			null  // dynamicTargetEvaluator
 		);
 	}
 
@@ -270,7 +272,8 @@ public class GuidanceSequencerWaypointTest
 			null,
 			null,
 			null,
-			null  // waypoints = null
+			null, // waypoints = null
+			null  // dynamicTargetEvaluator
 		);
 
 		AtomicBoolean stepAdvanced = new AtomicBoolean(false);
@@ -318,7 +321,8 @@ public class GuidanceSequencerWaypointTest
 			null,
 			null,
 			null,
-			Collections.emptyList()  // waypoints = empty list
+			Collections.emptyList(), // waypoints = empty list
+			null  // dynamicTargetEvaluator
 		);
 
 		AtomicBoolean stepAdvanced = new AtomicBoolean(false);

--- a/src/test/java/com/collectionloghelper/guidance/RequiredItemResolverTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/RequiredItemResolverTest.java
@@ -562,8 +562,9 @@ public class RequiredItemResolverTest
 			null,  // dynamicItemObjectTiers
 			null,  // completionZone
 			null,  // conditionalAlternatives
-			null,  // section
-			null   // waypoints
+			null, // section
+			null, // waypoints
+			null  // dynamicTargetEvaluator
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/guidance/dynamic/DynamicTargetEvaluatorRegistryTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/dynamic/DynamicTargetEvaluatorRegistryTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.guidance.dynamic;
+
+import com.collectionloghelper.guidance.DynamicTargetEvaluator;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+/**
+ * Unit tests for {@link DynamicTargetEvaluatorRegistry}.
+ *
+ * <p>Verified:
+ * <ol>
+ *   <li>The registry is populated at construction with the Wintertodt pilot evaluator.</li>
+ *   <li>{@link DynamicTargetEvaluatorRegistry#get(String)} returns the registered evaluator.</li>
+ *   <li>{@link DynamicTargetEvaluatorRegistry#get(String)} returns null for an unknown key.</li>
+ *   <li>{@link DynamicTargetEvaluatorRegistry#get(String)} returns null for a null key.</li>
+ *   <li>{@link DynamicTargetEvaluatorRegistry#register(String, DynamicTargetEvaluator)} replaces an existing entry.</li>
+ * </ol>
+ */
+public class DynamicTargetEvaluatorRegistryTest
+{
+	private DynamicTargetEvaluatorRegistry registry;
+
+	@Before
+	public void setUp()
+	{
+		registry = new DynamicTargetEvaluatorRegistry();
+	}
+
+	@Test
+	public void get_wintertodtKey_returnsEvaluator()
+	{
+		DynamicTargetEvaluator evaluator = registry.get(DynamicTargetEvaluatorRegistry.WINTERTODT_ACTIVE_BRAZIER);
+		assertNotNull("Wintertodt evaluator must be registered at construction", evaluator);
+	}
+
+	@Test
+	public void get_wintertodtKey_returnsWintertodtBrazierEvaluatorInstance()
+	{
+		DynamicTargetEvaluator evaluator = registry.get(DynamicTargetEvaluatorRegistry.WINTERTODT_ACTIVE_BRAZIER);
+		assertNotNull(evaluator);
+		assertEquals("WintertodtBrazierEvaluator",
+			evaluator.getClass().getSimpleName());
+	}
+
+	@Test
+	public void get_unknownKey_returnsNull()
+	{
+		assertNull("Unknown key must return null", registry.get("does_not_exist"));
+	}
+
+	@Test
+	public void get_nullKey_returnsNull()
+	{
+		assertNull("Null key must return null", registry.get(null));
+	}
+
+	@Test
+	public void register_replacesExistingEntry()
+	{
+		DynamicTargetEvaluator replacement = (client, step) -> null;
+		registry.register(DynamicTargetEvaluatorRegistry.WINTERTODT_ACTIVE_BRAZIER, replacement);
+		assertSame("register() must replace the existing evaluator",
+			replacement, registry.get(DynamicTargetEvaluatorRegistry.WINTERTODT_ACTIVE_BRAZIER));
+	}
+
+	@Test
+	public void register_newKey_isRetrievable()
+	{
+		DynamicTargetEvaluator evaluator = (client, step) -> null;
+		registry.register("new_puzzle_evaluator", evaluator);
+		assertSame(evaluator, registry.get("new_puzzle_evaluator"));
+	}
+
+	// ── Helper ────────────────────────────────────────────────────────────────
+
+	private static void assertEquals(String expected, String actual)
+	{
+		org.junit.Assert.assertEquals(expected, actual);
+	}
+}

--- a/src/test/java/com/collectionloghelper/guidance/dynamic/WintertodtBrazierEvaluatorTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/dynamic/WintertodtBrazierEvaluatorTest.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.guidance.dynamic;
+
+import com.collectionloghelper.data.CompletionCondition;
+import com.collectionloghelper.data.GuidanceStep;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import net.runelite.api.Client;
+import net.runelite.api.IndexedObjectSet;
+import net.runelite.api.NPC;
+import net.runelite.api.Player;
+import net.runelite.api.WorldView;
+import net.runelite.api.coords.WorldPoint;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link WintertodtBrazierEvaluator} with a mocked {@link Client}.
+ *
+ * <p>Verified scenarios:
+ * <ol>
+ *   <li>Returns null when the top-level WorldView is null.</li>
+ *   <li>Returns null when no active brazier NPC is in the WorldView.</li>
+ *   <li>Returns null when only broken/unlit braziers are present (ID 29314, 31926).</li>
+ *   <li>Returns the location of a single lit brazier (ID 29312).</li>
+ *   <li>Returns the location of a single lit brazier (ID 29313).</li>
+ *   <li>Returns the nearest lit brazier when multiple are present.</li>
+ *   <li>Falls back to first found brazier when player location is unavailable.</li>
+ * </ol>
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class WintertodtBrazierEvaluatorTest
+{
+	@Mock
+	private Client client;
+	@Mock
+	private WorldView worldView;
+	@Mock
+	private Player localPlayer;
+
+	private WintertodtBrazierEvaluator evaluator;
+	private GuidanceStep dummyStep;
+
+	/** A fixed player position inside the Wintertodt arena. */
+	private static final WorldPoint PLAYER_POS = new WorldPoint(1640, 4000, 0);
+
+	@Before
+	public void setUp()
+	{
+		evaluator = new WintertodtBrazierEvaluator();
+		dummyStep = makeStep();
+
+		when(client.getTopLevelWorldView()).thenReturn(worldView);
+		when(client.getLocalPlayer()).thenReturn(localPlayer);
+		when(localPlayer.getWorldLocation()).thenReturn(PLAYER_POS);
+	}
+
+	// ── Null/empty world view ─────────────────────────────────────────────────
+
+	@Test
+	public void evaluate_nullWorldView_returnsNull()
+	{
+		when(client.getTopLevelWorldView()).thenReturn(null);
+		assertNull(evaluator.evaluate(client, dummyStep));
+	}
+
+	@Test
+	public void evaluate_emptyNpcList_returnsNull()
+	{
+		stubNpcs(Collections.emptyList());
+		assertNull(evaluator.evaluate(client, dummyStep));
+	}
+
+	// ── Wrong NPC IDs ─────────────────────────────────────────────────────────
+
+	@Test
+	public void evaluate_onlyBrokenBrazierPresent_returnsNull()
+	{
+		NPC broken = mockNpc(29314, new WorldPoint(1620, 4000, 0));
+		stubNpcs(Collections.singletonList(broken));
+		assertNull("Broken brazier (29314) must not be returned", evaluator.evaluate(client, dummyStep));
+	}
+
+	@Test
+	public void evaluate_onlyUnlitBrazierVariant_returnsNull()
+	{
+		NPC unlit = mockNpc(31926, new WorldPoint(1620, 4000, 0));
+		stubNpcs(Collections.singletonList(unlit));
+		assertNull("Unlit brazier (31926) must not be returned", evaluator.evaluate(client, dummyStep));
+	}
+
+	// ── Single lit brazier ────────────────────────────────────────────────────
+
+	@Test
+	public void evaluate_singleLitBrazierType1_returnsItsLocation()
+	{
+		WorldPoint expected = new WorldPoint(1621, 3999, 0);
+		NPC lit = mockNpc(WintertodtBrazierEvaluator.BRAZIER_LIT_1, expected);
+		stubNpcs(Collections.singletonList(lit));
+		assertEquals(expected, evaluator.evaluate(client, dummyStep));
+	}
+
+	@Test
+	public void evaluate_singleLitBrazierType2_returnsItsLocation()
+	{
+		WorldPoint expected = new WorldPoint(1655, 4002, 0);
+		NPC lit = mockNpc(WintertodtBrazierEvaluator.BRAZIER_LIT_2, expected);
+		stubNpcs(Collections.singletonList(lit));
+		assertEquals(expected, evaluator.evaluate(client, dummyStep));
+	}
+
+	// ── Multiple lit braziers — nearest wins ──────────────────────────────────
+
+	@Test
+	public void evaluate_multipleLitBraziers_returnsNearest()
+	{
+		// PLAYER_POS = (1640, 4000). Near brazier at (1641, 4000) — distance 1.
+		// Far brazier at (1620, 4000) — distance 20.
+		WorldPoint nearPoint = new WorldPoint(1641, 4000, 0);
+		WorldPoint farPoint  = new WorldPoint(1620, 4000, 0);
+
+		NPC near = mockNpc(WintertodtBrazierEvaluator.BRAZIER_LIT_1, nearPoint);
+		NPC far  = mockNpc(WintertodtBrazierEvaluator.BRAZIER_LIT_2, farPoint);
+
+		stubNpcs(Arrays.asList(far, near));
+		assertEquals("Should return the nearest lit brazier", nearPoint,
+			evaluator.evaluate(client, dummyStep));
+	}
+
+	// ── No player location fallback ───────────────────────────────────────────
+
+	@Test
+	public void evaluate_noPlayerLocation_returnsFirstFoundBrazier()
+	{
+		when(client.getLocalPlayer()).thenReturn(null);
+
+		WorldPoint firstPoint  = new WorldPoint(1621, 3999, 0);
+		WorldPoint secondPoint = new WorldPoint(1655, 4002, 0);
+
+		NPC first  = mockNpc(WintertodtBrazierEvaluator.BRAZIER_LIT_1, firstPoint);
+		NPC second = mockNpc(WintertodtBrazierEvaluator.BRAZIER_LIT_2, secondPoint);
+
+		stubNpcs(Arrays.asList(first, second));
+		assertEquals("Should return the first found brazier when player location unavailable",
+			firstPoint, evaluator.evaluate(client, dummyStep));
+	}
+
+	// ── Helpers ───────────────────────────────────────────────────────────────
+
+	/** Stubs {@code worldView.npcs()} to iterate over {@code npcs}. */
+	@SuppressWarnings("unchecked")
+	private void stubNpcs(List<NPC> npcs)
+	{
+		IndexedObjectSet<NPC> npcSet = mock(IndexedObjectSet.class);
+		Iterator<NPC> iter1 = npcs.iterator();
+		Iterator<NPC> iter2 = npcs.iterator();
+		when(npcSet.iterator()).thenReturn(iter1, iter2);
+		doReturn(npcSet).when(worldView).npcs();
+	}
+
+	private static NPC mockNpc(int id, WorldPoint location)
+	{
+		NPC npc = mock(NPC.class);
+		when(npc.getId()).thenReturn(id);
+		when(npc.getWorldLocation()).thenReturn(location);
+		return npc;
+	}
+
+	private static GuidanceStep makeStep()
+	{
+		return new GuidanceStep(
+			"Light the nearest brazier",
+			null,  // perItemStepDescription
+			0, 0, 0,
+			0, null, null, null,
+			null, null,
+			null,  // perItemRequiredItemIds
+			null,  // recommendedItemIds
+			CompletionCondition.MANUAL,
+			0, 0, 0, 0,
+			null,  // completionNpcIds
+			null,  // worldMessage
+			0, null, null,
+			null, null,
+			null,
+			0, 0,
+			false,
+			0,     // objectMaxDistance
+			null,  // objectFilterTiles
+			null,  // highlightWidgetIds
+			0, 0,  // loopBackToStep, loopCount
+			null,  // skipIfHasAnyItemIds
+			null,  // dynamicItemObjectTiers
+			null,  // completionZone
+			null,  // conditionalAlternatives
+			null,  // section
+			null,  // waypoints
+			DynamicTargetEvaluatorRegistry.WINTERTODT_ACTIVE_BRAZIER  // dynamicTargetEvaluator
+		);
+	}
+}

--- a/src/test/java/com/collectionloghelper/lifecycle/GuidanceEventRouterTest.java
+++ b/src/test/java/com/collectionloghelper/lifecycle/GuidanceEventRouterTest.java
@@ -138,8 +138,9 @@ public class GuidanceEventRouterTest
 			null,  // dynamicItemObjectTiers
 			null,  // completionZone
 			null,  // conditionalAlternatives
-			null,  // section
-			null   // waypoints
+			null, // section
+			null, // waypoints
+			null  // dynamicTargetEvaluator
 		);
 	}
 

--- a/src/test/java/com/collectionloghelper/ui/widget/BankScanIntegrationTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/BankScanIntegrationTest.java
@@ -341,7 +341,8 @@ public class BankScanIntegrationTest
 			null, // completionZone
 			null, // conditionalAlternatives
 			null, // section
-			null  // waypoints
+			null, // waypoints
+			null  // dynamicTargetEvaluator
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/ui/widget/StepProgressViewTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/StepProgressViewTest.java
@@ -941,7 +941,8 @@ public class StepProgressViewTest
 			0, 0,
 			null, null, null, null,
 			section,
-			null  // waypoints
+			null, // waypoints
+			null  // dynamicTargetEvaluator
 		);
 	}
 
@@ -967,8 +968,9 @@ public class StepProgressViewTest
 			0, null, null,
 			0, 0,
 			null, null, null, null,
-			null,
-			null  // waypoints
+			null, // section
+			null, // waypoints
+			null   // dynamicTargetEvaluator
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/ui/widget/StepSectionGrouperTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/StepSectionGrouperTest.java
@@ -74,7 +74,8 @@ public class StepSectionGrouperTest
 			0, 0,
 			null, null, null, null,
 			section,
-			null  // waypoints
+			null, // waypoints
+			null  // dynamicTargetEvaluator
 		);
 	}
 


### PR DESCRIPTION
## Summary

- Adds DynamicTargetEvaluator interface with WorldPoint evaluate(Client, GuidanceStep) — called once per game tick for steps that opt in via the new dynamicTargetEvaluator String field on GuidanceStep.
- Adds DynamicTargetEvaluatorRegistry (singleton, Guice-injected into coordinator) mapping string keys to evaluator instances; pre-registers "wintertodt_active_brazier".
- Adds WintertodtBrazierEvaluator pilot — scans the top-level WorldView each tick for lit brazier NPCs (IDs 29312, 29313) and returns the nearest one WorldPoint. Broken/unlit IDs (29314, 31926) are excluded.
- GuidanceOverlayCoordinator.tick() gains tickDynamicTargetEvaluator(): when the active step has a non-null dynamicTargetEvaluator key, the evaluator is looked up, called, and its result pushed to all location-sensitive overlays (minimap, world map, overlay, hint arrow).

## Test plan

- [ ] B5RegressionTest — no production step in drop_rates.json carries dynamicTargetEvaluator (regression guard)
- [ ] DynamicTargetEvaluatorRegistryTest — registry lookup, null key, unknown key, replace registration
- [ ] WintertodtBrazierEvaluatorTest — null WorldView, empty NPC list, broken/unlit-only braziers return null; lit brazier types 29312/29313 return location; nearest-of-multiple selected; first-found fallback when no player location
- [ ] DynamicTargetEvaluatorDispatchTest — coordinator tick() dispatches to evaluator and pushes point to overlay; null key, unknown key, null return, inactive guidance are all no-ops
- [ ] ./gradlew test build passes (886 tests, 0 failures)