### PR TITLE
refactor: extract WorldMapController from GuidanceOverlayCoordinator (#503)

### DIFF
--- a/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
@@ -114,6 +114,7 @@ public class GuidanceOverlayCoordinator
 	private final GroundItemHighlightOverlay groundItemHighlightOverlay;
 	private final WidgetHighlightOverlay widgetHighlightOverlay;
 	private final OverlayStepApplier overlayStepApplier;
+	private final WorldMapController worldMapController;
 
 	// -- Guidance UI state (previously in plugin) --
 
@@ -188,7 +189,8 @@ public class GuidanceOverlayCoordinator
 		WorldMapDestinationOverlay worldMapDestinationOverlay,
 		GroundItemHighlightOverlay groundItemHighlightOverlay,
 		WidgetHighlightOverlay widgetHighlightOverlay,
-		OverlayStepApplier overlayStepApplier)
+		OverlayStepApplier overlayStepApplier,
+		WorldMapController worldMapController)
 	{
 		this.client = client;
 		this.clientThread = clientThread;
@@ -213,6 +215,7 @@ public class GuidanceOverlayCoordinator
 		this.groundItemHighlightOverlay = groundItemHighlightOverlay;
 		this.widgetHighlightOverlay = widgetHighlightOverlay;
 		this.overlayStepApplier = overlayStepApplier;
+		this.worldMapController = worldMapController;
 	}
 
 	/**
@@ -434,7 +437,7 @@ public class GuidanceOverlayCoordinator
 		tickDynamicTargetEvaluator();
 
 		// World map arrow rotation
-		updateWorldMapArrow();
+		worldMapController.updateArrow(activeMapPoint);
 	}
 
 	/**
@@ -473,7 +476,7 @@ public class GuidanceOverlayCoordinator
 		guidanceOverlay.setTargetPoint(dynamicPoint);
 		guidanceMinimapOverlay.setTargetPoint(dynamicPoint);
 		worldMapRouteOverlay.setTargetPoint(dynamicPoint);
-		worldMapDestinationOverlay.setTarget(dynamicPoint, resolveStepIconType(step));
+		worldMapDestinationOverlay.setTarget(dynamicPoint, worldMapController.resolveStepIconType(step, activeTargetItemId));
 		if (activeMapPoint != null)
 		{
 			worldMapPointManager.remove(activeMapPoint);
@@ -482,7 +485,7 @@ public class GuidanceOverlayCoordinator
 			step.resolveDescription(activeTargetItemId), collectionLogIcon);
 		worldMapPointManager.add(activeMapPoint);
 		worldMapDestinationOverlay.setMapPointActive(true);
-		if (shouldSetHintArrowTo(dynamicPoint))
+		if (worldMapController.shouldSetHintArrowTo(dynamicPoint))
 		{
 			client.setHintArrow(dynamicPoint);
 		}
@@ -566,7 +569,9 @@ public class GuidanceOverlayCoordinator
 	{
 		OverlayStepApplier.Result result = overlayStepApplier.apply(step, sourceName, source,
 			new OverlayStepApplier.Input(activeTargetItemId, lastMessagedStepIndex, activeMapPoint, collectionLogIcon),
-			this::resolveStepIconType, this::shouldSetHintArrowTo, wp -> pendingShortestPathTarget = wp);
+			step1 -> worldMapController.resolveStepIconType(step1, activeTargetItemId),
+			worldMapController::shouldSetHintArrowTo,
+			wp -> pendingShortestPathTarget = wp);
 		lastMessagedStepIndex = result.lastMessagedStepIndex;
 		activeMapPoint = result.activeMapPoint;
 		applyDynamicItemObjectOverlays();
@@ -672,7 +677,7 @@ public class GuidanceOverlayCoordinator
 		{
 			client.clearHintArrow();
 
-			if (shouldSetHintArrowTo(worldPoint))
+			if (worldMapController.shouldSetHintArrowTo(worldPoint))
 			{
 				client.setHintArrow(worldPoint);
 			}
@@ -821,129 +826,18 @@ public class GuidanceOverlayCoordinator
 		}
 	}
 
-	private void updateWorldMapArrow()
-	{
-		if (activeMapPoint == null)
-		{
-			return;
-		}
-
-		net.runelite.api.worldmap.WorldMap worldMap = client.getWorldMap();
-		if (worldMap == null)
-		{
-			return;
-		}
-
-		net.runelite.api.Point mapCenter = worldMap.getWorldMapPosition();
-		if (mapCenter == null)
-		{
-			return;
-		}
-
-		WorldPoint target = activeMapPoint.getWorldPoint();
-		int dx = target.getX() - mapCenter.getX();
-		// World map Y is inverted (higher Y = further north = up on map)
-		int dy = target.getY() - mapCenter.getY();
-
-		// Map 8 octants to arrow directions
-		int degrees;
-		if (Math.abs(dx) > Math.abs(dy) * 2)
-		{
-			degrees = dx > 0 ? 0 : 180;
-		}
-		else if (Math.abs(dy) > Math.abs(dx) * 2)
-		{
-			degrees = dy > 0 ? 270 : 90;
-		}
-		else if (dx > 0)
-		{
-			degrees = dy > 0 ? 315 : 45;
-		}
-		else
-		{
-			degrees = dy > 0 ? 225 : 135;
-		}
-
-		activeMapPoint.rotateArrow(degrees);
-	}
-
 	/**
 	 * Re-applies the hint arrow against the current guidance step, respecting
 	 * {@code config.showHintArrow()}. Called by the config-change handler when
 	 * "Show Hint Arrow" is toggled mid-guidance so the change takes effect
 	 * immediately rather than at the next step transition.
 	 *
-	 * <p>When the toggle goes OFF (or guidance is inactive), the arrow is
-	 * cleared. When the toggle goes ON and a step with a world target is
-	 * active, the arrow is re-set at that target.
-	 *
-	 * <p>All client mutations are dispatched on the client thread.
+	 * <p>Delegates to {@link WorldMapController#refreshHintArrow(boolean, GuidanceStep)},
+	 * supplying the current sequencer activity flag and current step.</p>
 	 */
 	public void refreshHintArrow()
 	{
-		clientThread.invokeLater(() ->
-		{
-			client.clearHintArrow();
-
-			if (!guidanceSequencer.isActive())
-			{
-				return;
-			}
-
-			GuidanceStep step = guidanceSequencer.getCurrentStep();
-			if (step == null || step.getWorldX() <= 0)
-			{
-				return;
-			}
-
-			WorldPoint worldPoint = new WorldPoint(
-				step.getWorldX(), step.getWorldY(), step.getWorldPlane());
-			if (shouldSetHintArrowTo(worldPoint))
-			{
-				client.setHintArrow(worldPoint);
-			}
-		});
+		worldMapController.refreshHintArrow(guidanceSequencer.isActive(), guidanceSequencer.getCurrentStep());
 	}
 
-	/**
-	 * Decides whether a hint arrow should be placed at the given world point.
-	 * Snapshots getLocalPlayer() once to avoid TOCTOU races. Skips hint arrows
-	 * inside non-top-level WorldViews (e.g. sailing boats).
-	 */
-	private boolean shouldSetHintArrowTo(WorldPoint worldPoint)
-	{
-		if (!config.showHintArrow() || worldPoint == null)
-		{
-			return false;
-		}
-		Player lp = client.getLocalPlayer();
-		if (lp == null)
-		{
-			return false;
-		}
-		if (lp.getWorldView() != client.getTopLevelWorldView())
-		{
-			return false;
-		}
-		WorldPoint playerLoc = lp.getWorldLocation();
-		return playerLoc != null && playerLoc.getPlane() == worldPoint.getPlane();
-	}
-
-	/**
-	 * Determines the world-map destination icon type for a guidance step.
-	 * NPC steps use the NPC icon, object steps use the object/chest icon,
-	 * and all other steps use the generic tile diamond.
-	 */
-	private WorldMapDestinationOverlay.StepIconType resolveStepIconType(GuidanceStep step)
-	{
-		if (step.resolveNpcId(activeTargetItemId) > 0)
-		{
-			return WorldMapDestinationOverlay.StepIconType.NPC;
-		}
-		if (step.getObjectId() > 0 || (step.getObjectIds() != null && !step.getObjectIds().isEmpty()))
-		{
-			return WorldMapDestinationOverlay.StepIconType.OBJECT;
-		}
-		return WorldMapDestinationOverlay.StepIconType.TILE;
-	}
 }

--- a/src/main/java/com/collectionloghelper/guidance/WorldMapController.java
+++ b/src/main/java/com/collectionloghelper/guidance/WorldMapController.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.guidance;
+
+import com.collectionloghelper.CollectionLogHelperConfig;
+import com.collectionloghelper.data.GuidanceStep;
+import com.collectionloghelper.overlay.CollectionLogWorldMapPoint;
+import com.collectionloghelper.overlay.WorldMapDestinationOverlay;
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.Player;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.callback.ClientThread;
+
+/**
+ * Owns world-map / hint-arrow plumbing for guidance.
+ *
+ * <p>Pure extraction from {@link GuidanceOverlayCoordinator}: this controller
+ * holds no mutable state of its own.  Coordinator state it needs to read
+ * (the active map point, current guidance step, active target item ID,
+ * sequencer activity flag) is passed in via parameters so the coordinator
+ * remains the single owner of guidance state.</p>
+ *
+ * <p>Responsibilities:
+ * <ul>
+ *   <li>Rotating the world-map edge-snap arrow each tick to point at the
+ *       active map point ({@link #updateArrow(CollectionLogWorldMapPoint)}).</li>
+ *   <li>Deciding whether a hint arrow should be placed at a given world
+ *       point ({@link #shouldSetHintArrowTo(WorldPoint)}).</li>
+ *   <li>Re-applying the hint arrow when {@code showHintArrow} is toggled or
+ *       on teleport ({@link #refreshHintArrow(boolean, GuidanceStep)}).</li>
+ *   <li>Mapping a guidance step to a {@link WorldMapDestinationOverlay.StepIconType}
+ *       ({@link #resolveStepIconType(GuidanceStep, Integer)}).</li>
+ * </ul>
+ */
+@Slf4j
+@Singleton
+public class WorldMapController
+{
+	private final Client client;
+	private final ClientThread clientThread;
+	private final CollectionLogHelperConfig config;
+
+	@Inject
+	WorldMapController(Client client, ClientThread clientThread, CollectionLogHelperConfig config)
+	{
+		this.client = client;
+		this.clientThread = clientThread;
+		this.config = config;
+	}
+
+	/**
+	 * Rotates the active world-map point's edge-snap arrow to point from the
+	 * current world-map viewport centre towards the target.  Returns silently
+	 * when there is no active map point or the world map is not loaded.
+	 *
+	 * <p>The world map Y axis is inverted relative to screen-space (higher Y =
+	 * further north = up on the map), so positive {@code dy} maps to "up".</p>
+	 */
+	public void updateArrow(@Nullable CollectionLogWorldMapPoint activeMapPoint)
+	{
+		if (activeMapPoint == null)
+		{
+			return;
+		}
+
+		net.runelite.api.worldmap.WorldMap worldMap = client.getWorldMap();
+		if (worldMap == null)
+		{
+			return;
+		}
+
+		net.runelite.api.Point mapCenter = worldMap.getWorldMapPosition();
+		if (mapCenter == null)
+		{
+			return;
+		}
+
+		WorldPoint target = activeMapPoint.getWorldPoint();
+		int dx = target.getX() - mapCenter.getX();
+		int dy = target.getY() - mapCenter.getY();
+
+		// Map 8 octants to arrow directions
+		int degrees;
+		if (Math.abs(dx) > Math.abs(dy) * 2)
+		{
+			degrees = dx > 0 ? 0 : 180;
+		}
+		else if (Math.abs(dy) > Math.abs(dx) * 2)
+		{
+			degrees = dy > 0 ? 270 : 90;
+		}
+		else if (dx > 0)
+		{
+			degrees = dy > 0 ? 315 : 45;
+		}
+		else
+		{
+			degrees = dy > 0 ? 225 : 135;
+		}
+
+		activeMapPoint.rotateArrow(degrees);
+	}
+
+	/**
+	 * Re-applies the hint arrow against the current guidance step, respecting
+	 * {@code config.showHintArrow()}.  Called by the config-change handler when
+	 * "Show Hint Arrow" is toggled mid-guidance so the change takes effect
+	 * immediately rather than at the next step transition.
+	 *
+	 * <p>When {@code isActive} is false or the step has no world target, the
+	 * arrow is cleared.  When the toggle is on and a step with a world target
+	 * is active, the arrow is re-set at that target.</p>
+	 *
+	 * <p>All client mutations are dispatched on the client thread.</p>
+	 */
+	public void refreshHintArrow(boolean isActive, @Nullable GuidanceStep step)
+	{
+		clientThread.invokeLater(() ->
+		{
+			client.clearHintArrow();
+
+			if (!isActive)
+			{
+				return;
+			}
+
+			if (step == null || step.getWorldX() <= 0)
+			{
+				return;
+			}
+
+			WorldPoint worldPoint = new WorldPoint(
+				step.getWorldX(), step.getWorldY(), step.getWorldPlane());
+			if (shouldSetHintArrowTo(worldPoint))
+			{
+				client.setHintArrow(worldPoint);
+			}
+		});
+	}
+
+	/**
+	 * Decides whether a hint arrow should be placed at the given world point.
+	 * Snapshots {@code getLocalPlayer()} once to avoid TOCTOU races.  Skips
+	 * hint arrows inside non-top-level {@code WorldView}s (e.g. sailing boats).
+	 */
+	public boolean shouldSetHintArrowTo(@Nullable WorldPoint worldPoint)
+	{
+		if (!config.showHintArrow() || worldPoint == null)
+		{
+			return false;
+		}
+		Player lp = client.getLocalPlayer();
+		if (lp == null)
+		{
+			return false;
+		}
+		if (lp.getWorldView() != client.getTopLevelWorldView())
+		{
+			return false;
+		}
+		WorldPoint playerLoc = lp.getWorldLocation();
+		return playerLoc != null && playerLoc.getPlane() == worldPoint.getPlane();
+	}
+
+	/**
+	 * Determines the world-map destination icon type for a guidance step.
+	 * NPC steps use the NPC icon, object steps use the object/chest icon,
+	 * and all other steps use the generic tile diamond.
+	 */
+	public WorldMapDestinationOverlay.StepIconType resolveStepIconType(
+		GuidanceStep step, @Nullable Integer activeTargetItemId)
+	{
+		if (step.resolveNpcId(activeTargetItemId) > 0)
+		{
+			return WorldMapDestinationOverlay.StepIconType.NPC;
+		}
+		if (step.getObjectId() > 0
+			|| (step.getObjectIds() != null && !step.getObjectIds().isEmpty()))
+		{
+			return WorldMapDestinationOverlay.StepIconType.OBJECT;
+		}
+		return WorldMapDestinationOverlay.StepIconType.TILE;
+	}
+}

--- a/src/test/java/com/collectionloghelper/guidance/DynamicTargetEvaluatorDispatchTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/DynamicTargetEvaluatorDispatchTest.java
@@ -149,6 +149,7 @@ public class DynamicTargetEvaluatorDispatchTest
 		registry.register(STUB_KEY, (c, step) -> DYNAMIC_POINT);
 
 		OverlayStepApplier overlayStepApplier = newOverlayStepApplier();
+		WorldMapController worldMapController = newWorldMapController();
 		Constructor<GuidanceOverlayCoordinator> ctor =
 			GuidanceOverlayCoordinator.class.getDeclaredConstructor(
 				Client.class,
@@ -173,7 +174,8 @@ public class DynamicTargetEvaluatorDispatchTest
 				WorldMapDestinationOverlay.class,
 				GroundItemHighlightOverlay.class,
 				WidgetHighlightOverlay.class,
-				OverlayStepApplier.class);
+				OverlayStepApplier.class,
+				WorldMapController.class);
 		ctor.setAccessible(true);
 		coordinator = ctor.newInstance(
 			client, clientThread, eventBus, config,
@@ -184,7 +186,7 @@ public class DynamicTargetEvaluatorDispatchTest
 			objectHighlightOverlay, itemHighlightOverlay,
 			worldMapRouteOverlay, worldMapDestinationOverlay,
 			groundItemHighlightOverlay, widgetHighlightOverlay,
-			overlayStepApplier);
+			overlayStepApplier, worldMapController);
 
 		lenient().when(client.getLocalPlayer()).thenReturn(localPlayer);
 		lenient().when(localPlayer.getWorldLocation()).thenReturn(new WorldPoint(3200, 3200, 0));
@@ -273,6 +275,14 @@ public class DynamicTargetEvaluatorDispatchTest
 	}
 
 	// ── Helper ────────────────────────────────────────────────────────────────
+
+	private WorldMapController newWorldMapController() throws Exception
+	{
+		Constructor<WorldMapController> ctor = WorldMapController.class.getDeclaredConstructor(
+			Client.class, ClientThread.class, CollectionLogHelperConfig.class);
+		ctor.setAccessible(true);
+		return ctor.newInstance(client, clientThread, config);
+	}
 
 	private OverlayStepApplier newOverlayStepApplier() throws Exception
 	{

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorDescriptionTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorDescriptionTest.java
@@ -144,6 +144,7 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 	public void setUp() throws Exception
 	{
 		OverlayStepApplier overlayStepApplier = newOverlayStepApplier();
+		WorldMapController worldMapController = newWorldMapController();
 		Constructor<GuidanceOverlayCoordinator> ctor =
 			GuidanceOverlayCoordinator.class.getDeclaredConstructor(
 				Client.class,
@@ -168,7 +169,8 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 				WorldMapDestinationOverlay.class,
 				GroundItemHighlightOverlay.class,
 				WidgetHighlightOverlay.class,
-				OverlayStepApplier.class);
+				OverlayStepApplier.class,
+				WorldMapController.class);
 		ctor.setAccessible(true);
 		coordinator = ctor.newInstance(
 			client, clientThread, eventBus, config,
@@ -179,7 +181,7 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 			objectHighlightOverlay, itemHighlightOverlay,
 			worldMapRouteOverlay, worldMapDestinationOverlay,
 			groundItemHighlightOverlay, widgetHighlightOverlay,
-			overlayStepApplier);
+			overlayStepApplier, worldMapController);
 
 		coordinator.setPanel(panel);
 
@@ -287,6 +289,14 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 			null, // waypoints
 			null  // dynamicTargetEvaluator
 		);
+	}
+
+	private WorldMapController newWorldMapController() throws Exception
+	{
+		Constructor<WorldMapController> ctor = WorldMapController.class.getDeclaredConstructor(
+			Client.class, ClientThread.class, CollectionLogHelperConfig.class);
+		ctor.setAccessible(true);
+		return ctor.newInstance(client, clientThread, config);
 	}
 
 	private OverlayStepApplier newOverlayStepApplier() throws Exception

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorMapPointTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorMapPointTest.java
@@ -130,6 +130,7 @@ public class GuidanceOverlayCoordinatorMapPointTest
 	public void setUp() throws Exception
 	{
 		OverlayStepApplier overlayStepApplier = newOverlayStepApplier();
+		WorldMapController worldMapController = newWorldMapController();
 		Constructor<GuidanceOverlayCoordinator> ctor =
 			GuidanceOverlayCoordinator.class.getDeclaredConstructor(
 				Client.class,
@@ -154,7 +155,8 @@ public class GuidanceOverlayCoordinatorMapPointTest
 				WorldMapDestinationOverlay.class,
 				GroundItemHighlightOverlay.class,
 				WidgetHighlightOverlay.class,
-				OverlayStepApplier.class);
+				OverlayStepApplier.class,
+				WorldMapController.class);
 		ctor.setAccessible(true);
 		coordinator = ctor.newInstance(
 			client, clientThread, eventBus, config,
@@ -165,7 +167,7 @@ public class GuidanceOverlayCoordinatorMapPointTest
 			objectHighlightOverlay, itemHighlightOverlay,
 			worldMapRouteOverlay, worldMapDestinationOverlay,
 			groundItemHighlightOverlay, widgetHighlightOverlay,
-			overlayStepApplier);
+			overlayStepApplier, worldMapController);
 
 		// Default stubs: no unmet requirements; buildRequirementRows called unconditionally
 		when(requirementsChecker.getUnmetRequirements(any())).thenReturn(Collections.emptyList());
@@ -246,6 +248,14 @@ public class GuidanceOverlayCoordinatorMapPointTest
 	}
 
 	// ---- helpers ----
+
+	private WorldMapController newWorldMapController() throws Exception
+	{
+		Constructor<WorldMapController> ctor = WorldMapController.class.getDeclaredConstructor(
+			Client.class, ClientThread.class, CollectionLogHelperConfig.class);
+		ctor.setAccessible(true);
+		return ctor.newInstance(client, clientThread, config);
+	}
 
 	/** Builds a minimal BOSSES source with coordinates but no guidance steps. */
 	private OverlayStepApplier newOverlayStepApplier() throws Exception

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorNpcIdTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorNpcIdTest.java
@@ -141,6 +141,7 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 	public void setUp() throws Exception
 	{
 		OverlayStepApplier overlayStepApplier = newOverlayStepApplier();
+		WorldMapController worldMapController = newWorldMapController();
 		Constructor<GuidanceOverlayCoordinator> ctor =
 			GuidanceOverlayCoordinator.class.getDeclaredConstructor(
 				Client.class,
@@ -165,7 +166,8 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 				WorldMapDestinationOverlay.class,
 				GroundItemHighlightOverlay.class,
 				WidgetHighlightOverlay.class,
-				OverlayStepApplier.class);
+				OverlayStepApplier.class,
+				WorldMapController.class);
 		ctor.setAccessible(true);
 		coordinator = ctor.newInstance(
 			client, clientThread, eventBus, config,
@@ -176,7 +178,7 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 			objectHighlightOverlay, itemHighlightOverlay,
 			worldMapRouteOverlay, worldMapDestinationOverlay,
 			groundItemHighlightOverlay, widgetHighlightOverlay,
-			overlayStepApplier);
+			overlayStepApplier, worldMapController);
 
 		when(requirementsChecker.getUnmetRequirements(any())).thenReturn(Collections.emptyList());
 		when(requirementsChecker.buildRequirementRows(any())).thenReturn(Collections.emptyList());
@@ -294,6 +296,14 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 			null, // waypoints
 			null  // dynamicTargetEvaluator
 		);
+	}
+
+	private WorldMapController newWorldMapController() throws Exception
+	{
+		Constructor<WorldMapController> ctor = WorldMapController.class.getDeclaredConstructor(
+			Client.class, ClientThread.class, CollectionLogHelperConfig.class);
+		ctor.setAccessible(true);
+		return ctor.newInstance(client, clientThread, config);
 	}
 
 	private OverlayStepApplier newOverlayStepApplier() throws Exception


### PR DESCRIPTION
## Summary

Continues the god-class breakup tracked in #503. Extracts the world-map / hint-arrow plumbing cluster out of `GuidanceOverlayCoordinator.java` into a new `@Singleton` helper `WorldMapController.java`, mirroring the DI idiom established by `OverlayStepApplier` in #510.

Methods moved (all formerly private to the coordinator):

- `updateArrow(CollectionLogWorldMapPoint)` (renamed from `updateWorldMapArrow`) — rotates the active map point's edge-snap arrow each tick.
- `shouldSetHintArrowTo(WorldPoint)` — pure predicate gating `client.setHintArrow` on `showHintArrow`, top-level `WorldView`, matching plane.
- `refreshHintArrow(boolean isActive, GuidanceStep step)` — clears + re-applies the hint arrow on the client thread. Coordinator state now passes through args instead of via a back-reference.
- `resolveStepIconType(GuidanceStep, Integer activeTargetItemId)` — maps a step to a `WorldMapDestinationOverlay.StepIconType`.

`GuidanceOverlayCoordinator` keeps a one-line public `refreshHintArrow()` delegating to the controller, preserving the external API contract used by `GuidanceMovementTracker` and `GuidanceEventRouter` (and the `verify(coordinator).refreshHintArrow()` assertions in their tests).

LOC: `GuidanceOverlayCoordinator` 949 → 843 (−106). New `WorldMapController` 210.

## Test plan

- [x] `./gradlew build` green (compile + test + JaCoCo verification + lintDropRates).
- [x] Existing `GuidanceMovementTrackerTest` and `GuidanceEventRouterTest` pass unmodified — public `refreshHintArrow()` signature unchanged.
- [x] Reflective-constructor tests updated minimally to add `WorldMapController.class` to the coordinator constructor signature: `GuidanceOverlayCoordinatorMapPointTest`, `GuidanceOverlayCoordinatorDescriptionTest`, `GuidanceOverlayCoordinatorNpcIdTest`, `DynamicTargetEvaluatorDispatchTest`.
- [x] JaCoCo 45% coverage gate holds.
- [ ] Manual smoke test in RuneLite: activate guidance on a step with `worldX > 0`, confirm hint arrow appears and follows player on teleport.
- [ ] Manual smoke test: toggle "Show Hint Arrow" mid-guidance, confirm arrow clears/reappears immediately.
- [ ] Manual smoke test: open world map during active guidance, confirm the edge-snap arrow rotates as the viewport pans.

Partially addresses #503.