### PR TITLE
refactor: rename guidance.helper package to guidance.bosses (#502)

### DIFF
--- a/src/main/java/com/collectionloghelper/data/CollectionLogSource.java
+++ b/src/main/java/com/collectionloghelper/data/CollectionLogSource.java
@@ -54,9 +54,9 @@ public class CollectionLogSource
 	List<GuidanceStep> guidanceSteps;
 
 	/**
-	 * Optional key naming a registered {@link com.collectionloghelper.guidance.helper.GuidanceHelper}
+	 * Optional key naming a registered {@link com.collectionloghelper.guidance.bosses.BossGuidance}
 	 * implementation that supplies steps for this source. When non-null the sequencer
-	 * delegates step generation to the helper instead of {@link #guidanceSteps}.
+	 * delegates step generation to the boss guidance instead of {@link #guidanceSteps}.
 	 *
 	 * <p>Null by default — existing JSON without this field deserialises unchanged.
 	 */

--- a/src/main/java/com/collectionloghelper/guidance/GuidanceSequencer.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceSequencer.java
@@ -32,8 +32,8 @@ import com.collectionloghelper.data.PlayerInventoryState;
 import com.collectionloghelper.data.RequirementsChecker;
 import com.collectionloghelper.data.StepWaypoint;
 import com.collectionloghelper.data.Zone;
-import com.collectionloghelper.guidance.helper.GuidanceHelper;
-import com.collectionloghelper.guidance.helper.GuidanceHelperRegistry;
+import com.collectionloghelper.guidance.bosses.BossGuidance;
+import com.collectionloghelper.guidance.bosses.BossGuidanceRegistry;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -55,7 +55,7 @@ public class GuidanceSequencer
 	private final PlayerInventoryState inventoryState;
 	private final PlayerCollectionState collectionState;
 	private final RequirementsChecker requirementsChecker;
-	private final GuidanceHelperRegistry helperRegistry;
+	private final BossGuidanceRegistry bossRegistry;
 
 	private volatile WorldPoint lastKnownPlayerLocation;
 	private volatile CollectionLogSource activeSource;
@@ -88,12 +88,12 @@ public class GuidanceSequencer
 
 	@Inject
 	private GuidanceSequencer(PlayerInventoryState inventoryState, PlayerCollectionState collectionState,
-		RequirementsChecker requirementsChecker, GuidanceHelperRegistry helperRegistry)
+		RequirementsChecker requirementsChecker, BossGuidanceRegistry bossRegistry)
 	{
 		this.inventoryState = inventoryState;
 		this.collectionState = collectionState;
 		this.requirementsChecker = requirementsChecker;
-		this.helperRegistry = helperRegistry;
+		this.bossRegistry = bossRegistry;
 	}
 
 	/**
@@ -113,14 +113,14 @@ public class GuidanceSequencer
 		Runnable sequenceComplete)
 	{
 		this.activeSource = source;
-		// Route through Java helper when the source opts in, else fall back to JSON steps
-		GuidanceHelper helper = helperRegistry != null
-			? helperRegistry.get(source.getGuidanceHelperKey())
+		// Route through Java boss guidance when the source opts in, else fall back to JSON steps
+		BossGuidance boss = bossRegistry != null
+			? bossRegistry.get(source.getGuidanceHelperKey())
 			: null;
-		if (helper != null)
+		if (boss != null)
 		{
-			log.debug("Using Java helper '{}' for source {}", source.getGuidanceHelperKey(), source.getName());
-			this.steps = helper.getSteps(null, null);
+			log.debug("Using Java boss guidance '{}' for source {}", source.getGuidanceHelperKey(), source.getName());
+			this.steps = boss.getSteps(null, null);
 		}
 		else
 		{

--- a/src/main/java/com/collectionloghelper/guidance/bosses/BossGuidance.java
+++ b/src/main/java/com/collectionloghelper/guidance/bosses/BossGuidance.java
@@ -22,7 +22,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.collectionloghelper.guidance.helper;
+package com.collectionloghelper.guidance.bosses;
 
 import com.collectionloghelper.data.GuidanceStep;
 import java.util.List;
@@ -33,17 +33,17 @@ import net.runelite.client.callback.ClientThread;
  * Optional escape hatch for sources that cannot be fully expressed in JSON.
  *
  * <p>When a {@link com.collectionloghelper.data.CollectionLogSource} has a
- * non-null {@code guidanceHelperKey}, the {@link GuidanceHelperRegistry}
+ * non-null {@code guidanceHelperKey}, the {@link BossGuidanceRegistry}
  * resolves it to an implementation of this interface. The
  * {@link com.collectionloghelper.guidance.GuidanceSequencer} then delegates
- * step generation and satisfaction checks to the helper instead of relying
- * solely on the source's {@code guidanceSteps} JSON list.
+ * step generation and satisfaction checks to the boss guidance instead of
+ * relying solely on the source's {@code guidanceSteps} JSON list.
  *
- * <p>This is the D-01 hybrid design: JSON stays primary; Java helpers are
- * the opt-in escape hatch for hard sources (dynamic re-render, arbitrary
+ * <p>This is the D-01 hybrid design: JSON stays primary; Java boss guidance
+ * is the opt-in escape hatch for hard sources (dynamic re-render, arbitrary
  * varbit predicates, puzzle logic).
  */
-public interface GuidanceHelper
+public interface BossGuidance
 {
 	/**
 	 * Returns the ordered list of guidance steps for this source.
@@ -68,8 +68,8 @@ public interface GuidanceHelper
 	 * satisfaction check should return {@code true} when appropriate.
 	 *
 	 * <p>For this pilot PR the implementation always returns {@code false}
-	 * (delegate to the default sequencer evaluation). Future helpers may
-	 * implement richer logic here.
+	 * (delegate to the default sequencer evaluation). Future implementations
+	 * may implement richer logic here.
 	 *
 	 * @param client    the RuneLite client
 	 * @param step      the step to evaluate

--- a/src/main/java/com/collectionloghelper/guidance/bosses/BossGuidanceRegistry.java
+++ b/src/main/java/com/collectionloghelper/guidance/bosses/BossGuidanceRegistry.java
@@ -22,7 +22,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.collectionloghelper.guidance.helper;
+package com.collectionloghelper.guidance.bosses;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -33,53 +33,53 @@ import javax.inject.Singleton;
 
 /**
  * Registry that maps {@code guidanceHelperKey} strings to their
- * {@link GuidanceHelper} implementations.
+ * {@link BossGuidance} implementations.
  *
  * <p>The registry is populated at plugin startup. When a
  * {@link com.collectionloghelper.data.CollectionLogSource} carries a non-null
  * {@code guidanceHelperKey}, the
  * {@link com.collectionloghelper.guidance.GuidanceSequencer} calls
- * {@link #get(String)} to retrieve the helper before starting a sequence.
+ * {@link #get(String)} to retrieve the boss guidance before starting a sequence.
  *
  * <p>Keys are lower-case strings matching the {@code guidanceHelperKey} field
  * value in {@code drop_rates.json} (e.g. {@code "cerberus"}).
  */
 @Singleton
-public class GuidanceHelperRegistry
+public class BossGuidanceRegistry
 {
-	private final Map<String, GuidanceHelper> helpers;
+	private final Map<String, BossGuidance> bosses;
 
 	@Inject
-	GuidanceHelperRegistry(CerberusHelper cerberusHelper)
+	BossGuidanceRegistry(CerberusGuidance cerberusGuidance)
 	{
-		Map<String, GuidanceHelper> map = new HashMap<>();
-		map.put("cerberus", cerberusHelper);
-		this.helpers = Collections.unmodifiableMap(map);
+		Map<String, BossGuidance> map = new HashMap<>();
+		map.put("cerberus", cerberusGuidance);
+		this.bosses = Collections.unmodifiableMap(map);
 	}
 
 	/**
-	 * Returns the {@link GuidanceHelper} registered for the given key, or
-	 * {@code null} if no helper is registered for that key.
+	 * Returns the {@link BossGuidance} registered for the given key, or
+	 * {@code null} if no boss guidance is registered for that key.
 	 *
 	 * @param key the {@code guidanceHelperKey} value from the source (may be null)
-	 * @return the registered helper, or {@code null}
+	 * @return the registered boss guidance, or {@code null}
 	 */
 	@Nullable
-	public GuidanceHelper get(@Nullable String key)
+	public BossGuidance get(@Nullable String key)
 	{
 		if (key == null)
 		{
 			return null;
 		}
-		return helpers.get(key);
+		return bosses.get(key);
 	}
 
 	/**
 	 * Returns an unmodifiable view of the full registry map.
 	 * Exposed for testing.
 	 */
-	public Map<String, GuidanceHelper> getAllHelpers()
+	public Map<String, BossGuidance> getAllBosses()
 	{
-		return helpers;
+		return bosses;
 	}
 }

--- a/src/main/java/com/collectionloghelper/guidance/bosses/CerberusGuidance.java
+++ b/src/main/java/com/collectionloghelper/guidance/bosses/CerberusGuidance.java
@@ -22,7 +22,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.collectionloghelper.guidance.helper;
+package com.collectionloghelper.guidance.bosses;
 
 import com.collectionloghelper.data.CompletionCondition;
 import com.collectionloghelper.data.GuidanceStep;
@@ -35,10 +35,10 @@ import net.runelite.api.Client;
 import net.runelite.client.callback.ClientThread;
 
 /**
- * Pilot Java helper for Cerberus (D-01 hybrid, B6).
+ * Pilot Java boss guidance for Cerberus (D-01 hybrid, B6).
  *
  * <p>This PR mirrors Cerberus's existing JSON guidance steps in Java code to
- * prove that the helper plumbing works end-to-end. The step data is
+ * prove that the boss-guidance plumbing works end-to-end. The step data is
  * intentionally identical to the JSON so that no behaviour changes occur when
  * the helper key is absent (plumbing-only milestone).
  *
@@ -47,7 +47,7 @@ import net.runelite.client.callback.ClientThread;
  * {@link com.collectionloghelper.guidance.GuidanceSequencer} logic.
  */
 @Singleton
-public class CerberusHelper implements GuidanceHelper
+public class CerberusGuidance implements BossGuidance
 {
 	/** NPC ID for Cerberus (all combat variants). */
 	static final int CERBERUS_NPC_ID = 5862;
@@ -60,7 +60,7 @@ public class CerberusHelper implements GuidanceHelper
 		Arrays.asList(2434, 3024, 12695));
 
 	@Inject
-	CerberusHelper()
+	CerberusGuidance()
 	{
 	}
 

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerNestedConditionalTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerNestedConditionalTest.java
@@ -87,7 +87,7 @@ public class GuidanceSequencerNestedConditionalTest
 
 		Constructor<GuidanceSequencer> ctor = GuidanceSequencer.class.getDeclaredConstructor(
 			PlayerInventoryState.class, PlayerCollectionState.class, RequirementsChecker.class,
-				com.collectionloghelper.guidance.helper.GuidanceHelperRegistry.class);
+				com.collectionloghelper.guidance.bosses.BossGuidanceRegistry.class);
 		ctor.setAccessible(true);
 		sequencer = ctor.newInstance(inventoryState, collectionState, requirementsChecker, null);
 	}

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
@@ -81,7 +81,7 @@ public class GuidanceSequencerTest
 
 		Constructor<GuidanceSequencer> ctor = GuidanceSequencer.class.getDeclaredConstructor(
 			PlayerInventoryState.class, PlayerCollectionState.class, RequirementsChecker.class,
-				com.collectionloghelper.guidance.helper.GuidanceHelperRegistry.class);
+				com.collectionloghelper.guidance.bosses.BossGuidanceRegistry.class);
 		ctor.setAccessible(true);
 		sequencer = ctor.newInstance(inventoryState, collectionState, requirementsChecker, null);
 	}

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerWaypointTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerWaypointTest.java
@@ -87,11 +87,11 @@ public class GuidanceSequencerWaypointTest
 
 		Constructor<GuidanceSequencer> ctor = GuidanceSequencer.class.getDeclaredConstructor(
 			PlayerInventoryState.class, PlayerCollectionState.class, RequirementsChecker.class,
-			com.collectionloghelper.guidance.helper.GuidanceHelperRegistry.class);
+			com.collectionloghelper.guidance.bosses.BossGuidanceRegistry.class);
 		ctor.setAccessible(true);
-		com.collectionloghelper.guidance.helper.GuidanceHelperRegistry helperRegistry =
-			org.mockito.Mockito.mock(com.collectionloghelper.guidance.helper.GuidanceHelperRegistry.class);
-		sequencer = ctor.newInstance(inventoryState, collectionState, requirementsChecker, helperRegistry);
+		com.collectionloghelper.guidance.bosses.BossGuidanceRegistry bossRegistry =
+			org.mockito.Mockito.mock(com.collectionloghelper.guidance.bosses.BossGuidanceRegistry.class);
+		sequencer = ctor.newInstance(inventoryState, collectionState, requirementsChecker, bossRegistry);
 	}
 
 	// ── Helpers ───────────────────────────────────────────────────────────────

--- a/src/test/java/com/collectionloghelper/guidance/bosses/BossGuidanceDispatchTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/bosses/BossGuidanceDispatchTest.java
@@ -22,7 +22,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.collectionloghelper.guidance.helper;
+package com.collectionloghelper.guidance.bosses;
 
 import com.collectionloghelper.data.CollectionLogCategory;
 import com.collectionloghelper.data.CollectionLogItem;
@@ -50,12 +50,12 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.lenient;
 
 /**
- * Verifies that GuidanceSequencer correctly dispatches to a GuidanceHelper when
+ * Verifies that GuidanceSequencer correctly dispatches to a BossGuidance when
  * the source has a non-null guidanceHelperKey, and falls back to JSON steps when
  * it does not.
  */
 @RunWith(MockitoJUnitRunner.class)
-public class GuidanceHelperDispatchTest
+public class BossGuidanceDispatchTest
 {
 	@Mock
 	private PlayerInventoryState inventoryState;
@@ -64,7 +64,7 @@ public class GuidanceHelperDispatchTest
 	@Mock
 	private RequirementsChecker requirementsChecker;
 
-	private GuidanceHelperRegistry registry;
+	private BossGuidanceRegistry registry;
 	private GuidanceSequencer sequencer;
 
 	@Before
@@ -75,18 +75,18 @@ public class GuidanceHelperDispatchTest
 		lenient().when(inventoryState.hasAllItems(anyList())).thenReturn(true);
 		lenient().when(collectionState.isItemObtained(anyInt())).thenReturn(false);
 
-		Constructor<CerberusHelper> cerberusCtor = CerberusHelper.class.getDeclaredConstructor();
+		Constructor<CerberusGuidance> cerberusCtor = CerberusGuidance.class.getDeclaredConstructor();
 		cerberusCtor.setAccessible(true);
-		CerberusHelper cerberusHelper = cerberusCtor.newInstance();
+		CerberusGuidance cerberusGuidance = cerberusCtor.newInstance();
 
-		Constructor<GuidanceHelperRegistry> regCtor =
-			GuidanceHelperRegistry.class.getDeclaredConstructor(CerberusHelper.class);
+		Constructor<BossGuidanceRegistry> regCtor =
+			BossGuidanceRegistry.class.getDeclaredConstructor(CerberusGuidance.class);
 		regCtor.setAccessible(true);
-		registry = regCtor.newInstance(cerberusHelper);
+		registry = regCtor.newInstance(cerberusGuidance);
 
 		Constructor<GuidanceSequencer> seqCtor = GuidanceSequencer.class.getDeclaredConstructor(
 			PlayerInventoryState.class, PlayerCollectionState.class, RequirementsChecker.class,
-			GuidanceHelperRegistry.class);
+			BossGuidanceRegistry.class);
 		seqCtor.setAccessible(true);
 		sequencer = seqCtor.newInstance(inventoryState, collectionState, requirementsChecker, registry);
 	}
@@ -122,7 +122,7 @@ public class GuidanceHelperDispatchTest
 	}
 
 	@Test
-	public void startSequence_withCerberusHelperKey_usesHelperSteps()
+	public void startSequence_withCerberusHelperKey_usesBossSteps()
 	{
 		GuidanceStep jsonOnlyStep = makeManualStep("JSON-only step");
 		CollectionLogSource source = makeSource("Cerberus", "cerberus",
@@ -136,9 +136,9 @@ public class GuidanceHelperDispatchTest
 		assertNotNull("Current step must not be null", current);
 		assertEquals(CompletionCondition.ARRIVE_AT_TILE, current.getCompletionCondition());
 		assertEquals("Travel", current.getSection());
-		assertEquals("Sequencer must use 3 steps from CerberusHelper",
+		assertEquals("Sequencer must use 3 steps from CerberusGuidance",
 			3, sequencer.getTotalSteps());
-		assertFalse("JSON-only step must not appear when helper is used",
+		assertFalse("JSON-only step must not appear when boss guidance is used",
 			"JSON-only step".equals(current.getDescription()));
 	}
 

--- a/src/test/java/com/collectionloghelper/guidance/bosses/BossGuidanceKeyRegressionTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/bosses/BossGuidanceKeyRegressionTest.java
@@ -22,7 +22,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.collectionloghelper.guidance.helper;
+package com.collectionloghelper.guidance.bosses;
 
 import com.collectionloghelper.data.CollectionLogSource;
 import com.collectionloghelper.data.DropRateDatabase;
@@ -41,10 +41,10 @@ import static org.junit.Assert.assertNull;
  *
  * <p>B6 adds the schema field but deliberately does not set it on any
  * production source yet. This test will fail if someone accidentally adds
- * the key to the JSON, reminding them to register the corresponding helper
- * before shipping.
+ * the key to the JSON, reminding them to register the corresponding boss
+ * guidance before shipping.
  */
-public class GuidanceHelperKeyRegressionTest
+public class BossGuidanceKeyRegressionTest
 {
 	private DropRateDatabase database;
 
@@ -67,7 +67,7 @@ public class GuidanceHelperKeyRegressionTest
 		{
 			assertNull(
 				"Production source '" + source.getName()
-					+ "' must not have guidanceHelperKey set until its helper is registered",
+					+ "' must not have guidanceHelperKey set until its boss guidance is registered",
 				source.getGuidanceHelperKey()
 			);
 		}

--- a/src/test/java/com/collectionloghelper/guidance/bosses/BossGuidanceRegistryTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/bosses/BossGuidanceRegistryTest.java
@@ -22,58 +22,58 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.collectionloghelper.guidance.helper;
+package com.collectionloghelper.guidance.bosses;
 
 import java.lang.reflect.Constructor;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
 
-public class GuidanceHelperRegistryTest
+public class BossGuidanceRegistryTest
 {
-	private GuidanceHelperRegistry buildRegistry() throws Exception
+	private BossGuidanceRegistry buildRegistry() throws Exception
 	{
-		CerberusHelper cerberusHelper = buildCerberusHelper();
-		Constructor<GuidanceHelperRegistry> ctor =
-			GuidanceHelperRegistry.class.getDeclaredConstructor(CerberusHelper.class);
+		CerberusGuidance cerberusGuidance = buildCerberusGuidance();
+		Constructor<BossGuidanceRegistry> ctor =
+			BossGuidanceRegistry.class.getDeclaredConstructor(CerberusGuidance.class);
 		ctor.setAccessible(true);
-		return ctor.newInstance(cerberusHelper);
+		return ctor.newInstance(cerberusGuidance);
 	}
 
-	private CerberusHelper buildCerberusHelper() throws Exception
+	private CerberusGuidance buildCerberusGuidance() throws Exception
 	{
-		Constructor<CerberusHelper> ctor = CerberusHelper.class.getDeclaredConstructor();
+		Constructor<CerberusGuidance> ctor = CerberusGuidance.class.getDeclaredConstructor();
 		ctor.setAccessible(true);
 		return ctor.newInstance();
 	}
 
 	@Test
-	public void get_cerberusKey_returnsCerberusHelper() throws Exception
+	public void get_cerberusKey_returnsCerberusGuidance() throws Exception
 	{
-		GuidanceHelperRegistry registry = buildRegistry();
-		GuidanceHelper helper = registry.get("cerberus");
-		assertNotNull("Registry must return a helper for 'cerberus'", helper);
-		assertTrue("Helper must be a CerberusHelper", helper instanceof CerberusHelper);
+		BossGuidanceRegistry registry = buildRegistry();
+		BossGuidance boss = registry.get("cerberus");
+		assertNotNull("Registry must return boss guidance for 'cerberus'", boss);
+		assertTrue("Boss guidance must be a CerberusGuidance", boss instanceof CerberusGuidance);
 	}
 
 	@Test
 	public void get_nullKey_returnsNull() throws Exception
 	{
-		GuidanceHelperRegistry registry = buildRegistry();
+		BossGuidanceRegistry registry = buildRegistry();
 		assertNull("Registry must return null for null key", registry.get(null));
 	}
 
 	@Test
 	public void get_unknownKey_returnsNull() throws Exception
 	{
-		GuidanceHelperRegistry registry = buildRegistry();
+		BossGuidanceRegistry registry = buildRegistry();
 		assertNull("Registry must return null for unknown key", registry.get("zulrah"));
 	}
 
 	@Test
-	public void getAllHelpers_containsCerberus() throws Exception
+	public void getAllBosses_containsCerberus() throws Exception
 	{
-		GuidanceHelperRegistry registry = buildRegistry();
-		assertTrue("'cerberus' must be in getAllHelpers()", registry.getAllHelpers().containsKey("cerberus"));
+		BossGuidanceRegistry registry = buildRegistry();
+		assertTrue("'cerberus' must be in getAllBosses()", registry.getAllBosses().containsKey("cerberus"));
 	}
 }

--- a/src/test/java/com/collectionloghelper/guidance/bosses/CerberusGuidanceTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/bosses/CerberusGuidanceTest.java
@@ -22,7 +22,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.collectionloghelper.guidance.helper;
+package com.collectionloghelper.guidance.bosses;
 
 import com.collectionloghelper.data.CompletionCondition;
 import com.collectionloghelper.data.GuidanceStep;
@@ -33,29 +33,29 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
-public class CerberusHelperTest
+public class CerberusGuidanceTest
 {
-	private CerberusHelper helper;
+	private CerberusGuidance guidance;
 
 	@Before
 	public void setUp() throws Exception
 	{
-		Constructor<CerberusHelper> ctor = CerberusHelper.class.getDeclaredConstructor();
+		Constructor<CerberusGuidance> ctor = CerberusGuidance.class.getDeclaredConstructor();
 		ctor.setAccessible(true);
-		helper = ctor.newInstance();
+		guidance = ctor.newInstance();
 	}
 
 	@Test
 	public void getSteps_returnsThreeSteps()
 	{
-		List<GuidanceStep> steps = helper.getSteps(null, null);
-		assertEquals("Cerberus helper must produce exactly 3 steps", 3, steps.size());
+		List<GuidanceStep> steps = guidance.getSteps(null, null);
+		assertEquals("Cerberus guidance must produce exactly 3 steps", 3, steps.size());
 	}
 
 	@Test
 	public void getSteps_firstStep_isTravelToTaverley()
 	{
-		List<GuidanceStep> steps = helper.getSteps(null, null);
+		List<GuidanceStep> steps = guidance.getSteps(null, null);
 		GuidanceStep travelStep = steps.get(0);
 		assertEquals(CompletionCondition.ARRIVE_AT_TILE, travelStep.getCompletionCondition());
 		assertEquals("Travel", travelStep.getSection());
@@ -68,10 +68,10 @@ public class CerberusHelperTest
 	@Test
 	public void getSteps_secondStep_isGateStep()
 	{
-		List<GuidanceStep> steps = helper.getSteps(null, null);
+		List<GuidanceStep> steps = guidance.getSteps(null, null);
 		GuidanceStep gateStep = steps.get(1);
 		assertEquals(CompletionCondition.MANUAL, gateStep.getCompletionCondition());
-		assertEquals(CerberusHelper.IRON_WINCH_OBJECT_ID, gateStep.getObjectId());
+		assertEquals(CerberusGuidance.IRON_WINCH_OBJECT_ID, gateStep.getObjectId());
 		assertEquals("Turn", gateStep.getObjectInteractAction());
 		assertEquals("Travel", gateStep.getSection());
 	}
@@ -79,11 +79,11 @@ public class CerberusHelperTest
 	@Test
 	public void getSteps_thirdStep_isKillCerberus()
 	{
-		List<GuidanceStep> steps = helper.getSteps(null, null);
+		List<GuidanceStep> steps = guidance.getSteps(null, null);
 		GuidanceStep killStep = steps.get(2);
 		assertEquals(CompletionCondition.ACTOR_DEATH, killStep.getCompletionCondition());
-		assertEquals(CerberusHelper.CERBERUS_NPC_ID, killStep.getNpcId());
-		assertEquals(CerberusHelper.CERBERUS_NPC_ID, killStep.getCompletionNpcId());
+		assertEquals(CerberusGuidance.CERBERUS_NPC_ID, killStep.getNpcId());
+		assertEquals(CerberusGuidance.CERBERUS_NPC_ID, killStep.getCompletionNpcId());
 		assertEquals("Attack", killStep.getInteractAction());
 		assertEquals("Combat", killStep.getSection());
 		assertNotNull("Kill step must have recommended items", killStep.getRecommendedItemIds());
@@ -93,12 +93,12 @@ public class CerberusHelperTest
 	@Test
 	public void isStepSatisfied_alwaysReturnsFalse()
 	{
-		List<GuidanceStep> steps = helper.getSteps(null, null);
+		List<GuidanceStep> steps = guidance.getSteps(null, null);
 		for (int i = 0; i < steps.size(); i++)
 		{
 			assertFalse(
 				"isStepSatisfied must always return false for step " + i,
-				helper.isStepSatisfied(null, steps.get(i), i));
+				guidance.isStepSatisfied(null, steps.get(i), i));
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Drop the redundant "helper" word from a package and class layer inside the `collection-log-helper` plugin. Previously the deepest type read as `com.collectionloghelper.guidance.helper.GuidanceHelperRegistry` — six occurrences of "helper" before reaching a useful class name. After this PR it reads as `com.collectionloghelper.guidance.bosses.BossGuidanceRegistry`.

### Renames

| Before | After |
| --- | --- |
| `guidance.helper.GuidanceHelper` | `guidance.bosses.BossGuidance` |
| `guidance.helper.GuidanceHelperRegistry` | `guidance.bosses.BossGuidanceRegistry` |
| `guidance.helper.CerberusHelper` | `guidance.bosses.CerberusGuidance` |
| `CerberusHelperTest` | `CerberusGuidanceTest` |
| `GuidanceHelperDispatchTest` | `BossGuidanceDispatchTest` |
| `GuidanceHelperRegistryTest` | `BossGuidanceRegistryTest` |
| `GuidanceHelperKeyRegressionTest` | `BossGuidanceKeyRegressionTest` |

Also renames the `GuidanceSequencer` field `helperRegistry` to `bossRegistry`, plus matching Javadoc `{@link …}` reference in `CollectionLogSource`.

The JSON-level `guidanceHelperKey` field on `CollectionLogSource` is intentionally left unchanged — it is a serialized data contract in `drop_rates.json` and renaming it would be a separate, breaking change.

12 files changed in the commit (3 main src renames, 4 test renames, 5 in-place importer edits).

## Test plan

- [x] `./gradlew build` is green (compiles main + tests, runs all unit tests, lintDropRates, JaCoCo 45% coverage gate)
- [x] `grep -rln "guidance\.helper" src/` returns 0 hits
- [x] `grep -rln "GuidanceHelper\b" src/` returns 0 hits
- [x] `grep -rln "CerberusHelper\b" src/` returns 0 hits
- [x] Old `src/main/java/com/collectionloghelper/guidance/helper/` and `src/test/java/com/collectionloghelper/guidance/helper/` directories no longer exist
- [x] `BossGuidanceKeyRegressionTest` still asserts no production source in `drop_rates.json` carries a non-null `guidanceHelperKey`

Closes #502