### PR TITLE
data: correct Kraken / Cave Kraken step descriptions to Piscatoris

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ### Fixed
 
+- **Kraken and Cave Kraken step descriptions corrected to point at Piscatoris** —
+  both sources had stale step descriptions referencing the "Fremennik Slayer
+  Dungeon" and a non-existent slayer-ring teleport to Kraken Cove. The
+  `worldX/worldY`, `npcId`, `locationDescription`, and `travelTip` fields
+  were already correct (Piscatoris Fishing Colony, fairy ring `AKQ`); only the
+  per-step text was misleading. Closes
+  [#494](../../issues/494). Surfaced during the [#484](../../issues/484)
+  fairy-ring audit and rolled forward as part of the broader pre-hub data
+  pass tracked in [#495](../../issues/495).
+
 - **ARRIVE_AT_TILE auto-advance in instanced regions** — `resolvePlayerWorldLocation`
   now translates the player's local point back to overworld template coordinates
   via `WorldPoint.fromLocalInstance` when the player is inside an instanced

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@
 - **Kraken and Cave Kraken step descriptions corrected to point at Piscatoris** —
   both sources had stale step descriptions referencing the "Fremennik Slayer
   Dungeon" and a non-existent slayer-ring teleport to Kraken Cove. The
-  `worldX/worldY`, `npcId`, `locationDescription`, and `travelTip` fields
-  were already correct (Piscatoris Fishing Colony, fairy ring `AKQ`); only the
-  per-step text was misleading. Closes
+  `worldX/worldY`, `npcId`, `locationDescription`, and source-level `travelTip`
+  fields were already correct (Piscatoris Fishing Colony, fairy ring `AKQ`); only
+  the per-step `description` (and step-level `travelTip` on the boss source) was
+  misleading. Descriptions now correctly state Kraken Cove is south-west of the
+  Piscatoris Fishing Colony, per the wiki. Closes
   [#494](../../issues/494). Surfaced during the [#484](../../issues/484)
   fairy-ring audit and rolled forward as part of the broader pre-hub data
   pass tracked in [#495](../../issues/495).

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -3661,13 +3661,13 @@
     ],
     "guidanceSteps": [
       {
-        "description": "Travel to the Kraken Cove in the Fremennik Slayer Dungeon (fairy ring AJR or slayer ring)",
+        "description": "Travel to the Kraken Cove north of Piscatoris Fishing Colony (fairy ring AKQ then run west)",
         "worldX": 2278,
         "worldY": 3611,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 15,
-        "travelTip": "Fairy ring AKQ, or Slayer ring to Stronghold Slayer Cave"
+        "travelTip": "Fairy ring AKQ then run west to Kraken Cove"
       },
       {
         "description": "Enter the crevice to access the Kraken's cave",
@@ -10272,7 +10272,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to the Kraken Cove (fairy ring AKQ or slayer ring to Fremennik Slayer Dungeon)",
+        "description": "Travel to the Kraken Cove north of Piscatoris Fishing Colony (fairy ring AKQ then run west). 87 Slayer, on task only",
         "worldX": 2278,
         "worldY": 3611,
         "worldPlane": 0,

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -3661,7 +3661,7 @@
     ],
     "guidanceSteps": [
       {
-        "description": "Travel to the Kraken Cove north of Piscatoris Fishing Colony (fairy ring AKQ then run west)",
+        "description": "Travel to the Kraken Cove south-west of Piscatoris Fishing Colony (fairy ring AKQ then run west)",
         "worldX": 2278,
         "worldY": 3611,
         "worldPlane": 0,
@@ -10272,7 +10272,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to the Kraken Cove north of Piscatoris Fishing Colony (fairy ring AKQ then run west). 87 Slayer, on task only",
+        "description": "Travel to the Kraken Cove south-west of Piscatoris Fishing Colony (fairy ring AKQ then run west). 87 Slayer, on task only",
         "worldX": 2278,
         "worldY": 3611,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Both Kraken sources in \`drop_rates.json\` had stale step descriptions referencing the **Fremennik Slayer Dungeon** and a non-existent slayer-ring teleport to Kraken Cove. The numeric data was always correct — both bosses live in the Kraken Cove north of the Piscatoris Fishing Colony, reached via fairy ring \`AKQ\`. Only the per-step text was misleading.

### Changes

- **Kraken** (boss, line 3664): step description + step \`travelTip\` rewritten to reference Piscatoris and remove the bogus \"Slayer ring to Stronghold Slayer Cave\" hint (the slayer ring has no teleport to Kraken Cove).
- **Cave Kraken** (regular slayer monster, line 10275): step description rewritten to reference Piscatoris and drop the \"or slayer ring to Fremennik Slayer Dungeon\" claim.

No schema changes. No coordinate, NPC ID, or fairy-ring waypoint changes — those were already correct.

## Validation

- \`validate_drop_rates\` (Kraken + all 225 sources): 0 issues
- \`guidance_lint\` (Kraken + all 225 sources): 0 CRITICAL, 3 WARNING (all pre-existing intentional wide-arrival zones unrelated to this PR)

## Test plan

- [x] \`validate_drop_rates --source_name Kraken\` passes
- [x] \`guidance_lint --source_name Kraken\` clean (only the expected underground Y-offset INFO for the boss instance step)
- [ ] In-game smoke pass: travel to Kraken using fairy ring AKQ + verify the panel shows the corrected text (rolled into the broader Phase 2 sweep under #495)

Closes #494. Part of the broader pre-hub data pass tracked in #495.