### PR TITLE
chore(meta): sync plugin description and refine tags (#500)

### DIFF
--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -1,6 +1,6 @@
 displayName=Collection Log Helper
 author=cha-ndler
 description=Guides players through efficient collection log completion with overlays and efficiency scoring
-tags=collection,log,helper,efficiency,guide
+tags=collection,clog,slayer,clues,efficiency,guide
 plugins=com.collectionloghelper.CollectionLogHelperPlugin
 icon=/com/collectionloghelper/panel_icon.png

--- a/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
@@ -112,8 +112,8 @@ import net.runelite.client.util.Text;
 @Slf4j
 @PluginDescriptor(
 	name = "Collection Log Helper",
-	description = "Guides players through efficient collection log completion",
-	tags = {"collection", "log", "helper", "efficiency", "guide"}
+	description = "Guides players through efficient collection log completion with overlays and efficiency scoring",
+	tags = {"collection", "clog", "slayer", "clues", "efficiency", "guide"}
 )
 public class CollectionLogHelperPlugin extends Plugin
 {


### PR DESCRIPTION
Closes #500.

## Summary

- Align `runelite-plugin.properties` `description` and `@PluginDescriptor.description` on the longer canonical text (Hub tile and in-client sidebar now show the same string).
- Refine tags: drop generic `log`/`helper`, add gameplay-meaningful `clog`/`slayer`/`clues`. Final set (6): `collection, clog, slayer, clues, efficiency, guide`.
- Tags array is identical in both surfaces.

## Descriptor diff test plan

- [x] `runelite-plugin.properties` `description` matches `@PluginDescriptor.description` byte-for-byte
- [x] `runelite-plugin.properties` `tags` matches `@PluginDescriptor.tags` (order and values)
- [x] `./gradlew build` passes
- [ ] Reviewer spot-checks Hub tile rendering vs in-client sidebar text after merge