### PR TITLE
fix(guidance): translate player coords through fromLocalInstance for ARRIVE_AT_TILE in instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 ## Unreleased
 
-_(none — all queued changes folded into 1.0.0-hub below.)_
+### Fixed
+
+- **ARRIVE_AT_TILE auto-advance in instanced regions** — `resolvePlayerWorldLocation`
+  now translates the player's local point back to overworld template coordinates
+  via `WorldPoint.fromLocalInstance` when the player is inside an instanced
+  region (Royal Titans, raids, GWD, Vorkath, many quest/clue rooms). Without this,
+  the player's reported coords inside an instance never matched the static
+  `worldX/worldY` in `drop_rates.json`, so step auto-advance silently failed for
+  every guidance sequence that crossed into an instance. Closes
+  [#485](../../issues/485).
 
 ## 1.0.0-hub — 2026-05-15
 

--- a/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
@@ -1028,16 +1028,25 @@ public class CollectionLogHelperPlugin extends Plugin
 	}
 
 	/**
-	 * Resolve the player's real-world location, transforming boat-local
-	 * coordinates when the player is inside a sailing WorldEntity.
+	 * Resolve the player's real-world location, transforming local coordinates
+	 * back to template/overworld coordinates so they compare correctly against
+	 * the static {@code worldX/worldY} values in {@code drop_rates.json}.
 	 *
-	 * When sailing, the player's WorldView is the boat's inner view (not
-	 * top-level).  We find the owning WorldEntity and use
-	 * {@code transformToMainWorld} to map the player's local point back to
-	 * overworld coordinates.
+	 * Three cases:
+	 * <ol>
+	 *   <li><b>Standard top-level world view</b> — return {@code getWorldLocation()}.</li>
+	 *   <li><b>Instanced region</b> (CoX/ToB/ToA, GWD, Vorkath, Royal Titans, many
+	 *       quest/clue rooms, etc.) — {@code getWorldLocation()} returns
+	 *       instance-template coords that don't match the static JSON tile.
+	 *       Translate via {@link WorldPoint#fromLocalInstance(Client, LocalPoint)}
+	 *       to recover the overworld coords.</li>
+	 *   <li><b>Sailing WorldEntity</b> — player is inside a non-top-level
+	 *       WorldView; map the local point back through
+	 *       {@code transformToMainWorld}.</li>
+	 * </ol>
 	 *
-	 * Falls back to the plain {@code getWorldLocation()} if the WorldEntity
-	 * API is unavailable (older RuneLite) or on any error.
+	 * Falls back to plain {@code getWorldLocation()} on any error or when the
+	 * required API is unavailable.
 	 */
 	private WorldPoint resolvePlayerWorldLocation()
 	{
@@ -1052,6 +1061,22 @@ public class CollectionLogHelperPlugin extends Plugin
 			WorldView playerView = lp.getWorldView();
 			if (playerView == null || playerView.isTopLevel())
 			{
+				// Top-level view — handle instanced regions by translating
+				// the player's local point back to the overworld template tile.
+				// Without this, ARRIVE_AT_TILE checks in instanced bosses
+				// (Royal Titans, raids, etc.) never match the JSON coords.
+				if (client.isInInstancedRegion())
+				{
+					LocalPoint localPoint = lp.getLocalLocation();
+					if (localPoint != null)
+					{
+						WorldPoint templatePoint = WorldPoint.fromLocalInstance(client, localPoint);
+						if (templatePoint != null)
+						{
+							return templatePoint;
+						}
+					}
+				}
 				return fallback;
 			}
 
@@ -1076,7 +1101,7 @@ public class CollectionLogHelperPlugin extends Plugin
 		}
 		catch (Exception e)
 		{
-			log.debug("WorldEntity transform failed, using fallback location", e);
+			log.debug("Player-location resolution failed, using fallback", e);
 		}
 		return fallback;
 	}


### PR DESCRIPTION
## Summary

- Adds an instance-translation branch to `resolvePlayerWorldLocation` so the player's location compares correctly against the static `worldX/worldY` tiles in `drop_rates.json` when the player is inside an instanced region.
- Behavior in the standard top-level case and the sailing WorldEntity path is unchanged.
- Closes #485.

## Why

`Player.getWorldLocation()` returns instance-template coordinates inside an instance, not the overworld template tile. Every ARRIVE_AT_TILE check in `GuidanceSequencer` compares against the static JSON tile, so for any instanced source (Royal Titans, CoX/ToB/ToA, GWD, Vorkath, many quest/clue rooms) the comparison never matched and the sequencer never auto-advanced.

Reproduced in-game on 2026-05-16:
- **Royal Titans** — step 1/2 "Travel to the Asgarnian Ice Dungeon" did not advance on entering the boss instance; manual Skip required.
- **Hard Treasure Trails** — same auto-advance failure pattern (see #483).

`client.log` showed no Java exceptions — the code path was running, the condition was just never matching. That ruled out the dispatch refactors from the 2026-05-14 cascade (B2 #456, B5 #473, B6 #474) and pointed at the player-location source feeding `onPlayerMoved`.

## The fix

```java
if (client.isInInstancedRegion()) {
    LocalPoint localPoint = lp.getLocalLocation();
    if (localPoint != null) {
        WorldPoint templatePoint = WorldPoint.fromLocalInstance(client, localPoint);
        if (templatePoint != null) {
            return templatePoint;
        }
    }
}
return fallback;
```

Standard RuneLite pattern. The `fromLocalInstance` API is what Quest Helper and runelite-core's own plugins use for in-instance world-point recovery.

## Test plan

- [x] `./gradlew build` green; existing 503 tests pass.
- [ ] **In-game** — re-run validation log Phase 1 Smoke step 4 on Royal Titans. Step 1/2 should auto-advance on entering the boss instance without Skip.
- [ ] **In-game** — re-run validation log Phase 2 PR #473 Wintertodt brazier evaluator (Wintertodt is also instanced; previously masked by this bug).
- [ ] **In-game** — re-run validation log Phase 1 Smoke step 4 on Hard Clue (#483 has a separate panel-overlap issue; check whether the auto-advance half now works).

Unit test coverage of the instance branch requires static-mocking of `WorldPoint.fromLocalInstance` which Mockito can't do without an extra dependency (PowerMock or Mockito's inline mockmaker). Deferred — leaving as in-game-validated for now per the validation log workflow. If desired, follow-up PR can extract the translation to a helper and add a mockable wrapper.

## Notes

- This is fix 1 of 6 hub-blockers surfaced in the 2026-05-16 in-game validation pass. Sibling issues: #483 (clue panel overlap), #484 (data fix), #486 (C7 overlay incomplete), #487 (C5 quest count), #488 (F1/F2 sync UX).
- Per user direction (2026-05-16) the v1.0.0-hub tag and Plugin Hub resubmit are on hold until all 6 are resolved.