### PR TITLE
feat(guidance): B6 — Java helper pilot with Cerberus (D-01 hybrid)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -563,7 +563,7 @@ Focus: god-object decomposition, build hardening, test expansion. Resulted in th
 - [ ] B4.3.5 — Barracuda Trials per-trial mapping  status: deferred  owner: —  updated: 2026-05-14  note: Flagged in #420 — re-audit after Sailing mechanics stabilize before scoping.
 - [ ] B4.4 — Top Pick auto-drives per-item method choice (North Star UI alignment)  status: planned  owner: —  updated: 2026-05-13
 - [/] B5 — Puzzle/dynamic step type                     status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #473  note: DynamicTargetEvaluator interface + registry + WintertodtBrazierEvaluator pilot. Coordinator tick() dispatches per-tick; regression guard ensures no production step carries the field.
-- [ ] B6 — Decision D-01 pilot (hybrid Java helper)     status: planned       owner: —          updated: 2026-04-16
+- [/] B6 — Decision D-01 pilot (hybrid Java helper)     status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #474  note: GuidanceHelper interface + GuidanceHelperRegistry + CerberusHelper pilot (mirrors JSON steps). guidanceHelperKey field added to CollectionLogSource. Sequencer routes through helper when key is set. Regression test guards against premature production key. Build passes, all tests green.
 
 **Tier B.5 — UI parity with Quest Helper**
 

--- a/src/main/java/com/collectionloghelper/data/CollectionLogSource.java
+++ b/src/main/java/com/collectionloghelper/data/CollectionLogSource.java
@@ -52,6 +52,17 @@ public class CollectionLogSource
 	String interactAction;
 	List<String> dialogOptions;
 	List<GuidanceStep> guidanceSteps;
+
+	/**
+	 * Optional key naming a registered {@link com.collectionloghelper.guidance.helper.GuidanceHelper}
+	 * implementation that supplies steps for this source. When non-null the sequencer
+	 * delegates step generation to the helper instead of {@link #guidanceSteps}.
+	 *
+	 * <p>Null by default — existing JSON without this field deserialises unchanged.
+	 */
+	@Nullable
+	String guidanceHelperKey;
+
 	SourceRequirements requirements;
 	int cumulativeTrackItemId;
 	List<Integer> cumulativeTrackObjectIds;

--- a/src/main/java/com/collectionloghelper/guidance/GuidanceSequencer.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceSequencer.java
@@ -32,6 +32,8 @@ import com.collectionloghelper.data.PlayerInventoryState;
 import com.collectionloghelper.data.RequirementsChecker;
 import com.collectionloghelper.data.StepWaypoint;
 import com.collectionloghelper.data.Zone;
+import com.collectionloghelper.guidance.helper.GuidanceHelper;
+import com.collectionloghelper.guidance.helper.GuidanceHelperRegistry;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -53,6 +55,7 @@ public class GuidanceSequencer
 	private final PlayerInventoryState inventoryState;
 	private final PlayerCollectionState collectionState;
 	private final RequirementsChecker requirementsChecker;
+	private final GuidanceHelperRegistry helperRegistry;
 
 	private volatile WorldPoint lastKnownPlayerLocation;
 	private volatile CollectionLogSource activeSource;
@@ -85,11 +88,12 @@ public class GuidanceSequencer
 
 	@Inject
 	private GuidanceSequencer(PlayerInventoryState inventoryState, PlayerCollectionState collectionState,
-		RequirementsChecker requirementsChecker)
+		RequirementsChecker requirementsChecker, GuidanceHelperRegistry helperRegistry)
 	{
 		this.inventoryState = inventoryState;
 		this.collectionState = collectionState;
 		this.requirementsChecker = requirementsChecker;
+		this.helperRegistry = helperRegistry;
 	}
 
 	/**
@@ -109,7 +113,19 @@ public class GuidanceSequencer
 		Runnable sequenceComplete)
 	{
 		this.activeSource = source;
-		this.steps = source.getGuidanceSteps();
+		// Route through Java helper when the source opts in, else fall back to JSON steps
+		GuidanceHelper helper = helperRegistry != null
+			? helperRegistry.get(source.getGuidanceHelperKey())
+			: null;
+		if (helper != null)
+		{
+			log.debug("Using Java helper '{}' for source {}", source.getGuidanceHelperKey(), source.getName());
+			this.steps = helper.getSteps(null, null);
+		}
+		else
+		{
+			this.steps = source.getGuidanceSteps();
+		}
 		this.currentIndex = 0;
 		this.loopIterationsCompleted = 0;
 		this.cumulativeActionCount = 0;

--- a/src/main/java/com/collectionloghelper/guidance/helper/CerberusHelper.java
+++ b/src/main/java/com/collectionloghelper/guidance/helper/CerberusHelper.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.guidance.helper;
+
+import com.collectionloghelper.data.CompletionCondition;
+import com.collectionloghelper.data.GuidanceStep;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import net.runelite.api.Client;
+import net.runelite.client.callback.ClientThread;
+
+/**
+ * Pilot Java helper for Cerberus (D-01 hybrid, B6).
+ *
+ * <p>This PR mirrors Cerberus's existing JSON guidance steps in Java code to
+ * prove that the helper plumbing works end-to-end. The step data is
+ * intentionally identical to the JSON so that no behaviour changes occur when
+ * the helper key is absent (plumbing-only milestone).
+ *
+ * <p>{@link #isStepSatisfied} always returns {@code false}, delegating all
+ * satisfaction evaluation to the default
+ * {@link com.collectionloghelper.guidance.GuidanceSequencer} logic.
+ */
+@Singleton
+public class CerberusHelper implements GuidanceHelper
+{
+	/** NPC ID for Cerberus (all combat variants). */
+	static final int CERBERUS_NPC_ID = 5862;
+
+	/** Object ID for the Iron Winch gate in the Cerberus arena. */
+	static final int IRON_WINCH_OBJECT_ID = 23104;
+
+	/** Recommended item IDs: Prayer potion (4), Super combat potion (4), Antidote++ (4). */
+	static final List<Integer> RECOMMENDED_ITEMS = Collections.unmodifiableList(
+		Arrays.asList(2434, 3024, 12695));
+
+	@Inject
+	CerberusHelper()
+	{
+	}
+
+	@Override
+	public List<GuidanceStep> getSteps(Client client, ClientThread clientThread)
+	{
+		GuidanceStep travelStep = new GuidanceStep(
+			"Use a Key master teleport or teleport to your house in Taverley",
+			null,              // perItemStepDescription
+			1310, 1251, 0,     // worldX, worldY, worldPlane (dungeon entrance)
+			0, null,           // npcId, perItemNpcId
+			null,              // interactAction
+			null,              // dialogOptions
+			"Key master teleport (fastest), or POH Taverley portal + navigate dungeon",
+			null,              // requiredItemIds
+			null,              // perItemRequiredItemIds
+			null,              // recommendedItemIds
+			null,              // perItemRecommendedItemIds
+			CompletionCondition.ARRIVE_AT_TILE,
+			0, 0, 8, 0,        // completionItemId, completionItemCount, completionDistance, completionNpcId
+			null,              // completionNpcIds
+			null,              // worldMessage
+			0, null, null,     // objectId, objectIds, objectInteractAction
+			null, null,        // highlightItemIds, groundItemIds
+			null,              // completionChatPattern
+			0, 0,              // completionVarbitId, completionVarbitValue
+			false,             // useItemOnObject
+			0,                 // objectMaxDistance
+			null,              // objectFilterTiles
+			null,              // highlightWidgetIds
+			0, 0,              // loopBackToStep, loopCount
+			null,              // skipIfHasAnyItemIds
+			null,              // dynamicItemObjectTiers
+			null,              // completionZone
+			null,              // conditionalAlternatives
+			"Travel",          // section
+			null,              // waypoints
+			null               // dynamicTargetEvaluator
+		);
+
+		GuidanceStep gateStep = new GuidanceStep(
+			"Turn an Iron Winch to open a gate and enter the boss arena."
+				+ " Requires a hellhound Slayer task",
+			null,              // perItemStepDescription
+			1291, 1254, 0,     // worldX, worldY, worldPlane (winch location)
+			0, null,           // npcId, perItemNpcId
+			null,              // interactAction
+			null,              // dialogOptions
+			null,              // travelTip
+			null,              // requiredItemIds
+			null,              // perItemRequiredItemIds
+			null,              // recommendedItemIds
+			null,              // perItemRecommendedItemIds
+			CompletionCondition.MANUAL,
+			0, 0, 0, 0,        // completionItemId, completionItemCount, completionDistance, completionNpcId
+			null,              // completionNpcIds
+			null,              // worldMessage
+			IRON_WINCH_OBJECT_ID, null, "Turn",  // objectId, objectIds, objectInteractAction
+			null, null,        // highlightItemIds, groundItemIds
+			null,              // completionChatPattern
+			0, 0,              // completionVarbitId, completionVarbitValue
+			false,             // useItemOnObject
+			0,                 // objectMaxDistance
+			null,              // objectFilterTiles
+			null,              // highlightWidgetIds
+			0, 0,              // loopBackToStep, loopCount
+			null,              // skipIfHasAnyItemIds
+			null,              // dynamicItemObjectTiers
+			null,              // completionZone
+			null,              // conditionalAlternatives
+			"Travel",          // section
+			null,              // waypoints
+			null               // dynamicTargetEvaluator
+		);
+
+		GuidanceStep killStep = new GuidanceStep(
+			"Kill Cerberus. Protect from Magic, watch for the triple ghost special attack",
+			null,              // perItemStepDescription
+			1240, 1251, 0,     // worldX, worldY, worldPlane (arena centre)
+			CERBERUS_NPC_ID, null,  // npcId, perItemNpcId
+			"Attack",          // interactAction
+			null,              // dialogOptions
+			null,              // travelTip
+			null,              // requiredItemIds
+			null,              // perItemRequiredItemIds
+			RECOMMENDED_ITEMS, // recommendedItemIds
+			null,              // perItemRecommendedItemIds
+			CompletionCondition.ACTOR_DEATH,
+			0, 0, 0, CERBERUS_NPC_ID,  // completionItemId, completionItemCount, completionDistance, completionNpcId
+			null,              // completionNpcIds
+			null,              // worldMessage
+			0, null, null,     // objectId, objectIds, objectInteractAction
+			null, null,        // highlightItemIds, groundItemIds
+			null,              // completionChatPattern
+			0, 0,              // completionVarbitId, completionVarbitValue
+			false,             // useItemOnObject
+			0,                 // objectMaxDistance
+			null,              // objectFilterTiles
+			null,              // highlightWidgetIds
+			0, 0,              // loopBackToStep, loopCount
+			null,              // skipIfHasAnyItemIds
+			null,              // dynamicItemObjectTiers
+			null,              // completionZone
+			null,              // conditionalAlternatives
+			"Combat",          // section
+			null,              // waypoints
+			null               // dynamicTargetEvaluator
+		);
+
+		return Arrays.asList(travelStep, gateStep, killStep);
+	}
+
+	/**
+	 * Always returns {@code false}, delegating satisfaction evaluation to the
+	 * default sequencer logic. This is intentional for the B6 plumbing pilot
+	 * — future iterations may add richer Cerberus-specific checks here.
+	 */
+	@Override
+	public boolean isStepSatisfied(Client client, GuidanceStep step, int stepIndex)
+	{
+		return false;
+	}
+}

--- a/src/main/java/com/collectionloghelper/guidance/helper/GuidanceHelper.java
+++ b/src/main/java/com/collectionloghelper/guidance/helper/GuidanceHelper.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.guidance.helper;
+
+import com.collectionloghelper.data.GuidanceStep;
+import java.util.List;
+import net.runelite.api.Client;
+import net.runelite.client.callback.ClientThread;
+
+/**
+ * Optional escape hatch for sources that cannot be fully expressed in JSON.
+ *
+ * <p>When a {@link com.collectionloghelper.data.CollectionLogSource} has a
+ * non-null {@code guidanceHelperKey}, the {@link GuidanceHelperRegistry}
+ * resolves it to an implementation of this interface. The
+ * {@link com.collectionloghelper.guidance.GuidanceSequencer} then delegates
+ * step generation and satisfaction checks to the helper instead of relying
+ * solely on the source's {@code guidanceSteps} JSON list.
+ *
+ * <p>This is the D-01 hybrid design: JSON stays primary; Java helpers are
+ * the opt-in escape hatch for hard sources (dynamic re-render, arbitrary
+ * varbit predicates, puzzle logic).
+ */
+public interface GuidanceHelper
+{
+	/**
+	 * Returns the ordered list of guidance steps for this source.
+	 *
+	 * <p>Called once when a guidance sequence is started for the source.
+	 * The returned list is used in place of the source's JSON
+	 * {@code guidanceSteps}.
+	 *
+	 * @param client       the RuneLite client (may be null in tests)
+	 * @param clientThread the RuneLite client thread for deferred callbacks
+	 * @return non-null, non-empty list of steps; order is significant
+	 */
+	List<GuidanceStep> getSteps(Client client, ClientThread clientThread);
+
+	/**
+	 * Returns true if the given step is already satisfied given current
+	 * client state, allowing the sequencer to skip it on start-up.
+	 *
+	 * <p>Returning {@code false} means "I don't know" — the sequencer
+	 * falls back to its built-in {@link com.collectionloghelper.data.CompletionCondition}
+	 * evaluation. Implementations that want to override the default
+	 * satisfaction check should return {@code true} when appropriate.
+	 *
+	 * <p>For this pilot PR the implementation always returns {@code false}
+	 * (delegate to the default sequencer evaluation). Future helpers may
+	 * implement richer logic here.
+	 *
+	 * @param client    the RuneLite client
+	 * @param step      the step to evaluate
+	 * @param stepIndex 0-based index of the step in the list returned by
+	 *                  {@link #getSteps}
+	 * @return {@code true} if the step is definitely already satisfied;
+	 *         {@code false} to fall back to default evaluation
+	 */
+	boolean isStepSatisfied(Client client, GuidanceStep step, int stepIndex);
+}

--- a/src/main/java/com/collectionloghelper/guidance/helper/GuidanceHelperRegistry.java
+++ b/src/main/java/com/collectionloghelper/guidance/helper/GuidanceHelperRegistry.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.guidance.helper;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ * Registry that maps {@code guidanceHelperKey} strings to their
+ * {@link GuidanceHelper} implementations.
+ *
+ * <p>The registry is populated at plugin startup. When a
+ * {@link com.collectionloghelper.data.CollectionLogSource} carries a non-null
+ * {@code guidanceHelperKey}, the
+ * {@link com.collectionloghelper.guidance.GuidanceSequencer} calls
+ * {@link #get(String)} to retrieve the helper before starting a sequence.
+ *
+ * <p>Keys are lower-case strings matching the {@code guidanceHelperKey} field
+ * value in {@code drop_rates.json} (e.g. {@code "cerberus"}).
+ */
+@Singleton
+public class GuidanceHelperRegistry
+{
+	private final Map<String, GuidanceHelper> helpers;
+
+	@Inject
+	GuidanceHelperRegistry(CerberusHelper cerberusHelper)
+	{
+		Map<String, GuidanceHelper> map = new HashMap<>();
+		map.put("cerberus", cerberusHelper);
+		this.helpers = Collections.unmodifiableMap(map);
+	}
+
+	/**
+	 * Returns the {@link GuidanceHelper} registered for the given key, or
+	 * {@code null} if no helper is registered for that key.
+	 *
+	 * @param key the {@code guidanceHelperKey} value from the source (may be null)
+	 * @return the registered helper, or {@code null}
+	 */
+	@Nullable
+	public GuidanceHelper get(@Nullable String key)
+	{
+		if (key == null)
+		{
+			return null;
+		}
+		return helpers.get(key);
+	}
+
+	/**
+	 * Returns an unmodifiable view of the full registry map.
+	 * Exposed for testing.
+	 */
+	public Map<String, GuidanceHelper> getAllHelpers()
+	{
+		return helpers;
+	}
+}

--- a/src/test/java/com/collectionloghelper/ActivateGuidanceClientThreadTest.java
+++ b/src/test/java/com/collectionloghelper/ActivateGuidanceClientThreadTest.java
@@ -131,6 +131,7 @@ public class ActivateGuidanceClientThreadTest
 			null,      // interactAction
 			null,      // dialogOptions
 			null,      // guidanceSteps
+			null,      // guidanceHelperKey
 			null,      // requirements
 			0,         // cumulativeTrackItemId
 			null,      // cumulativeTrackObjectIds

--- a/src/test/java/com/collectionloghelper/OnSequenceCompletePerItemTest.java
+++ b/src/test/java/com/collectionloghelper/OnSequenceCompletePerItemTest.java
@@ -169,7 +169,8 @@ public class OnSequenceCompletePerItemTest
 			null, 0, false, 0,
 			null, 0, null, null,
 			null,
-			null, 0, null, 0,
-			Collections.emptyList(), null /* metaAuthoredDate */);
+			null, null, 0, null, 0,
+			Collections.emptyList()
+		, null);
 	}
 }

--- a/src/test/java/com/collectionloghelper/data/CollectionLogSourceTest.java
+++ b/src/test/java/com/collectionloghelper/data/CollectionLogSourceTest.java
@@ -48,8 +48,9 @@ public class CollectionLogSourceTest
 	{
 		return new CollectionLogSource(name, CollectionLogCategory.BOSSES, x, y, plane,
 			60, 0, locationDesc, waypoints,
-			null, 0, null, 0, false, 0, null, 0, null, null, null, null, 0, null, 0,
+			null, 0, null, 0, false, 0, null, 0, null, null, null, null, null, 0, null, 0,
 			Collections.emptyList(), null);
+
 	}
 
 	// ========================================================================

--- a/src/test/java/com/collectionloghelper/efficiency/CrossSourceRankerTest.java
+++ b/src/test/java/com/collectionloghelper/efficiency/CrossSourceRankerTest.java
@@ -119,7 +119,8 @@ public class CrossSourceRankerTest
 	{
 		return new CollectionLogSource(name, CollectionLogCategory.BOSSES, 3000, 3000, 0,
 			killTimeSeconds, 0, name, Collections.emptyList(),
-			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0, items, null /* metaAuthoredDate */);
+			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null,
+			null /* guidanceHelperKey */, null, 0, null, 0, items, null /* metaAuthoredDate */);
 	}
 
 	private CollectionLogItem makeItem(int id, String name, double dropRate)

--- a/src/test/java/com/collectionloghelper/efficiency/EfficiencyCalculatorTest.java
+++ b/src/test/java/com/collectionloghelper/efficiency/EfficiencyCalculatorTest.java
@@ -99,7 +99,7 @@ public class EfficiencyCalculatorTest
 	{
 		return new CollectionLogSource(name, category, 3000, 3000, 0,
 			killTimeSeconds, 0, name, Collections.emptyList(),
-			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0, items, null);
+			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0, items, null);
 	}
 
 	private CollectionLogSource makeShopSource(String name, int killTimeSeconds,
@@ -107,7 +107,7 @@ public class EfficiencyCalculatorTest
 	{
 		return new CollectionLogSource(name, CollectionLogCategory.OTHER, 3000, 3000, 0,
 			killTimeSeconds, 0, name, Collections.emptyList(),
-			RewardType.SHOP, pointsPerHour, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0, items, null);
+			RewardType.SHOP, pointsPerHour, null, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0, items, null);
 	}
 
 	private CollectionLogSource makeMilestoneSource(String name, int killTimeSeconds,
@@ -115,7 +115,7 @@ public class EfficiencyCalculatorTest
 	{
 		return new CollectionLogSource(name, CollectionLogCategory.OTHER, 3000, 3000, 0,
 			killTimeSeconds, 0, name, Collections.emptyList(),
-			RewardType.MILESTONE, 0, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0, items, null);
+			RewardType.MILESTONE, 0, null, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0, items, null);
 	}
 
 	private CollectionLogSource makeMixedSource(String name, int killTimeSeconds,
@@ -123,7 +123,7 @@ public class EfficiencyCalculatorTest
 	{
 		return new CollectionLogSource(name, CollectionLogCategory.OTHER, 3000, 3000, 0,
 			killTimeSeconds, 0, name, Collections.emptyList(),
-			RewardType.MIXED, pointsPerHour, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0, items, null);
+			RewardType.MIXED, pointsPerHour, null, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0, items, null);
 	}
 
 	private CollectionLogSource makeAggregatedSource(String name, int killTimeSeconds,
@@ -131,7 +131,7 @@ public class EfficiencyCalculatorTest
 	{
 		return new CollectionLogSource(name, CollectionLogCategory.OTHER, 3000, 3000, 0,
 			killTimeSeconds, 0, name, Collections.emptyList(),
-			RewardType.DROP, 0, null, 1, true, 0, null, 0, null, null, null, null, 0, null, 0, items, null);
+			RewardType.DROP, 0, null, 1, true, 0, null, 0, null, null, null, null, null, 0, null, 0, items, null);
 	}
 
 	private CollectionLogItem makeItem(int id, String name, double dropRate)
@@ -164,7 +164,7 @@ public class EfficiencyCalculatorTest
 	{
 		return new CollectionLogSource(name, category, 3000, 3000, 0,
 			killTimeSeconds, 0, name, Collections.emptyList(),
-			RewardType.DROP, 0, variants, 1, false, 0, null, 0, null, null, null, null, 0, null, 0, items, null);
+			RewardType.DROP, 0, variants, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0, items, null);
 	}
 
 	// --- Per-item scoring: score = best individual item's score ---
@@ -389,7 +389,7 @@ public class EfficiencyCalculatorTest
 		List<CollectionLogItem> items = Collections.singletonList(makeItem(1, "Drop", 1.0 / 512));
 		CollectionLogSource source = new CollectionLogSource("Test", CollectionLogCategory.BOSSES,
 			3000, 3000, 0, 120, 0, "Test", Collections.emptyList(),
-			RewardType.DROP, 0, null, 2, false, 0, null, 0, null, null, null, null, 0, null, 0, items, null);
+			RewardType.DROP, 0, null, 2, false, 0, null, 0, null, null, null, null, null, 0, null, 0, items, null);
 		when(collectionState.isItemObtained(anyInt())).thenReturn(false);
 
 		ScoredItem result = calculator.scoreSource(source, false);
@@ -543,7 +543,7 @@ public class EfficiencyCalculatorTest
 		CollectionLogSource source = new CollectionLogSource("Easy Treasure Trails",
 			CollectionLogCategory.CLUES, 3000, 3000, 0, 600, 0,
 			"Easy Treasure Trails", Collections.emptyList(),
-			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0,
+			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0,
 			Collections.singletonList(makeItem(1, "Drop", 0.01)), null);
 		when(clueEstimator.estimateCompletionSeconds("Easy Treasure Trails")).thenReturn(900);
 
@@ -557,7 +557,7 @@ public class EfficiencyCalculatorTest
 		CollectionLogSource source = new CollectionLogSource("Easy Treasure Trails",
 			CollectionLogCategory.CLUES, 3000, 3000, 0, 600, 0,
 			"Easy Treasure Trails", Collections.emptyList(),
-			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0,
+			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0,
 			Collections.singletonList(makeItem(1, "Drop", 0.01)), null);
 		when(clueEstimator.estimateCompletionSeconds("Easy Treasure Trails")).thenReturn(0);
 
@@ -649,7 +649,7 @@ public class EfficiencyCalculatorTest
 		// Source with afkLevel 0 should be excluded when filter is AFK+ (minLevel=2)
 		CollectionLogSource source = new CollectionLogSource("Test Boss", CollectionLogCategory.BOSSES,
 			3000, 3000, 0, 60, 0, "Test Boss", Collections.emptyList(),
-			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0,
+			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0,
 			Collections.singletonList(makeItem(1, "Drop", 0.01)), null);
 		lenient().when(collectionState.isItemObtained(1)).thenReturn(false);
 		when(database.getAllSources()).thenReturn(Collections.singletonList(source));
@@ -665,7 +665,7 @@ public class EfficiencyCalculatorTest
 		// Source with afkLevel 2 should be included when filter is AFK+ (minLevel=2)
 		CollectionLogSource source = new CollectionLogSource("AFK Source", CollectionLogCategory.BOSSES,
 			3000, 3000, 0, 60, 0, "AFK Source", Collections.emptyList(),
-			RewardType.DROP, 0, null, 1, false, 2, null, 0, null, null, null, null, 0, null, 0,
+			RewardType.DROP, 0, null, 1, false, 2, null, 0, null, null, null, null, null, 0, null, 0,
 			Collections.singletonList(makeItem(1, "Drop", 0.01)), null);
 		when(collectionState.isItemObtained(1)).thenReturn(false);
 		when(database.getAllSources()).thenReturn(Collections.singletonList(source));
@@ -681,7 +681,7 @@ public class EfficiencyCalculatorTest
 		// When filter is OFF, all sources show regardless of afkLevel
 		CollectionLogSource source = new CollectionLogSource("Test Boss", CollectionLogCategory.BOSSES,
 			3000, 3000, 0, 60, 0, "Test Boss", Collections.emptyList(),
-			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0,
+			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0,
 			Collections.singletonList(makeItem(1, "Drop", 0.01)), null);
 		when(collectionState.isItemObtained(1)).thenReturn(false);
 		when(database.getAllSources()).thenReturn(Collections.singletonList(source));
@@ -700,7 +700,7 @@ public class EfficiencyCalculatorTest
 		// effective kill time should be 20/0.05 = 400s
 		CollectionLogSource source = new CollectionLogSource("Abyssal Demon", CollectionLogCategory.OTHER,
 			3000, 3000, 0, 20, 0, "Abyssal Demon", Collections.emptyList(),
-			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0,
+			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0,
 			Collections.singletonList(makeItem(1, "Whip", 0.001953)), null);
 		when(slayerMasterDatabase.getMasterNames()).thenReturn(Collections.singletonList("Duradel"));
 		when(slayerMasterDatabase.getTaskProbability("Duradel", "abyssal demons")).thenReturn(0.05);
@@ -715,7 +715,7 @@ public class EfficiencyCalculatorTest
 		// If currently on abyssal demon task, no overhead applied
 		CollectionLogSource source = new CollectionLogSource("Abyssal Demon", CollectionLogCategory.OTHER,
 			3000, 3000, 0, 20, 0, "Abyssal Demon", Collections.emptyList(),
-			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0,
+			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0,
 			Collections.singletonList(makeItem(1, "Whip", 0.001953)), null);
 		when(slayerTaskState.isTaskActive()).thenReturn(true);
 		when(slayerTaskState.getCreatureName()).thenReturn("Abyssal demons");
@@ -730,7 +730,7 @@ public class EfficiencyCalculatorTest
 		// "Abyssal Sire" is NOT task-only (it's a boss), so no overhead
 		CollectionLogSource source = new CollectionLogSource("Abyssal Sire", CollectionLogCategory.BOSSES,
 			3000, 3000, 0, 180, 0, "Abyssal Sire", Collections.emptyList(),
-			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0,
+			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0,
 			Collections.singletonList(makeItem(1, "Unsired", 0.0078)), null);
 
 		int effectiveTime = calculator.getEffectiveKillTime(source);
@@ -743,7 +743,7 @@ public class EfficiencyCalculatorTest
 		// Two masters: Duradel P=0.06, Nieve P=0.04 — should use Duradel (higher P = lower overhead)
 		CollectionLogSource source = new CollectionLogSource("Abyssal Demon", CollectionLogCategory.OTHER,
 			3000, 3000, 0, 12, 0, "Abyssal Demon", Collections.emptyList(),
-			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0,
+			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0,
 			Collections.singletonList(makeItem(1, "Whip", 0.001953)), null);
 		when(slayerMasterDatabase.getMasterNames()).thenReturn(Arrays.asList("Duradel", "Nieve"));
 		when(slayerMasterDatabase.getTaskProbability("Duradel", "abyssal demons")).thenReturn(0.06);
@@ -947,7 +947,7 @@ public class EfficiencyCalculatorTest
 		// Source with ironKillTimeSeconds=120, base=60. Iron should use 120.
 		CollectionLogSource source = new CollectionLogSource("Test Boss", CollectionLogCategory.BOSSES,
 			3000, 3000, 0, 60, 120, "Test Boss", Collections.emptyList(),
-			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0,
+			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0,
 			Collections.singletonList(makeItem(1, "Drop", 0.01)), null);
 		when(config.accountType()).thenReturn(AccountType.IRONMAN);
 
@@ -961,7 +961,7 @@ public class EfficiencyCalculatorTest
 		// Source with ironKillTimeSeconds=0 — iron should fall back to base killTime
 		CollectionLogSource source = new CollectionLogSource("Test Boss", CollectionLogCategory.BOSSES,
 			3000, 3000, 0, 60, 0, "Test Boss", Collections.emptyList(),
-			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0,
+			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0,
 			Collections.singletonList(makeItem(1, "Drop", 0.01)), null);
 		when(config.accountType()).thenReturn(AccountType.IRONMAN);
 
@@ -975,7 +975,7 @@ public class EfficiencyCalculatorTest
 		// Main account should use base killTime even if ironKillTimeSeconds is set
 		CollectionLogSource source = new CollectionLogSource("Test Boss", CollectionLogCategory.BOSSES,
 			3000, 3000, 0, 60, 120, "Test Boss", Collections.emptyList(),
-			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0,
+			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0,
 			Collections.singletonList(makeItem(1, "Drop", 0.01)), null);
 		when(config.accountType()).thenReturn(AccountType.MAIN);
 
@@ -1196,7 +1196,7 @@ public class EfficiencyCalculatorTest
 		// Raid source with ironKillTimeSeconds — should apply both iron time AND raid multiplier
 		CollectionLogSource source = new CollectionLogSource("Test Raid", CollectionLogCategory.RAIDS,
 			3000, 3000, 0, 1800, 2400, "Test Raid", Collections.emptyList(),
-			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0,
+			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0,
 			Collections.singletonList(makeItem(1, "Unique", 0.01)), null);
 		when(config.accountType()).thenReturn(AccountType.IRONMAN);
 		when(config.raidTeamSize()).thenReturn(RaidTeamSize.SOLO);

--- a/src/test/java/com/collectionloghelper/efficiency/SlayerStrategyCalculatorTest.java
+++ b/src/test/java/com/collectionloghelper/efficiency/SlayerStrategyCalculatorTest.java
@@ -76,7 +76,7 @@ public class SlayerStrategyCalculatorTest
 	{
 		return new CollectionLogSource(name, CollectionLogCategory.OTHER, 3000, 3000, 0,
 			60, 0, name, Collections.emptyList(),
-			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, 0, null, 0, items, null);
+			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0, items, null);
 	}
 
 	private CollectionLogItem makeItem(int id, String name)

--- a/src/test/java/com/collectionloghelper/guidance/DynamicTargetEvaluatorDispatchTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/DynamicTargetEvaluatorDispatchTest.java
@@ -280,7 +280,8 @@ public class DynamicTargetEvaluatorDispatchTest
 			0, null, null, null,
 			null, null,
 			null,  // perItemRequiredItemIds
-			null,  // recommendedItemIds
+			null,
+			null /* perItemRecommendedItemIds */,  // recommendedItemIds
 			CompletionCondition.MANUAL,
 			0, 0, 0, 0,
 			null,  // completionNpcIds

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorDescriptionTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorDescriptionTest.java
@@ -297,7 +297,7 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 			null, 0, false, 0,
 			null, 0, null, null,
 			Arrays.asList(steps),
-			null, 0, null, 0,
+			null, null, 0, null, 0,
 			Collections.emptyList()
 		, null);
 	}

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorMapPointTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorMapPointTest.java
@@ -266,6 +266,7 @@ public class GuidanceOverlayCoordinatorMapPointTest
 			null,  // interactAction
 			null,  // dialogOptions
 			null,  // guidanceSteps — no multi-step
+			null,  // guidanceHelperKey
 			null,  // requirements
 			0,     // cumulativeTrackItemId
 			null,  // cumulativeTrackObjectIds
@@ -296,6 +297,7 @@ public class GuidanceOverlayCoordinatorMapPointTest
 			null,
 			null,
 			Collections.emptyList(),  // empty guidanceSteps — skips multi-step branch
+			null,  // guidanceHelperKey
 			null,
 			0,
 			null,

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorNpcIdTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorNpcIdTest.java
@@ -304,6 +304,7 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 			null, 0, false, 0,
 			null, 0, null, null,
 			Arrays.asList(steps),
+			null,
 			null, 0, null, 0,
 			Collections.emptyList()
 		, null);

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerNestedConditionalTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerNestedConditionalTest.java
@@ -86,9 +86,10 @@ public class GuidanceSequencerNestedConditionalTest
 		lenient().when(collectionState.isItemObtained(anyInt())).thenReturn(false);
 
 		Constructor<GuidanceSequencer> ctor = GuidanceSequencer.class.getDeclaredConstructor(
-			PlayerInventoryState.class, PlayerCollectionState.class, RequirementsChecker.class);
+			PlayerInventoryState.class, PlayerCollectionState.class, RequirementsChecker.class,
+				com.collectionloghelper.guidance.helper.GuidanceHelperRegistry.class);
 		ctor.setAccessible(true);
-		sequencer = ctor.newInstance(inventoryState, collectionState, requirementsChecker);
+		sequencer = ctor.newInstance(inventoryState, collectionState, requirementsChecker, null);
 	}
 
 	// ── 1. Flat conditional — identical to legacy ─────────────────────────────
@@ -534,9 +535,7 @@ public class GuidanceSequencerNestedConditionalTest
 			"Test Source", CollectionLogCategory.BOSSES, 3000, 3000, 0,
 			60, 0, "Test Source", Collections.emptyList(),
 			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null,
-			steps, null, 0, null, 0, Collections.emptyList(),
-			null /* metaAuthoredDate */
-		);
+			steps, null, null, 0, null, 0, Collections.emptyList(), null);
 		sequencer.startSequence(source, step -> {}, () -> {});
 	}
 }

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
@@ -80,9 +80,10 @@ public class GuidanceSequencerTest
 		lenient().when(collectionState.isItemObtained(anyInt())).thenReturn(false);
 
 		Constructor<GuidanceSequencer> ctor = GuidanceSequencer.class.getDeclaredConstructor(
-			PlayerInventoryState.class, PlayerCollectionState.class, RequirementsChecker.class);
+			PlayerInventoryState.class, PlayerCollectionState.class, RequirementsChecker.class,
+				com.collectionloghelper.guidance.helper.GuidanceHelperRegistry.class);
 		ctor.setAccessible(true);
-		sequencer = ctor.newInstance(inventoryState, collectionState, requirementsChecker);
+		sequencer = ctor.newInstance(inventoryState, collectionState, requirementsChecker, null);
 	}
 
 	// ---- Helper methods ----
@@ -472,7 +473,7 @@ public class GuidanceSequencerTest
 		return new CollectionLogSource(name, CollectionLogCategory.BOSSES, 3000, 3000, 0,
 			60, 0, name, Collections.emptyList(),
 			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null,
-			steps, null, 0, null, cumulativeTrackThreshold, Collections.emptyList(), null);
+			steps, null, null, 0, null, cumulativeTrackThreshold, Collections.emptyList(), null);
 	}
 
 	private void startSequence(List<GuidanceStep> steps)

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerWaypointTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerWaypointTest.java
@@ -86,9 +86,12 @@ public class GuidanceSequencerWaypointTest
 		lenient().when(collectionState.isItemObtained(anyInt())).thenReturn(false);
 
 		Constructor<GuidanceSequencer> ctor = GuidanceSequencer.class.getDeclaredConstructor(
-			PlayerInventoryState.class, PlayerCollectionState.class, RequirementsChecker.class);
+			PlayerInventoryState.class, PlayerCollectionState.class, RequirementsChecker.class,
+			com.collectionloghelper.guidance.helper.GuidanceHelperRegistry.class);
 		ctor.setAccessible(true);
-		sequencer = ctor.newInstance(inventoryState, collectionState, requirementsChecker);
+		com.collectionloghelper.guidance.helper.GuidanceHelperRegistry helperRegistry =
+			org.mockito.Mockito.mock(com.collectionloghelper.guidance.helper.GuidanceHelperRegistry.class);
+		sequencer = ctor.newInstance(inventoryState, collectionState, requirementsChecker, helperRegistry);
 	}
 
 	// ── Helpers ───────────────────────────────────────────────────────────────
@@ -173,7 +176,8 @@ public class GuidanceSequencerWaypointTest
 		return new CollectionLogSource("Waypoint Test Source", CollectionLogCategory.BOSSES, 3200, 3400, 0,
 			60, 0, "Test Source", Collections.emptyList(),
 			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null,
-			Arrays.asList(steps), null, 0, null, 0, Collections.emptyList(), null /* metaAuthoredDate */);
+			Arrays.asList(steps),
+			null /* guidanceHelperKey */, null, 0, null, 0, Collections.emptyList(), null /* metaAuthoredDate */);
 	}
 
 	// ── Test cases ────────────────────────────────────────────────────────────

--- a/src/test/java/com/collectionloghelper/guidance/RequiredItemResolverTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/RequiredItemResolverTest.java
@@ -690,7 +690,8 @@ public class RequiredItemResolverTest
 			null,  // completionZone
 			null,  // conditionalAlternatives
 			null,  // section
-			null   // waypoints
+			null,  // waypoints
+			null   // dynamicTargetEvaluator
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/guidance/dynamic/WintertodtBrazierEvaluatorTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/dynamic/WintertodtBrazierEvaluatorTest.java
@@ -209,7 +209,8 @@ public class WintertodtBrazierEvaluatorTest
 			0, null, null, null,
 			null, null,
 			null,  // perItemRequiredItemIds
-			null,  // recommendedItemIds
+			null,
+			null /* perItemRecommendedItemIds */,  // recommendedItemIds
 			CompletionCondition.MANUAL,
 			0, 0, 0, 0,
 			null,  // completionNpcIds

--- a/src/test/java/com/collectionloghelper/guidance/helper/CerberusHelperTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/helper/CerberusHelperTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.guidance.helper;
+
+import com.collectionloghelper.data.CompletionCondition;
+import com.collectionloghelper.data.GuidanceStep;
+import java.lang.reflect.Constructor;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class CerberusHelperTest
+{
+	private CerberusHelper helper;
+
+	@Before
+	public void setUp() throws Exception
+	{
+		Constructor<CerberusHelper> ctor = CerberusHelper.class.getDeclaredConstructor();
+		ctor.setAccessible(true);
+		helper = ctor.newInstance();
+	}
+
+	@Test
+	public void getSteps_returnsThreeSteps()
+	{
+		List<GuidanceStep> steps = helper.getSteps(null, null);
+		assertEquals("Cerberus helper must produce exactly 3 steps", 3, steps.size());
+	}
+
+	@Test
+	public void getSteps_firstStep_isTravelToTaverley()
+	{
+		List<GuidanceStep> steps = helper.getSteps(null, null);
+		GuidanceStep travelStep = steps.get(0);
+		assertEquals(CompletionCondition.ARRIVE_AT_TILE, travelStep.getCompletionCondition());
+		assertEquals("Travel", travelStep.getSection());
+		assertEquals(1310, travelStep.getWorldX());
+		assertEquals(1251, travelStep.getWorldY());
+		assertEquals(0, travelStep.getWorldPlane());
+		assertEquals(8, travelStep.getCompletionDistance());
+	}
+
+	@Test
+	public void getSteps_secondStep_isGateStep()
+	{
+		List<GuidanceStep> steps = helper.getSteps(null, null);
+		GuidanceStep gateStep = steps.get(1);
+		assertEquals(CompletionCondition.MANUAL, gateStep.getCompletionCondition());
+		assertEquals(CerberusHelper.IRON_WINCH_OBJECT_ID, gateStep.getObjectId());
+		assertEquals("Turn", gateStep.getObjectInteractAction());
+		assertEquals("Travel", gateStep.getSection());
+	}
+
+	@Test
+	public void getSteps_thirdStep_isKillCerberus()
+	{
+		List<GuidanceStep> steps = helper.getSteps(null, null);
+		GuidanceStep killStep = steps.get(2);
+		assertEquals(CompletionCondition.ACTOR_DEATH, killStep.getCompletionCondition());
+		assertEquals(CerberusHelper.CERBERUS_NPC_ID, killStep.getNpcId());
+		assertEquals(CerberusHelper.CERBERUS_NPC_ID, killStep.getCompletionNpcId());
+		assertEquals("Attack", killStep.getInteractAction());
+		assertEquals("Combat", killStep.getSection());
+		assertNotNull("Kill step must have recommended items", killStep.getRecommendedItemIds());
+		assertFalse("Recommended items must not be empty", killStep.getRecommendedItemIds().isEmpty());
+	}
+
+	@Test
+	public void isStepSatisfied_alwaysReturnsFalse()
+	{
+		List<GuidanceStep> steps = helper.getSteps(null, null);
+		for (int i = 0; i < steps.size(); i++)
+		{
+			assertFalse(
+				"isStepSatisfied must always return false for step " + i,
+				helper.isStepSatisfied(null, steps.get(i), i));
+		}
+	}
+}

--- a/src/test/java/com/collectionloghelper/guidance/helper/GuidanceHelperDispatchTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/helper/GuidanceHelperDispatchTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.guidance.helper;
+
+import com.collectionloghelper.data.CollectionLogCategory;
+import com.collectionloghelper.data.CollectionLogItem;
+import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.data.CompletionCondition;
+import com.collectionloghelper.data.GuidanceStep;
+import com.collectionloghelper.data.PlayerCollectionState;
+import com.collectionloghelper.data.PlayerInventoryState;
+import com.collectionloghelper.data.RequirementsChecker;
+import com.collectionloghelper.data.RewardType;
+import com.collectionloghelper.guidance.GuidanceSequencer;
+import java.lang.reflect.Constructor;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.lenient;
+
+/**
+ * Verifies that GuidanceSequencer correctly dispatches to a GuidanceHelper when
+ * the source has a non-null guidanceHelperKey, and falls back to JSON steps when
+ * it does not.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class GuidanceHelperDispatchTest
+{
+	@Mock
+	private PlayerInventoryState inventoryState;
+	@Mock
+	private PlayerCollectionState collectionState;
+	@Mock
+	private RequirementsChecker requirementsChecker;
+
+	private GuidanceHelperRegistry registry;
+	private GuidanceSequencer sequencer;
+
+	@Before
+	public void setUp() throws Exception
+	{
+		lenient().when(inventoryState.hasItem(anyInt())).thenReturn(false);
+		lenient().when(inventoryState.hasItemCount(anyInt(), anyInt())).thenReturn(false);
+		lenient().when(inventoryState.hasAllItems(anyList())).thenReturn(true);
+		lenient().when(collectionState.isItemObtained(anyInt())).thenReturn(false);
+
+		Constructor<CerberusHelper> cerberusCtor = CerberusHelper.class.getDeclaredConstructor();
+		cerberusCtor.setAccessible(true);
+		CerberusHelper cerberusHelper = cerberusCtor.newInstance();
+
+		Constructor<GuidanceHelperRegistry> regCtor =
+			GuidanceHelperRegistry.class.getDeclaredConstructor(CerberusHelper.class);
+		regCtor.setAccessible(true);
+		registry = regCtor.newInstance(cerberusHelper);
+
+		Constructor<GuidanceSequencer> seqCtor = GuidanceSequencer.class.getDeclaredConstructor(
+			PlayerInventoryState.class, PlayerCollectionState.class, RequirementsChecker.class,
+			GuidanceHelperRegistry.class);
+		seqCtor.setAccessible(true);
+		sequencer = seqCtor.newInstance(inventoryState, collectionState, requirementsChecker, registry);
+	}
+
+	private static GuidanceStep makeManualStep(String description)
+	{
+		return new GuidanceStep(
+			description,
+			null, 0, 0, 0, 0, null, null, null, null, null, null, null,
+			null /* perItemRecommendedItemIds */,
+			CompletionCondition.MANUAL,
+			0, 0, 0, 0, null, null,
+			0, null, null, null, null, null,
+			0, 0, false, 0, null, null, 0, 0, null, null, null, null, null,
+			null /* waypoints */, null /* dynamicTargetEvaluator */
+		);
+	}
+
+	private static CollectionLogSource makeSource(String name, String helperKey, List<GuidanceStep> jsonSteps)
+	{
+		List<CollectionLogItem> items = Collections.singletonList(
+			new CollectionLogItem(1, "Test Item", 0.001, false, null, 0, 0, false, false));
+		return new CollectionLogSource(
+			name, CollectionLogCategory.BOSSES,
+			0, 0, 0, 60, 67, null,
+			Collections.emptyList(),
+			RewardType.DROP, 0, null, 1, false, 0,
+			null, 5862, "Attack", null,
+			jsonSteps,
+			helperKey,
+			null, 0, null, 0, items, null /* metaAuthoredDate */
+		);
+	}
+
+	@Test
+	public void startSequence_withCerberusHelperKey_usesHelperSteps()
+	{
+		GuidanceStep jsonOnlyStep = makeManualStep("JSON-only step");
+		CollectionLogSource source = makeSource("Cerberus", "cerberus",
+			Collections.singletonList(jsonOnlyStep));
+
+		AtomicReference<GuidanceStep> firstStep = new AtomicReference<>();
+		sequencer.startSequence(source, firstStep::set, () -> {});
+
+		assertTrue("Sequencer must be active", sequencer.isActive());
+		GuidanceStep current = sequencer.getCurrentStep();
+		assertNotNull("Current step must not be null", current);
+		assertEquals(CompletionCondition.ARRIVE_AT_TILE, current.getCompletionCondition());
+		assertEquals("Travel", current.getSection());
+		assertEquals("Sequencer must use 3 steps from CerberusHelper",
+			3, sequencer.getTotalSteps());
+		assertFalse("JSON-only step must not appear when helper is used",
+			"JSON-only step".equals(current.getDescription()));
+	}
+
+	@Test
+	public void startSequence_withNullHelperKey_usesJsonSteps()
+	{
+		GuidanceStep jsonStep = makeManualStep("My JSON step");
+		CollectionLogSource source = makeSource("Test Source", null,
+			Collections.singletonList(jsonStep));
+
+		sequencer.startSequence(source, s -> {}, () -> {});
+
+		assertTrue("Sequencer must be active", sequencer.isActive());
+		GuidanceStep current = sequencer.getCurrentStep();
+		assertNotNull(current);
+		assertEquals("JSON step description must be used when no helper key",
+			"My JSON step", current.getDescription());
+		assertEquals("Only 1 JSON step", 1, sequencer.getTotalSteps());
+	}
+
+	@Test
+	public void startSequence_withUnknownHelperKey_fallsBackToJsonSteps()
+	{
+		GuidanceStep jsonStep = makeManualStep("Fallback JSON step");
+		CollectionLogSource source = makeSource("Unknown", "no_such_helper",
+			Collections.singletonList(jsonStep));
+
+		sequencer.startSequence(source, s -> {}, () -> {});
+
+		assertTrue("Sequencer must be active", sequencer.isActive());
+		GuidanceStep current = sequencer.getCurrentStep();
+		assertNotNull(current);
+		assertEquals("Unknown helper key must fall back to JSON step",
+			"Fallback JSON step", current.getDescription());
+	}
+}

--- a/src/test/java/com/collectionloghelper/guidance/helper/GuidanceHelperKeyRegressionTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/helper/GuidanceHelperKeyRegressionTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.guidance.helper;
+
+import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.data.DropRateDatabase;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.lang.reflect.Field;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNull;
+
+/**
+ * Regression guard: no production source in drop_rates.json may carry a
+ * non-null {@code guidanceHelperKey}.
+ *
+ * <p>B6 adds the schema field but deliberately does not set it on any
+ * production source yet. This test will fail if someone accidentally adds
+ * the key to the JSON, reminding them to register the corresponding helper
+ * before shipping.
+ */
+public class GuidanceHelperKeyRegressionTest
+{
+	private DropRateDatabase database;
+
+	@Before
+	public void setUp() throws Exception
+	{
+		database = new DropRateDatabase();
+		Gson gson = new GsonBuilder().create();
+		Field gsonField = DropRateDatabase.class.getDeclaredField("gson");
+		gsonField.setAccessible(true);
+		gsonField.set(database, gson);
+		database.load();
+	}
+
+	@Test
+	public void noProductionSource_hasGuidanceHelperKey()
+	{
+		List<CollectionLogSource> sources = database.getAllSources();
+		for (CollectionLogSource source : sources)
+		{
+			assertNull(
+				"Production source '" + source.getName()
+					+ "' must not have guidanceHelperKey set until its helper is registered",
+				source.getGuidanceHelperKey()
+			);
+		}
+	}
+}

--- a/src/test/java/com/collectionloghelper/guidance/helper/GuidanceHelperRegistryTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/helper/GuidanceHelperRegistryTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.guidance.helper;
+
+import java.lang.reflect.Constructor;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class GuidanceHelperRegistryTest
+{
+	private GuidanceHelperRegistry buildRegistry() throws Exception
+	{
+		CerberusHelper cerberusHelper = buildCerberusHelper();
+		Constructor<GuidanceHelperRegistry> ctor =
+			GuidanceHelperRegistry.class.getDeclaredConstructor(CerberusHelper.class);
+		ctor.setAccessible(true);
+		return ctor.newInstance(cerberusHelper);
+	}
+
+	private CerberusHelper buildCerberusHelper() throws Exception
+	{
+		Constructor<CerberusHelper> ctor = CerberusHelper.class.getDeclaredConstructor();
+		ctor.setAccessible(true);
+		return ctor.newInstance();
+	}
+
+	@Test
+	public void get_cerberusKey_returnsCerberusHelper() throws Exception
+	{
+		GuidanceHelperRegistry registry = buildRegistry();
+		GuidanceHelper helper = registry.get("cerberus");
+		assertNotNull("Registry must return a helper for 'cerberus'", helper);
+		assertTrue("Helper must be a CerberusHelper", helper instanceof CerberusHelper);
+	}
+
+	@Test
+	public void get_nullKey_returnsNull() throws Exception
+	{
+		GuidanceHelperRegistry registry = buildRegistry();
+		assertNull("Registry must return null for null key", registry.get(null));
+	}
+
+	@Test
+	public void get_unknownKey_returnsNull() throws Exception
+	{
+		GuidanceHelperRegistry registry = buildRegistry();
+		assertNull("Registry must return null for unknown key", registry.get("zulrah"));
+	}
+
+	@Test
+	public void getAllHelpers_containsCerberus() throws Exception
+	{
+		GuidanceHelperRegistry registry = buildRegistry();
+		assertTrue("'cerberus' must be in getAllHelpers()", registry.getAllHelpers().containsKey("cerberus"));
+	}
+}

--- a/src/test/java/com/collectionloghelper/learning/DryStreakAnalyzerTest.java
+++ b/src/test/java/com/collectionloghelper/learning/DryStreakAnalyzerTest.java
@@ -378,11 +378,13 @@ public class DryStreakAnalyzerTest
 			null,       // interactAction
 			null,       // dialogOptions
 			null,       // guidanceSteps
+			null,       // guidanceHelperKey
 			null,       // requirements
 			0,          // cumulativeTrackItemId
 			null,       // cumulativeTrackObjectIds
 			0,          // cumulativeTrackThreshold
-			items
+			items,
+			null        // metaAuthoredDate
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/learning/PersonalizedKillTimeTest.java
+++ b/src/test/java/com/collectionloghelper/learning/PersonalizedKillTimeTest.java
@@ -77,7 +77,8 @@ public class PersonalizedKillTimeTest
 			/* mutuallyExclusiveSources */ null, /* rollsPerKill */ 0,
 			/* aggregated */ false, /* afkLevel */ 0, /* travelTip */ null,
 			/* npcId */ 0, /* interactAction */ null, /* dialogOptions */ null,
-			/* guidanceSteps */ null, /* requirements */ null,
+			/* guidanceSteps */ null,
+			null /* guidanceHelperKey */, /* requirements */ null,
 			/* cumulativeTrackItemId */ 0, /* cumulativeTrackObjectIds */ null,
 			/* cumulativeTrackThreshold */ 0,
 			Collections.emptyList(), null /* metaAuthoredDate */);

--- a/src/test/java/com/collectionloghelper/learning/PersonalizedKillTimeTest.java
+++ b/src/test/java/com/collectionloghelper/learning/PersonalizedKillTimeTest.java
@@ -77,8 +77,7 @@ public class PersonalizedKillTimeTest
 			/* mutuallyExclusiveSources */ null, /* rollsPerKill */ 0,
 			/* aggregated */ false, /* afkLevel */ 0, /* travelTip */ null,
 			/* npcId */ 0, /* interactAction */ null, /* dialogOptions */ null,
-			/* guidanceSteps */ null,
-			null /* guidanceHelperKey */, /* requirements */ null,
+			/* guidanceSteps */ null, /* guidanceHelperKey */ null, /* requirements */ null,
 			/* cumulativeTrackItemId */ 0, /* cumulativeTrackObjectIds */ null,
 			/* cumulativeTrackThreshold */ 0,
 			Collections.emptyList(), null /* metaAuthoredDate */);

--- a/src/test/java/com/collectionloghelper/lifecycle/GuidanceEventRouterTest.java
+++ b/src/test/java/com/collectionloghelper/lifecycle/GuidanceEventRouterTest.java
@@ -168,6 +168,7 @@ public class GuidanceEventRouterTest
 			null,      // interactAction
 			null,      // dialogOptions
 			null,      // guidanceSteps
+			null,      // guidanceHelperKey
 			null,      // requirements
 			0,         // cumulativeTrackItemId
 			null,      // cumulativeTrackObjectIds
@@ -197,6 +198,7 @@ public class GuidanceEventRouterTest
 			0,
 			null,
 			0,
+			null,
 			null,
 			null,
 			null,

--- a/src/test/java/com/collectionloghelper/ui/ItemRowPanelHoverTest.java
+++ b/src/test/java/com/collectionloghelper/ui/ItemRowPanelHoverTest.java
@@ -79,8 +79,8 @@ public class ItemRowPanelHoverTest
 		CollectionLogSource source = new CollectionLogSource(
 			"Shayzien Armour", CollectionLogCategory.OTHER,
 			1516, 3617, 0, 36, 0, null, null, null, 0, null, 0, false, 2,
-			null, 0, null, null, null, null, 0, null, 0,
-			Collections.singletonList(item), null /* metaAuthoredDate */);
+			null, 0, null, null, null, null, null, 0, null, 0,
+			Collections.singletonList(item), null);
 
 		row = new ItemRowPanel(item, source, false, 0, false,
 			Collections.emptyList(), itemManager, () -> {});

--- a/src/test/java/com/collectionloghelper/ui/mode/DryStreakFeedModeControllerTest.java
+++ b/src/test/java/com/collectionloghelper/ui/mode/DryStreakFeedModeControllerTest.java
@@ -243,11 +243,13 @@ public class DryStreakFeedModeControllerTest
 			null,
 			null,
 			null,
+			null /* guidanceHelperKey */,
 			null,
 			0,
 			null,
 			0,
-			Collections.emptyList()
+			Collections.emptyList(),
+			null /* metaAuthoredDate */
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/ui/mode/StatisticsModeControllerTest.java
+++ b/src/test/java/com/collectionloghelper/ui/mode/StatisticsModeControllerTest.java
@@ -113,7 +113,7 @@ public class StatisticsModeControllerTest
 			null, null, null, 0.0, null,
 			0, false, 0, null,
 			0, null, null, null, null,
-			0, null, 0, Collections.emptyList(), null);
+			null, 0, null, 0, Collections.emptyList(), null);
 		List<CollectionLogSource> bossList = Collections.singletonList(source);
 		when(database.getSourcesByCategory(CollectionLogCategory.BOSSES)).thenReturn(bossList);
 		when(collectionState.getCategoryCount(CollectionLogCategory.BOSSES)).thenReturn(5);

--- a/src/test/java/com/collectionloghelper/ui/widget/GuidanceBannerViewTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/GuidanceBannerViewTest.java
@@ -50,7 +50,7 @@ public class GuidanceBannerViewTest
 	{
 		return new CollectionLogSource(name, CollectionLogCategory.BOSSES, 0, 0, 0,
 			60, 0, null, null,
-			null, 0, null, 0, false, 0, null, 0, null, null, null, null, 0, null, 0,
+			null, 0, null, 0, false, 0, null, 0, null, null, null, null, null, 0, null, 0,
 			Collections.emptyList(), null);
 	}
 

--- a/src/test/java/com/collectionloghelper/ui/widget/QuickGuidePanelViewTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/QuickGuidePanelViewTest.java
@@ -58,7 +58,7 @@ public class QuickGuidePanelViewTest
 	private static CollectionLogSource makeSource(String name)
 	{
 		return new CollectionLogSource(name, CollectionLogCategory.BOSSES, 0, 0, 0,
-			60, 0, null, null, null, 0, null, 0, false, 0, null, 0, null, null, null, null, 0, null, 0,
+			60, 0, null, null, null, 0, null, 0, false, 0, null, 0, null, null, null, null, null, 0, null, 0,
 			Collections.emptyList(), null);
 	}
 

--- a/src/test/java/com/collectionloghelper/ui/widget/SourceRequirementsHeaderTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/SourceRequirementsHeaderTest.java
@@ -517,6 +517,7 @@ public class SourceRequirementsHeaderTest
 			/* interactAction */ null,
 			/* dialogOptions */ null,
 			/* guidanceSteps */ null,
+			/* guidanceHelperKey */ null,
 			requirements,
 			/* cumulativeTrackItemId */ 0,
 			/* cumulativeTrackObjectIds */ null,


### PR DESCRIPTION
## Summary

- Adds `GuidanceHelper` interface (`getSteps`, `isStepSatisfied`) as the D-01 opt-in escape hatch for sources that cannot be fully expressed in JSON
- Adds `GuidanceHelperRegistry` mapping string keys to helper instances; `"cerberus"` is the first registered entry
- Adds `CerberusHelper` pilot that mirrors the existing Cerberus JSON steps in Java (travel -> gate -> kill), proving the plumbing end-to-end
- Adds `guidanceHelperKey: String` (nullable) to `CollectionLogSource`; when set, `GuidanceSequencer` delegates step generation to the registered helper instead of the JSON `guidanceSteps` list
- `CerberusHelper.isStepSatisfied` returns `false` throughout (plumbing-only milestone; satisfaction falls back to default sequencer logic)
- Regression guard: `GuidanceHelperKeyRegressionTest` asserts no production source in `drop_rates.json` has `guidanceHelperKey` set yet

## Test plan

- [ ] `./gradlew test build` passes (verified locally, all tests green)
- [ ] `GuidanceHelperRegistryTest` -- registry resolves `"cerberus"` key, returns null for unknown/null keys
- [ ] `CerberusHelperTest` -- 3 steps returned, step fields match JSON data, `isStepSatisfied` always false
- [ ] `GuidanceHelperDispatchTest` -- sequencer uses helper steps when key is `"cerberus"`, falls back to JSON when key is null or unknown
- [ ] `GuidanceHelperKeyRegressionTest` -- no production source has `guidanceHelperKey` set
- [ ] No existing test regressions (all existing tests updated for new constructor arg)