### PR TITLE
fix(overlay): clarify C7 quest-count row label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 ## Unreleased
 
-_(none — all queued changes folded into 1.0.0-hub below.)_
+### Fixed
+
+- **C7 overlay quest-count row label disambiguated** — renamed `"Quests done"`
+  to `"Quests + miniquests"` and added a dim explanatory sub-row
+  `"(RuneLite enum count)"`. The previous label invited confusion when the
+  number exceeded the player-visible in-game Quest List count (e.g. 207 vs
+  179/179) because the RuneLite Quest enum includes miniquests + RFD
+  sub-entries. Closes [#487](../../issues/487).
 
 ## 1.0.0-hub — 2026-05-15
 

--- a/src/main/java/com/collectionloghelper/overlay/PlayerCapabilityDebugOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/PlayerCapabilityDebugOverlay.java
@@ -131,9 +131,17 @@ public class PlayerCapabilityDebugOverlay extends OverlayPanel
 			addRow("Task", "none");
 		}
 
-		// Quest completions (count of FINISHED quests, not the full list)
+		// Quest completions. The RuneLite Quest enum includes miniquests and
+		// some sub-entries (RFD subquests, etc.) as distinct values, so this
+		// count exceeds the player-visible "Completed N/N" shown in the in-game
+		// Quest List. Labeled "Quests + miniquests" to make the discrepancy
+		// self-explaining; see #487 for the longer-term reclassification.
 		int finishedCount = countFinishedQuests();
-		addRow("Quests done", String.valueOf(finishedCount));
+		addRow("Quests + miniquests", String.valueOf(finishedCount));
+		panelComponent.getChildren().add(LineComponent.builder()
+			.left("  (RuneLite enum count)")
+			.leftColor(new Color(140, 140, 140))
+			.build());
 
 		// POH availability
 		int pohLocation = safeVarbit(VARBIT_POH_LOCATION);


### PR DESCRIPTION
## Summary

- Renames the C7 debug overlay row from `"Quests done"` to `"Quests + miniquests"`.
- Adds a dim explanatory sub-row `"(RuneLite enum count)"`.
- Closes #487.

## Why

`countFinishedQuests()` iterates `Quest.values()` and counts `FINISHED` entries. The RuneLite Quest enum includes miniquests (Barbarian Training, etc.) and RFD subquests as distinct values. On a maxed account that produces 207, while the in-game Quest List shows 179/179. The original "Quests done" label invited "wait, that count is wrong" reactions during the 2026-05-16 in-game validation pass.

## What it now renders

```
Quests + miniquests   207
  (RuneLite enum count)
```

The dim sub-row makes the source of the number obvious without forcing the user to read the code.

## Why not surface the in-game count alongside

The in-game Quest List count (179/179) isn't directly accessible:
- No varbit holds the displayed total.
- The Quest List widget value requires the player to have opened the Quest List in this session.
- Hardcoding the list of "main quests" goes stale on every game update.

A follow-up could read the Quest List widget when it's loaded and cache the count, but it's not in scope for this fix.

## Conflict note

If [#490](https://github.com/cha-ndler/collection-log-helper/pull/490) (which renames the same row to `"Quest entries"`) merges first, this PR will need a trivial conflict resolution — keep the `"Quests + miniquests"` label from this PR and the C1-C5 section additions from #490.

## Test plan

- [x] `./gradlew build` green; all tests pass.
- [ ] **In-game** — enable C7 debug overlay → row now reads `"Quests + miniquests: 207"` with dim `"(RuneLite enum count)"` below it.

## Notes

- Fix 5 of 6 hub-blockers from the 2026-05-16 validation pass.
- Per user direction the v1.0.0-hub tag remains on hold until all 6 are resolved.