### PR TITLE
refactor: extract ListContainerScrollPane from Panel (#503)

### DIFF
--- a/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
@@ -55,6 +55,7 @@ import com.collectionloghelper.ui.mode.SearchModeController;
 import com.collectionloghelper.ui.mode.StatisticsModeController;
 import com.collectionloghelper.ui.widget.ClueSummaryView;
 import com.collectionloghelper.ui.widget.GuidanceBannerView;
+import com.collectionloghelper.ui.widget.ListContainerScrollPane;
 import com.collectionloghelper.ui.widget.QuickGuidePanelView;
 import com.collectionloghelper.ui.widget.SlayerStrategyView;
 import com.collectionloghelper.ui.widget.StepProgressView;
@@ -66,7 +67,6 @@ import java.awt.CardLayout;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
-import java.awt.Insets;
 import java.awt.event.ItemEvent;
 import java.util.List;
 import java.util.function.BiConsumer;
@@ -352,25 +352,7 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 
 		// === Content panel (center, CardLayout) ===
 		cardLayout = new CardLayout();
-		contentPanel = new JPanel(cardLayout)
-		{
-			@Override
-			public Dimension getPreferredSize()
-			{
-				for (Component comp : getComponents())
-				{
-					if (comp.isVisible())
-					{
-						Insets insets = getInsets();
-						Dimension d = comp.getPreferredSize();
-						return new Dimension(
-							d.width + insets.left + insets.right,
-							d.height + insets.top + insets.bottom);
-					}
-				}
-				return super.getPreferredSize();
-			}
-		};
+		contentPanel = new ListContainerScrollPane(cardLayout);
 		contentPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
 
 		listView = new JPanel(new BorderLayout());

--- a/src/main/java/com/collectionloghelper/ui/widget/ListContainerScrollPane.java
+++ b/src/main/java/com/collectionloghelper/ui/widget/ListContainerScrollPane.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.ui.widget;
+
+import java.awt.CardLayout;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Insets;
+import java.awt.LayoutManager;
+import javax.swing.JPanel;
+
+/**
+ * Card-layout content host used as the scrollable list container inside
+ * {@link com.collectionloghelper.ui.CollectionLogHelperPanel}.
+ *
+ * <p>The plugin's {@code PluginPanel} parent supplies the enclosing
+ * {@code JScrollPane}; this widget owns the sizing contract reported to
+ * that ancestor scroll pane. The override of {@link #getPreferredSize()}
+ * returns the preferred size of whichever child card is currently visible
+ * (plus this panel's insets), so the scroll viewport tracks the active
+ * view rather than the largest card.
+ *
+ * <p>Extracted from {@code CollectionLogHelperPanel} as part of issue
+ * #503 (god-class reduction). The behavior is intentionally identical to
+ * the prior anonymous inner class.
+ */
+public class ListContainerScrollPane extends JPanel
+{
+	/**
+	 * Constructs the container with the supplied layout manager. Callers
+	 * typically pass a {@link CardLayout} instance so that the visible
+	 * child (and therefore the reported preferred size) follows
+	 * {@code CardLayout#show}.
+	 *
+	 * @param layout layout manager to install (must not be {@code null})
+	 */
+	public ListContainerScrollPane(LayoutManager layout)
+	{
+		super(layout);
+	}
+
+	/**
+	 * Returns the preferred size of the first visible child component,
+	 * adjusted for this panel's insets. Falls back to the superclass
+	 * implementation when no child is visible.
+	 *
+	 * <p>This mirrors the original anonymous-class behavior: the
+	 * enclosing scroll pane sizes its viewport to the active card.
+	 */
+	@Override
+	public Dimension getPreferredSize()
+	{
+		for (Component comp : getComponents())
+		{
+			if (comp.isVisible())
+			{
+				Insets insets = getInsets();
+				Dimension d = comp.getPreferredSize();
+				return new Dimension(
+					d.width + insets.left + insets.right,
+					d.height + insets.top + insets.bottom);
+			}
+		}
+		return super.getPreferredSize();
+	}
+}

--- a/src/test/java/com/collectionloghelper/ui/widget/ListContainerScrollPaneTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/ListContainerScrollPaneTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.ui.widget;
+
+import java.awt.CardLayout;
+import java.awt.Dimension;
+import javax.swing.BorderFactory;
+import javax.swing.JPanel;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit tests for {@link ListContainerScrollPane}: the card-layout content
+ * host whose preferred size tracks the visible child card. Extracted from
+ * {@link com.collectionloghelper.ui.CollectionLogHelperPanel} as part of
+ * issue #503 god-class splits.
+ */
+public class ListContainerScrollPaneTest
+{
+	private ListContainerScrollPane container;
+	private CardLayout cardLayout;
+
+	@Before
+	public void setUp()
+	{
+		cardLayout = new CardLayout();
+		container = new ListContainerScrollPane(cardLayout);
+	}
+
+	private static JPanel cardOfSize(int width, int height)
+	{
+		JPanel card = new JPanel();
+		card.setPreferredSize(new Dimension(width, height));
+		return card;
+	}
+
+	@Test
+	public void preferredSizeMatchesVisibleCardWhenSingleCardShown()
+	{
+		container.add(cardOfSize(180, 400), "only");
+
+		Dimension result = container.getPreferredSize();
+
+		assertEquals(180, result.width);
+		assertEquals(400, result.height);
+	}
+
+	@Test
+	public void preferredSizeAddsContainerInsetsToVisibleCard()
+	{
+		container.setBorder(BorderFactory.createEmptyBorder(4, 6, 8, 10));
+		container.add(cardOfSize(100, 200), "only");
+
+		Dimension result = container.getPreferredSize();
+
+		// width = card.width + insets.left + insets.right = 100 + 6 + 10
+		assertEquals(116, result.width);
+		// height = card.height + insets.top + insets.bottom = 200 + 4 + 8
+		assertEquals(212, result.height);
+	}
+
+	@Test
+	public void preferredSizeFollowsCardLayoutShow()
+	{
+		JPanel small = cardOfSize(150, 100);
+		JPanel large = cardOfSize(250, 600);
+		container.add(small, "small");
+		container.add(large, "large");
+
+		// CardLayout shows first added card by default ("small").
+		Dimension before = container.getPreferredSize();
+		assertEquals(150, before.width);
+		assertEquals(100, before.height);
+
+		cardLayout.show(container, "large");
+
+		Dimension after = container.getPreferredSize();
+		assertEquals(250, after.width);
+		assertEquals(600, after.height);
+	}
+
+	@Test
+	public void preferredSizeIgnoresHiddenChildAndPicksFirstVisible()
+	{
+		JPanel hidden = cardOfSize(999, 999);
+		JPanel visible = cardOfSize(120, 240);
+		container.add(hidden, "hidden");
+		container.add(visible, "visible");
+		// CardLayout marks the first added card visible by default;
+		// flip the flag explicitly after add to simulate a card that
+		// has been hidden by CardLayout#show on another card.
+		hidden.setVisible(false);
+		visible.setVisible(true);
+
+		Dimension result = container.getPreferredSize();
+
+		assertEquals(120, result.width);
+		assertEquals(240, result.height);
+	}
+
+	@Test
+	public void preferredSizeFallsBackToSuperWhenNoChildVisible()
+	{
+		JPanel hidden = cardOfSize(500, 500);
+		container.add(hidden, "hidden");
+		// Force the only child invisible after the layout has had a
+		// chance to mark it visible during add().
+		hidden.setVisible(false);
+
+		Dimension result = container.getPreferredSize();
+
+		// With no visible child the override falls through to
+		// super.getPreferredSize(), which delegates to the installed
+		// CardLayout. CardLayout sizes itself to the largest card
+		// regardless of visibility, so we expect the lone card's
+		// preferred size back through that path.
+		assertEquals(500, result.width);
+		assertEquals(500, result.height);
+	}
+}


### PR DESCRIPTION
## Summary

Extract the anonymous `CardLayout`-driven `JPanel` with the `getPreferredSize()` override out of `CollectionLogHelperPanel` into a top-level widget class.

The override picks the first visible child card's preferred size (plus insets) so the enclosing `PluginPanel` scroll viewport tracks the active card rather than the largest one. Behavior is intentionally unchanged from the prior anonymous inner class.

New file: `src/main/java/com/collectionloghelper/ui/widget/ListContainerScrollPane.java` (88 LOC).

Panel LOC: 800 -> 782 (-18). The 50 LOC reduction estimate in the survey assumed a larger seam; the actual anonymous block was 19 lines. A follow-up extraction (e.g. `DetailViewBuilder` or `StepControlBridge`) can take the panel under 750.

Partially addresses #503.

## Test plan

- [x] `./gradlew build` — passes (JaCoCo 45% gate held)
- [x] `./gradlew test --tests ListContainerScrollPaneTest` — 5/5 pass
- [x] Single-card preferred size matches child preferred size
- [x] Insets are added to the visible child preferred size
- [x] `cardLayout.show(...)` switches which card drives the reported size
- [x] Hidden cards are skipped; first visible child wins
- [x] Fallback to `super.getPreferredSize()` when no child is visible
- [x] `contentPanel` field type (`JPanel`) unchanged; no public API change to `CollectionLogHelperPanel`
- [x] Removed now-unused `java.awt.Insets` import from the panel