### PR TITLE
refactor: extract EfficiencyModule (#504)

### DIFF
--- a/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
@@ -29,6 +29,7 @@ import com.collectionloghelper.data.CollectionLogSource;
 import com.collectionloghelper.data.PlayerTravelCapabilities;
 import com.collectionloghelper.data.RequirementsChecker;
 import com.collectionloghelper.di.DataModule;
+import com.collectionloghelper.di.EfficiencyModule;
 import com.collectionloghelper.di.GuidanceModule;
 import com.collectionloghelper.sync.CollectionLogNetImporter;
 import com.collectionloghelper.sync.ImportResult;
@@ -37,11 +38,7 @@ import com.collectionloghelper.sync.SourceKcStore;
 import com.collectionloghelper.sync.SyncResult;
 import com.collectionloghelper.sync.TempleOsrsKcSyncer;
 import com.collectionloghelper.efficiency.ClueCompletionEstimator;
-import com.collectionloghelper.efficiency.EfficiencyCalculator;
 import com.collectionloghelper.efficiency.ScoredItem;
-import com.collectionloghelper.efficiency.SlayerStrategyCalculator;
-import com.collectionloghelper.learning.DryStreakAnalyzer;
-import com.collectionloghelper.learning.KillTimeTracker;
 import com.collectionloghelper.lifecycle.AuthoringLogger;
 import com.collectionloghelper.lifecycle.OverlayRegistry;
 import com.collectionloghelper.lifecycle.SceneEventRouter;
@@ -135,22 +132,13 @@ public class CollectionLogHelperPlugin extends Plugin
 	private DataModule data;
 
 	@Inject
-	private EfficiencyCalculator calculator;
-
-	@Inject
-	private ClueCompletionEstimator clueEstimator;
+	private EfficiencyModule efficiency;
 
 	@Inject
 	private RequirementsChecker requirementsChecker;
 
 	@Inject
 	private GuidanceModule guidance;
-
-	@Inject
-	private SlayerStrategyCalculator slayerStrategyCalculator;
-
-	@Inject
-	private DryStreakAnalyzer dryStreakAnalyzer;
 
 	@Inject
 	private PlayerTravelCapabilities travelCapabilities;
@@ -169,9 +157,6 @@ public class CollectionLogHelperPlugin extends Plugin
 
 	@Inject
 	private CollectionLogNetImporter collectionLogNetImporter;
-
-	@Inject
-	private KillTimeTracker killTimeTracker;
 
 	@Inject
 	private TempleOsrsKcSyncer templeOsrsKcSyncer;
@@ -229,10 +214,10 @@ public class CollectionLogHelperPlugin extends Plugin
 		});
 
 		panel = new CollectionLogHelperPanel(
-			config, data.getDatabase(), data.getCollectionState(), calculator, clueEstimator,
+			config, data.getDatabase(), data.getCollectionState(), efficiency.getCalculator(), efficiency.getClueEstimator(),
 			itemManager, requirementsChecker, data.getDataSyncState(), data.getSlayerTaskState(),
-			slayerStrategyCalculator, data.getPlayerInventoryState(), data.getPlayerBankState(),
-			dryStreakAnalyzer,
+			efficiency.getSlayerStrategyCalculator(), data.getPlayerInventoryState(), data.getPlayerBankState(),
+			efficiency.getDryStreakAnalyzer(),
 			(java.util.function.BiConsumer<CollectionLogSource, Integer>) this::activateGuidance,
 			this::deactivateGuidance,
 			filter -> configManager.setConfiguration("collectionloghelper", "afkFilter", filter.name()),
@@ -329,7 +314,7 @@ public class CollectionLogHelperPlugin extends Plugin
 		guidance.getGuidanceEventRouter().setOnSyncConfigChanged(this::onSyncConfigChanged);
 		eventBus.register(guidance.getGuidanceEventRouter());
 		eventBus.register(guidance.getGuidanceMovementTracker());
-		eventBus.register(killTimeTracker);
+		eventBus.register(efficiency.getKillTimeTracker());
 
 		// If already logged in (e.g., plugin enabled mid-session), load state
 		if (client.getGameState() == GameState.LOGGED_IN)
@@ -370,8 +355,8 @@ public class CollectionLogHelperPlugin extends Plugin
 		eventBus.unregister(sceneEventRouter);
 		eventBus.unregister(guidance.getGuidanceEventRouter());
 		eventBus.unregister(guidance.getGuidanceMovementTracker());
-		eventBus.unregister(killTimeTracker);
-		killTimeTracker.reset();
+		eventBus.unregister(efficiency.getKillTimeTracker());
+		efficiency.getKillTimeTracker().reset();
 		deactivateGuidance();
 		syncStateCoordinator.reset();
 		sourceKcStore.clear();
@@ -452,7 +437,7 @@ public class CollectionLogHelperPlugin extends Plugin
 		{
 			data.getCollectionState().clearState();
 			requirementsChecker.clearCache();
-			clueEstimator.resetBucket();
+			efficiency.getClueEstimator().resetBucket();
 			data.getSlayerTaskState().reset();
 			syncStateCoordinator.onGameStateLoginScreen();
 			syncStateCoordinator.setLastObtainedCount(-1);
@@ -466,7 +451,7 @@ public class CollectionLogHelperPlugin extends Plugin
 			data.getPlayerBankState().reset();
 			data.getPlayerInventoryState().reset();
 			travelCapabilities.reset();
-			killTimeTracker.reset();
+			efficiency.getKillTimeTracker().reset();
 			data.getPluginDataManager().reset();
 		}
 	}
@@ -542,7 +527,7 @@ public class CollectionLogHelperPlugin extends Plugin
 	@Subscribe
 	public void onStatChanged(StatChanged event)
 	{
-		clueEstimator.resetBucket();
+		efficiency.getClueEstimator().resetBucket();
 		pendingRequirementsRefresh = true;
 	}
 
@@ -632,7 +617,7 @@ public class CollectionLogHelperPlugin extends Plugin
 		{
 			if (data.getPluginDataManager().init())
 			{
-				killTimeTracker.init(data.getPluginDataManager().getCharacterDir());
+				efficiency.getKillTimeTracker().init(data.getPluginDataManager().getCharacterDir());
 			}
 		}
 
@@ -705,7 +690,7 @@ public class CollectionLogHelperPlugin extends Plugin
 			exportFile = new java.io.File(
 				net.runelite.client.RuneLite.RUNELITE_DIR, "collection-log-efficiency-export.txt");
 		}
-		calculator.exportEfficiencyList(exportFile, client);
+		efficiency.getCalculator().exportEfficiencyList(exportFile, client);
 	}
 
 	/**
@@ -788,7 +773,7 @@ public class CollectionLogHelperPlugin extends Plugin
 	{
 		if (rankedSourcesDirty || cachedRankedSources == null)
 		{
-			cachedRankedSources = calculator.rankByEfficiency();
+			cachedRankedSources = efficiency.getCalculator().rankByEfficiency();
 			rankedSourcesDirty = false;
 		}
 		return cachedRankedSources;

--- a/src/main/java/com/collectionloghelper/di/EfficiencyModule.java
+++ b/src/main/java/com/collectionloghelper/di/EfficiencyModule.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.di;
+
+import com.collectionloghelper.efficiency.ClueCompletionEstimator;
+import com.collectionloghelper.efficiency.EfficiencyCalculator;
+import com.collectionloghelper.efficiency.SlayerStrategyCalculator;
+import com.collectionloghelper.learning.DryStreakAnalyzer;
+import com.collectionloghelper.learning.KillTimeTracker;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.Getter;
+
+/**
+ * Aggregate holder for the plugin's efficiency-layer Guice singletons.
+ *
+ * <p>Groups the five efficiency/analytics dependencies that {@code CollectionLogHelperPlugin}
+ * previously injected individually, reducing the plugin's {@code @Inject} field count
+ * and providing a single seam for efficiency-layer wiring.
+ *
+ * <p>Third of four planned sub-module extractions tracked by issue #504.
+ */
+@Singleton
+@Getter
+public class EfficiencyModule
+{
+	private final EfficiencyCalculator calculator;
+	private final ClueCompletionEstimator clueEstimator;
+	private final SlayerStrategyCalculator slayerStrategyCalculator;
+	private final DryStreakAnalyzer dryStreakAnalyzer;
+	private final KillTimeTracker killTimeTracker;
+
+	@Inject
+	public EfficiencyModule(
+		EfficiencyCalculator calculator,
+		ClueCompletionEstimator clueEstimator,
+		SlayerStrategyCalculator slayerStrategyCalculator,
+		DryStreakAnalyzer dryStreakAnalyzer,
+		KillTimeTracker killTimeTracker)
+	{
+		this.calculator = calculator;
+		this.clueEstimator = clueEstimator;
+		this.slayerStrategyCalculator = slayerStrategyCalculator;
+		this.dryStreakAnalyzer = dryStreakAnalyzer;
+		this.killTimeTracker = killTimeTracker;
+	}
+}

--- a/src/test/java/com/collectionloghelper/OnSequenceCompletePerItemTest.java
+++ b/src/test/java/com/collectionloghelper/OnSequenceCompletePerItemTest.java
@@ -27,6 +27,7 @@ package com.collectionloghelper;
 import com.collectionloghelper.data.CollectionLogCategory;
 import com.collectionloghelper.data.CollectionLogItem;
 import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.di.EfficiencyModule;
 import com.collectionloghelper.di.GuidanceModule;
 import com.collectionloghelper.efficiency.EfficiencyCalculator;
 import com.collectionloghelper.efficiency.ScoredItem;
@@ -87,7 +88,9 @@ public class OnSequenceCompletePerItemTest
 			null, guidanceCoordinator, null, null, null, null, null, null);
 		injectField("guidance", guidanceModule);
 		injectField("config", config);
-		injectField("calculator", calculator);
+		EfficiencyModule efficiencyModule = new EfficiencyModule(
+			calculator, null, null, null, null);
+		injectField("efficiency", efficiencyModule);
 
 		// Make clientThread.invokeLater execute the runnable immediately so
 		// coordinator.activateGuidance is reachable within the same test call.


### PR DESCRIPTION
## Summary

Consolidates the five efficiency/analytics-layer `@Inject` fields in `CollectionLogHelperPlugin` into a new `EfficiencyModule` aggregate, mirroring `DataModule` (#509) and `GuidanceModule` (#514).

Fields extracted:
- `EfficiencyCalculator calculator`
- `ClueCompletionEstimator clueEstimator`
- `SlayerStrategyCalculator slayerStrategyCalculator`
- `DryStreakAnalyzer dryStreakAnalyzer`
- `KillTimeTracker killTimeTracker`

`CollectionLogHelperPlugin` `@Inject` count: 25 -> 21 (net -4: five fields removed, one module field added).

Third of four planned sub-module extractions. Partially addresses #504.

## Test plan

- [x] `./gradlew build` passes (compile + tests + JaCoCo 45% gate + lintDropRates)
- [x] `./gradlew test` passes (1195 tests, 0 failures)
- [x] `@Inject` count in `CollectionLogHelperPlugin.java` drops from 25 to 21
- [x] All 16 efficiency-field use sites in `CollectionLogHelperPlugin.java` rewritten to route through `efficiency.getX()` getters
- [x] No log-message bleed-through: `grep -nE '"[^"]*efficiency\.get[A-Z][a-zA-Z]*\(\)' CollectionLogHelperPlugin.java` returns 0 hits
- [x] `EfficiencyModule.java` mirrors `DataModule` / `GuidanceModule` exactly (`@Singleton`, `@Getter`, final fields, constructor `@Inject`)
- [x] `OnSequenceCompletePerItemTest` reflection updated from `injectField("calculator", ...)` to construct an `EfficiencyModule` and `injectField("efficiency", ...)`