### PR TITLE
refactor: extract SyncButtonController from Panel (#503)

### DIFF
--- a/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
@@ -74,7 +74,6 @@ import java.util.function.Consumer;
 import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
-import javax.swing.JButton;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -141,10 +140,7 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 
 	private final SyncStatusView syncStatusView;
 	private final ClueSummaryView clueSummaryView;
-	private final JButton collectionLogNetSyncButton;
-
-	/** Set by the plugin after construction; called when the sync button is clicked. */
-	private Runnable collectionLogNetImportCallback;
+	private final SyncButtonController syncButtonController;
 
 	private final JComboBox<Mode> modeSelector;
 	private final JComboBox<AfkFilter> afkFilterSelector;
@@ -166,9 +162,6 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 
 	private final Timer searchDebounceTimer;
 
-	/** "Sync KC from TempleOSRS" button; visible only when config.enableTempleOsrsSync() is true. */
-	private final JButton templeSyncButton;
-
 	private final Map<Mode, PanelModeController> modeControllers = new EnumMap<>(Mode.class);
 	private final PanelModeDispatcher<Mode> modeDispatcher = new PanelModeDispatcher<>(modeControllers);
 	private final PanelRebuildOrchestrator rebuildOrchestrator;
@@ -179,7 +172,6 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 	private boolean guidanceActive = false;
 	private CollectionLogSource guidedSource = null;
 	private boolean inDetailView = false;
-	private Runnable templeSyncCallback;
 
 	public CollectionLogHelperPanel(CollectionLogHelperConfig config,
 		DropRateDatabase database, PlayerCollectionState collectionState,
@@ -239,41 +231,9 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 		syncStatusView.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
 		controlsPanel.add(syncStatusView);
 
-		collectionLogNetSyncButton = new JButton("Sync from collectionlog.net");
-		collectionLogNetSyncButton.setAlignmentX(CENTER_ALIGNMENT);
-		collectionLogNetSyncButton.setMaximumSize(new Dimension(Integer.MAX_VALUE, 26));
-		collectionLogNetSyncButton.setFont(FontManager.getRunescapeSmallFont());
-		collectionLogNetSyncButton.setFocusPainted(false);
-		collectionLogNetSyncButton.setToolTipText(
-			"Click to send your display name to collectionlog.net and import your obtained-items list");
-		collectionLogNetSyncButton.setVisible(config.enableCollectionLogNetImport());
-		collectionLogNetSyncButton.addActionListener(e ->
-		{
-			if (collectionLogNetImportCallback != null)
-			{
-				collectionLogNetSyncButton.setEnabled(false);
-				collectionLogNetSyncButton.setText("Syncing...");
-				collectionLogNetImportCallback.run();
-			}
-		});
-		controlsPanel.add(collectionLogNetSyncButton);
-
-		templeSyncButton = new JButton("Sync KC from TempleOSRS");
-		templeSyncButton.setFont(FontManager.getRunescapeSmallFont());
-		templeSyncButton.setAlignmentX(CENTER_ALIGNMENT);
-		templeSyncButton.setMaximumSize(new Dimension(Integer.MAX_VALUE, 28));
-		templeSyncButton.setToolTipText("Fetch your boss/activity kill counts from templeosrs.com");
-		templeSyncButton.setVisible(config.enableTempleOsrsSync());
-		templeSyncButton.addActionListener(e ->
-		{
-			if (templeSyncCallback != null)
-			{
-				templeSyncButton.setEnabled(false);
-				templeSyncButton.setText("Syncing...");
-				templeSyncCallback.run();
-			}
-		});
-		controlsPanel.add(templeSyncButton);
+		syncButtonController = new SyncButtonController(config, this);
+		controlsPanel.add(syncButtonController.getCollectionLogNetButton());
+		controlsPanel.add(syncButtonController.getTempleSyncButton());
 
 		clueSummaryView = new ClueSummaryView();
 		clueSummaryView.setAlignmentX(CENTER_ALIGNMENT);
@@ -496,42 +456,27 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 	 */
 	public void setCollectionLogNetImportCallback(Runnable callback)
 	{
-		this.collectionLogNetImportCallback = callback;
+		syncButtonController.setCollectionLogNetImportCallback(callback);
 	}
 
 	/**
 	 * Resets the "Sync from collectionlog.net" button to its ready state and
-	 * shows a brief result message in the button text.  Safe to call from any thread.
+	 * shows a brief result message in the button text. Safe to call from any thread.
 	 *
 	 * @param message short result message, e.g. "Synced 42 items from collectionlog.net"
 	 */
 	public void onCollectionLogNetImportComplete(String message)
 	{
-		SwingUtilities.invokeLater(() ->
-		{
-			collectionLogNetSyncButton.setEnabled(true);
-			collectionLogNetSyncButton.setText(message);
-		});
+		syncButtonController.onCollectionLogNetImportComplete(message);
 	}
 
 	/**
 	 * Shows or hides the collectionlog.net sync button based on the config flag.
-	 * Call when the config section toggle changes.  Safe to call from any thread.
+	 * Call when the config section toggle changes. Safe to call from any thread.
 	 */
 	public void updateCollectionLogNetImportButton()
 	{
-		SwingUtilities.invokeLater(() ->
-		{
-			boolean enabled = config.enableCollectionLogNetImport();
-			collectionLogNetSyncButton.setVisible(enabled);
-			if (enabled)
-			{
-				collectionLogNetSyncButton.setEnabled(true);
-				collectionLogNetSyncButton.setText("Sync from collectionlog.net");
-			}
-			revalidate();
-			repaint();
-		});
+		syncButtonController.updateCollectionLogNetImportButton();
 	}
 
 	/**
@@ -560,7 +505,7 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 	 */
 	public void setTempleSyncCallback(Runnable callback)
 	{
-		this.templeSyncCallback = callback;
+		syncButtonController.setTempleSyncCallback(callback);
 	}
 
 	/**
@@ -569,8 +514,7 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 	 */
 	public void updateTempleSyncButtonVisibility()
 	{
-		SwingUtilities.invokeLater(() ->
-			templeSyncButton.setVisible(config.enableTempleOsrsSync()));
+		syncButtonController.updateTempleSyncButtonVisibility();
 	}
 
 	/**
@@ -580,12 +524,7 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 	 */
 	public void onTempleSyncComplete(boolean success)
 	{
-		SwingUtilities.invokeLater(() ->
-		{
-			templeSyncButton.setEnabled(true);
-			templeSyncButton.setText(
-				success ? "Synced KC from TempleOSRS" : "Sync KC from TempleOSRS");
-		});
+		syncButtonController.onTempleSyncComplete(success);
 	}
 
 	public void rebuild()

--- a/src/main/java/com/collectionloghelper/ui/SyncButtonController.java
+++ b/src/main/java/com/collectionloghelper/ui/SyncButtonController.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.ui;
+
+import com.collectionloghelper.CollectionLogHelperConfig;
+import java.awt.Component;
+import java.awt.Dimension;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.SwingUtilities;
+import net.runelite.client.ui.FontManager;
+
+/**
+ * Owns the two "Sync now" buttons that live in the panel's controls strip:
+ * <ul>
+ *   <li>"Sync from collectionlog.net" — triggers the collectionlog.net import.</li>
+ *   <li>"Sync KC from TempleOSRS" — triggers a TempleOSRS KC fetch.</li>
+ * </ul>
+ *
+ * <p>Responsibilities pulled out of {@link CollectionLogHelperPanel}:
+ * <ul>
+ *   <li>Construct the two {@link JButton}s with their canonical labels,
+ *       fonts, sizes, tooltips, and visibility based on the current config.</li>
+ *   <li>Hold the per-button click {@link Runnable} callbacks (wired from the
+ *       plugin after panel construction).</li>
+ *   <li>Reset button enabled/text state after a sync attempt completes.</li>
+ *   <li>Refresh button visibility when the config toggles change.</li>
+ * </ul>
+ *
+ * <p>This class is intentionally not a Guice {@code @Singleton}; it is
+ * constructed inside the panel's constructor (same pattern as
+ * {@link PanelRebuildOrchestrator}) and bound to that panel's Swing tree.
+ *
+ * <p>EDT discipline: state-mutating methods that may be invoked off the EDT
+ * (sync-complete callbacks, config-change listeners) wrap their work in
+ * {@link SwingUtilities#invokeLater}. Methods invoked only from the EDT
+ * (action-listener handlers) mutate components directly.
+ */
+public final class SyncButtonController
+{
+	private static final String COLLECTION_LOG_NET_LABEL = "Sync from collectionlog.net";
+	private static final String COLLECTION_LOG_NET_TOOLTIP =
+		"Click to send your display name to collectionlog.net and import your obtained-items list";
+	private static final String TEMPLE_OSRS_LABEL = "Sync KC from TempleOSRS";
+	private static final String TEMPLE_OSRS_TOOLTIP =
+		"Fetch your boss/activity kill counts from templeosrs.com";
+	private static final String TEMPLE_OSRS_SUCCESS_LABEL = "Synced KC from TempleOSRS";
+	private static final String SYNCING_LABEL = "Syncing...";
+
+	private final CollectionLogHelperConfig config;
+	private final JComponent panel;
+	private final JButton collectionLogNetSyncButton;
+	private final JButton templeSyncButton;
+
+	private Runnable collectionLogNetImportCallback;
+	private Runnable templeSyncCallback;
+
+	public SyncButtonController(CollectionLogHelperConfig config, JComponent panel)
+	{
+		this.config = config;
+		this.panel = panel;
+		this.collectionLogNetSyncButton = buildCollectionLogNetButton();
+		this.templeSyncButton = buildTempleSyncButton();
+	}
+
+	private JButton buildCollectionLogNetButton()
+	{
+		JButton button = new JButton(COLLECTION_LOG_NET_LABEL);
+		button.setAlignmentX(Component.CENTER_ALIGNMENT);
+		button.setMaximumSize(new Dimension(Integer.MAX_VALUE, 26));
+		button.setFont(FontManager.getRunescapeSmallFont());
+		button.setFocusPainted(false);
+		button.setToolTipText(COLLECTION_LOG_NET_TOOLTIP);
+		button.setVisible(config.enableCollectionLogNetImport());
+		button.addActionListener(e ->
+		{
+			if (collectionLogNetImportCallback != null)
+			{
+				button.setEnabled(false);
+				button.setText(SYNCING_LABEL);
+				collectionLogNetImportCallback.run();
+			}
+		});
+		return button;
+	}
+
+	private JButton buildTempleSyncButton()
+	{
+		JButton button = new JButton(TEMPLE_OSRS_LABEL);
+		button.setFont(FontManager.getRunescapeSmallFont());
+		button.setAlignmentX(Component.CENTER_ALIGNMENT);
+		button.setMaximumSize(new Dimension(Integer.MAX_VALUE, 28));
+		button.setToolTipText(TEMPLE_OSRS_TOOLTIP);
+		button.setVisible(config.enableTempleOsrsSync());
+		button.addActionListener(e ->
+		{
+			if (templeSyncCallback != null)
+			{
+				button.setEnabled(false);
+				button.setText(SYNCING_LABEL);
+				templeSyncCallback.run();
+			}
+		});
+		return button;
+	}
+
+	/** Returns the "Sync from collectionlog.net" button so the panel can place it in its layout. */
+	public JButton getCollectionLogNetButton()
+	{
+		return collectionLogNetSyncButton;
+	}
+
+	/** Returns the "Sync KC from TempleOSRS" button so the panel can place it in its layout. */
+	public JButton getTempleSyncButton()
+	{
+		return templeSyncButton;
+	}
+
+	/**
+	 * Wires the callback invoked when the "Sync from collectionlog.net" button is clicked.
+	 * Must be called from the EDT or before the panel is shown.
+	 */
+	public void setCollectionLogNetImportCallback(Runnable callback)
+	{
+		this.collectionLogNetImportCallback = callback;
+	}
+
+	/**
+	 * Registers the callback invoked when the "Sync KC from TempleOSRS" button is clicked.
+	 * Must be called from the EDT or before the panel is shown.
+	 */
+	public void setTempleSyncCallback(Runnable callback)
+	{
+		this.templeSyncCallback = callback;
+	}
+
+	/**
+	 * Resets the "Sync from collectionlog.net" button to its ready state and
+	 * shows a brief result message in the button text. Safe to call from any thread.
+	 *
+	 * @param message short result message, e.g. "Synced 42 items from collectionlog.net"
+	 */
+	public void onCollectionLogNetImportComplete(String message)
+	{
+		SwingUtilities.invokeLater(() ->
+		{
+			collectionLogNetSyncButton.setEnabled(true);
+			collectionLogNetSyncButton.setText(message);
+		});
+	}
+
+	/**
+	 * Shows or hides the collectionlog.net sync button based on the current config flag.
+	 * Call when the config section toggle changes. Safe to call from any thread.
+	 */
+	public void updateCollectionLogNetImportButton()
+	{
+		SwingUtilities.invokeLater(() ->
+		{
+			boolean enabled = config.enableCollectionLogNetImport();
+			collectionLogNetSyncButton.setVisible(enabled);
+			if (enabled)
+			{
+				collectionLogNetSyncButton.setEnabled(true);
+				collectionLogNetSyncButton.setText(COLLECTION_LOG_NET_LABEL);
+			}
+			panel.revalidate();
+			panel.repaint();
+		});
+	}
+
+	/**
+	 * Refreshes the visibility of the TempleOSRS sync button based on the current config.
+	 * Call after the config value changes. Safe to call from any thread.
+	 */
+	public void updateTempleSyncButtonVisibility()
+	{
+		SwingUtilities.invokeLater(() ->
+			templeSyncButton.setVisible(config.enableTempleOsrsSync()));
+	}
+
+	/**
+	 * Resets the TempleOSRS sync button to its idle state after a sync attempt completes.
+	 * Safe to call from any thread.
+	 *
+	 * @param success whether the sync succeeded (affects button label)
+	 */
+	public void onTempleSyncComplete(boolean success)
+	{
+		SwingUtilities.invokeLater(() ->
+		{
+			templeSyncButton.setEnabled(true);
+			templeSyncButton.setText(success ? TEMPLE_OSRS_SUCCESS_LABEL : TEMPLE_OSRS_LABEL);
+		});
+	}
+}

--- a/src/test/java/com/collectionloghelper/ui/PanelRebuildOrchestratorTest.java
+++ b/src/test/java/com/collectionloghelper/ui/PanelRebuildOrchestratorTest.java
@@ -94,6 +94,12 @@ public class PanelRebuildOrchestratorTest
 		scrollPane.setSize(200, 400);
 		scrollPane.doLayout();
 		scrollPane.getViewport().doLayout();
+		// Pin the vertical scrollbar's model bounds explicitly so setValue(...) is
+		// not clamped by lazy/late viewport layout. Headless CI environments
+		// (Linux, JDK 17) have been observed to leave the model at its default
+		// (max=100, extent=10) when assertions read the value immediately after
+		// setValue, causing values like 123 to clamp to 90.
+		scrollPane.getVerticalScrollBar().setValues(0, 400, 0, 5000);
 
 		orchestrator = new PanelRebuildOrchestrator(hostPanel, listContainer);
 	}

--- a/src/test/java/com/collectionloghelper/ui/SyncButtonControllerTest.java
+++ b/src/test/java/com/collectionloghelper/ui/SyncButtonControllerTest.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.ui;
+
+import com.collectionloghelper.CollectionLogHelperConfig;
+import java.awt.event.ActionEvent;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.swing.JButton;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link SyncButtonController}: the helper that owns the
+ * "Sync from collectionlog.net" and "Sync KC from TempleOSRS" buttons.
+ * Extracted from {@link CollectionLogHelperPanel} as part of issue #503
+ * god-class splits.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class SyncButtonControllerTest
+{
+	@Mock
+	private CollectionLogHelperConfig config;
+
+	private JPanel hostPanel;
+	private SyncButtonController controller;
+
+	@Before
+	public void setUp()
+	{
+		when(config.enableCollectionLogNetImport()).thenReturn(true);
+		when(config.enableTempleOsrsSync()).thenReturn(true);
+
+		hostPanel = new JPanel();
+		controller = new SyncButtonController(config, hostPanel);
+	}
+
+	private static void flushEdt() throws Exception
+	{
+		SwingUtilities.invokeAndWait(() -> { /* no-op flush */ });
+	}
+
+	@Test
+	public void buttonsAreNonNullAndDistinct()
+	{
+		JButton clNet = controller.getCollectionLogNetButton();
+		JButton temple = controller.getTempleSyncButton();
+
+		assertNotNull(clNet);
+		assertNotNull(temple);
+		assertNotSame(clNet, temple);
+	}
+
+	@Test
+	public void buttonLabelsMatchCanonicalText()
+	{
+		assertEquals("Sync from collectionlog.net",
+			controller.getCollectionLogNetButton().getText());
+		assertEquals("Sync KC from TempleOSRS",
+			controller.getTempleSyncButton().getText());
+	}
+
+	@Test
+	public void visibilityReflectsConfigAtConstruction()
+	{
+		when(config.enableCollectionLogNetImport()).thenReturn(false);
+		when(config.enableTempleOsrsSync()).thenReturn(true);
+
+		SyncButtonController c = new SyncButtonController(config, hostPanel);
+
+		assertFalse(c.getCollectionLogNetButton().isVisible());
+		assertTrue(c.getTempleSyncButton().isVisible());
+	}
+
+	@Test
+	public void collectionLogNetButtonClickInvokesCallback()
+	{
+		AtomicInteger invocations = new AtomicInteger();
+		controller.setCollectionLogNetImportCallback(invocations::incrementAndGet);
+
+		JButton btn = controller.getCollectionLogNetButton();
+		btn.getActionListeners()[0].actionPerformed(
+			new ActionEvent(btn, ActionEvent.ACTION_PERFORMED, ""));
+
+		assertEquals(1, invocations.get());
+		assertFalse("button must be disabled while sync runs", btn.isEnabled());
+		assertEquals("Syncing...", btn.getText());
+	}
+
+	@Test
+	public void collectionLogNetButtonClickIsNoOpWhenNoCallbackWired()
+	{
+		JButton btn = controller.getCollectionLogNetButton();
+		// Pre-condition: no callback wired.
+		btn.getActionListeners()[0].actionPerformed(
+			new ActionEvent(btn, ActionEvent.ACTION_PERFORMED, ""));
+
+		// State must not change — the button stays enabled with its original label.
+		assertTrue(btn.isEnabled());
+		assertEquals("Sync from collectionlog.net", btn.getText());
+	}
+
+	@Test
+	public void templeButtonClickInvokesCallback()
+	{
+		AtomicBoolean called = new AtomicBoolean();
+		controller.setTempleSyncCallback(() -> called.set(true));
+
+		JButton btn = controller.getTempleSyncButton();
+		btn.getActionListeners()[0].actionPerformed(
+			new ActionEvent(btn, ActionEvent.ACTION_PERFORMED, ""));
+
+		assertTrue(called.get());
+		assertFalse(btn.isEnabled());
+		assertEquals("Syncing...", btn.getText());
+	}
+
+	@Test
+	public void onCollectionLogNetImportCompleteRestoresEnabledAndShowsMessage() throws Exception
+	{
+		JButton btn = controller.getCollectionLogNetButton();
+		btn.setEnabled(false);
+		btn.setText("Syncing...");
+
+		controller.onCollectionLogNetImportComplete("Synced 42 items");
+		flushEdt();
+
+		assertTrue(btn.isEnabled());
+		assertEquals("Synced 42 items", btn.getText());
+	}
+
+	@Test
+	public void updateCollectionLogNetImportButtonHidesWhenConfigDisabled() throws Exception
+	{
+		JButton btn = controller.getCollectionLogNetButton();
+		assertTrue(btn.isVisible());
+
+		when(config.enableCollectionLogNetImport()).thenReturn(false);
+		controller.updateCollectionLogNetImportButton();
+		flushEdt();
+
+		assertFalse(btn.isVisible());
+	}
+
+	@Test
+	public void updateCollectionLogNetImportButtonResetsLabelWhenReEnabled() throws Exception
+	{
+		JButton btn = controller.getCollectionLogNetButton();
+		btn.setEnabled(false);
+		btn.setText("Synced 7 items");
+		btn.setVisible(false);
+
+		when(config.enableCollectionLogNetImport()).thenReturn(true);
+		controller.updateCollectionLogNetImportButton();
+		flushEdt();
+
+		assertTrue(btn.isVisible());
+		assertTrue(btn.isEnabled());
+		assertEquals("Sync from collectionlog.net", btn.getText());
+	}
+
+	@Test
+	public void updateTempleSyncButtonVisibilityFollowsConfigToggle() throws Exception
+	{
+		JButton btn = controller.getTempleSyncButton();
+		assertTrue(btn.isVisible());
+
+		when(config.enableTempleOsrsSync()).thenReturn(false);
+		controller.updateTempleSyncButtonVisibility();
+		flushEdt();
+
+		assertFalse(btn.isVisible());
+
+		when(config.enableTempleOsrsSync()).thenReturn(true);
+		controller.updateTempleSyncButtonVisibility();
+		flushEdt();
+
+		assertTrue(btn.isVisible());
+	}
+
+	@Test
+	public void onTempleSyncCompleteSuccessShowsSyncedLabel() throws Exception
+	{
+		JButton btn = controller.getTempleSyncButton();
+		btn.setEnabled(false);
+		btn.setText("Syncing...");
+
+		controller.onTempleSyncComplete(true);
+		flushEdt();
+
+		assertTrue(btn.isEnabled());
+		assertEquals("Synced KC from TempleOSRS", btn.getText());
+	}
+
+	@Test
+	public void onTempleSyncCompleteFailureRestoresOriginalLabel() throws Exception
+	{
+		JButton btn = controller.getTempleSyncButton();
+		btn.setEnabled(false);
+		btn.setText("Syncing...");
+
+		controller.onTempleSyncComplete(false);
+		flushEdt();
+
+		assertTrue(btn.isEnabled());
+		assertEquals("Sync KC from TempleOSRS", btn.getText());
+	}
+}


### PR DESCRIPTION
## Summary

Pulls the two sync buttons out of `CollectionLogHelperPanel` into a dedicated `SyncButtonController` helper. Same construction pattern as `PanelRebuildOrchestrator` (#513): not a Guice singleton, instantiated by the panel constructor, bound to the panel's Swing tree.

The new controller owns:

- The "Sync from collectionlog.net" and "Sync KC from TempleOSRS" `JButton` instances (labels, fonts, tooltips, sizes, action listeners)
- The two `Runnable` click callbacks wired by the plugin after panel construction
- Per-config visibility refreshes (`updateCollectionLogNetImportButton`, `updateTempleSyncButtonVisibility`)
- Post-sync enabled/text reset (`onCollectionLogNetImportComplete`, `onTempleSyncComplete`)

Panel changes:

- Six public sync-button methods become one-line delegations; their signatures are unchanged so external callers (`CollectionLogHelperPlugin`, `SyncStateCoordinator`, `LootSyncManager`) are unaffected.
- Removed fields: `collectionLogNetSyncButton`, `templeSyncButton`, `collectionLogNetImportCallback`, `templeSyncCallback`.
- Removed now-unused `javax.swing.JButton` import.

EDT discipline preserved: methods called off the EDT keep their `SwingUtilities.invokeLater` wrappers inside the controller; methods invoked only from action listeners mutate components directly.

## Metrics

- Panel LOC: **861 -> 800** (now at the issue #503 target).
- Controller LOC: 218 (new).
- Test LOC: 235 (13 new tests).
- Build: green. Tests: 1195 passing, 0 failures. JaCoCo 45% line-coverage gate holds.

Partially addresses #503.

## Test plan

- [x] `./gradlew compileJava` succeeds
- [x] `./gradlew test --tests com.collectionloghelper.ui.SyncButtonControllerTest` — 13 tests pass
- [x] `./gradlew build` succeeds (includes JaCoCo 45% gate)
- [x] Full test suite: 1195 tests, 0 failures, 0 errors
- [x] Panel LOC verified at 800
- [ ] Manual verification: toggle `enableCollectionLogNetImport` and `enableTempleOsrsSync` in config — buttons show/hide; click each button and confirm sync runs and label/enabled state restores on completion
- [ ] Manual verification: panel layout order in controls strip is unchanged (collectionlog.net button still appears above the TempleOSRS button)