### PR TITLE
refactor: extract LootSyncManager from Plugin (#503)

### DIFF
--- a/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
@@ -31,6 +31,7 @@ import com.collectionloghelper.data.RequirementsChecker;
 import com.collectionloghelper.di.DataModule;
 import com.collectionloghelper.sync.CollectionLogNetImporter;
 import com.collectionloghelper.sync.ImportResult;
+import com.collectionloghelper.sync.LootSyncManager;
 import com.collectionloghelper.sync.SourceKcStore;
 import com.collectionloghelper.sync.SyncResult;
 import com.collectionloghelper.sync.TempleOsrsKcSyncer;
@@ -85,7 +86,6 @@ import net.runelite.api.events.ScriptPreFired;
 import net.runelite.api.ScriptEvent;
 import net.runelite.api.events.StatChanged;
 import net.runelite.api.events.VarbitChanged;
-import net.runelite.api.gameval.InventoryID;
 import net.runelite.api.gameval.ItemID;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.chat.ChatCommandManager;
@@ -95,7 +95,6 @@ import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.NpcLootReceived;
 import net.runelite.client.events.RuneScapeProfileChanged;
 import net.runelite.client.game.ItemManager;
-import net.runelite.client.game.ItemStack;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.ClientToolbar;
@@ -206,6 +205,9 @@ public class CollectionLogHelperPlugin extends Plugin
 
 	@Inject
 	private SourceKcStore sourceKcStore;
+
+	@Inject
+	private LootSyncManager lootSyncManager;
 
 
 	private CollectionLogHelperPanel panel;
@@ -614,78 +616,13 @@ public class CollectionLogHelperPlugin extends Plugin
 	@Subscribe
 	public void onNpcLootReceived(NpcLootReceived event)
 	{
-		for (ItemStack itemStack : event.getItems())
-		{
-			int itemId = itemStack.getId();
-			CollectionLogItem item = data.getDatabase().getItemById(itemId);
-			if (item != null && !data.getCollectionState().isItemObtained(itemId))
-			{
-				client.addChatMessage(ChatMessageType.GAMEMESSAGE, "",
-					"<col=00c8c8>[Collection Log Helper]</col> Collection log drop: " + item.getName(),
-					null);
-				guidanceSequencer.onItemObtained(itemId);
-			}
-		}
+		lootSyncManager.handleNpcLoot(event);
 	}
 
 	@Subscribe
 	public void onItemContainerChanged(ItemContainerChanged event)
 	{
-		log.debug("ItemContainerChanged fired: containerId={}, BANK={}, match={}",
-			event.getContainerId(), InventoryID.BANK, event.getContainerId() == InventoryID.BANK);
-
-		if (config.guidanceAuthoring())
-		{
-			authoringLogger.logContainerChange(event, client);
-		}
-
-		if (event.getContainerId() == InventoryID.INV)
-		{
-			net.runelite.api.ItemContainer invContainer = event.getItemContainer();
-			if (invContainer != null)
-			{
-				data.getPlayerInventoryState().scanInventory(invContainer);
-
-				if (guidanceSequencer.isActive())
-				{
-					guidanceSequencer.onInventoryChanged();
-					guidanceCoordinator.onItemContainerChanged();
-				}
-			}
-		}
-
-		if (event.getContainerId() == InventoryID.WORN)
-		{
-			net.runelite.api.ItemContainer equipContainer = event.getItemContainer();
-			if (equipContainer != null)
-			{
-				data.getPlayerInventoryState().scanEquipment(equipContainer);
-			}
-		}
-
-		if (event.getContainerId() == InventoryID.BANK)
-		{
-			// Scan bank for clue-related items and travel teleports every time it updates
-			net.runelite.api.ItemContainer bankContainer = event.getItemContainer();
-			if (bankContainer != null)
-			{
-				data.getPlayerBankState().scanBank(bankContainer);
-				travelCapabilities.scanBank(bankContainer);
-			}
-
-			if (!data.getDataSyncState().isBankScanned())
-			{
-				data.getDataSyncState().setBankScanned(true);
-				guidanceOverlay.setShowBankReminder(false);
-				log.info("Bank opened — marked as scanned for this session");
-			}
-
-			if (panel != null)
-			{
-				panel.updateDataSyncWarning();
-				panel.updateClueSummary(data.getPlayerBankState());
-			}
-		}
+		lootSyncManager.handleItemContainerChanged(event, panel);
 	}
 
 	@Subscribe

--- a/src/main/java/com/collectionloghelper/sync/LootSyncManager.java
+++ b/src/main/java/com/collectionloghelper/sync/LootSyncManager.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.sync;
+
+import com.collectionloghelper.CollectionLogHelperConfig;
+import com.collectionloghelper.data.CollectionLogItem;
+import com.collectionloghelper.data.PlayerTravelCapabilities;
+import com.collectionloghelper.di.DataModule;
+import com.collectionloghelper.guidance.GuidanceOverlayCoordinator;
+import com.collectionloghelper.guidance.GuidanceSequencer;
+import com.collectionloghelper.lifecycle.AuthoringLogger;
+import com.collectionloghelper.overlay.GuidanceOverlay;
+import com.collectionloghelper.ui.CollectionLogHelperPanel;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.Client;
+import net.runelite.api.ItemContainer;
+import net.runelite.api.events.ItemContainerChanged;
+import net.runelite.api.gameval.InventoryID;
+import net.runelite.client.events.NpcLootReceived;
+import net.runelite.client.game.ItemStack;
+
+/**
+ * Processes loot and inventory/bank container change events.
+ *
+ * <p>Owns the logic that previously lived in the plugin's {@code onNpcLootReceived}
+ * and {@code onItemContainerChanged} handlers. The plugin keeps the {@code @Subscribe}
+ * methods (so the RuneLite event bus discovers them via the existing
+ * {@code eventBus.register(plugin)} call in {@code startUp}) and delegates the bodies
+ * here.
+ *
+ * <p>Part of issue #503 — splitting the {@code CollectionLogHelperPlugin} god-class
+ * into focused collaborators.
+ */
+@Slf4j
+@Singleton
+public class LootSyncManager
+{
+	private final Client client;
+	private final CollectionLogHelperConfig config;
+	private final DataModule data;
+	private final GuidanceSequencer guidanceSequencer;
+	private final GuidanceOverlayCoordinator guidanceCoordinator;
+	private final GuidanceOverlay guidanceOverlay;
+	private final AuthoringLogger authoringLogger;
+	private final PlayerTravelCapabilities travelCapabilities;
+
+	@Inject
+	LootSyncManager(
+		Client client,
+		CollectionLogHelperConfig config,
+		DataModule data,
+		GuidanceSequencer guidanceSequencer,
+		GuidanceOverlayCoordinator guidanceCoordinator,
+		GuidanceOverlay guidanceOverlay,
+		AuthoringLogger authoringLogger,
+		PlayerTravelCapabilities travelCapabilities)
+	{
+		this.client = client;
+		this.config = config;
+		this.data = data;
+		this.guidanceSequencer = guidanceSequencer;
+		this.guidanceCoordinator = guidanceCoordinator;
+		this.guidanceOverlay = guidanceOverlay;
+		this.authoringLogger = authoringLogger;
+		this.travelCapabilities = travelCapabilities;
+	}
+
+	/**
+	 * Handles {@link NpcLootReceived} — emits a chat notification for newly obtained
+	 * collection-log drops and pokes the guidance sequencer.
+	 *
+	 * <p>Marking the item obtained happens later on
+	 * {@code ChatMessage} ("New item added to your collection log: ...") to stay
+	 * authoritative with the game's own notification.
+	 */
+	public void handleNpcLoot(NpcLootReceived event)
+	{
+		for (ItemStack itemStack : event.getItems())
+		{
+			int itemId = itemStack.getId();
+			CollectionLogItem item = data.getDatabase().getItemById(itemId);
+			if (item != null && !data.getCollectionState().isItemObtained(itemId))
+			{
+				client.addChatMessage(ChatMessageType.GAMEMESSAGE, "",
+					"<col=00c8c8>[Collection Log Helper]</col> Collection log drop: " + item.getName(),
+					null);
+				guidanceSequencer.onItemObtained(itemId);
+			}
+		}
+	}
+
+	/**
+	 * Handles {@link ItemContainerChanged} for inventory ({@link InventoryID#INV}),
+	 * worn equipment ({@link InventoryID#WORN}), and bank ({@link InventoryID#BANK}).
+	 *
+	 * <p>The {@code panel} reference is passed in from the plugin because it is
+	 * created lazily in the plugin's {@code startUp}, not via Guice. The plugin
+	 * forwards a possibly-null panel; this method handles the null case.
+	 *
+	 * @param event the container-change event from the RuneLite event bus
+	 * @param panel the side panel; may be {@code null} before {@code startUp} wires it
+	 */
+	public void handleItemContainerChanged(ItemContainerChanged event, CollectionLogHelperPanel panel)
+	{
+		log.debug("ItemContainerChanged fired: containerId={}, BANK={}, match={}",
+			event.getContainerId(), InventoryID.BANK, event.getContainerId() == InventoryID.BANK);
+
+		if (config.guidanceAuthoring())
+		{
+			authoringLogger.logContainerChange(event, client);
+		}
+
+		if (event.getContainerId() == InventoryID.INV)
+		{
+			ItemContainer invContainer = event.getItemContainer();
+			if (invContainer != null)
+			{
+				data.getPlayerInventoryState().scanInventory(invContainer);
+
+				if (guidanceSequencer.isActive())
+				{
+					guidanceSequencer.onInventoryChanged();
+					guidanceCoordinator.onItemContainerChanged();
+				}
+			}
+		}
+
+		if (event.getContainerId() == InventoryID.WORN)
+		{
+			ItemContainer equipContainer = event.getItemContainer();
+			if (equipContainer != null)
+			{
+				data.getPlayerInventoryState().scanEquipment(equipContainer);
+			}
+		}
+
+		if (event.getContainerId() == InventoryID.BANK)
+		{
+			// Scan bank for clue-related items and travel teleports every time it updates
+			ItemContainer bankContainer = event.getItemContainer();
+			if (bankContainer != null)
+			{
+				data.getPlayerBankState().scanBank(bankContainer);
+				travelCapabilities.scanBank(bankContainer);
+			}
+
+			if (!data.getDataSyncState().isBankScanned())
+			{
+				data.getDataSyncState().setBankScanned(true);
+				guidanceOverlay.setShowBankReminder(false);
+				log.info("Bank opened — marked as scanned for this session");
+			}
+
+			if (panel != null)
+			{
+				panel.updateDataSyncWarning();
+				panel.updateClueSummary(data.getPlayerBankState());
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Extract `onNpcLootReceived` and `onItemContainerChanged` handler bodies from `CollectionLogHelperPlugin` into a new `LootSyncManager` in the existing `sync` package.
- The `@Subscribe` methods stay on the plugin so the RuneLite event bus keeps discovering them via the existing `eventBus.register(plugin)` call in `startUp`. Their bodies are now one-line delegations.
- `LootSyncManager` consumes the `DataModule` aggregate (added in #509) rather than re-injecting individual data-layer states.
- `Plugin.java`: 1157 -> 1094 LOC (-63). New `LootSyncManager.java`: 186 LOC.

Partially addresses #503.

## Test plan

- [x] `./gradlew build` passes (includes `jacocoTestCoverageVerification` 45% gate).
- [x] `./gradlew test` — 1172 tests, 0 failures, 0 errors.
- [x] `wc -l src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java` reports 1094 (was 1157 on master).
- [x] `grep -c "@Inject" src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java` = 32 (added `LootSyncManager`).
- [x] Behavioral parity verified by inspection: the manager's `handleNpcLoot` and `handleItemContainerChanged` bodies match the originals line-for-line, with `InventoryID.INV`/`WORN`/`BANK` branches, `authoringLogger.logContainerChange`, `travelCapabilities.scanBank`, `DataSyncState.bankScanned` flip, `guidanceOverlay.setShowBankReminder(false)`, and the `panel`-null guard preserved.
- [x] Unused imports (`net.runelite.api.gameval.InventoryID`, `net.runelite.client.game.ItemStack`) removed from `Plugin.java`.