### PR TITLE
ci(lint): fail build on non-ASCII characters in drop_rates.json + replace em-dashes with ASCII (#501)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,6 +115,34 @@ test {
 
 check.dependsOn jacocoTestCoverageVerification
 
+tasks.register('lintDropRates') {
+	group = 'verification'
+	description = 'Fails if drop_rates.json contains non-ASCII characters.'
+	def jsonFile = file('src/main/resources/com/collectionloghelper/drop_rates.json')
+	inputs.file(jsonFile)
+	doLast {
+		if (!jsonFile.exists()) {
+			throw new GradleException("Missing ${jsonFile}")
+		}
+		def violations = []
+		int lineNo = 0
+		jsonFile.eachLine('UTF-8') { line ->
+			lineNo++
+			for (int i = 0; i < line.length(); i++) {
+				int cp = line.codePointAt(i)
+				if (cp > 0x7f) {
+					violations << "  line ${lineNo} col ${i + 1}: codepoint U+${String.format('%04X', cp)} ('${new String(Character.toChars(cp))}')"
+					break
+				}
+			}
+		}
+		if (!violations.isEmpty()) {
+			throw new GradleException("Non-ASCII characters in drop_rates.json:\n" + violations.take(20).join("\n") + (violations.size() > 20 ? "\n  ... and ${violations.size() - 20} more" : "") + "\nPolicy: drop_rates.json must be ASCII-only. Replace fancy punctuation (em-dash, smart quotes, ellipsis, non-breaking space) with ASCII equivalents.")
+		}
+	}
+}
+check.dependsOn lintDropRates
+
 tasks.register('shadowJar', Jar) {
 	dependsOn configurations.runtimeClasspath
 	manifest {

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -1139,7 +1139,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill the Alchemical Hydra. Use the coloured vents to weaken each phase — walk over the correct vent matching the Hydra's colour",
+        "description": "Kill the Alchemical Hydra. Use the coloured vents to weaken each phase - walk over the correct vent matching the Hydra's colour",
         "worldX": 1364,
         "worldY": 10265,
         "worldPlane": 0,
@@ -3432,7 +3432,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Kill Dagannoth Rex. Use Magic (fire spells work best). Rex is weak to Magic and uses melee — Protect from Melee when nearby",
+        "description": "Kill Dagannoth Rex. Use Magic (fire spells work best). Rex is weak to Magic and uses melee - Protect from Melee when nearby",
         "worldX": 2521,
         "worldY": 3740,
         "worldPlane": 0,
@@ -3504,7 +3504,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Kill Dagannoth Prime. Use Ranged. Prime attacks with Magic — use Protect from Magic when targeting Prime",
+        "description": "Kill Dagannoth Prime. Use Ranged. Prime attacks with Magic - use Protect from Magic when targeting Prime",
         "worldX": 2521,
         "worldY": 3740,
         "worldPlane": 0,
@@ -3576,7 +3576,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Kill Dagannoth Supreme. Use Melee. Supreme attacks with Ranged — use Protect from Missiles when targeting Supreme",
+        "description": "Kill Dagannoth Supreme. Use Melee. Supreme attacks with Ranged - use Protect from Missiles when targeting Supreme",
         "worldX": 2521,
         "worldY": 3740,
         "worldPlane": 0,
@@ -4029,7 +4029,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Kill the Chaos Elemental. Wear cheap gear — it can unequip your items. Use Protect from Magic and bring high-healing food",
+        "description": "Kill the Chaos Elemental. Wear cheap gear - it can unequip your items. Use Protect from Magic and bring high-healing food",
         "worldX": 3261,
         "worldY": 3927,
         "worldPlane": 0,
@@ -4442,7 +4442,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Kill Callisto. Use Verac's or Arclight. Watch for the knockback shockwave and the healing cubs — kill cubs first",
+        "description": "Kill Callisto. Use Verac's or Arclight. Watch for the knockback shockwave and the healing cubs - kill cubs first",
         "worldX": 3291,
         "worldY": 3849,
         "worldPlane": 0,
@@ -4909,7 +4909,7 @@
         "section": "Travel"
       },
       {
-        "description": "Enter the raid and scout rooms. Complete each room — combat, puzzle, and resource rooms — on your way to the final boss",
+        "description": "Enter the raid and scout rooms. Complete each room - combat, puzzle, and resource rooms - on your way to the final boss",
         "worldX": 1233,
         "worldY": 3573,
         "worldPlane": 0,
@@ -5150,7 +5150,7 @@
         "section": "Travel"
       },
       {
-        "description": "Enter the raid and scout rooms. Complete each room — combat, puzzle, and resource rooms — on your way to the final boss",
+        "description": "Enter the raid and scout rooms. Complete each room - combat, puzzle, and resource rooms - on your way to the final boss",
         "worldX": 1233,
         "worldY": 3573,
         "worldPlane": 0,
@@ -7328,7 +7328,7 @@
         "completionCondition": "MANUAL"
       },
       {
-        "description": "Defeat Sol Heredit in the final wave. He has multiple attack styles and powerful special attacks — learn the mechanics for consistent clears",
+        "description": "Defeat Sol Heredit in the final wave. He has multiple attack styles and powerful special attacks - learn the mechanics for consistent clears",
         "worldX": 1794,
         "worldY": 3107,
         "worldPlane": 0,
@@ -7664,7 +7664,7 @@
         "completionDistance": 80
       },
       {
-        "description": "Complete Perilous Moons. Fight the three Moon bosses in sequence. Each has unique mechanics — learn the safe tiles and prayer switches",
+        "description": "Complete Perilous Moons. Fight the three Moon bosses in sequence. Each has unique mechanics - learn the safe tiles and prayer switches",
         "perItemStepDescription": {
           "29019": "Fight the Blue Moon and open the Lunar Chest to receive your Blue Moon armour.",
           "29013": "Fight the Blue Moon and open the Lunar Chest to receive your Blue Moon armour.",
@@ -8061,7 +8061,7 @@
         "completionCondition": "MANUAL"
       },
       {
-        "description": "Kill revenants in the caves for unique drops. Bring risk — it's multi-combat Wilderness.",
+        "description": "Kill revenants in the caves for unique drops. Bring risk - it's multi-combat Wilderness.",
         "worldX": 3073,
         "worldY": 3654,
         "worldPlane": 0,
@@ -8109,7 +8109,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Kill Crawling Hands in the Slayer Tower basement. Very low combat — good for early slayer tasks",
+        "description": "Kill Crawling Hands in the Slayer Tower basement. Very low combat - good for early slayer tasks",
         "worldX": 3418,
         "worldY": 3543,
         "worldPlane": 0,
@@ -8931,7 +8931,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Kill Gryphons on the islands accessible via Sailing. Standard combat — no special mechanics",
+        "description": "Kill Gryphons on the islands accessible via Sailing. Standard combat - no special mechanics",
         "worldX": 1456,
         "worldY": 2880,
         "worldPlane": 0,
@@ -9999,7 +9999,7 @@
         "completionDistance": 15
       },
       {
-        "description": "Kill Spiritual Mages in the God Wars Dungeon. Requires 83 Slayer. Found in all four god chambers — equip the corresponding god item for protection",
+        "description": "Kill Spiritual Mages in the God Wars Dungeon. Requires 83 Slayer. Found in all four god chambers - equip the corresponding god item for protection",
         "worldX": 2844,
         "worldY": 5280,
         "worldPlane": 2,
@@ -10342,7 +10342,7 @@
         "completionDistance": 15
       },
       {
-        "description": "Kill Dark Beasts in the Mourner Tunnels or Catacombs of Kourend. Use Protect from Melee. High Defence — use accurate weapon styles",
+        "description": "Kill Dark Beasts in the Mourner Tunnels or Catacombs of Kourend. Use Protect from Melee. High Defence - use accurate weapon styles",
         "worldX": 1920,
         "worldY": 4672,
         "worldPlane": 0,
@@ -13805,7 +13805,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Play Last Man Standing — a battle royale minigame on the island east of Ferox Enclave. Earn points to buy the Halos and Dragon Claws ornament kit",
+        "description": "Play Last Man Standing - a battle royale minigame on the island east of Ferox Enclave. Earn points to buy the Halos and Dragon Claws ornament kit",
         "worldX": 3151,
         "worldY": 3634,
         "worldPlane": 0,
@@ -19318,7 +19318,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Kill both Royal Titans (Eldric + Branda). Duo recommended. Focus DPS on both evenly — if one falls first, the other enrages. Dodge the ice/fire waves and elemental spawns",
+        "description": "Kill both Royal Titans (Eldric + Branda). Duo recommended. Focus DPS on both evenly - if one falls first, the other enrages. Dodge the ice/fire waves and elemental spawns",
         "worldX": 3008,
         "worldY": 3150,
         "worldPlane": 0,
@@ -24866,7 +24866,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Catch black chinchompas in the Wilderness (level 32-36). Bring minimal risk — PKers frequent this area. Best caught with box traps at 80+ Hunter",
+        "description": "Catch black chinchompas in the Wilderness (level 32-36). Bring minimal risk - PKers frequent this area. Best caught with box traps at 80+ Hunter",
         "worldX": 3143,
         "worldY": 3771,
         "worldPlane": 0,

--- a/src/test/java/com/collectionloghelper/data/DropRateDatabaseTest.java
+++ b/src/test/java/com/collectionloghelper/data/DropRateDatabaseTest.java
@@ -354,25 +354,31 @@ public class DropRateDatabaseTest
 	}
 
 	// ========================================================================
-	// Charset regression — issue #433
+	// Charset regression - issue #433 / ASCII-only policy - issue #501
 	// ========================================================================
 
 	/**
-	 * Verifies that em-dash characters in step descriptions are loaded correctly
-	 * as the Unicode em-dash (U+2014, "—") rather than the Windows-1252 mojibake
-	 * sequence "â€"" that results from reading UTF-8 bytes with the platform
-	 * default charset on Windows.
+	 * Guards against two related corruption modes in guidance step descriptions:
 	 *
-	 * <p>The Perilous Moons step 3 description ("… Each has unique mechanics — learn
-	 * the safe tiles …") is the known reproducer from issue #433.
+	 * <ul>
+	 *   <li>Windows-1252 mojibake (e.g. UTF-8 em-dash bytes misread as cp1252)
+	 *       that results from reading UTF-8 with the platform default charset
+	 *       on Windows (issue #433).</li>
+	 *   <li>Any non-ASCII codepoint in description text. Per issue #501,
+	 *       drop_rates.json is ASCII-only; fancy punctuation (em-dash, smart
+	 *       quotes, ellipsis, non-breaking space) must be replaced with ASCII
+	 *       equivalents. The Gradle task {@code lintDropRates} enforces this on
+	 *       the raw file; this test extends the guarantee to the loaded model so
+	 *       it catches drift introduced via {@code perItemStepDescription}
+	 *       overrides or future merge accidents.</li>
+	 * </ul>
 	 */
 	@Test
 	public void load_guidanceStepDescriptions_noCharsetCorruption()
 	{
-		final String MOJIBAKE = "â€”"; // UTF-8 em-dash bytes misread as Windows-1252
-		final String EM_DASH   = "—";              // correct em-dash
-
-		boolean foundAtLeastOneEmDash = false;
+		// UTF-8 em-dash (0xE2 0x80 0x94) misread as cp1252 yields U+00E2 U+20AC U+201D.
+		// We detect the leading two codepoints, which uniquely indicate cp1252 mojibake.
+		final String MOJIBAKE_PREFIX = new String(new char[]{(char) 0x00E2, (char) 0x20AC});
 
 		for (CollectionLogSource source : database.getAllSources())
 		{
@@ -386,13 +392,10 @@ public class DropRateDatabaseTest
 				if (desc != null)
 				{
 					assertFalse(
-						"Mojibake em-dash detected in description for source '"
+						"Mojibake sequence detected in description for source '"
 							+ source.getName() + "': " + desc,
-						desc.contains(MOJIBAKE));
-					if (desc.contains(EM_DASH))
-					{
-						foundAtLeastOneEmDash = true;
-					}
+						desc.contains(MOJIBAKE_PREFIX));
+					assertAscii("description for source '" + source.getName() + "'", desc);
 				}
 
 				if (step.getPerItemStepDescription() != null)
@@ -403,20 +406,32 @@ public class DropRateDatabaseTest
 						if (override != null)
 						{
 							assertFalse(
-								"Mojibake em-dash detected in perItemStepDescription (item "
+								"Mojibake sequence detected in perItemStepDescription (item "
 									+ entry.getKey() + ") for source '" + source.getName()
 									+ "': " + override,
-								override.contains(MOJIBAKE));
+								override.contains(MOJIBAKE_PREFIX));
+							assertAscii(
+								"perItemStepDescription (item " + entry.getKey()
+									+ ") for source '" + source.getName() + "'",
+								override);
 						}
 					}
 				}
 			}
 		}
+	}
 
-		assertTrue(
-			"Expected at least one em-dash in guidance step descriptions — "
-				+ "test data may be empty or step sources changed",
-			foundAtLeastOneEmDash);
+	private static void assertAscii(String context, String value)
+	{
+		for (int i = 0; i < value.length(); i++)
+		{
+			int cp = value.codePointAt(i);
+			if (cp > 0x7F)
+			{
+				fail("Non-ASCII codepoint U+" + String.format("%04X", cp)
+					+ " at index " + i + " in " + context + ": " + value);
+			}
+		}
 	}
 
 	// ========================================================================


### PR DESCRIPTION
## Summary

- Replaces 20x U+2014 em-dashes with ASCII `-` in step descriptions in `src/main/resources/com/collectionloghelper/drop_rates.json` (18 lines touched).
- Adds a `lintDropRates` Gradle task that scans `drop_rates.json` for any codepoint > U+007F and fails with line/column/codepoint info. Wired into the `check` lifecycle so `./gradlew build` gates on it.
- Updates `DropRateDatabaseTest.load_guidanceStepDescriptions_noCharsetCorruption` to enforce the new ASCII-only invariant on the loaded model (descriptions + perItemStepDescription overrides), while keeping the cp1252 mojibake guard from issue #433.

Policy: drop_rates.json is ASCII-only. Fancy punctuation (em-dash, smart quotes, ellipsis, non-breaking space) must be replaced with ASCII equivalents.

## Test plan

- [x] `./gradlew lintDropRates` passes on clean content
- [x] Injecting one em-dash into a step description causes `./gradlew lintDropRates` to fail with line/col + codepoint U+2014 in the error message (verified locally, then reverted)
- [x] `./gradlew build` passes end-to-end (lintDropRates + jacocoTestCoverageVerification both run inside `check`)
- [x] Spot-checked 3 of the 18 modified descriptions for natural readability after `-` replacement (no doubled spaces, no broken word breaks)

Closes #501