### PR TITLE
refactor: extract OverlayStepApplier from GuidanceOverlayCoordinator (#503)

### DIFF
--- a/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
@@ -37,7 +37,6 @@ import com.collectionloghelper.data.PlayerInventoryState;
 import com.collectionloghelper.data.PlayerTravelCapabilities;
 import com.collectionloghelper.data.RequirementRow;
 import com.collectionloghelper.data.RequirementsChecker;
-import com.collectionloghelper.guidance.DynamicTargetEvaluator;
 import com.collectionloghelper.guidance.dynamic.DynamicTargetEvaluatorRegistry;
 import com.collectionloghelper.overlay.CollectionLogWorldMapPoint;
 import com.collectionloghelper.overlay.DialogHighlightOverlay;
@@ -114,6 +113,7 @@ public class GuidanceOverlayCoordinator
 	private final WorldMapDestinationOverlay worldMapDestinationOverlay;
 	private final GroundItemHighlightOverlay groundItemHighlightOverlay;
 	private final WidgetHighlightOverlay widgetHighlightOverlay;
+	private final OverlayStepApplier overlayStepApplier;
 
 	// -- Guidance UI state (previously in plugin) --
 
@@ -187,7 +187,8 @@ public class GuidanceOverlayCoordinator
 		WorldMapRouteOverlay worldMapRouteOverlay,
 		WorldMapDestinationOverlay worldMapDestinationOverlay,
 		GroundItemHighlightOverlay groundItemHighlightOverlay,
-		WidgetHighlightOverlay widgetHighlightOverlay)
+		WidgetHighlightOverlay widgetHighlightOverlay,
+		OverlayStepApplier overlayStepApplier)
 	{
 		this.client = client;
 		this.clientThread = clientThread;
@@ -211,6 +212,7 @@ public class GuidanceOverlayCoordinator
 		this.worldMapDestinationOverlay = worldMapDestinationOverlay;
 		this.groundItemHighlightOverlay = groundItemHighlightOverlay;
 		this.widgetHighlightOverlay = widgetHighlightOverlay;
+		this.overlayStepApplier = overlayStepApplier;
 	}
 
 	/**
@@ -559,180 +561,14 @@ public class GuidanceOverlayCoordinator
 
 	// -- Private methods --
 
-	/**
-	 * Applies a single guidance step's data to all overlays.
-	 */
+	/** Applies a step to all overlays via {@link OverlayStepApplier}, then runs the dynamic override. */
 	private void applyStepToOverlays(GuidanceStep step, String sourceName, CollectionLogSource source)
 	{
-		// Send world message hint if this step has one (only once per step, not on re-notify)
-		int stepIndex = guidanceSequencer.getCurrentIndex();
-		if (step.getWorldMessage() != null && !step.getWorldMessage().isEmpty()
-			&& stepIndex != lastMessagedStepIndex)
-		{
-			lastMessagedStepIndex = stepIndex;
-			clientThread.invokeLater(() ->
-				client.addChatMessage(ChatMessageType.GAMEMESSAGE, "",
-					"<col=00c8c8>[Collection Log Helper]</col> " + step.getWorldMessage(),
-					null));
-		}
-
-		// Set tile filter before target IDs so it's active during rescan
-		if (step.getObjectFilterTiles() != null && !step.getObjectFilterTiles().isEmpty())
-		{
-			List<WorldPoint> tiles = new ArrayList<>();
-			for (int[] t : step.getObjectFilterTiles())
-			{
-				if (t != null && t.length >= 3)
-				{
-					tiles.add(new WorldPoint(t[0], t[1], t[2]));
-				}
-			}
-			objectHighlightOverlay.setObjectFilterTiles(tiles);
-		}
-		else if (step.getObjectMaxDistance() > 0 && step.getWorldX() > 0)
-		{
-			objectHighlightOverlay.setObjectFilter(
-				new WorldPoint(step.getWorldX(), step.getWorldY(), step.getWorldPlane()),
-				step.getObjectMaxDistance());
-		}
-		else
-		{
-			objectHighlightOverlay.setObjectFilter(null, 0);
-		}
-		objectHighlightOverlay.setTargetObjectIds(step.getAllObjectIds());
-		objectHighlightOverlay.setObjectInteractAction(step.getObjectInteractAction());
-		objectHighlightOverlay.setUseItemOnObject(step.isUseItemOnObject());
-		objectHighlightOverlay.setTooltipText(step.resolveDescription(activeTargetItemId));
-
-		itemHighlightOverlay.setTargetItemIds(step.getHighlightItemIds());
-
-		groundItemHighlightOverlay.setTargetGroundItemIds(
-			step.getGroundItemIds() != null ? new HashSet<>(step.getGroundItemIds()) : null);
-
-		if (step.getHighlightWidgetIds() != null && step.getHighlightWidgetIds().length > 0)
-		{
-			List<int[]> widgets = new ArrayList<>();
-			for (int[] ref : step.getHighlightWidgetIds())
-			{
-				if (ref != null && ref.length >= 2)
-				{
-					widgets.add(ref);
-				}
-			}
-			widgetHighlightOverlay.setHighlightWidgets(widgets);
-		}
-		else
-		{
-			widgetHighlightOverlay.clearHighlights();
-		}
-
-		// Suppress tile highlight when ObjectHighlightOverlay handles the visual
-		guidanceOverlay.setSuppressTileHighlight(!step.getAllObjectIds().isEmpty());
-
-		// Resolve required-item availability for this step once and push to the
-		// overlay; the render loop must never touch inventory/bank state.
-		//
-		// MUST run on the client thread: RequiredItemResolver.resolve() calls
-		// ItemManager.getItemComposition(int), which asserts caller-is-client-
-		// thread. Calling from the EDT (which is where activateGuidance lives
-		// when triggered by a panel button click) throws AssertionError, aborts
-		// the rest of activateGuidance mid-flight, and leaves the panel state
-		// out of sync with the overlay state (overlay set, panel button stays
-		// "Guide Me"). See cha-ndler/collection-log-helper#388 for the trace
-		// that surfaced this. The deferral is cheap (~1 tick at worst) and
-		// idempotent against rapid step changes because each call wins.
-		final GuidanceStep stepForResolve = step;
-		clientThread.invokeLater(() ->
-			guidanceOverlay.setRequiredItems(requiredItemResolver.resolve(stepForResolve)));
-
-		if (step.getWorldX() > 0)
-		{
-			WorldPoint worldPoint = new WorldPoint(step.getWorldX(), step.getWorldY(), step.getWorldPlane());
-			guidanceOverlay.setTargetPoint(worldPoint);
-			guidanceOverlay.setTargetName(sourceName);
-			guidanceOverlay.setLocationDescription(step.resolveDescription(activeTargetItemId));
-			String rawTravelTip = step.getTravelTip();
-			if ((rawTravelTip == null || rawTravelTip.isEmpty()) && source != null)
-			{
-				rawTravelTip = source.getTravelTip();
-			}
-			String travelTip = travelCapabilities.selectBestTravelTip(rawTravelTip);
-			guidanceOverlay.setTravelTip(travelTip);
-			log.debug("Travel capabilities for step '{}': {}", step.getDescription(), travelCapabilities.getSummary());
-			guidanceOverlay.setTargetNpcId(step.resolveNpcId(activeTargetItemId));
-			guidanceOverlay.setInteractAction(step.getInteractAction());
-			dialogHighlightOverlay.setTargetDialogOptions(step.getDialogOptions());
-			dialogHighlightOverlay.setGuidanceActive(true);
-			guidanceMinimapOverlay.setTargetPoint(worldPoint);
-			worldMapRouteOverlay.setTargetPoint(worldPoint);
-			worldMapDestinationOverlay.setTarget(worldPoint, resolveStepIconType(step));
-			// Register a CollectionLogWorldMapPoint for click-to-focus behaviour
-			// (setJumpOnClick). WorldMapDestinationOverlay draws the on-screen icon
-			// but does not receive click events — only a WorldMapPoint does (#429).
-			// To avoid a double edge-snap arrow (#410), WorldMapDestinationOverlay
-			// suppresses its own off-screen arrow while the map point is active
-			// (see WorldMapDestinationOverlay.setMapPointActive).
-			if (activeMapPoint != null)
-			{
-				worldMapPointManager.remove(activeMapPoint);
-			}
-			activeMapPoint = new CollectionLogWorldMapPoint(worldPoint,
-				step.resolveDescription(activeTargetItemId), collectionLogIcon);
-			worldMapPointManager.add(activeMapPoint);
-			worldMapDestinationOverlay.setMapPointActive(true);
-
-			clientThread.invokeLater(() ->
-			{
-				client.clearHintArrow();
-
-				// Skip hint arrow inside Sailing instances -- surface world
-				// coords render at wrong positions in instanced WorldViews
-				if (shouldSetHintArrowTo(worldPoint))
-				{
-					client.setHintArrow(worldPoint);
-				}
-
-				if (config.useShortestPath())
-				{
-					eventBus.post(new PluginMessage("shortestpath", "clear"));
-					pendingShortestPathTarget = worldPoint;
-				}
-			});
-		}
-		else
-		{
-			// Step with no location -- clear previous target and show text overlay only.
-			// Dialog options are still applied here: a step may be a pure dialog-choice
-			// step with no world coordinates (e.g. "Choose the 'Yes' option").
-			dialogHighlightOverlay.setTargetDialogOptions(step.getDialogOptions());
-			dialogHighlightOverlay.setGuidanceActive(true);
-			guidanceOverlay.setTargetPoint(null);
-			guidanceOverlay.setTargetName(null);
-			guidanceOverlay.setTargetNpcId(0);
-			guidanceOverlay.setInteractAction(null);
-			guidanceOverlay.setLocationDescription(null);
-			guidanceOverlay.setTravelTip(null);
-			guidanceMinimapOverlay.setTargetPoint(null);
-			worldMapRouteOverlay.setTargetPoint(null);
-			worldMapDestinationOverlay.clearTarget();
-			worldMapDestinationOverlay.setMapPointActive(false);
-			if (activeMapPoint != null)
-			{
-				worldMapPointManager.remove(activeMapPoint);
-				activeMapPoint = null;
-			}
-			guidanceOverlay.setClueGuidanceText(step.resolveDescription(activeTargetItemId));
-			clientThread.invokeLater(() ->
-			{
-				client.clearHintArrow();
-				if (config.useShortestPath())
-				{
-					eventBus.post(new PluginMessage("shortestpath", "clear"));
-				}
-			});
-		}
-
-		// Dynamic overlay override for Shades of Mort'ton key/chest highlighting
+		OverlayStepApplier.Result result = overlayStepApplier.apply(step, sourceName, source,
+			new OverlayStepApplier.Input(activeTargetItemId, lastMessagedStepIndex, activeMapPoint, collectionLogIcon),
+			this::resolveStepIconType, this::shouldSetHintArrowTo, wp -> pendingShortestPathTarget = wp);
+		lastMessagedStepIndex = result.lastMessagedStepIndex;
+		activeMapPoint = result.activeMapPoint;
 		applyDynamicItemObjectOverlays();
 	}
 

--- a/src/main/java/com/collectionloghelper/guidance/OverlayStepApplier.java
+++ b/src/main/java/com/collectionloghelper/guidance/OverlayStepApplier.java
@@ -1,0 +1,375 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.guidance;
+
+import com.collectionloghelper.CollectionLogHelperConfig;
+import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.data.GuidanceStep;
+import com.collectionloghelper.data.PlayerTravelCapabilities;
+import com.collectionloghelper.overlay.CollectionLogWorldMapPoint;
+import com.collectionloghelper.overlay.DialogHighlightOverlay;
+import com.collectionloghelper.overlay.GroundItemHighlightOverlay;
+import com.collectionloghelper.overlay.GuidanceMinimapOverlay;
+import com.collectionloghelper.overlay.GuidanceOverlay;
+import com.collectionloghelper.overlay.ItemHighlightOverlay;
+import com.collectionloghelper.overlay.ObjectHighlightOverlay;
+import com.collectionloghelper.overlay.WidgetHighlightOverlay;
+import com.collectionloghelper.overlay.WorldMapDestinationOverlay;
+import com.collectionloghelper.overlay.WorldMapRouteOverlay;
+import java.awt.image.BufferedImage;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.Client;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.eventbus.EventBus;
+import net.runelite.client.events.PluginMessage;
+import net.runelite.client.ui.overlay.worldmap.WorldMapPointManager;
+
+/**
+ * Applies a single {@link GuidanceStep}'s data to all guidance overlays.
+ *
+ * <p>Pure extraction from {@link GuidanceOverlayCoordinator}: this class holds
+ * no mutable state of its own. Mutable coordinator state that the step
+ * application touches (last messaged step index, active world map point,
+ * pending shortest-path target) is passed in via {@link Input} and returned
+ * via {@link Result} so the coordinator remains the single owner of that
+ * state.</p>
+ */
+@Slf4j
+@Singleton
+public class OverlayStepApplier
+{
+	private final Client client;
+	private final ClientThread clientThread;
+	private final EventBus eventBus;
+	private final CollectionLogHelperConfig config;
+	private final GuidanceSequencer guidanceSequencer;
+	private final PlayerTravelCapabilities travelCapabilities;
+	private final RequiredItemResolver requiredItemResolver;
+	private final WorldMapPointManager worldMapPointManager;
+	private final GuidanceOverlay guidanceOverlay;
+	private final GuidanceMinimapOverlay guidanceMinimapOverlay;
+	private final DialogHighlightOverlay dialogHighlightOverlay;
+	private final ObjectHighlightOverlay objectHighlightOverlay;
+	private final ItemHighlightOverlay itemHighlightOverlay;
+	private final WorldMapRouteOverlay worldMapRouteOverlay;
+	private final WorldMapDestinationOverlay worldMapDestinationOverlay;
+	private final GroundItemHighlightOverlay groundItemHighlightOverlay;
+	private final WidgetHighlightOverlay widgetHighlightOverlay;
+
+	@Inject
+	OverlayStepApplier(
+		Client client,
+		ClientThread clientThread,
+		EventBus eventBus,
+		CollectionLogHelperConfig config,
+		GuidanceSequencer guidanceSequencer,
+		PlayerTravelCapabilities travelCapabilities,
+		RequiredItemResolver requiredItemResolver,
+		WorldMapPointManager worldMapPointManager,
+		GuidanceOverlay guidanceOverlay,
+		GuidanceMinimapOverlay guidanceMinimapOverlay,
+		DialogHighlightOverlay dialogHighlightOverlay,
+		ObjectHighlightOverlay objectHighlightOverlay,
+		ItemHighlightOverlay itemHighlightOverlay,
+		WorldMapRouteOverlay worldMapRouteOverlay,
+		WorldMapDestinationOverlay worldMapDestinationOverlay,
+		GroundItemHighlightOverlay groundItemHighlightOverlay,
+		WidgetHighlightOverlay widgetHighlightOverlay)
+	{
+		this.client = client;
+		this.clientThread = clientThread;
+		this.eventBus = eventBus;
+		this.config = config;
+		this.guidanceSequencer = guidanceSequencer;
+		this.travelCapabilities = travelCapabilities;
+		this.requiredItemResolver = requiredItemResolver;
+		this.worldMapPointManager = worldMapPointManager;
+		this.guidanceOverlay = guidanceOverlay;
+		this.guidanceMinimapOverlay = guidanceMinimapOverlay;
+		this.dialogHighlightOverlay = dialogHighlightOverlay;
+		this.objectHighlightOverlay = objectHighlightOverlay;
+		this.itemHighlightOverlay = itemHighlightOverlay;
+		this.worldMapRouteOverlay = worldMapRouteOverlay;
+		this.worldMapDestinationOverlay = worldMapDestinationOverlay;
+		this.groundItemHighlightOverlay = groundItemHighlightOverlay;
+		this.widgetHighlightOverlay = widgetHighlightOverlay;
+	}
+
+	/**
+	 * Applies the given step's data to all overlays. Pure extraction of
+	 * {@code GuidanceOverlayCoordinator.applyStepToOverlays} -- no behavioral
+	 * change. The coordinator's mutable state related to this method is
+	 * carried in {@link Input} and returned in {@link Result}.
+	 *
+	 * @param step the step to render
+	 * @param sourceName user-facing source label
+	 * @param source the active collection log source (may be null for non-sequencer paths)
+	 * @param in coordinator-owned mutable state read by this apply pass
+	 * @param iconTypeResolver delegate to {@code resolveStepIconType} on the coordinator
+	 * @param hintArrowPredicate delegate to {@code shouldSetHintArrowTo} on the coordinator
+	 * @param pendingShortestPathTargetSetter callback invoked on the client thread to assign
+	 *                                        the coordinator's {@code pendingShortestPathTarget}
+	 *                                        field (matches original deferred-write semantics)
+	 * @return updated state to be written back onto the coordinator
+	 */
+	Result apply(
+		GuidanceStep step,
+		String sourceName,
+		@Nullable CollectionLogSource source,
+		Input in,
+		Function<GuidanceStep, WorldMapDestinationOverlay.StepIconType> iconTypeResolver,
+		Predicate<WorldPoint> hintArrowPredicate,
+		Consumer<WorldPoint> pendingShortestPathTargetSetter)
+	{
+		int updatedLastMessagedStepIndex = in.lastMessagedStepIndex;
+		CollectionLogWorldMapPoint updatedMapPoint = in.activeMapPoint;
+
+		// Send world message hint if this step has one (only once per step, not on re-notify)
+		int stepIndex = guidanceSequencer.getCurrentIndex();
+		if (step.getWorldMessage() != null && !step.getWorldMessage().isEmpty()
+			&& stepIndex != updatedLastMessagedStepIndex)
+		{
+			updatedLastMessagedStepIndex = stepIndex;
+			clientThread.invokeLater(() ->
+				client.addChatMessage(ChatMessageType.GAMEMESSAGE, "",
+					"<col=00c8c8>[Collection Log Helper]</col> " + step.getWorldMessage(),
+					null));
+		}
+
+		// Set tile filter before target IDs so it's active during rescan
+		if (step.getObjectFilterTiles() != null && !step.getObjectFilterTiles().isEmpty())
+		{
+			List<WorldPoint> tiles = new ArrayList<>();
+			for (int[] t : step.getObjectFilterTiles())
+			{
+				if (t != null && t.length >= 3)
+				{
+					tiles.add(new WorldPoint(t[0], t[1], t[2]));
+				}
+			}
+			objectHighlightOverlay.setObjectFilterTiles(tiles);
+		}
+		else if (step.getObjectMaxDistance() > 0 && step.getWorldX() > 0)
+		{
+			objectHighlightOverlay.setObjectFilter(
+				new WorldPoint(step.getWorldX(), step.getWorldY(), step.getWorldPlane()),
+				step.getObjectMaxDistance());
+		}
+		else
+		{
+			objectHighlightOverlay.setObjectFilter(null, 0);
+		}
+		objectHighlightOverlay.setTargetObjectIds(step.getAllObjectIds());
+		objectHighlightOverlay.setObjectInteractAction(step.getObjectInteractAction());
+		objectHighlightOverlay.setUseItemOnObject(step.isUseItemOnObject());
+		objectHighlightOverlay.setTooltipText(step.resolveDescription(in.activeTargetItemId));
+
+		itemHighlightOverlay.setTargetItemIds(step.getHighlightItemIds());
+
+		groundItemHighlightOverlay.setTargetGroundItemIds(
+			step.getGroundItemIds() != null ? new HashSet<>(step.getGroundItemIds()) : null);
+
+		if (step.getHighlightWidgetIds() != null && step.getHighlightWidgetIds().length > 0)
+		{
+			List<int[]> widgets = new ArrayList<>();
+			for (int[] ref : step.getHighlightWidgetIds())
+			{
+				if (ref != null && ref.length >= 2)
+				{
+					widgets.add(ref);
+				}
+			}
+			widgetHighlightOverlay.setHighlightWidgets(widgets);
+		}
+		else
+		{
+			widgetHighlightOverlay.clearHighlights();
+		}
+
+		// Suppress tile highlight when ObjectHighlightOverlay handles the visual
+		guidanceOverlay.setSuppressTileHighlight(!step.getAllObjectIds().isEmpty());
+
+		// Resolve required-item availability for this step once and push to the
+		// overlay; the render loop must never touch inventory/bank state.
+		//
+		// MUST run on the client thread: RequiredItemResolver.resolve() calls
+		// ItemManager.getItemComposition(int), which asserts caller-is-client-
+		// thread. Calling from the EDT (which is where activateGuidance lives
+		// when triggered by a panel button click) throws AssertionError, aborts
+		// the rest of activateGuidance mid-flight, and leaves the panel state
+		// out of sync with the overlay state (overlay set, panel button stays
+		// "Guide Me"). See cha-ndler/collection-log-helper#388 for the trace
+		// that surfaced this. The deferral is cheap (~1 tick at worst) and
+		// idempotent against rapid step changes because each call wins.
+		final GuidanceStep stepForResolve = step;
+		clientThread.invokeLater(() ->
+			guidanceOverlay.setRequiredItems(requiredItemResolver.resolve(stepForResolve)));
+
+		if (step.getWorldX() > 0)
+		{
+			WorldPoint worldPoint = new WorldPoint(step.getWorldX(), step.getWorldY(), step.getWorldPlane());
+			guidanceOverlay.setTargetPoint(worldPoint);
+			guidanceOverlay.setTargetName(sourceName);
+			guidanceOverlay.setLocationDescription(step.resolveDescription(in.activeTargetItemId));
+			String rawTravelTip = step.getTravelTip();
+			if ((rawTravelTip == null || rawTravelTip.isEmpty()) && source != null)
+			{
+				rawTravelTip = source.getTravelTip();
+			}
+			String travelTip = travelCapabilities.selectBestTravelTip(rawTravelTip);
+			guidanceOverlay.setTravelTip(travelTip);
+			log.debug("Travel capabilities for step '{}': {}", step.getDescription(), travelCapabilities.getSummary());
+			guidanceOverlay.setTargetNpcId(step.resolveNpcId(in.activeTargetItemId));
+			guidanceOverlay.setInteractAction(step.getInteractAction());
+			dialogHighlightOverlay.setTargetDialogOptions(step.getDialogOptions());
+			dialogHighlightOverlay.setGuidanceActive(true);
+			guidanceMinimapOverlay.setTargetPoint(worldPoint);
+			worldMapRouteOverlay.setTargetPoint(worldPoint);
+			worldMapDestinationOverlay.setTarget(worldPoint, iconTypeResolver.apply(step));
+			// Register a CollectionLogWorldMapPoint for click-to-focus behaviour
+			// (setJumpOnClick). WorldMapDestinationOverlay draws the on-screen icon
+			// but does not receive click events -- only a WorldMapPoint does (#429).
+			// To avoid a double edge-snap arrow (#410), WorldMapDestinationOverlay
+			// suppresses its own off-screen arrow while the map point is active
+			// (see WorldMapDestinationOverlay.setMapPointActive).
+			if (updatedMapPoint != null)
+			{
+				worldMapPointManager.remove(updatedMapPoint);
+			}
+			updatedMapPoint = new CollectionLogWorldMapPoint(worldPoint,
+				step.resolveDescription(in.activeTargetItemId), in.collectionLogIcon);
+			worldMapPointManager.add(updatedMapPoint);
+			worldMapDestinationOverlay.setMapPointActive(true);
+
+			final WorldPoint hintTarget = worldPoint;
+			clientThread.invokeLater(() ->
+			{
+				client.clearHintArrow();
+
+				// Skip hint arrow inside Sailing instances -- surface world
+				// coords render at wrong positions in instanced WorldViews
+				if (hintArrowPredicate.test(hintTarget))
+				{
+					client.setHintArrow(hintTarget);
+				}
+
+				if (config.useShortestPath())
+				{
+					eventBus.post(new PluginMessage("shortestpath", "clear"));
+					pendingShortestPathTargetSetter.accept(hintTarget);
+				}
+			});
+		}
+		else
+		{
+			// Step with no location -- clear previous target and show text overlay only.
+			// Dialog options are still applied here: a step may be a pure dialog-choice
+			// step with no world coordinates (e.g. "Choose the 'Yes' option").
+			dialogHighlightOverlay.setTargetDialogOptions(step.getDialogOptions());
+			dialogHighlightOverlay.setGuidanceActive(true);
+			guidanceOverlay.setTargetPoint(null);
+			guidanceOverlay.setTargetName(null);
+			guidanceOverlay.setTargetNpcId(0);
+			guidanceOverlay.setInteractAction(null);
+			guidanceOverlay.setLocationDescription(null);
+			guidanceOverlay.setTravelTip(null);
+			guidanceMinimapOverlay.setTargetPoint(null);
+			worldMapRouteOverlay.setTargetPoint(null);
+			worldMapDestinationOverlay.clearTarget();
+			worldMapDestinationOverlay.setMapPointActive(false);
+			if (updatedMapPoint != null)
+			{
+				worldMapPointManager.remove(updatedMapPoint);
+				updatedMapPoint = null;
+			}
+			guidanceOverlay.setClueGuidanceText(step.resolveDescription(in.activeTargetItemId));
+			clientThread.invokeLater(() ->
+			{
+				client.clearHintArrow();
+				if (config.useShortestPath())
+				{
+					eventBus.post(new PluginMessage("shortestpath", "clear"));
+				}
+			});
+		}
+
+		return new Result(updatedLastMessagedStepIndex, updatedMapPoint);
+	}
+
+	/**
+	 * Snapshot of the coordinator-owned state this applier reads.
+	 */
+	static final class Input
+	{
+		@Nullable
+		final Integer activeTargetItemId;
+		final int lastMessagedStepIndex;
+		@Nullable
+		final CollectionLogWorldMapPoint activeMapPoint;
+		@Nullable
+		final BufferedImage collectionLogIcon;
+
+		Input(
+			@Nullable Integer activeTargetItemId,
+			int lastMessagedStepIndex,
+			@Nullable CollectionLogWorldMapPoint activeMapPoint,
+			@Nullable BufferedImage collectionLogIcon)
+		{
+			this.activeTargetItemId = activeTargetItemId;
+			this.lastMessagedStepIndex = lastMessagedStepIndex;
+			this.activeMapPoint = activeMapPoint;
+			this.collectionLogIcon = collectionLogIcon;
+		}
+	}
+
+	/**
+	 * Updated state the coordinator must write back onto itself after an apply pass.
+	 */
+	static final class Result
+	{
+		final int lastMessagedStepIndex;
+		@Nullable
+		final CollectionLogWorldMapPoint activeMapPoint;
+
+		Result(
+			int lastMessagedStepIndex,
+			@Nullable CollectionLogWorldMapPoint activeMapPoint)
+		{
+			this.lastMessagedStepIndex = lastMessagedStepIndex;
+			this.activeMapPoint = activeMapPoint;
+		}
+	}
+}

--- a/src/test/java/com/collectionloghelper/guidance/DynamicTargetEvaluatorDispatchTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/DynamicTargetEvaluatorDispatchTest.java
@@ -148,6 +148,7 @@ public class DynamicTargetEvaluatorDispatchTest
 		// Register a predictable stub evaluator
 		registry.register(STUB_KEY, (c, step) -> DYNAMIC_POINT);
 
+		OverlayStepApplier overlayStepApplier = newOverlayStepApplier();
 		Constructor<GuidanceOverlayCoordinator> ctor =
 			GuidanceOverlayCoordinator.class.getDeclaredConstructor(
 				Client.class,
@@ -171,7 +172,8 @@ public class DynamicTargetEvaluatorDispatchTest
 				WorldMapRouteOverlay.class,
 				WorldMapDestinationOverlay.class,
 				GroundItemHighlightOverlay.class,
-				WidgetHighlightOverlay.class);
+				WidgetHighlightOverlay.class,
+				OverlayStepApplier.class);
 		ctor.setAccessible(true);
 		coordinator = ctor.newInstance(
 			client, clientThread, eventBus, config,
@@ -181,7 +183,8 @@ public class DynamicTargetEvaluatorDispatchTest
 			guidanceOverlay, guidanceMinimapOverlay, dialogHighlightOverlay,
 			objectHighlightOverlay, itemHighlightOverlay,
 			worldMapRouteOverlay, worldMapDestinationOverlay,
-			groundItemHighlightOverlay, widgetHighlightOverlay);
+			groundItemHighlightOverlay, widgetHighlightOverlay,
+			overlayStepApplier);
 
 		lenient().when(client.getLocalPlayer()).thenReturn(localPlayer);
 		lenient().when(localPlayer.getWorldLocation()).thenReturn(new WorldPoint(3200, 3200, 0));
@@ -270,6 +273,24 @@ public class DynamicTargetEvaluatorDispatchTest
 	}
 
 	// ── Helper ────────────────────────────────────────────────────────────────
+
+	private OverlayStepApplier newOverlayStepApplier() throws Exception
+	{
+		Constructor<OverlayStepApplier> ctor = OverlayStepApplier.class.getDeclaredConstructor(
+			Client.class, ClientThread.class, EventBus.class, CollectionLogHelperConfig.class,
+			GuidanceSequencer.class, PlayerTravelCapabilities.class, RequiredItemResolver.class,
+			WorldMapPointManager.class, GuidanceOverlay.class, GuidanceMinimapOverlay.class,
+			DialogHighlightOverlay.class, ObjectHighlightOverlay.class, ItemHighlightOverlay.class,
+			WorldMapRouteOverlay.class, WorldMapDestinationOverlay.class,
+			GroundItemHighlightOverlay.class, WidgetHighlightOverlay.class);
+		ctor.setAccessible(true);
+		return ctor.newInstance(client, clientThread, eventBus, config, guidanceSequencer,
+			travelCapabilities, requiredItemResolver, worldMapPointManager,
+			guidanceOverlay, guidanceMinimapOverlay, dialogHighlightOverlay,
+			objectHighlightOverlay, itemHighlightOverlay,
+			worldMapRouteOverlay, worldMapDestinationOverlay,
+			groundItemHighlightOverlay, widgetHighlightOverlay);
+	}
 
 	private static GuidanceStep stepWithEvaluator(String evaluatorKey)
 	{

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorDescriptionTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorDescriptionTest.java
@@ -143,6 +143,7 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 	@Before
 	public void setUp() throws Exception
 	{
+		OverlayStepApplier overlayStepApplier = newOverlayStepApplier();
 		Constructor<GuidanceOverlayCoordinator> ctor =
 			GuidanceOverlayCoordinator.class.getDeclaredConstructor(
 				Client.class,
@@ -166,7 +167,8 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 				WorldMapRouteOverlay.class,
 				WorldMapDestinationOverlay.class,
 				GroundItemHighlightOverlay.class,
-				WidgetHighlightOverlay.class);
+				WidgetHighlightOverlay.class,
+				OverlayStepApplier.class);
 		ctor.setAccessible(true);
 		coordinator = ctor.newInstance(
 			client, clientThread, eventBus, config,
@@ -176,7 +178,8 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 			guidanceOverlay, guidanceMinimapOverlay, dialogHighlightOverlay,
 			objectHighlightOverlay, itemHighlightOverlay,
 			worldMapRouteOverlay, worldMapDestinationOverlay,
-			groundItemHighlightOverlay, widgetHighlightOverlay);
+			groundItemHighlightOverlay, widgetHighlightOverlay,
+			overlayStepApplier);
 
 		coordinator.setPanel(panel);
 
@@ -284,6 +287,24 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 			null, // waypoints
 			null  // dynamicTargetEvaluator
 		);
+	}
+
+	private OverlayStepApplier newOverlayStepApplier() throws Exception
+	{
+		Constructor<OverlayStepApplier> ctor = OverlayStepApplier.class.getDeclaredConstructor(
+			Client.class, ClientThread.class, EventBus.class, CollectionLogHelperConfig.class,
+			GuidanceSequencer.class, PlayerTravelCapabilities.class, RequiredItemResolver.class,
+			WorldMapPointManager.class, GuidanceOverlay.class, GuidanceMinimapOverlay.class,
+			DialogHighlightOverlay.class, ObjectHighlightOverlay.class, ItemHighlightOverlay.class,
+			WorldMapRouteOverlay.class, WorldMapDestinationOverlay.class,
+			GroundItemHighlightOverlay.class, WidgetHighlightOverlay.class);
+		ctor.setAccessible(true);
+		return ctor.newInstance(client, clientThread, eventBus, config, guidanceSequencer,
+			travelCapabilities, requiredItemResolver, worldMapPointManager,
+			guidanceOverlay, guidanceMinimapOverlay, dialogHighlightOverlay,
+			objectHighlightOverlay, itemHighlightOverlay,
+			worldMapRouteOverlay, worldMapDestinationOverlay,
+			groundItemHighlightOverlay, widgetHighlightOverlay);
 	}
 
 	private static CollectionLogSource sourceWithSteps(String name, GuidanceStep... steps)

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorMapPointTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorMapPointTest.java
@@ -129,6 +129,7 @@ public class GuidanceOverlayCoordinatorMapPointTest
 	@Before
 	public void setUp() throws Exception
 	{
+		OverlayStepApplier overlayStepApplier = newOverlayStepApplier();
 		Constructor<GuidanceOverlayCoordinator> ctor =
 			GuidanceOverlayCoordinator.class.getDeclaredConstructor(
 				Client.class,
@@ -152,7 +153,8 @@ public class GuidanceOverlayCoordinatorMapPointTest
 				WorldMapRouteOverlay.class,
 				WorldMapDestinationOverlay.class,
 				GroundItemHighlightOverlay.class,
-				WidgetHighlightOverlay.class);
+				WidgetHighlightOverlay.class,
+				OverlayStepApplier.class);
 		ctor.setAccessible(true);
 		coordinator = ctor.newInstance(
 			client, clientThread, eventBus, config,
@@ -162,7 +164,8 @@ public class GuidanceOverlayCoordinatorMapPointTest
 			guidanceOverlay, guidanceMinimapOverlay, dialogHighlightOverlay,
 			objectHighlightOverlay, itemHighlightOverlay,
 			worldMapRouteOverlay, worldMapDestinationOverlay,
-			groundItemHighlightOverlay, widgetHighlightOverlay);
+			groundItemHighlightOverlay, widgetHighlightOverlay,
+			overlayStepApplier);
 
 		// Default stubs: no unmet requirements; buildRequirementRows called unconditionally
 		when(requirementsChecker.getUnmetRequirements(any())).thenReturn(Collections.emptyList());
@@ -245,6 +248,24 @@ public class GuidanceOverlayCoordinatorMapPointTest
 	// ---- helpers ----
 
 	/** Builds a minimal BOSSES source with coordinates but no guidance steps. */
+	private OverlayStepApplier newOverlayStepApplier() throws Exception
+	{
+		Constructor<OverlayStepApplier> ctor = OverlayStepApplier.class.getDeclaredConstructor(
+			Client.class, ClientThread.class, EventBus.class, CollectionLogHelperConfig.class,
+			GuidanceSequencer.class, PlayerTravelCapabilities.class, RequiredItemResolver.class,
+			WorldMapPointManager.class, GuidanceOverlay.class, GuidanceMinimapOverlay.class,
+			DialogHighlightOverlay.class, ObjectHighlightOverlay.class, ItemHighlightOverlay.class,
+			WorldMapRouteOverlay.class, WorldMapDestinationOverlay.class,
+			GroundItemHighlightOverlay.class, WidgetHighlightOverlay.class);
+		ctor.setAccessible(true);
+		return ctor.newInstance(client, clientThread, eventBus, config, guidanceSequencer,
+			travelCapabilities, requiredItemResolver, worldMapPointManager,
+			guidanceOverlay, guidanceMinimapOverlay, dialogHighlightOverlay,
+			objectHighlightOverlay, itemHighlightOverlay,
+			worldMapRouteOverlay, worldMapDestinationOverlay,
+			groundItemHighlightOverlay, widgetHighlightOverlay);
+	}
+
 	private static CollectionLogSource sourceAtCoords(
 		String name, int x, int y, int plane)
 	{

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorNpcIdTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorNpcIdTest.java
@@ -140,6 +140,7 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 	@Before
 	public void setUp() throws Exception
 	{
+		OverlayStepApplier overlayStepApplier = newOverlayStepApplier();
 		Constructor<GuidanceOverlayCoordinator> ctor =
 			GuidanceOverlayCoordinator.class.getDeclaredConstructor(
 				Client.class,
@@ -163,7 +164,8 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 				WorldMapRouteOverlay.class,
 				WorldMapDestinationOverlay.class,
 				GroundItemHighlightOverlay.class,
-				WidgetHighlightOverlay.class);
+				WidgetHighlightOverlay.class,
+				OverlayStepApplier.class);
 		ctor.setAccessible(true);
 		coordinator = ctor.newInstance(
 			client, clientThread, eventBus, config,
@@ -173,7 +175,8 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 			guidanceOverlay, guidanceMinimapOverlay, dialogHighlightOverlay,
 			objectHighlightOverlay, itemHighlightOverlay,
 			worldMapRouteOverlay, worldMapDestinationOverlay,
-			groundItemHighlightOverlay, widgetHighlightOverlay);
+			groundItemHighlightOverlay, widgetHighlightOverlay,
+			overlayStepApplier);
 
 		when(requirementsChecker.getUnmetRequirements(any())).thenReturn(Collections.emptyList());
 		when(requirementsChecker.buildRequirementRows(any())).thenReturn(Collections.emptyList());
@@ -291,6 +294,24 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 			null, // waypoints
 			null  // dynamicTargetEvaluator
 		);
+	}
+
+	private OverlayStepApplier newOverlayStepApplier() throws Exception
+	{
+		Constructor<OverlayStepApplier> ctor = OverlayStepApplier.class.getDeclaredConstructor(
+			Client.class, ClientThread.class, EventBus.class, CollectionLogHelperConfig.class,
+			GuidanceSequencer.class, PlayerTravelCapabilities.class, RequiredItemResolver.class,
+			WorldMapPointManager.class, GuidanceOverlay.class, GuidanceMinimapOverlay.class,
+			DialogHighlightOverlay.class, ObjectHighlightOverlay.class, ItemHighlightOverlay.class,
+			WorldMapRouteOverlay.class, WorldMapDestinationOverlay.class,
+			GroundItemHighlightOverlay.class, WidgetHighlightOverlay.class);
+		ctor.setAccessible(true);
+		return ctor.newInstance(client, clientThread, eventBus, config, guidanceSequencer,
+			travelCapabilities, requiredItemResolver, worldMapPointManager,
+			guidanceOverlay, guidanceMinimapOverlay, dialogHighlightOverlay,
+			objectHighlightOverlay, itemHighlightOverlay,
+			worldMapRouteOverlay, worldMapDestinationOverlay,
+			groundItemHighlightOverlay, widgetHighlightOverlay);
 	}
 
 	private static CollectionLogSource sourceWithSteps(String name, GuidanceStep... steps)


### PR DESCRIPTION
## Summary

Pure extraction of `GuidanceOverlayCoordinator.applyStepToOverlays()` (~173 LOC) into a new dedicated class `OverlayStepApplier` in `com.collectionloghelper.guidance`. The applier is stateless: coordinator-owned mutable state (`activeTargetItemId`, `lastMessagedStepIndex`, `activeMapPoint`, `collectionLogIcon`) is passed in via `Input` and the updated values are returned via `Result`. The deferred `pendingShortestPathTarget` assignment preserves its original client-thread timing via a `Consumer` callback. Coordinator-local helpers `shouldSetHintArrowTo` / `resolveStepIconType` stay on the coordinator (still used by `applySourceToOverlays`, `tickDynamicTargetEvaluator`, `updateWorldMapArrow`) and are passed in as method references.

`GuidanceOverlayCoordinator.java` shrinks from **1113 LOC** to **949 LOC**. Four reflective-constructor tests are updated to add `OverlayStepApplier` to the constructor signature; each builds a real applier from the same overlay mocks the test already provides so the existing verifications continue to observe the same `setX()` calls.

Partially addresses #503.

## Test plan

- [x] `./gradlew build` passes
- [x] `./gradlew test` passes (1172 tests, 0 failures, 0 ignored); JaCoCo 45% gate holds
- [x] `GuidanceOverlayCoordinator.java` LOC drops from **1113** to **949** (under the 950 target)
- [x] `OverlayStepApplier` wires all overlay/dep references the original method used (9 overlays + `Client`, `ClientThread`, `EventBus`, `Config`, `GuidanceSequencer`, `PlayerTravelCapabilities`, `RequiredItemResolver`, `WorldMapPointManager`)
- [x] Behavioral diff: zero -- pure extraction; `setX()` call ordering, deferred `clientThread.invokeLater` blocks, and `pendingShortestPathTarget` write timing preserved verbatim