### PR TITLE
fix: post-cascade review fixes (executor leak, duplicate sync block, HTTP hardening)

### DIFF
--- a/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
@@ -65,8 +65,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
@@ -242,8 +244,13 @@ public class CollectionLogHelperPlugin extends Plugin
 	private volatile boolean pendingTravelVarbitRefresh = false;
 	private BufferedImage collectionLogIcon;
 
-	// Deferred cache-fresh check: set once the full sync completes
-	private boolean hasCompletedFullSync;
+	/**
+	 * Daemon executor used to wait on async sync futures (collectionlog.net import,
+	 * TempleOSRS KC sync) off the EDT/client thread. Lazily created in startUp and
+	 * shut down in shutDown; one shared instance prevents the per-click executor
+	 * leak that the ad-hoc {@code Executors.newSingleThreadExecutor()} pattern caused.
+	 */
+	private ExecutorService httpResultExecutor;
 
 	/**
 	 * Player location cached on the client thread each game tick.
@@ -265,6 +272,13 @@ public class CollectionLogHelperPlugin extends Plugin
 	{
 		database.load();
 		slayerMasterDatabase.load();
+
+		httpResultExecutor = Executors.newSingleThreadExecutor(r ->
+		{
+			Thread t = new Thread(r, "clh-http-result-waiter");
+			t.setDaemon(true);
+			return t;
+		});
 
 		panel = new CollectionLogHelperPanel(
 			config, database, collectionState, calculator, clueEstimator,
@@ -302,13 +316,8 @@ public class CollectionLogHelperPlugin extends Plugin
 			}
 			Future<ImportResult> future =
 				collectionLogNetImporter.importProfile(username);
-			// Poll the result on a daemon thread so the EDT is not blocked
-			Executors.newSingleThreadExecutor(r ->
-			{
-				Thread t = new Thread(r, "clh-import-result-waiter");
-				t.setDaemon(true);
-				return t;
-			}).submit(() ->
+			// Poll the result on the shared daemon executor so the EDT is not blocked
+			httpResultExecutor.submit(() ->
 			{
 				try
 				{
@@ -418,6 +427,11 @@ public class CollectionLogHelperPlugin extends Plugin
 		syncStateCoordinator.reset();
 		sourceKcStore.clear();
 		templeOsrsKcSyncer.shutdown();
+		if (httpResultExecutor != null)
+		{
+			httpResultExecutor.shutdownNow();
+			httpResultExecutor = null;
+		}
 		sourcesWithMissingItems.clear();
 		pendingPanelRebuild = false;
 		rankedSourcesDirty = true;
@@ -738,37 +752,6 @@ public class CollectionLogHelperPlugin extends Plugin
 			}
 		}
 
-		// Deferred cache-fresh check: varps aren't loaded during LOGGED_IN or
-		// RuneScapeProfileChanged, so retry here once totalObtained becomes valid
-		if (!hasCompletedFullSync && collectionState.getTotalObtained() > 0
-			&& collectionState.isCacheFresh())
-		{
-			dataSyncState.setCollectionLogSynced(true);
-			hasCompletedFullSync = true;
-			log.info("Cache is fresh (varp {} matches last sync) — skipping sync prompt",
-				collectionState.getTotalObtained());
-
-			if (playerBankState.loadFromCache())
-			{
-				dataSyncState.setBankScanned(true);
-				log.info("Bank cache loaded — skipping bank scan prompt");
-			}
-
-			exportEfficiencyIfEnabled();
-
-			if (panel != null)
-			{
-				panel.updateSyncStatus(CollectionLogHelperPanel.SyncState.SYNCED,
-					collectionState.getTotalObtained());
-				panel.updateDataSyncWarning();
-			}
-			pendingPanelRebuild = true;
-			rankedSourcesDirty = true;
-
-			guidanceOverlay.setShowCollectionLogReminder(false);
-			guidanceOverlay.setShowBankReminder(false);
-		}
-
 		// Dispatch deferred ShortestPath "path" and world map arrow via coordinator
 		guidanceCoordinator.tick();
 
@@ -970,17 +953,17 @@ public class CollectionLogHelperPlugin extends Plugin
 			return;
 		}
 
-		log.info("Requesting TempleOSRS KC sync for '{}'", playerName);
+		log.debug("Requesting TempleOSRS KC sync for '{}'", playerName);
 
-		java.util.concurrent.Future<SyncResult> future = templeOsrsKcSyncer.syncKc(playerName);
+		Future<SyncResult> future = templeOsrsKcSyncer.syncKc(playerName);
 
-		// Wait for the result on a separate thread so the EDT is not blocked
-		java.util.concurrent.Executors.newSingleThreadExecutor().submit(() ->
+		// Wait for the result on the shared daemon executor so the EDT is not blocked
+		httpResultExecutor.submit(() ->
 		{
 			SyncResult result;
 			try
 			{
-				result = future.get(30, java.util.concurrent.TimeUnit.SECONDS);
+				result = future.get(30, TimeUnit.SECONDS);
 			}
 			catch (Exception e)
 			{

--- a/src/main/java/com/collectionloghelper/sync/CollectionLogNetImporter.java
+++ b/src/main/java/com/collectionloghelper/sync/CollectionLogNetImporter.java
@@ -61,6 +61,9 @@ public class CollectionLogNetImporter
 {
 	static final String BASE_URL = "https://api.collectionlog.net/collectionlog/user/";
 
+	/** Hard cap on response body size to prevent OOM from a misbehaving/malicious server. */
+	private static final long MAX_RESPONSE_BYTES = 10L * 1024L * 1024L;
+
 	private final OkHttpClient httpClient;
 	private final Gson gson;
 	private final PlayerCollectionState collectionState;
@@ -140,7 +143,21 @@ public class CollectionLogNetImporter
 				return ImportResult.serviceUnavailable(code);
 			}
 
+			long contentLength = body.contentLength();
+			if (contentLength > MAX_RESPONSE_BYTES)
+			{
+				log.warn("collectionlog.net: response too large ({} bytes) for user '{}'",
+					contentLength, username);
+				return ImportResult.serviceUnavailable(code);
+			}
+
 			String json = body.string();
+			if (json.length() > MAX_RESPONSE_BYTES)
+			{
+				log.warn("collectionlog.net: response body exceeded {} bytes for user '{}'",
+					MAX_RESPONSE_BYTES, username);
+				return ImportResult.serviceUnavailable(code);
+			}
 			return parseAndMark(json, username);
 		}
 		catch (IOException e)
@@ -253,7 +270,7 @@ public class CollectionLogNetImporter
 				}
 			}
 
-			log.info("collectionlog.net import complete for '{}': {} items marked, {} skipped",
+			log.debug("collectionlog.net import complete for '{}': {} items marked, {} skipped",
 				username, marked, skipped);
 			return ImportResult.success(marked);
 		}

--- a/src/main/java/com/collectionloghelper/sync/TempleOsrsKcSyncer.java
+++ b/src/main/java/com/collectionloghelper/sync/TempleOsrsKcSyncer.java
@@ -70,6 +70,9 @@ public class TempleOsrsKcSyncer
 {
 	static final String BASE_URL = "https://templeosrs.com/api/player_info.php";
 
+	/** Hard cap on response body size to prevent OOM from a misbehaving/malicious server. */
+	private static final long MAX_RESPONSE_BYTES = 1L * 1024L * 1024L;
+
 	/**
 	 * Static name mapping from TempleOSRS display name to CLH source name.
 	 *
@@ -163,10 +166,29 @@ public class TempleOsrsKcSyncer
 				return SyncResult.failure(msg);
 			}
 
-			String body = response.body() != null ? response.body().string() : null;
-			if (body == null || body.isEmpty())
+			if (response.body() == null)
 			{
 				return SyncResult.failure("Empty response from TempleOSRS");
+			}
+
+			long contentLength = response.body().contentLength();
+			if (contentLength > MAX_RESPONSE_BYTES)
+			{
+				log.warn("TempleOSRS response too large ({} bytes) for user '{}'",
+					contentLength, username);
+				return SyncResult.failure("TempleOSRS response exceeded size cap");
+			}
+
+			String body = response.body().string();
+			if (body.isEmpty())
+			{
+				return SyncResult.failure("Empty response from TempleOSRS");
+			}
+			if (body.length() > MAX_RESPONSE_BYTES)
+			{
+				log.warn("TempleOSRS response body exceeded {} bytes for user '{}'",
+					MAX_RESPONSE_BYTES, username);
+				return SyncResult.failure("TempleOSRS response exceeded size cap");
 			}
 
 			return parseResponse(body);


### PR DESCRIPTION
## Summary

Four post-cascade-merge review findings rolled into one bug-fix PR (all severity HIGH/MEDIUM, no behavior-visible regressions).

- **HIGH — executor leak.** `onTempleSyncRequested` and the collectionlog.net import callback each called `Executors.newSingleThreadExecutor()` per click. The TempleOSRS form created non-daemon threads that survived plugin reload. Replaced with a single shared daemon executor (`clh-http-result-waiter`) created in `startUp` and shut down in `shutDown`.
- **HIGH — duplicate cache-fresh check.** `CollectionLogHelperPlugin.onGameTick` ran the cache-fresh promotion block, then immediately delegated to `SyncStateCoordinator.tickSync` which ran the same block again. On the tick when the cache first became fresh both fired, so `exportEfficiencyIfEnabled()` and `panel.updateSyncStatus/updateDataSyncWarning` each ran twice. Removed the plugin-side block; the coordinator already owns it (and its `panelCallback`/`exportCallback` reproduce every side-effect).
- **MEDIUM — no HTTP response size cap.** `collectionlog.net` and `TempleOSRS` responses were read in full via `body.string()` without checking `Content-Length`. Added a 10 MB cap for collectionlog.net and a 1 MB cap for TempleOSRS, checked both via `contentLength()` and on the materialised string.
- **MEDIUM — RSN at `info` level.** Two `log.info` lines included the player's display name and would land in RuneLite's persistent log file. Downgraded both to `log.debug`.

## Test plan

- [x] `./gradlew build` (1172/1172 tests pass, JaCoCo gate PASS)
- [ ] In-game: trigger collectionlog.net import and verify daemon thread name `clh-http-result-waiter` (not `clh-import-result-waiter`) in jstack/thread dump
- [ ] In-game: trigger TempleOSRS sync twice and confirm no thread accumulation
- [ ] In-game: log in with a fresh cache and verify the sync-status badge transitions to SYNCED exactly once (was visibly racing previously? — author has not reproduced this in-game; the fix is by inspection)
- [ ] Read the RuneLite log at INFO level after a sync and confirm no RSN appears

## Review trail

- `java-reviewer` (Java/RuneLite SDK conformance): flagged H1 + H2
- `security-reviewer`: flagged M5 + M6
- `clh-pr-reviewer`: source tree privacy-clean, mojibake-free, attribution-clean
- `plugin_hub_validate`: 0 critical, 0 high, 1 medium (debatable `runelite-plugin` Gradle plugin — example-plugin uses the same manual structure we have)

Doc-sync findings (CHANGELOG drift, ROADMAP status log) deferred to a follow-up PR per single-concern squash-merge convention.