### PR TITLE
refactor: extract PanelRebuildOrchestrator from Panel (#503)

### DIFF
--- a/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
@@ -60,9 +60,7 @@ import com.collectionloghelper.ui.widget.SlayerStrategyView;
 import com.collectionloghelper.ui.widget.StepProgressView;
 import com.collectionloghelper.ui.widget.SyncStatusView;
 import java.util.EnumMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import java.awt.BorderLayout;
 import java.awt.CardLayout;
 import java.awt.Color;
@@ -173,6 +171,7 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 
 	private final Map<Mode, PanelModeController> modeControllers = new EnumMap<>(Mode.class);
 	private final PanelModeDispatcher<Mode> modeDispatcher = new PanelModeDispatcher<>(modeControllers);
+	private final PanelRebuildOrchestrator rebuildOrchestrator;
 
 	private Mode currentMode = Mode.EFFICIENT;
 	private boolean rebuilding = false;
@@ -420,6 +419,7 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 		listContainer.setLayout(new BoxLayout(listContainer, BoxLayout.Y_AXIS));
 		listContainer.setBackground(ColorScheme.DARK_GRAY_COLOR);
 		listView.add(listContainer, BorderLayout.NORTH);
+		rebuildOrchestrator = new PanelRebuildOrchestrator(this, listContainer);
 
 		detailView = new JPanel(new BorderLayout());
 		detailView.setBackground(ColorScheme.DARK_GRAY_COLOR);
@@ -601,28 +601,7 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 			rebuilding = true;
 			try
 			{
-				// Save scroll position before rebuild
-				int savedScrollPosition = 0;
-				JScrollPane scrollPane = (JScrollPane) SwingUtilities.getAncestorOfClass(
-					JScrollPane.class, this);
-				if (scrollPane != null)
-				{
-					savedScrollPosition = scrollPane.getVerticalScrollBar().getValue();
-				}
-
-				// Save expanded category names before clearing
-				Set<String> expandedCategories = new HashSet<>();
-				for (Component comp : listContainer.getComponents())
-				{
-					if (comp instanceof CategorySummaryPanel)
-					{
-						CategorySummaryPanel csp = (CategorySummaryPanel) comp;
-						if (csp.isExpanded())
-						{
-							expandedCategories.add(csp.getCategoryName());
-						}
-					}
-				}
+				PanelRebuildOrchestrator.RebuildSnapshot snapshot = rebuildOrchestrator.capture();
 
 				SwingUtil.fastRemoveAll(listContainer);
 				updateCompletionHeader();
@@ -630,32 +609,14 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 
 				modeDispatcher.buildView(currentMode);
 
-				// Restore expanded category state
-				for (Component comp : listContainer.getComponents())
-				{
-					if (comp instanceof CategorySummaryPanel)
-					{
-						CategorySummaryPanel csp = (CategorySummaryPanel) comp;
-						if (expandedCategories.contains(csp.getCategoryName()))
-						{
-							csp.setExpanded(true);
-						}
-					}
-				}
+				rebuildOrchestrator.restoreExpanded(snapshot);
 
 				listContainer.revalidate();
 				listContainer.repaint();
 				if (!inDetailView)
 				{
 					showListView();
-
-					// Restore scroll position after rebuild
-					final int restorePosition = savedScrollPosition;
-					if (scrollPane != null && restorePosition > 0)
-					{
-						SwingUtilities.invokeLater(() ->
-							scrollPane.getVerticalScrollBar().setValue(restorePosition));
-					}
+					rebuildOrchestrator.deferScrollRestore(snapshot);
 				}
 			}
 			finally

--- a/src/main/java/com/collectionloghelper/ui/PanelRebuildOrchestrator.java
+++ b/src/main/java/com/collectionloghelper/ui/PanelRebuildOrchestrator.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.ui;
+
+import java.awt.Component;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import javax.swing.JComponent;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.SwingUtilities;
+
+/**
+ * Captures and restores transient view state across a panel rebuild so the user
+ * does not lose their place when the panel tears down and re-builds the list
+ * container.
+ *
+ * <p>Two pieces of state are managed:
+ * <ul>
+ *   <li>Vertical scroll position of the enclosing {@link JScrollPane} (if any).</li>
+ *   <li>The set of expanded category names — looked up by matching
+ *       {@link CategorySummaryPanel#getCategoryName()} against the children of
+ *       the list container before and after the rebuild.</li>
+ * </ul>
+ *
+ * <p>This class is intentionally not a Guice {@code @Singleton}; it is
+ * constructed inside the panel's constructor and bound to that panel's
+ * Swing components.
+ *
+ * <p>The expected call sequence wrapping a rebuild is:
+ * <pre>{@code
+ *   RebuildSnapshot snap = orchestrator.capture();
+ *   // ... tear down and re-populate listContainer ...
+ *   orchestrator.restoreExpanded(snap);
+ *   // ... revalidate / repaint / showListView ...
+ *   orchestrator.deferScrollRestore(snap);
+ * }</pre>
+ */
+public final class PanelRebuildOrchestrator
+{
+	private final JComponent panel;
+	private final JPanel listContainer;
+
+	public PanelRebuildOrchestrator(JComponent panel, JPanel listContainer)
+	{
+		this.panel = panel;
+		this.listContainer = listContainer;
+	}
+
+	/**
+	 * Snapshots the current scroll position and expanded-category state.
+	 * Caller is responsible for EDT discipline (matches the original inline
+	 * code, which ran inside {@code SwingUtilities.invokeLater}).
+	 */
+	public RebuildSnapshot capture()
+	{
+		int scrollPosition = 0;
+		JScrollPane scrollPane = (JScrollPane) SwingUtilities.getAncestorOfClass(
+			JScrollPane.class, panel);
+		if (scrollPane != null)
+		{
+			scrollPosition = scrollPane.getVerticalScrollBar().getValue();
+		}
+
+		Set<String> expandedCategories = new HashSet<>();
+		for (Component comp : listContainer.getComponents())
+		{
+			if (comp instanceof CategorySummaryPanel)
+			{
+				CategorySummaryPanel csp = (CategorySummaryPanel) comp;
+				if (csp.isExpanded())
+				{
+					expandedCategories.add(csp.getCategoryName());
+				}
+			}
+		}
+
+		return new RebuildSnapshot(scrollPane, scrollPosition, expandedCategories);
+	}
+
+	/**
+	 * Restores expanded state on category panels in the list container whose
+	 * name matched a previously-expanded entry.
+	 */
+	public void restoreExpanded(RebuildSnapshot snapshot)
+	{
+		if (snapshot == null || snapshot.expandedCategories.isEmpty())
+		{
+			return;
+		}
+		for (Component comp : listContainer.getComponents())
+		{
+			if (comp instanceof CategorySummaryPanel)
+			{
+				CategorySummaryPanel csp = (CategorySummaryPanel) comp;
+				if (snapshot.expandedCategories.contains(csp.getCategoryName()))
+				{
+					csp.setExpanded(true);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Schedules a deferred scroll-position restore via
+	 * {@link SwingUtilities#invokeLater} so the new component tree has a chance
+	 * to lay out before we re-apply the saved offset. No-op when the panel is
+	 * not inside a scroll pane or when the saved offset is zero.
+	 */
+	public void deferScrollRestore(RebuildSnapshot snapshot)
+	{
+		if (snapshot == null
+			|| snapshot.scrollPane == null
+			|| snapshot.scrollPosition <= 0)
+		{
+			return;
+		}
+		final JScrollPane scrollPane = snapshot.scrollPane;
+		final int restorePosition = snapshot.scrollPosition;
+		SwingUtilities.invokeLater(() ->
+			scrollPane.getVerticalScrollBar().setValue(restorePosition));
+	}
+
+	/**
+	 * Immutable snapshot of view state captured before a rebuild.
+	 */
+	public static final class RebuildSnapshot
+	{
+		private final JScrollPane scrollPane;
+		private final int scrollPosition;
+		private final Set<String> expandedCategories;
+
+		RebuildSnapshot(JScrollPane scrollPane, int scrollPosition,
+			Set<String> expandedCategories)
+		{
+			this.scrollPane = scrollPane;
+			this.scrollPosition = scrollPosition;
+			this.expandedCategories = Collections.unmodifiableSet(
+				new HashSet<>(expandedCategories));
+		}
+
+		public int getScrollPosition()
+		{
+			return scrollPosition;
+		}
+
+		public Set<String> getExpandedCategories()
+		{
+			return expandedCategories;
+		}
+	}
+}

--- a/src/test/java/com/collectionloghelper/ui/PanelRebuildOrchestratorTest.java
+++ b/src/test/java/com/collectionloghelper/ui/PanelRebuildOrchestratorTest.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.ui;
+
+import com.collectionloghelper.data.CollectionLogCategory;
+import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.data.PlayerCollectionState;
+import com.collectionloghelper.data.RequirementsChecker;
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.util.Collections;
+import java.util.Set;
+import javax.swing.BoxLayout;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollBar;
+import javax.swing.JScrollPane;
+import javax.swing.SwingUtilities;
+import net.runelite.client.game.ItemManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link PanelRebuildOrchestrator}: the helper that snapshots
+ * and restores scroll position + expanded-category state across a panel
+ * rebuild. Extracted from {@link CollectionLogHelperPanel#rebuild()} as part
+ * of issue #503 god-class splits.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class PanelRebuildOrchestratorTest
+{
+	@Mock
+	private PlayerCollectionState collectionState;
+	@Mock
+	private RequirementsChecker requirementsChecker;
+	@Mock
+	private ItemManager itemManager;
+	@Mock
+	private CategorySummaryPanel.ItemClickHandler clickHandler;
+
+	private JPanel hostPanel;
+	private JPanel listContainer;
+	private JScrollPane scrollPane;
+	private PanelRebuildOrchestrator orchestrator;
+
+	@Before
+	public void setUp()
+	{
+		when(collectionState.getCategoryCount(any())).thenReturn(0);
+		when(collectionState.getCategoryMax(any())).thenReturn(10);
+
+		listContainer = new JPanel();
+		listContainer.setLayout(new BoxLayout(listContainer, BoxLayout.Y_AXIS));
+
+		hostPanel = new JPanel(new BorderLayout());
+		// Give the host a tall preferred size so the enclosing JScrollPane's
+		// vertical scrollbar has actual range to scroll within.
+		hostPanel.setPreferredSize(new Dimension(200, 5000));
+		hostPanel.add(listContainer, BorderLayout.NORTH);
+
+		scrollPane = new JScrollPane(hostPanel);
+		scrollPane.setSize(200, 400);
+		scrollPane.doLayout();
+		scrollPane.getViewport().doLayout();
+
+		orchestrator = new PanelRebuildOrchestrator(hostPanel, listContainer);
+	}
+
+	private CategorySummaryPanel newCategoryPanel(CollectionLogCategory category)
+	{
+		return new CategorySummaryPanel(
+			category,
+			Collections.<CollectionLogSource>emptyList(),
+			collectionState,
+			requirementsChecker,
+			itemManager,
+			clickHandler,
+			false);
+	}
+
+	private JScrollBar vBar()
+	{
+		return scrollPane.getVerticalScrollBar();
+	}
+
+	@Test
+	public void captureReturnsZeroScrollAndEmptySetWhenNothingExpanded()
+	{
+		PanelRebuildOrchestrator.RebuildSnapshot snapshot = orchestrator.capture();
+
+		assertNotNull(snapshot);
+		assertEquals(0, snapshot.getScrollPosition());
+		assertTrue(snapshot.getExpandedCategories().isEmpty());
+	}
+
+	@Test
+	public void captureRecordsScrollPositionFromEnclosingScrollPane()
+	{
+		vBar().setValue(250);
+
+		PanelRebuildOrchestrator.RebuildSnapshot snapshot = orchestrator.capture();
+
+		assertEquals(250, snapshot.getScrollPosition());
+	}
+
+	@Test
+	public void captureRecordsOnlyCurrentlyExpandedCategoryNames()
+	{
+		CategorySummaryPanel bosses = newCategoryPanel(CollectionLogCategory.BOSSES);
+		CategorySummaryPanel raids = newCategoryPanel(CollectionLogCategory.RAIDS);
+		CategorySummaryPanel clues = newCategoryPanel(CollectionLogCategory.CLUES);
+		listContainer.add(bosses);
+		listContainer.add(raids);
+		listContainer.add(clues);
+		bosses.setExpanded(true);
+		clues.setExpanded(true);
+
+		Set<String> expanded = orchestrator.capture().getExpandedCategories();
+
+		assertEquals(2, expanded.size());
+		assertTrue(expanded.contains("Bosses"));
+		assertTrue(expanded.contains("Clues"));
+		assertFalse(expanded.contains("Raids"));
+	}
+
+	@Test
+	public void captureIgnoresNonCategoryChildren()
+	{
+		listContainer.add(new JLabel("ignored"));
+		listContainer.add(newCategoryPanel(CollectionLogCategory.BOSSES));
+
+		PanelRebuildOrchestrator.RebuildSnapshot snapshot = orchestrator.capture();
+
+		// non-category child must not appear; the unexpanded category is also absent.
+		assertTrue(snapshot.getExpandedCategories().isEmpty());
+	}
+
+	@Test
+	public void restoreExpandedReExpandsMatchingCategoriesAfterRebuild()
+	{
+		CategorySummaryPanel bosses = newCategoryPanel(CollectionLogCategory.BOSSES);
+		CategorySummaryPanel raids = newCategoryPanel(CollectionLogCategory.RAIDS);
+		listContainer.add(bosses);
+		listContainer.add(raids);
+		bosses.setExpanded(true);
+
+		PanelRebuildOrchestrator.RebuildSnapshot snapshot = orchestrator.capture();
+
+		// Simulate a rebuild: tear down and re-create with same categories.
+		listContainer.removeAll();
+		CategorySummaryPanel bosses2 = newCategoryPanel(CollectionLogCategory.BOSSES);
+		CategorySummaryPanel raids2 = newCategoryPanel(CollectionLogCategory.RAIDS);
+		listContainer.add(bosses2);
+		listContainer.add(raids2);
+
+		orchestrator.restoreExpanded(snapshot);
+
+		assertTrue("Bosses should be re-expanded", bosses2.isExpanded());
+		assertFalse("Raids was not in snapshot - must remain collapsed", raids2.isExpanded());
+	}
+
+	@Test
+	public void restoreExpandedIsNoOpWhenSnapshotIsEmpty()
+	{
+		CategorySummaryPanel bosses = newCategoryPanel(CollectionLogCategory.BOSSES);
+		listContainer.add(bosses);
+
+		PanelRebuildOrchestrator.RebuildSnapshot empty = orchestrator.capture();
+		orchestrator.restoreExpanded(empty);
+
+		assertFalse(bosses.isExpanded());
+	}
+
+	@Test
+	public void restoreExpandedDoesNotReExpandRemovedCategory()
+	{
+		CategorySummaryPanel bosses = newCategoryPanel(CollectionLogCategory.BOSSES);
+		listContainer.add(bosses);
+		bosses.setExpanded(true);
+
+		PanelRebuildOrchestrator.RebuildSnapshot snapshot = orchestrator.capture();
+
+		// Rebuild produces a different set of categories - Bosses is gone.
+		listContainer.removeAll();
+		CategorySummaryPanel raids = newCategoryPanel(CollectionLogCategory.RAIDS);
+		listContainer.add(raids);
+
+		orchestrator.restoreExpanded(snapshot);
+
+		assertFalse("Raids was not in snapshot - must remain collapsed", raids.isExpanded());
+	}
+
+	@Test
+	public void deferScrollRestoreSchedulesValueOnVerticalScrollBar() throws Exception
+	{
+		vBar().setValue(400);
+		PanelRebuildOrchestrator.RebuildSnapshot snapshot = orchestrator.capture();
+		vBar().setValue(0);
+
+		orchestrator.deferScrollRestore(snapshot);
+		// Flush the EDT to let the deferred invokeLater run.
+		SwingUtilities.invokeAndWait(() -> { /* no-op flush */ });
+
+		assertEquals(400, vBar().getValue());
+	}
+
+	@Test
+	public void deferScrollRestoreIsNoOpWhenScrollPositionIsZero() throws Exception
+	{
+		PanelRebuildOrchestrator.RebuildSnapshot snapshot = orchestrator.capture();
+		vBar().setValue(123);
+
+		orchestrator.deferScrollRestore(snapshot);
+		SwingUtilities.invokeAndWait(() -> { /* no-op flush */ });
+
+		// No restore was scheduled - the post-call scroll value sticks.
+		assertEquals(123, vBar().getValue());
+	}
+
+	@Test
+	public void deferScrollRestoreIsNoOpWhenPanelNotInScrollPane() throws Exception
+	{
+		JPanel orphanPanel = new JPanel();
+		JPanel orphanList = new JPanel();
+		PanelRebuildOrchestrator orphan = new PanelRebuildOrchestrator(orphanPanel, orphanList);
+
+		PanelRebuildOrchestrator.RebuildSnapshot snapshot = orphan.capture();
+
+		// Just call it; assert no exception thrown.
+		orphan.deferScrollRestore(snapshot);
+		SwingUtilities.invokeAndWait(() -> { /* no-op flush */ });
+
+		assertEquals(0, snapshot.getScrollPosition());
+	}
+
+	@Test
+	public void snapshotExpandedCategoriesIsImmutable()
+	{
+		CategorySummaryPanel bosses = newCategoryPanel(CollectionLogCategory.BOSSES);
+		listContainer.add(bosses);
+		bosses.setExpanded(true);
+
+		Set<String> snap = orchestrator.capture().getExpandedCategories();
+
+		try
+		{
+			snap.add("Mutated");
+			throw new AssertionError("Expected snapshot set to be unmodifiable");
+		}
+		catch (UnsupportedOperationException expected)
+		{
+			// pass
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Extracts the scroll-position + expanded-category snapshot/restore logic out of `CollectionLogHelperPanel.rebuild()` into a new `PanelRebuildOrchestrator` helper. The panel's rebuild body now reads as a short orchestration: capture state, tear down `listContainer`, let `modeDispatcher.buildView()` repopulate it, restore expanded categories, defer scroll restore. Behaviour is unchanged; thread discipline (the outer `SwingUtilities.invokeLater` and the `rebuilding` / `rebuildPending` state machine) remains on the panel where it belongs.

Partially addresses #503.

### Changes

- **New** `src/main/java/com/collectionloghelper/ui/PanelRebuildOrchestrator.java` (175 LOC)
  - `capture()` snapshots scroll position (via the enclosing `JScrollPane` ancestor) and the set of currently-expanded `CategorySummaryPanel` names in `listContainer`.
  - `restoreExpanded(snapshot)` re-applies the expanded set to whichever category panels are present after rebuild, looked up by name.
  - `deferScrollRestore(snapshot)` schedules the scroll restore via `SwingUtilities.invokeLater` so the new component tree has a chance to lay out before the offset is re-applied. No-ops cleanly when there is no scroll pane or the saved offset is zero.
  - Immutable nested `RebuildSnapshot` value holder (Java 11 target, so a plain final-field class, not a record).
- **Modified** `src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java`
  - `rebuild()` body shrinks from 80 LOC to 41 LOC.
  - Panel total LOC: 900 → 861 (−39).
  - New `private final PanelRebuildOrchestrator rebuildOrchestrator` field, constructed in the panel constructor after `listContainer` is created.
  - Removed unused `java.util.HashSet` / `java.util.Set` imports.
- **New** `src/test/java/com/collectionloghelper/ui/PanelRebuildOrchestratorTest.java` (11 tests)

### LOC

| File | Before | After | Delta |
|---|---|---|---|
| `CollectionLogHelperPanel.java` | 900 | 861 | −39 |
| `PanelRebuildOrchestrator.java` | — | 175 | new |

## Test plan

- [x] `./gradlew build` passes (includes `jacocoTestCoverageVerification`)
- [x] `./gradlew test` — 1183 tests, 0 failures, 0 errors, 0 skipped (+11 new tests on the orchestrator)
- [x] New unit tests cover:
  - capture returns zero scroll + empty expanded set when nothing is expanded and the scrollbar is at 0
  - capture records non-zero scroll position from the enclosing `JScrollPane`
  - capture records only currently-expanded category names (not collapsed or non-category children)
  - `restoreExpanded` re-expands matching categories after a rebuild that recreates the same names
  - `restoreExpanded` is a no-op on an empty snapshot
  - `restoreExpanded` does not re-expand a category whose name is absent from the snapshot
  - `deferScrollRestore` schedules a value-set on the vertical scrollbar via `invokeLater`
  - `deferScrollRestore` no-ops when the saved offset is 0
  - `deferScrollRestore` no-ops when the panel is not inside a scroll pane
  - the snapshot's `expandedCategories` set is unmodifiable
- [x] Existing panel tests under `src/test/java/com/collectionloghelper/ui/` continue to pass; panel public API unchanged
- [x] No new `SwingUtilities.invokeLater` wrapping introduced beyond the original (`deferScrollRestore` matches the original inline `invokeLater` for the deferred scroll restore exactly)