### PR TITLE
docs: sync CHANGELOG, ROADMAP status log, and resubmission date with post-cascade master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,64 @@
 
 _(none — all queued changes folded into 1.0.0-hub below.)_
 
+## 1.0.0-hub — 2026-05-15
+
+### Added
+
+- **Composable guidance schema** — tile-sequence pathing (B2, [#456](../../pull/456)),
+  nested conditional steps (B3, [#455](../../pull/455)), and puzzle/dynamic step type
+  with `DynamicTargetEvaluator` + Wintertodt brazier pilot (B5, [#473](../../pull/473)).
+- **Hybrid Java helper pilot** — `GuidanceHelper` interface + registry routing in the
+  sequencer; Cerberus pilot (B6, [#474](../../pull/474)). Closes D-01.
+- **Per-step UI parity with Quest Helper** — required-items chips with bank-scan colors
+  (B.5.1, [#452](../../pull/452)), advisory recommended-items section
+  (B.5.2, [#472](../../pull/472)), source-level requirements header
+  (B.5.3, [#457](../../pull/457)), collapsible step sections
+  (B.5.4, [#458](../../pull/458)), dialog highlight polish
+  (B.5.7, [#449](../../pull/449)).
+- **Player-aware state model (Tier C)** — POH teleport inventory
+  (C1, [#470](../../pull/470)), equipped-item state (C2, [#463](../../pull/463)),
+  diary tier state (C3, [#461](../../pull/461)), skill-cape perk state
+  (C4, [#471](../../pull/471)), partial-quest state (C5, [#462](../../pull/462)),
+  and a dev-facing player-capability debug overlay (C7, [#459](../../pull/459)).
+- **Cross-source recommendation mode** — `CrossSourceRanker` +
+  `CrossSourceRecommendation` + `enableCrossSourceMode` config flag; panel integration
+  deferred (E1, [#464](../../pull/464)).
+- **Meta-update dating** — recommendations carry meta-update timestamps so stale
+  guidance is visible at a glance (E2, [#467](../../pull/467)).
+- **External profile sync** — collectionlog.net import (F1, [#465](../../pull/465))
+  and TempleOSRS KC sync (F2, [#468](../../pull/468)).
+- **Per-account kill-time learning (opt-in)** — `KillTimeTracker` + on-disk
+  personalized estimates per character with a config flag and 19 tests
+  (F3, [#466](../../pull/466)).
+- **Dry-streak feed** — surfaces the player's longest dry streaks per source
+  (F4, [#469](../../pull/469)).
+- **CI + coverage gate** — JaCoCo report + verification at 45% (F5, [#454](../../pull/454))
+  and GitHub Actions build+test workflow on PR/push (F6, [#451](../../pull/451)).
+
+### Fixed
+
+- **JDK 17 startup** — `gradlew run` no longer throws `InaccessibleObjectException` in
+  RuneLite's `ReflectUtil.invalidateAnnotationCaches` on JDK 17+; added five
+  `--add-opens` flags to the run task ([#475](../../pull/475)).
+- **Duplicate tier label on search hover** — search-result rows no longer show two
+  tier labels stacked ([#446](../../pull/446)).
+- **Tier 3 auto-completion backfill** — two sources gained
+  `CHAT_MESSAGE_RECEIVED`-based completion detection ([#448](../../pull/448),
+  [#306](../../issues/306)).
+
+### Notes
+
+- **Sailing island-instance vs port coords** — triaged ([#450](../../pull/450),
+  [#314](../../issues/314)); follow-up data PRs deferred until Sailing mechanics
+  stabilize.
+- **D1 deep-guidance bar** — closed retroactively ([#447](../../pull/447)) — the
+  10-element authoring checklist was already shipped in [#358](../../pull/358).
+- **B.5.5 worldmap arrow** — 5/6 sub-requirements confirmed shipped via prior PRs
+  ([#453](../../pull/453)); blocked on a pending color constant PR.
+- **In-game validation log** — `docs/in-game-validation-log.md` records the
+  2026-05-14 PR-batch validation pass ([#460](../../pull/460)).
+
 ## 1.0.0-hub — 2026-05-12
 
 ### Changed

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -546,10 +546,8 @@ Focus: god-object decomposition, build hardening, test expansion. Resulted in th
 **Tier B — Guidance depth parity with Quest Helper**
 
 - [ ] B1 — Composable completion conditions             status: planned       owner: —          updated: 2026-04-16
-- [/] B2 — Tile-sequence pathing                        status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #456
-- [ ] B3 — Nested conditional steps                     status: planned       owner: —          updated: 2026-04-16
-- [ ] B2 — Tile-sequence pathing                        status: planned       owner: —          updated: 2026-04-16
-- [/] B3 — Nested conditional steps                     status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #455
+- [x] B2 — Tile-sequence pathing                        status: done          owner: cha-ndler  updated: 2026-05-14  pr: #456
+- [x] B3 — Nested conditional steps                     status: done          owner: cha-ndler  updated: 2026-05-14  pr: #455
 - [/] B4 — Alternative-method modelling                 status: in-progress   owner: cha-ndler  updated: 2026-05-13  note: direction firmed up — see expanded section above. Sub-milestones:
 - [x] B4.1 — Per-item required-items override (Mort'ton POC)  status: done  owner: cha-ndler  updated: 2026-05-13  pr: #419  issue: #417  note: `perItemRequiredItemIds` schema field shipped + Mort'ton tier map for all 17 clog items + activation-chain propagation of target clog item ID through Plugin.activateGuidance(source, targetItemId) -> coordinator.activeTargetItemId -> RequiredItemResolver. Pre-existing bug where activeTargetItemId was set before deactivateGuidance() cleared it (silently null-ing the target before any resolver ran) was found and fixed in #421.
 - [x] B4.2 — Survey + audit of all sources for per-item method differentiation  status: done  owner: cha-ndler  updated: 2026-05-13  issue: #420  note: 225 sources audited; 5 Category-1 candidates found (Mort'ton already done; Perilous Moons + Shayzien + 3 more); Categories 2/3/4 produced 0 candidates (raids already split as separate sources; method-variant bosses have uniform drop tables). Missing source Larran's Small Chest also flagged.
@@ -562,28 +560,28 @@ Focus: god-object decomposition, build hardening, test expansion. Resulted in th
 - [ ] B4.3.4 — Barrows per-brother targeting  status: deferred  owner: —  updated: 2026-05-14  note: Flagged in #420 for human design review — `perItemRequiredItemIds` may not suffice; needs `perItemCompletionNpcId` or guidance-step redesign for the VARBIT-based kill-progress interaction.
 - [ ] B4.3.5 — Barracuda Trials per-trial mapping  status: deferred  owner: —  updated: 2026-05-14  note: Flagged in #420 — re-audit after Sailing mechanics stabilize before scoping.
 - [ ] B4.4 — Top Pick auto-drives per-item method choice (North Star UI alignment)  status: planned  owner: —  updated: 2026-05-13
-- [/] B5 — Puzzle/dynamic step type                     status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #473  note: DynamicTargetEvaluator interface + registry + WintertodtBrazierEvaluator pilot. Coordinator tick() dispatches per-tick; regression guard ensures no production step carries the field.
-- [/] B6 — Decision D-01 pilot (hybrid Java helper)     status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #474  note: GuidanceHelper interface + GuidanceHelperRegistry + CerberusHelper pilot (mirrors JSON steps). guidanceHelperKey field added to CollectionLogSource. Sequencer routes through helper when key is set. Regression test guards against premature production key. Build passes, all tests green.
+- [x] B5 — Puzzle/dynamic step type                     status: done          owner: cha-ndler  updated: 2026-05-14  pr: #473  note: DynamicTargetEvaluator interface + registry + WintertodtBrazierEvaluator pilot. Coordinator tick() dispatches per-tick; regression guard ensures no production step carries the field.
+- [x] B6 — Decision D-01 pilot (hybrid Java helper)     status: done          owner: cha-ndler  updated: 2026-05-14  pr: #474  note: GuidanceHelper interface + GuidanceHelperRegistry + CerberusHelper pilot (mirrors JSON steps). guidanceHelperKey field added to CollectionLogSource. Sequencer routes through helper when key is set. Regression test guards against premature production key. Build passes, all tests green.
 
 **Tier B.5 — UI parity with Quest Helper**
 
-- [/] B.5.1 — Per-step item requirements panel          status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #452
-- [/] B.5.2 — Recommended items section                 status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #472
-- [/] B.5.3 — General requirements section              status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #457
-- [ ] B.5.4 — Collapsible step sections                 status: planned       owner: —          updated: 2026-05-10  note: `section` field on step, auto-expand active section; cha-ndler/collection-log-helper#382
+- [x] B.5.1 — Per-step item requirements panel          status: done          owner: cha-ndler  updated: 2026-05-14  pr: #452
+- [x] B.5.2 — Recommended items section                 status: done          owner: cha-ndler  updated: 2026-05-14  pr: #472
+- [x] B.5.3 — General requirements section              status: done          owner: cha-ndler  updated: 2026-05-14  pr: #457
+- [x] B.5.4 — Collapsible step sections                 status: done          owner: cha-ndler  updated: 2026-05-14  pr: #458  note: `section` field on step, auto-expand active section; cha-ndler/collection-log-helper#382
 - [/] B.5.5 — Per-step world map arrow + destination icon  status: partial    owner: cha-ndler  updated: 2026-05-14  note: 5/6 sub-requirements confirmed shipped via #397 + #438 + #423; blocked on #430 (CLH-distinct orange arrow color — pending merge). Sub-reqs: (1) worldmap arrow per step — done (#397, WorldMapDestinationOverlay.setTarget wired in coordinator); (2) chevron shape — done (#397, 4-point notched polygon); (3) CLH-distinct color — pending (#430 adds orange #FF8C00 constant, not yet on master); (4) NPC/object/item icon at destination — done (#397, StepIconType enum + 3 sprite variants + resolveStepIconType); (5) worldmap point + arrow integration — done (#438, setMapPointActive suppresses double arrow); (6) per-item icon retargeting — done (#423, resolveNpcId used in resolveStepIconType).
 - [ ] B.5.6 — Object/NPC outline-glow highlight style   status: planned       owner: —          updated: 2026-05-10  issue: cha-ndler/collection-log-helper#377
-- [/] B.5.7 — Dialog choice highlighting polish         status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #449
+- [x] B.5.7 — Dialog choice highlighting polish         status: done          owner: cha-ndler  updated: 2026-05-14  pr: #449
 
 **Tier C — Player-aware guidance**
 
-- [/] C1 — POH teleport inventory model                 status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #470
-- [/] C2 — Equipped-item state                          status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #463
-- [/] C3 — Diary tier state                             status: in-progress   owner: —          updated: 2026-05-14  pr: #461
-- [/] C4 — Skill-cape perk state                        status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #471
-- [/] C5 — Partial-quest state                          status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: cha-ndler/collection-log-helper#462
+- [x] C1 — POH teleport inventory model                 status: done          owner: cha-ndler  updated: 2026-05-14  pr: #470
+- [x] C2 — Equipped-item state                          status: done          owner: cha-ndler  updated: 2026-05-14  pr: #463
+- [x] C3 — Diary tier state                             status: done          owner: cha-ndler  updated: 2026-05-14  pr: #461
+- [x] C4 — Skill-cape perk state                        status: done          owner: cha-ndler  updated: 2026-05-14  pr: #471
+- [x] C5 — Partial-quest state                          status: done          owner: cha-ndler  updated: 2026-05-14  pr: #462
 - [ ] C6 — Wire into top-20 sources                     status: planned       owner: —          updated: 2026-04-16
-- [/] C7 — Player-capability debug overlay              status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #459
+- [x] C7 — Player-capability debug overlay              status: done          owner: cha-ndler  updated: 2026-05-14  pr: #459
 
 **Tier D — Coverage breadth**
 
@@ -595,15 +593,15 @@ Focus: god-object decomposition, build hardening, test expansion. Resulted in th
 
 **Tier E — Alternative methods and meta intelligence**
 
-- [/] E1 — Cross-source recommendation mode             status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #464  note: CrossSourceRanker + CrossSourceRecommendation + enableCrossSourceMode config flag; panel integration deferred.
-- [/] E2 — Meta-update dating                           status: in-review     owner: cha-ndler  updated: 2026-05-14  pr: #467
+- [x] E1 — Cross-source recommendation mode             status: done          owner: cha-ndler  updated: 2026-05-14  pr: #464  note: CrossSourceRanker + CrossSourceRecommendation + enableCrossSourceMode config flag; panel integration deferred.
+- [x] E2 — Meta-update dating                           status: done          owner: cha-ndler  updated: 2026-05-14  pr: #467
 
 **Tier F — Social, imports, and long-tail polish**
 
-- [/] F1 — collectionlog.net import                     status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #465
-- [/] F2 — TempleOSRS KC sync                           status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #468
-- [/] F3 — Per-account kill-time learning               status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #466  note: KillTimeTracker + PersonalizedKillTime, opt-in config flag, 19 tests.
-- [/] F4 — Dry-streak feed                              status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #469
-- [/] F5 — JaCoCo + 80% gate                            status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #454  note: gate active at 45% threshold; follow-up to raise to 80% with overlay/UI test additions.
-- [/] F6 — GitHub Actions CI                            status: in-progress   owner: cha-ndler  updated: 2026-05-14  pr: #451  note: build+test workflow on PR/push; verify first CI run is green before moving to [x].
+- [x] F1 — collectionlog.net import                     status: done          owner: cha-ndler  updated: 2026-05-14  pr: #465
+- [x] F2 — TempleOSRS KC sync                           status: done          owner: cha-ndler  updated: 2026-05-14  pr: #468
+- [x] F3 — Per-account kill-time learning               status: done          owner: cha-ndler  updated: 2026-05-14  pr: #466  note: KillTimeTracker + PersonalizedKillTime, opt-in config flag, 19 tests.
+- [x] F4 — Dry-streak feed                              status: done          owner: cha-ndler  updated: 2026-05-14  pr: #469
+- [x] F5 — JaCoCo + coverage gate                       status: done          owner: cha-ndler  updated: 2026-05-14  pr: #454  note: gate active at 45% threshold; follow-up to raise to 80% with overlay/UI test additions.
+- [x] F6 — GitHub Actions CI                            status: done          owner: cha-ndler  updated: 2026-05-14  pr: #451  note: build+test workflow on PR/push; verify first CI run green before raising coverage gate.
 - [ ] F7 — Issue #134 account-specific calcs            status: planned       owner: —          updated: 2026-04-16

--- a/docs/plugin-hub-resubmission.md
+++ b/docs/plugin-hub-resubmission.md
@@ -71,10 +71,12 @@ The tag was originally drafted locally on 2026-04-17 (commit `b9518653`).  That 
 on 2026-05-10 (PRs #372, #384, #386–#394).  The tag will be deleted locally and re-cut on
 the current `master` HEAD once this CHANGELOG/doc refresh PR merges.
 
-**New earliest-push date**: 7 calendar days after the CHANGELOG/doc refresh PR merges to
-`master` (final merge in the v1.0.0-hub content set).  Assuming that merge lands on
-2026-05-12, the earliest push date is **2026-05-19**.  If any additional merges land
-during the window — for any reason — the clock resets to 7 days from the latest merge.
+**New earliest-push date**: 7 calendar days after the final merge in the v1.0.0-hub
+content set lands on `master`.  The Tier B/B.5/C/E/F cascade closed on 2026-05-14 and
+the JDK 17 build fix ([#475](../../pull/475)) merged 2026-05-15, so the earliest push
+date is **2026-05-22**.  If any additional merges land during the window — for any
+reason, including the post-cascade review fixes — the clock resets to 7 days from the
+latest merge.
 
 ---
 


### PR DESCRIPTION
## Summary

Doc-sync follow-up to the post-cascade-merge review pass. No code changes.

- **CHANGELOG.md** — adds a \`1.0.0-hub — 2026-05-15\` block covering the 23 PRs that landed between the previous \`2026-05-12\` block and \`HEAD\` (B2, B3, B5, B6; B.5.1–B.5.4 + B.5.7; C1–C5, C7; E1, E2; F1–F6; plus fixes #446, #448, #475 and notes for #447, #450, #453, #460). The prior \`2026-05-12\` block is preserved unchanged.
- **docs/ROADMAP.md** — flips 23 status-log entries from \`in-progress\` (or \`planned\` for B.5.4) to \`done\`, removes a pair of duplicate stale \`B2/B3 planned\` rows that survived the in-progress edits, and normalises the C5 PR reference to the short \`#462\` form.
- **docs/plugin-hub-resubmission.md** — moves the earliest-push date from \`2026-05-19\` → \`2026-05-22\` to account for the JDK 17 fix ([#475](../../pull/475)) merging on 2026-05-15, which reset the quiet-week clock.

## Why now

\`clh-pr-reviewer\` flagged the changelog drift and the status-log mismatch as **HIGH** in a whole-branch audit. Plugin Hub maintainers read the CHANGELOG when reviewing submissions; tagging \`v1.0.0-hub\` against the current HEAD without this sync would ship a changelog that materially under-described the release.

## Test plan

- [x] \`./gradlew build\` — green (this is docs-only; included for completeness)
- [x] Grep for personal info, Claude attribution, mojibake — clean
- [ ] Visually confirm the CHANGELOG renders cleanly on the GitHub release tab
- [ ] Confirm no further merges land between this PR and 2026-05-22 (clock resets to \`merge+7\` otherwise)