### PR TITLE
fix(panel): wrap long step descriptions to panel width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ### Fixed
 
+- **Long step descriptions no longer overflow the guidance panel** —
+  `StepProgressView.showStep` now wraps the step text in
+  `<html><body style='width:220px'>…</body></html>` so Swing word-wraps
+  long step descriptions instead of stretching the JLabel's preferred
+  width past the panel's clip region. Most visible on clue tiers where
+  step strings like "Buy a sleek hairband from the Falador hairdresser"
+  pushed content outside the sidebar box. Closes
+  [#483](../../issues/483) (rendering half; the auto-advance half is
+  covered by [#485](../../issues/485)).
+
 - **Kraken and Cave Kraken step descriptions corrected to point at Piscatoris** —
   both sources had stale step descriptions referencing the "Fremennik Slayer
   Dungeon" and a non-existent slayer-ring teleport to Kraken Cove. The

--- a/src/main/java/com/collectionloghelper/ui/widget/StepProgressView.java
+++ b/src/main/java/com/collectionloghelper/ui/widget/StepProgressView.java
@@ -351,8 +351,14 @@ public class StepProgressView extends JPanel
 
 		SwingUtilities.invokeLater(() ->
 		{
+			// Wrap inside a fixed-width <body> so Swing actually word-wraps long
+			// step descriptions instead of stretching the JLabel's preferred width
+			// past the panel's clip region — visible on clue tiers with long
+			// step text such as "Buy a sleek hairband from the Falador hairdresser",
+			// where the unwrapped label rendered outside the panel box (#483).
 			stepProgressLabel.setText(
-				"<html>Step " + current + "/" + total + ": " + description + "</html>");
+				"<html><body style='width:220px'>Step " + current + "/" + total + ": "
+					+ description + "</body></html>");
 			nextStepButton.setVisible(isManual);
 
 			if (groups.isEmpty())

--- a/src/main/java/com/collectionloghelper/ui/widget/StepProgressView.java
+++ b/src/main/java/com/collectionloghelper/ui/widget/StepProgressView.java
@@ -91,6 +91,13 @@ public class StepProgressView extends JPanel
 	/** Tooltip suffix appended to items whose status is IN_BANK. */
 	private static final String IN_BANK_TOOLTIP_SUFFIX = " ℹ in bank";
 
+	/**
+	 * Inner-width budget (px) used to force Swing's JLabel HTML renderer to
+	 * word-wrap long step descriptions. Matches the usable column of the
+	 * default RuneLite plugin panel (~250px minus padding/scroll gutters).
+	 */
+	private static final int PANEL_TEXT_WRAP_WIDTH_PX = 220;
+
 	private static final Color BG = new Color(25, 35, 55);
 	private static final Color SECTION_HEADER_FG = new Color(200, 200, 200);
 	private static final Color SECTION_HEADER_ACTIVE_FG = new Color(80, 180, 255);
@@ -357,8 +364,8 @@ public class StepProgressView extends JPanel
 			// step text such as "Buy a sleek hairband from the Falador hairdresser",
 			// where the unwrapped label rendered outside the panel box (#483).
 			stepProgressLabel.setText(
-				"<html><body style='width:220px'>Step " + current + "/" + total + ": "
-					+ description + "</body></html>");
+				"<html><body style='width:" + PANEL_TEXT_WRAP_WIDTH_PX + "px'>Step "
+					+ current + "/" + total + ": " + description + "</body></html>");
 			nextStepButton.setVisible(isManual);
 
 			if (groups.isEmpty())


### PR DESCRIPTION
## Summary

- `StepProgressView.showStep` now wraps the step description in `<html><body style='width:220px'>…</body></html>` so Swing word-wraps.
- Closes #483 (rendering half — the auto-advance half is covered by #489).

## Why

In the 2026-05-16 in-game validation pass, the user activated guidance on Hard Treasure Trails and reported "rendering not working properly for clue collection log guidance — overlapping outside box."

Hard Treasure Trails has **48 guidance steps**, the longest of any source by an order of magnitude. Step descriptions for clue scrolls are long ("Buy a sleek hairband from the Falador hairdresser", "Speak to the Sand Crab tutor at the Mage Training Arena", etc.).

The render path:
```java
stepProgressLabel.setText("<html>Step " + current + "/" + total + ": " + description + "</html>");
```

Swing JLabel HTML without a width hint expands the label's preferred width to fit the longest line. The label then renders wider than its `BoxLayout.Y_AXIS` parent's column, escaping the sidebar clip region.

## The fix

```java
stepProgressLabel.setText(
    "<html><body style='width:220px'>Step " + current + "/" + total + ": "
        + description + "</body></html>");
```

`<body style='width:220px'>` constrains the layout width and tells Swing's HTML renderer to wrap. 220px is the usable inner width of the default RuneLite plugin panel (~250px minus padding/scroll gutters).

## Why not dynamic width

Tried sourcing `getParent().getWidth()` mentally — but during `showStep` the parent may not have laid out yet, and the label is hosted inside a `BoxLayout.Y_AXIS` shell which doesn't reliably propagate width during update. Hardcoded 220px matches the design width and is robust across rebuilds.

A future enhancement could read `getWidth()` post-layout via a `ComponentListener` and recompute. Not needed for this fix.

## HTML escaping

Not added in this PR. `drop_rates.json` step descriptions are authored as plain text with no `<`, `>`, or `&` characters today. If that changes, a follow-up should sanitise.

## Test plan

- [x] `./gradlew build` green; all tests pass.
- [ ] **In-game** (after #489 lands so step-advance works): activate guidance on **Hard Treasure Trails** → step 1 description wraps within the panel; nothing extends past the sidebar's right edge.
- [ ] **In-game** — activate guidance on a short-description source (Cerberus / Vorkath) → step text still renders correctly; no excessive wrapping or layout regression.

## Notes

- Fix 6 of 6 hub-blockers from the 2026-05-16 validation pass.
- The audit issue (#495) for Phase 2/5 sweep + data audit remains open as the next session's focus.