### PR TITLE
fix(build): add JDK 17 --add-opens JVM args to gradlew run task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,16 @@ tasks.register('run', JavaExec) {
 	classpath = sourceSets.test.runtimeClasspath
 	mainClass = 'com.collectionloghelper.CollectionLogHelperPluginTest'
 
-	jvmArgs "-ea"
+	// JDK 17+ requires explicit module opens for RuneLite's reflection paths.
+	// Without these, ReflectUtil.invalidateAnnotationCaches() throws
+	// InaccessibleObjectException during startup and reflection-heavy features
+	// (annotation cache busting, AWT/Swing internals, GPU plugin) degrade silently.
+	jvmArgs "-ea",
+		"--add-opens=java.base/java.lang=ALL-UNNAMED",
+		"--add-opens=java.base/java.lang.reflect=ALL-UNNAMED",
+		"--add-opens=java.base/java.util=ALL-UNNAMED",
+		"--add-opens=java.desktop/sun.awt=ALL-UNNAMED",
+		"--add-opens=java.desktop/javax.swing.text.html=ALL-UNNAMED"
 	args "--developer-mode", "--debug"
 }
 


### PR DESCRIPTION
## Summary
`./gradlew run` was throwing `InaccessibleObjectException` at startup under JDK 17 because RuneLite 1.12.26.3's `ReflectUtil.invalidateAnnotationCaches()` needs `setAccessible()` on `java.lang.reflect.Executable.declaredAnnotations` — blocked by JPMS without explicit `--add-opens`.

The dev client appeared to launch (plugin logged "Collection Log Helper started") but the annotation cache wasn't being invalidated and several reflection-heavy paths (AWT internals, Swing HTML, GPU plugin lookups) were degrading silently.

## Fix
Added RuneLite's canonical launcher `--add-opens` flags to the `run` task in `build.gradle`:
- `java.base/java.lang`
- `java.base/java.lang.reflect`
- `java.base/java.util`
- `java.desktop/sun.awt`
- `java.desktop/javax.swing.text.html`

## Test plan
- [x] `./gradlew run` — dev client starts, no `InaccessibleObjectException`, plugin loaded cleanly.
- [x] `./gradlew build` — all tests pass (UP-TO-DATE on second run after cache warm), JaCoCo gate at 45% still passes.
- [ ] In-client verification of overlay/panel rendering (manual smoke test).