### PR TITLE
test: stabilize PanelRebuildOrchestratorTest on JDK 17 headless (master CI fix)

### DIFF
--- a/src/test/java/com/collectionloghelper/ui/PanelRebuildOrchestratorTest.java
+++ b/src/test/java/com/collectionloghelper/ui/PanelRebuildOrchestratorTest.java
@@ -99,9 +99,26 @@ public class PanelRebuildOrchestratorTest
 		// (Linux, JDK 17) have been observed to leave the model at its default
 		// (max=100, extent=10) when assertions read the value immediately after
 		// setValue, causing values like 123 to clamp to 90.
-		scrollPane.getVerticalScrollBar().setValues(0, 400, 0, 5000);
+		pinScrollBounds(scrollPane.getVerticalScrollBar());
 
 		orchestrator = new PanelRebuildOrchestrator(hostPanel, listContainer);
+	}
+
+	/**
+	 * Pin the given scrollbar's {@code BoundedRangeModel} to a wide, deterministic
+	 * range so subsequent {@link JScrollBar#setValue(int)} calls in tests are not
+	 * clamped by lazy viewport layout. Must be called immediately before any
+	 * {@code setValue(...)} in a test, because intervening Swing layout/validation
+	 * passes can otherwise re-clamp the model to its computed (viewport-derived)
+	 * bounds before assertions read the value back.
+	 *
+	 * Headless Linux + JDK 17 has exhibited this flake twice (#515 setUp,
+	 * #516 captureRecordsScrollPositionFromEnclosingScrollPane); this helper
+	 * centralises the workaround so future test methods cannot regress.
+	 */
+	private static void pinScrollBounds(JScrollBar bar)
+	{
+		bar.setValues(0, 400, 0, 5000);
 	}
 
 	private CategorySummaryPanel newCategoryPanel(CollectionLogCategory category)
@@ -134,6 +151,7 @@ public class PanelRebuildOrchestratorTest
 	@Test
 	public void captureRecordsScrollPositionFromEnclosingScrollPane()
 	{
+		pinScrollBounds(vBar());
 		vBar().setValue(250);
 
 		PanelRebuildOrchestrator.RebuildSnapshot snapshot = orchestrator.capture();
@@ -231,8 +249,10 @@ public class PanelRebuildOrchestratorTest
 	@Test
 	public void deferScrollRestoreSchedulesValueOnVerticalScrollBar() throws Exception
 	{
+		pinScrollBounds(vBar());
 		vBar().setValue(400);
 		PanelRebuildOrchestrator.RebuildSnapshot snapshot = orchestrator.capture();
+		pinScrollBounds(vBar());
 		vBar().setValue(0);
 
 		orchestrator.deferScrollRestore(snapshot);
@@ -246,6 +266,7 @@ public class PanelRebuildOrchestratorTest
 	public void deferScrollRestoreIsNoOpWhenScrollPositionIsZero() throws Exception
 	{
 		PanelRebuildOrchestrator.RebuildSnapshot snapshot = orchestrator.capture();
+		pinScrollBounds(vBar());
 		vBar().setValue(123);
 
 		orchestrator.deferScrollRestore(snapshot);


### PR DESCRIPTION
## Summary

Master is RED on `1264eb3d` (PR #516 merge) from the second occurrence of the same JDK-17 headless flake class first fixed in #515 (commit `19620fc1`). That commit pinned the vertical scrollbar `BoundedRangeModel` once in `setUp()`; this PR proactively pins it again at every `setValue(...)` call site so intervening Swing layout/validation passes cannot re-clamp the model before assertions read the value back.

- Failing test: `PanelRebuildOrchestratorTest.captureRecordsScrollPositionFromEnclosingScrollPane` — `setValue(250)` clamped to 90 on headless Linux JDK 17.
- Root cause: lazy viewport layout leaves `BoundedRangeModel` at its default (max=100, extent=10); `setUp()`-time `setValues(0, 400, 0, 5000)` can be invalidated by a later layout pass before the test body executes.
- Fix: extract `pinScrollBounds(JScrollBar)` helper and call it immediately before every `setValue(...)` in every test method that mutates a scrollbar. Same conceptual fix as #515, applied class-wide so a third hot-fix is not needed.

Methods updated (bounds-pinning added at the call site):

- `captureRecordsScrollPositionFromEnclosingScrollPane`
- `deferScrollRestoreSchedulesValueOnVerticalScrollBar` (both setValues)
- `deferScrollRestoreIsNoOpWhenScrollPositionIsZero`

`setUp()` still pins once for completeness; tests that do not mutate the scrollbar inherit that pin.

## Test plan

- [x] `./gradlew test --tests com.collectionloghelper.ui.PanelRebuildOrchestratorTest --rerun-tasks` (3x consecutive runs, all green on Windows JDK 17)
- [x] `./gradlew build` green
- [ ] CI on Linux JDK 17 confirms green