### PR TITLE
refactor: extract GuidanceModule (#504)

### DIFF
--- a/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
@@ -29,6 +29,7 @@ import com.collectionloghelper.data.CollectionLogSource;
 import com.collectionloghelper.data.PlayerTravelCapabilities;
 import com.collectionloghelper.data.RequirementsChecker;
 import com.collectionloghelper.di.DataModule;
+import com.collectionloghelper.di.GuidanceModule;
 import com.collectionloghelper.sync.CollectionLogNetImporter;
 import com.collectionloghelper.sync.ImportResult;
 import com.collectionloghelper.sync.LootSyncManager;
@@ -40,18 +41,11 @@ import com.collectionloghelper.efficiency.EfficiencyCalculator;
 import com.collectionloghelper.efficiency.ScoredItem;
 import com.collectionloghelper.efficiency.SlayerStrategyCalculator;
 import com.collectionloghelper.learning.DryStreakAnalyzer;
-import com.collectionloghelper.guidance.GuidanceOverlayCoordinator;
-import com.collectionloghelper.guidance.GuidanceSequencer;
-import com.collectionloghelper.guidance.RequiredItemResolver;
 import com.collectionloghelper.learning.KillTimeTracker;
 import com.collectionloghelper.lifecycle.AuthoringLogger;
-import com.collectionloghelper.lifecycle.GuidanceEventRouter;
-import com.collectionloghelper.lifecycle.GuidanceUIState;
 import com.collectionloghelper.lifecycle.OverlayRegistry;
 import com.collectionloghelper.lifecycle.SceneEventRouter;
 import com.collectionloghelper.lifecycle.SyncStateCoordinator;
-import com.collectionloghelper.overlay.GuidanceOverlay;
-import com.collectionloghelper.overlay.ObjectHighlightOverlay;
 import com.collectionloghelper.ui.CollectionLogHelperPanel;
 import com.google.inject.Provides;
 import java.awt.image.BufferedImage;
@@ -150,10 +144,7 @@ public class CollectionLogHelperPlugin extends Plugin
 	private RequirementsChecker requirementsChecker;
 
 	@Inject
-	private GuidanceOverlay guidanceOverlay;
-
-	@Inject
-	private ObjectHighlightOverlay objectHighlightOverlay;
+	private GuidanceModule guidance;
 
 	@Inject
 	private SlayerStrategyCalculator slayerStrategyCalculator;
@@ -163,15 +154,6 @@ public class CollectionLogHelperPlugin extends Plugin
 
 	@Inject
 	private PlayerTravelCapabilities travelCapabilities;
-
-	@Inject
-	private GuidanceSequencer guidanceSequencer;
-
-	@Inject
-	private GuidanceOverlayCoordinator guidanceCoordinator;
-
-	@Inject
-	private RequiredItemResolver requiredItemResolver;
 
 	@Inject
 	private OverlayRegistry overlayRegistry;
@@ -184,15 +166,6 @@ public class CollectionLogHelperPlugin extends Plugin
 
 	@Inject
 	private SyncStateCoordinator syncStateCoordinator;
-
-	@Inject
-	private GuidanceUIState guidanceUIState;
-
-	@Inject
-	private GuidanceEventRouter guidanceEventRouter;
-
-	@Inject
-	private com.collectionloghelper.guidance.GuidanceMovementTracker guidanceMovementTracker;
 
 	@Inject
 	private CollectionLogNetImporter collectionLogNetImporter;
@@ -271,10 +244,10 @@ public class CollectionLogHelperPlugin extends Plugin
 		// that are client-thread-only, matching the pattern established in
 		// commits c528d0ae and cha-ndler/collection-log-helper#409.
 		panel.setStepCallbacks(
-			() -> clientThread.invokeLater(guidanceSequencer::advanceStep),
-			() -> clientThread.invokeLater(guidanceSequencer::skipStep),
-			() -> clientThread.invokeLater(guidanceSequencer::restartFromStep0),
-			() -> clientThread.invokeLater(guidanceSequencer::syncToCurrentState)
+			() -> clientThread.invokeLater(guidance.getGuidanceSequencer()::advanceStep),
+			() -> clientThread.invokeLater(guidance.getGuidanceSequencer()::skipStep),
+			() -> clientThread.invokeLater(guidance.getGuidanceSequencer()::restartFromStep0),
+			() -> clientThread.invokeLater(guidance.getGuidanceSequencer()::syncToCurrentState)
 		);
 
 		// Wire collectionlog.net import callback — fetches username from the logged-in player.
@@ -316,11 +289,11 @@ public class CollectionLogHelperPlugin extends Plugin
 		panel.setTempleSyncCallback(this::onTempleSyncRequested);
 
 		// Wire coordinator with references it needs from the plugin
-		guidanceCoordinator.setPluginInstance(this);
-		guidanceCoordinator.setPanel(panel);
-		guidanceCoordinator.setOnSequenceCompleteCallback(this::onSequenceComplete);
+		guidance.getGuidanceCoordinator().setPluginInstance(this);
+		guidance.getGuidanceCoordinator().setPanel(panel);
+		guidance.getGuidanceCoordinator().setOnSequenceCompleteCallback(this::onSequenceComplete);
 		// Wire coordinator into resolver (post-construction, avoids circular injection)
-		requiredItemResolver.setCoordinator(guidanceCoordinator);
+		guidance.getRequiredItemResolver().setCoordinator(guidance.getGuidanceCoordinator());
 
 		// Use a placeholder icon initially, then swap to the real item sprite once loaded
 		final BufferedImage placeholder = ImageUtil.loadImageResource(getClass(), "panel_icon.png");
@@ -334,7 +307,7 @@ public class CollectionLogHelperPlugin extends Plugin
 
 		// AsyncBufferedImage may be blank at startup; onLoaded rebuilds the nav button
 		collectionLogIcon = itemManager.getImage(ItemID.COLLECTION_LOG);
-		guidanceCoordinator.setCollectionLogIcon(collectionLogIcon);
+		guidance.getGuidanceCoordinator().setCollectionLogIcon(collectionLogIcon);
 		((net.runelite.client.util.AsyncBufferedImage) collectionLogIcon).onLoaded(() ->
 		{
 			clientToolbar.removeNavigation(navButton);
@@ -349,13 +322,13 @@ public class CollectionLogHelperPlugin extends Plugin
 		overlayRegistry.registerAll();
 		sceneEventRouter.setAuthoringLogger(msg -> authoringLogger.log("%s", msg));
 		eventBus.register(sceneEventRouter);
-		guidanceEventRouter.setMissingItemsSupplier(() -> sourcesWithMissingItems);
-		guidanceEventRouter.setActivateGuidanceCallback(
+		guidance.getGuidanceEventRouter().setMissingItemsSupplier(() -> sourcesWithMissingItems);
+		guidance.getGuidanceEventRouter().setActivateGuidanceCallback(
 			(java.util.function.Consumer<CollectionLogSource>) this::activateGuidance);
-		guidanceEventRouter.setOnFilterConfigChanged(this::onFilterConfigChanged);
-		guidanceEventRouter.setOnSyncConfigChanged(this::onSyncConfigChanged);
-		eventBus.register(guidanceEventRouter);
-		eventBus.register(guidanceMovementTracker);
+		guidance.getGuidanceEventRouter().setOnFilterConfigChanged(this::onFilterConfigChanged);
+		guidance.getGuidanceEventRouter().setOnSyncConfigChanged(this::onSyncConfigChanged);
+		eventBus.register(guidance.getGuidanceEventRouter());
+		eventBus.register(guidance.getGuidanceMovementTracker());
 		eventBus.register(killTimeTracker);
 
 		// If already logged in (e.g., plugin enabled mid-session), load state
@@ -395,8 +368,8 @@ public class CollectionLogHelperPlugin extends Plugin
 		clientToolbar.removeNavigation(navButton);
 		overlayRegistry.unregisterAll();
 		eventBus.unregister(sceneEventRouter);
-		eventBus.unregister(guidanceEventRouter);
-		eventBus.unregister(guidanceMovementTracker);
+		eventBus.unregister(guidance.getGuidanceEventRouter());
+		eventBus.unregister(guidance.getGuidanceMovementTracker());
 		eventBus.unregister(killTimeTracker);
 		killTimeTracker.reset();
 		deactivateGuidance();
@@ -413,8 +386,8 @@ public class CollectionLogHelperPlugin extends Plugin
 		rankedSourcesDirty = true;
 		cachedRankedSources = null;
 		cachedPlayerLocation = null;
-		guidanceOverlay.setShowCollectionLogReminder(false);
-		guidanceOverlay.setShowBankReminder(false);
+		guidance.getGuidanceOverlay().setShowCollectionLogReminder(false);
+		guidance.getGuidanceOverlay().setShowBankReminder(false);
 		data.getDataSyncState().reset();
 		data.getPlayerBankState().reset();
 		data.getPlayerInventoryState().reset();
@@ -449,7 +422,7 @@ public class CollectionLogHelperPlugin extends Plugin
 				rebuildSourcesWithMissingItems();
 
 				// Rescan scene for tracked objects after scene (re)load
-				objectHighlightOverlay.rescanScene();
+				guidance.getObjectHighlightOverlay().rescanScene();
 
 				// Per-character dir and cache-fresh check are handled in
 				// onGameTick once varps and player name are available.
@@ -487,8 +460,8 @@ public class CollectionLogHelperPlugin extends Plugin
 			slayerRefreshPending = false;
 			pendingTravelVarbitRefresh = false;
 			cachedPlayerLocation = null;
-			guidanceOverlay.setShowCollectionLogReminder(false);
-			guidanceOverlay.setShowBankReminder(false);
+			guidance.getGuidanceOverlay().setShowCollectionLogReminder(false);
+			guidance.getGuidanceOverlay().setShowBankReminder(false);
 			data.getDataSyncState().reset();
 			data.getPlayerBankState().reset();
 			data.getPlayerInventoryState().reset();
@@ -525,7 +498,7 @@ public class CollectionLogHelperPlugin extends Plugin
 		}
 
 		// Forward varbit change to guidance sequencer for VARBIT_AT_LEAST completion
-		guidanceSequencer.onVarbitChanged(event.getVarbitId(), event.getValue());
+		guidance.getGuidanceSequencer().onVarbitChanged(event.getVarbitId(), event.getValue());
 
 		// Refresh Slayer task state and rebuild if the task changed
 		boolean wasActive = data.getSlayerTaskState().isTaskActive();
@@ -588,9 +561,9 @@ public class CollectionLogHelperPlugin extends Plugin
 		}
 
 		// Forward chat messages to guidance sequencer for CHAT_MESSAGE_RECEIVED condition
-		if (guidanceSequencer.isActive())
+		if (guidance.getGuidanceSequencer().isActive())
 		{
-			guidanceSequencer.onChatMessage(Text.removeTags(event.getMessage()));
+			guidance.getGuidanceSequencer().onChatMessage(Text.removeTags(event.getMessage()));
 		}
 
 		Matcher matcher = COLLECTION_LOG_PATTERN.matcher(Text.removeTags(event.getMessage()));
@@ -604,7 +577,7 @@ public class CollectionLogHelperPlugin extends Plugin
 			if (item != null)
 			{
 				data.getCollectionState().markItemObtained(item.getItemId());
-				guidanceSequencer.onItemObtained(item.getItemId());
+				guidance.getGuidanceSequencer().onItemObtained(item.getItemId());
 				log.debug("Marked item {} (ID: {}) as obtained", itemName, item.getItemId());
 			}
 
@@ -664,7 +637,7 @@ public class CollectionLogHelperPlugin extends Plugin
 		}
 
 		// Dispatch deferred ShortestPath "path" and world map arrow via coordinator
-		guidanceCoordinator.tick();
+		guidance.getGuidanceCoordinator().tick();
 
 		// Cache player location for guidance sequencer and authoring log (client thread only).
 		// When sailing, the player is inside a WorldEntity whose inner WorldView
@@ -677,10 +650,10 @@ public class CollectionLogHelperPlugin extends Plugin
 			authoringLogger.setPlayerLocation(cachedPlayerLocation);
 
 			// Check ARRIVE_AT_TILE completion for guidance sequencer
-			if (guidanceSequencer.isActive())
+			if (guidance.getGuidanceSequencer().isActive())
 			{
-				guidanceSequencer.setPlayerLocation(cachedPlayerLocation);
-				guidanceSequencer.onPlayerMoved(cachedPlayerLocation);
+				guidance.getGuidanceSequencer().setPlayerLocation(cachedPlayerLocation);
+				guidance.getGuidanceSequencer().onPlayerMoved(cachedPlayerLocation);
 			}
 
 		}
@@ -770,7 +743,7 @@ public class CollectionLogHelperPlugin extends Plugin
 		// Route through the client thread: RequirementsChecker.buildRequirementRows
 		// and related coordinator work require client-thread context.  Mirrors the
 		// step-advance / skip wrap added in commit c528d0ae.
-		clientThread.invokeLater(() -> guidanceCoordinator.activateGuidance(
+		clientThread.invokeLater(() -> guidance.getGuidanceCoordinator().activateGuidance(
 			source, cachedPlayerLocation, targetItemId));
 	}
 
@@ -851,7 +824,7 @@ public class CollectionLogHelperPlugin extends Plugin
 
 	public void deactivateGuidance()
 	{
-		guidanceCoordinator.deactivateGuidance();
+		guidance.getGuidanceCoordinator().deactivateGuidance();
 	}
 
 	/**
@@ -952,7 +925,7 @@ public class CollectionLogHelperPlugin extends Plugin
 	 */
 	private void rebuildSourcesWithMissingItems()
 	{
-		sourcesWithMissingItems = guidanceCoordinator.rebuildSourcesWithMissingItems(
+		sourcesWithMissingItems = guidance.getGuidanceCoordinator().rebuildSourcesWithMissingItems(
 			data.getDatabase(), data.getCollectionState());
 	}
 
@@ -1051,11 +1024,11 @@ public class CollectionLogHelperPlugin extends Plugin
 		}
 
 		String guidanceLine;
-		if (guidanceSequencer.isActive() && guidanceSequencer.getActiveSource() != null)
+		if (guidance.getGuidanceSequencer().isActive() && guidance.getGuidanceSequencer().getActiveSource() != null)
 		{
-			String sourceName = guidanceSequencer.getActiveSource().getName();
-			int step = guidanceSequencer.getCurrentIndex() + 1;
-			int totalSteps = guidanceSequencer.getTotalSteps();
+			String sourceName = guidance.getGuidanceSequencer().getActiveSource().getName();
+			int step = guidance.getGuidanceSequencer().getCurrentIndex() + 1;
+			int totalSteps = guidance.getGuidanceSequencer().getTotalSteps();
 			guidanceLine = String.format("Guiding: %s step %d/%d", sourceName, step, totalSteps);
 		}
 		else

--- a/src/main/java/com/collectionloghelper/di/GuidanceModule.java
+++ b/src/main/java/com/collectionloghelper/di/GuidanceModule.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.di;
+
+import com.collectionloghelper.guidance.GuidanceMovementTracker;
+import com.collectionloghelper.guidance.GuidanceOverlayCoordinator;
+import com.collectionloghelper.guidance.GuidanceSequencer;
+import com.collectionloghelper.guidance.RequiredItemResolver;
+import com.collectionloghelper.lifecycle.GuidanceEventRouter;
+import com.collectionloghelper.lifecycle.GuidanceUIState;
+import com.collectionloghelper.overlay.GuidanceOverlay;
+import com.collectionloghelper.overlay.ObjectHighlightOverlay;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.Getter;
+
+/**
+ * Aggregate holder for the plugin's guidance-layer Guice singletons.
+ *
+ * <p>Groups the eight guidance-layer dependencies that {@code CollectionLogHelperPlugin}
+ * previously injected individually, reducing the plugin's {@code @Inject} field count
+ * and providing a single seam for guidance-layer wiring.
+ *
+ * <p>Second of four planned sub-module extractions tracked by issue #504.
+ */
+@Singleton
+@Getter
+public class GuidanceModule
+{
+	private final GuidanceSequencer guidanceSequencer;
+	private final GuidanceOverlayCoordinator guidanceCoordinator;
+	private final GuidanceOverlay guidanceOverlay;
+	private final ObjectHighlightOverlay objectHighlightOverlay;
+	private final RequiredItemResolver requiredItemResolver;
+	private final GuidanceUIState guidanceUIState;
+	private final GuidanceEventRouter guidanceEventRouter;
+	private final GuidanceMovementTracker guidanceMovementTracker;
+
+	@Inject
+	public GuidanceModule(
+		GuidanceSequencer guidanceSequencer,
+		GuidanceOverlayCoordinator guidanceCoordinator,
+		GuidanceOverlay guidanceOverlay,
+		ObjectHighlightOverlay objectHighlightOverlay,
+		RequiredItemResolver requiredItemResolver,
+		GuidanceUIState guidanceUIState,
+		GuidanceEventRouter guidanceEventRouter,
+		GuidanceMovementTracker guidanceMovementTracker)
+	{
+		this.guidanceSequencer = guidanceSequencer;
+		this.guidanceCoordinator = guidanceCoordinator;
+		this.guidanceOverlay = guidanceOverlay;
+		this.objectHighlightOverlay = objectHighlightOverlay;
+		this.requiredItemResolver = requiredItemResolver;
+		this.guidanceUIState = guidanceUIState;
+		this.guidanceEventRouter = guidanceEventRouter;
+		this.guidanceMovementTracker = guidanceMovementTracker;
+	}
+}

--- a/src/test/java/com/collectionloghelper/ActivateGuidanceClientThreadTest.java
+++ b/src/test/java/com/collectionloghelper/ActivateGuidanceClientThreadTest.java
@@ -26,6 +26,7 @@ package com.collectionloghelper;
 
 import com.collectionloghelper.data.CollectionLogCategory;
 import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.di.GuidanceModule;
 import com.collectionloghelper.guidance.GuidanceOverlayCoordinator;
 import java.lang.reflect.Field;
 import net.runelite.client.callback.ClientThread;
@@ -66,7 +67,9 @@ public class ActivateGuidanceClientThreadTest
 	{
 		plugin = new CollectionLogHelperPlugin();
 		injectField("clientThread", clientThread);
-		injectField("guidanceCoordinator", guidanceCoordinator);
+		GuidanceModule guidanceModule = new GuidanceModule(
+			null, guidanceCoordinator, null, null, null, null, null, null);
+		injectField("guidance", guidanceModule);
 	}
 
 	/**

--- a/src/test/java/com/collectionloghelper/OnSequenceCompletePerItemTest.java
+++ b/src/test/java/com/collectionloghelper/OnSequenceCompletePerItemTest.java
@@ -27,6 +27,7 @@ package com.collectionloghelper;
 import com.collectionloghelper.data.CollectionLogCategory;
 import com.collectionloghelper.data.CollectionLogItem;
 import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.di.GuidanceModule;
 import com.collectionloghelper.efficiency.EfficiencyCalculator;
 import com.collectionloghelper.efficiency.ScoredItem;
 import com.collectionloghelper.guidance.GuidanceOverlayCoordinator;
@@ -82,7 +83,9 @@ public class OnSequenceCompletePerItemTest
 	{
 		plugin = new CollectionLogHelperPlugin();
 		injectField("clientThread", clientThread);
-		injectField("guidanceCoordinator", guidanceCoordinator);
+		GuidanceModule guidanceModule = new GuidanceModule(
+			null, guidanceCoordinator, null, null, null, null, null, null);
+		injectField("guidance", guidanceModule);
 		injectField("config", config);
 		injectField("calculator", calculator);
 


### PR DESCRIPTION
## Summary

Extracts the second of four planned guidance sub-modules tracked by #504, mirroring the `DataModule` pattern shipped in #509.

Groups eight guidance-layer `@Inject` fields into a single `GuidanceModule` aggregate holder:

- `GuidanceSequencer`
- `GuidanceOverlayCoordinator`
- `GuidanceOverlay`
- `ObjectHighlightOverlay`
- `RequiredItemResolver`
- `GuidanceUIState`
- `GuidanceEventRouter`
- `GuidanceMovementTracker`

`CollectionLogHelperPlugin` `@Inject` count drops from 32 to 25 (8 removed, 1 added). Use sites rewritten to module access (`guidance.getGuidanceSequencer()` etc.).

Partially addresses #504.

## Test plan

- [x] `./gradlew build` passes
- [x] `./gradlew test` passes (1183 tests, 0 failures)
- [x] JaCoCo 45% coverage gate holds (`jacocoTestCoverageVerification` passes)
- [x] No string-literal bleed-through: `grep -nE '"[^"]*guidance\.get[A-Z][a-zA-Z]*\(\)' Plugin.java` returns 0 hits
- [x] `@Inject` count in `Plugin.java` confirmed at 25 (was 32)
- [x] Reflection-based tests (`ActivateGuidanceClientThreadTest`, `OnSequenceCompletePerItemTest`) rewired to inject a `GuidanceModule` containing the mocked coordinator