### PR TITLE
refactor: extract DetailViewBuilder from Panel (#503)

### DIFF
--- a/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
@@ -165,6 +165,7 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 	private final Map<Mode, PanelModeController> modeControllers = new EnumMap<>(Mode.class);
 	private final PanelModeDispatcher<Mode> modeDispatcher = new PanelModeDispatcher<>(modeControllers);
 	private final PanelRebuildOrchestrator rebuildOrchestrator;
+	private final DetailViewBuilder detailViewBuilder;
 
 	private Mode currentMode = Mode.EFFICIENT;
 	private boolean rebuilding = false;
@@ -362,6 +363,13 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 		listContainer.setBackground(ColorScheme.DARK_GRAY_COLOR);
 		listView.add(listContainer, BorderLayout.NORTH);
 		rebuildOrchestrator = new PanelRebuildOrchestrator(this, listContainer);
+		detailViewBuilder = new DetailViewBuilder(
+			collectionState,
+			requirementsChecker,
+			itemManager,
+			clueEstimator,
+			guidanceActivator,
+			guidanceDeactivator);
 
 		detailView = new JPanel(new BorderLayout());
 		detailView.setBackground(ColorScheme.DARK_GRAY_COLOR);
@@ -590,34 +598,7 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 	@Override
 	public void showDetail(CollectionLogItem item, CollectionLogSource source)
 	{
-		boolean obtained = collectionState.isItemObtained(item.getItemId());
-		boolean locked = !requirementsChecker.isAccessible(source.getName());
-		boolean isGuidingThis = guidanceActive && guidedSource != null
-			&& guidedSource.getName().equals(source.getName());
-
-		int sourceTotal = source.getItems().size();
-		int sourceObtained = 0;
-		for (CollectionLogItem si : source.getItems())
-		{
-			if (collectionState.isItemObtained(si.getItemId()))
-			{
-				sourceObtained++;
-			}
-		}
-
-		detailView.removeAll();
-		ItemDetailPanel detail = new ItemDetailPanel(
-			item, source, obtained, locked,
-			requirementsChecker.getUnmetRequirements(source.getName()),
-			sourceObtained, sourceTotal,
-			itemManager, clueEstimator,
-			requirementsChecker.hasFairyRingAccess(),
-			this::showListView,
-			() -> guidanceActivator.accept(source, item.getItemId()),
-			() -> guidanceDeactivator.run(),
-			isGuidingThis
-		);
-		detailView.add(detail, BorderLayout.NORTH);
+		detailViewBuilder.populate(detailView, item, source, guidanceActive, guidedSource, this::showListView);
 		showDetailView();
 	}
 

--- a/src/main/java/com/collectionloghelper/ui/DetailViewBuilder.java
+++ b/src/main/java/com/collectionloghelper/ui/DetailViewBuilder.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.ui;
+
+import com.collectionloghelper.data.CollectionLogItem;
+import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.data.PlayerCollectionState;
+import com.collectionloghelper.data.RequirementsChecker;
+import com.collectionloghelper.efficiency.ClueCompletionEstimator;
+import java.awt.BorderLayout;
+import java.util.Objects;
+import java.util.function.BiConsumer;
+import javax.swing.JPanel;
+import net.runelite.client.game.ItemManager;
+
+/**
+ * Builder that populates the detail-view container with an
+ * {@link ItemDetailPanel} for the given item + source. Extracted from
+ * {@link CollectionLogHelperPanel#showDetail(CollectionLogItem, CollectionLogSource)}
+ * as part of the issue #503 god-class split.
+ *
+ * <p>This class is intentionally not a Guice {@code @Singleton}; it is
+ * panel-constructed alongside {@link PanelRebuildOrchestrator} and
+ * {@link SyncButtonController}. It holds collaborators that supply the data
+ * needed to render an item-detail card (obtained state, accessibility,
+ * per-source obtained-of-total counts, fairy-ring access, etc.) and exposes a
+ * single {@link #populate} method that wires up the view's callbacks.</p>
+ */
+public class DetailViewBuilder
+{
+	private final PlayerCollectionState collectionState;
+	private final RequirementsChecker requirementsChecker;
+	private final ItemManager itemManager;
+	private final ClueCompletionEstimator clueEstimator;
+	private final BiConsumer<CollectionLogSource, Integer> guidanceActivator;
+	private final Runnable guidanceDeactivator;
+
+	public DetailViewBuilder(
+		PlayerCollectionState collectionState,
+		RequirementsChecker requirementsChecker,
+		ItemManager itemManager,
+		ClueCompletionEstimator clueEstimator,
+		BiConsumer<CollectionLogSource, Integer> guidanceActivator,
+		Runnable guidanceDeactivator)
+	{
+		this.collectionState = Objects.requireNonNull(collectionState, "collectionState");
+		this.requirementsChecker = Objects.requireNonNull(requirementsChecker, "requirementsChecker");
+		this.itemManager = Objects.requireNonNull(itemManager, "itemManager");
+		this.clueEstimator = Objects.requireNonNull(clueEstimator, "clueEstimator");
+		this.guidanceActivator = Objects.requireNonNull(guidanceActivator, "guidanceActivator");
+		this.guidanceDeactivator = Objects.requireNonNull(guidanceDeactivator, "guidanceDeactivator");
+	}
+
+	/**
+	 * Clears the supplied detail-view container and renders a fresh
+	 * {@link ItemDetailPanel} for the given item + source pinned to
+	 * {@link BorderLayout#NORTH}.
+	 *
+	 * @param target          the detail-view container; must not be {@code null}
+	 * @param item            the item to display
+	 * @param source          the source the item is associated with
+	 * @param guidanceActive  whether guidance is currently active on any source
+	 * @param guidedSource    the currently guided source, or {@code null}
+	 * @param onBack          callback for the back button (e.g., return to list view)
+	 */
+	public void populate(
+		JPanel target,
+		CollectionLogItem item,
+		CollectionLogSource source,
+		boolean guidanceActive,
+		CollectionLogSource guidedSource,
+		Runnable onBack)
+	{
+		Objects.requireNonNull(target, "target");
+		Objects.requireNonNull(item, "item");
+		Objects.requireNonNull(source, "source");
+		Objects.requireNonNull(onBack, "onBack");
+
+		boolean obtained = collectionState.isItemObtained(item.getItemId());
+		boolean locked = !requirementsChecker.isAccessible(source.getName());
+		boolean isGuidingThis = guidanceActive && guidedSource != null
+			&& guidedSource.getName().equals(source.getName());
+
+		int sourceTotal = source.getItems().size();
+		int sourceObtained = countObtainedItems(source);
+
+		target.removeAll();
+		ItemDetailPanel detail = new ItemDetailPanel(
+			item, source, obtained, locked,
+			requirementsChecker.getUnmetRequirements(source.getName()),
+			sourceObtained, sourceTotal,
+			itemManager, clueEstimator,
+			requirementsChecker.hasFairyRingAccess(),
+			onBack,
+			() -> guidanceActivator.accept(source, item.getItemId()),
+			guidanceDeactivator,
+			isGuidingThis
+		);
+		target.add(detail, BorderLayout.NORTH);
+	}
+
+	private int countObtainedItems(CollectionLogSource source)
+	{
+		int count = 0;
+		for (CollectionLogItem si : source.getItems())
+		{
+			if (collectionState.isItemObtained(si.getItemId()))
+			{
+				count++;
+			}
+		}
+		return count;
+	}
+}

--- a/src/test/java/com/collectionloghelper/ui/DetailViewBuilderTest.java
+++ b/src/test/java/com/collectionloghelper/ui/DetailViewBuilderTest.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.ui;
+
+import com.collectionloghelper.data.CollectionLogCategory;
+import com.collectionloghelper.data.CollectionLogItem;
+import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.data.PlayerCollectionState;
+import com.collectionloghelper.data.RequirementsChecker;
+import com.collectionloghelper.efficiency.ClueCompletionEstimator;
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.util.AsyncBufferedImage;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link DetailViewBuilder}: the helper that populates the
+ * detail-view container with an {@link ItemDetailPanel}. Extracted from
+ * {@link CollectionLogHelperPanel#showDetail} as part of the issue #503
+ * god-class split.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class DetailViewBuilderTest
+{
+	@Mock
+	private PlayerCollectionState collectionState;
+	@Mock
+	private RequirementsChecker requirementsChecker;
+	@Mock
+	private ItemManager itemManager;
+	@Mock
+	private ClueCompletionEstimator clueEstimator;
+
+	private DetailViewBuilder builder;
+	private JPanel target;
+	private CollectionLogItem item;
+	private CollectionLogItem otherItem;
+	private CollectionLogSource source;
+	private AtomicReference<CollectionLogSource> activatorSource;
+	private AtomicInteger activatorItemId;
+	private AtomicInteger deactivatorCalls;
+
+	@Before
+	public void setUp()
+	{
+		// ItemManager.getImage(int) returns an AsyncBufferedImage that
+		// ItemDetailPanel immediately uses for an ImageIcon and onLoaded callback.
+		AsyncBufferedImage img = mock(AsyncBufferedImage.class);
+		lenient().when(itemManager.getImage(anyInt())).thenReturn(img);
+		lenient().when(requirementsChecker.getUnmetRequirements(anyString())).thenReturn(Collections.emptyList());
+		lenient().when(requirementsChecker.hasFairyRingAccess()).thenReturn(false);
+
+		activatorSource = new AtomicReference<>();
+		activatorItemId = new AtomicInteger(-1);
+		deactivatorCalls = new AtomicInteger(0);
+
+		BiConsumer<CollectionLogSource, Integer> activator = (s, id) ->
+		{
+			activatorSource.set(s);
+			activatorItemId.set(id);
+		};
+		Runnable deactivator = () -> deactivatorCalls.incrementAndGet();
+
+		builder = new DetailViewBuilder(
+			collectionState, requirementsChecker, itemManager, clueEstimator,
+			activator, deactivator);
+
+		target = new JPanel(new BorderLayout());
+
+		item = new CollectionLogItem(101, "Test Item", 1.0 / 128, false, "wiki", 0, 0, false, false);
+		otherItem = new CollectionLogItem(102, "Other Item", 1.0 / 256, false, "wiki2", 0, 0, false, false);
+		List<CollectionLogItem> items = Arrays.asList(item, otherItem);
+		source = newSource("Test Boss", items);
+	}
+
+	private static CollectionLogSource newSource(String name, List<CollectionLogItem> items)
+	{
+		return new CollectionLogSource(
+			name,                          // name
+			CollectionLogCategory.BOSSES,  // category
+			0, 0, 0,                       // worldX, worldY, worldPlane
+			60,                            // killTimeSeconds
+			60,                            // ironKillTimeSeconds
+			"",                            // locationDescription
+			Collections.emptyList(),       // waypoints
+			null,                          // rewardType
+			0.0,                           // pointsPerHour
+			Collections.emptyList(),       // mutuallyExclusiveSources
+			1,                             // rollsPerKill
+			false,                         // aggregated
+			0,                             // afkLevel
+			"",                            // travelTip
+			-1,                            // npcId
+			"",                            // interactAction
+			Collections.emptyList(),       // dialogOptions
+			Collections.emptyList(),       // guidanceSteps
+			null,                          // guidanceHelperKey
+			null,                          // requirements
+			0,                             // cumulativeTrackItemId
+			Collections.emptyList(),       // cumulativeTrackObjectIds
+			0,                             // cumulativeTrackThreshold
+			items,                         // items
+			null);                         // metaAuthoredDate
+	}
+
+	@Test
+	public void populateClearsTargetAndAddsItemDetailPanelToNorth()
+	{
+		// pre-seed target with a stale child to verify it gets cleared
+		target.add(new JLabel("stale"), BorderLayout.NORTH);
+		assertEquals(1, target.getComponentCount());
+
+		when(collectionState.isItemObtained(anyInt())).thenReturn(false);
+		when(requirementsChecker.isAccessible("Test Boss")).thenReturn(true);
+
+		builder.populate(target, item, source, false, null, () -> { });
+
+		assertEquals("Target should hold exactly one child (the ItemDetailPanel)",
+			1, target.getComponentCount());
+		Component child = target.getComponent(0);
+		assertTrue("Child must be an ItemDetailPanel", child instanceof ItemDetailPanel);
+		// The child should be pinned to NORTH on the BorderLayout target.
+		assertSame(child, ((BorderLayout) target.getLayout()).getLayoutComponent(BorderLayout.NORTH));
+	}
+
+	@Test
+	public void populateCountsObtainedItemsAcrossSource()
+	{
+		// Only `item` is obtained, not `otherItem`. The builder must iterate
+		// every item in the source to compute sourceObtained / sourceTotal.
+		when(collectionState.isItemObtained(101)).thenReturn(true);
+		when(collectionState.isItemObtained(102)).thenReturn(false);
+		when(requirementsChecker.isAccessible("Test Boss")).thenReturn(true);
+
+		builder.populate(target, item, source, false, null, () -> { });
+
+		// Verify the iteration touched every item in the source (the loop
+		// also queries item 101 in addition to the explicit `obtained` check,
+		// so `atLeastOnce()` is the right assertion strength here).
+		org.mockito.Mockito.verify(collectionState, org.mockito.Mockito.atLeastOnce()).isItemObtained(101);
+		org.mockito.Mockito.verify(collectionState).isItemObtained(102);
+	}
+
+	@Test
+	public void populateRebindsBackCallbackToCallerSuppliedRunnable()
+	{
+		AtomicInteger backCalls = new AtomicInteger(0);
+		when(collectionState.isItemObtained(anyInt())).thenReturn(false);
+		when(requirementsChecker.isAccessible(anyString())).thenReturn(true);
+
+		builder.populate(target, item, source, false, null, () -> backCalls.incrementAndGet());
+
+		// Locate the Back button on the produced ItemDetailPanel and click it.
+		ItemDetailPanel detail = (ItemDetailPanel) target.getComponent(0);
+		javax.swing.JButton back = findFirstButton(detail, "Back");
+		assertNotNull("ItemDetailPanel should have a Back button", back);
+		back.doClick();
+
+		assertEquals("Back callback should fire once", 1, backCalls.get());
+	}
+
+	@Test
+	public void populateWiresGuidanceActivatorWithSourceAndItemId()
+	{
+		when(collectionState.isItemObtained(anyInt())).thenReturn(false);
+		when(requirementsChecker.isAccessible(anyString())).thenReturn(true);
+
+		// guidanceActive=false so the Guide Me button is not in the Stop state.
+		builder.populate(target, item, source, false, null, () -> { });
+
+		ItemDetailPanel detail = (ItemDetailPanel) target.getComponent(0);
+		javax.swing.JButton guideMe = findFirstButton(detail, "Guide Me");
+		assertNotNull("ItemDetailPanel should have a Guide Me button", guideMe);
+		guideMe.doClick();
+
+		assertSame("Guide Me should pass the source to the activator", source, activatorSource.get());
+		assertEquals("Guide Me should pass the clicked item's id to the activator",
+			101, activatorItemId.get());
+		assertEquals("Deactivator should not fire when guidance was inactive",
+			0, deactivatorCalls.get());
+	}
+
+	@Test
+	public void populateWiresGuidanceDeactivatorWhenGuidingThisSource()
+	{
+		when(collectionState.isItemObtained(anyInt())).thenReturn(false);
+		when(requirementsChecker.isAccessible(anyString())).thenReturn(true);
+
+		// guidanceActive=true AND guidedSource.name == source.name => isGuidingThis=true.
+		// In that state the button is in "Stop Guidance" mode and triggers the deactivator.
+		builder.populate(target, item, source, true, source, () -> { });
+
+		ItemDetailPanel detail = (ItemDetailPanel) target.getComponent(0);
+		javax.swing.JButton stop = findFirstButton(detail, "Stop Guidance");
+		assertNotNull("ItemDetailPanel should expose a Stop Guidance button when guiding this source", stop);
+		stop.doClick();
+
+		assertEquals("Deactivator should fire once when Stop Guidance is clicked",
+			1, deactivatorCalls.get());
+		assertEquals("Activator must NOT fire when stopping guidance", -1, activatorItemId.get());
+	}
+
+	private static javax.swing.JButton findFirstButton(java.awt.Container root, String labelSubstring)
+	{
+		for (Component c : root.getComponents())
+		{
+			if (c instanceof javax.swing.JButton)
+			{
+				javax.swing.JButton b = (javax.swing.JButton) c;
+				String text = b.getText();
+				if (text != null && text.contains(labelSubstring))
+				{
+					return b;
+				}
+			}
+			if (c instanceof java.awt.Container)
+			{
+				javax.swing.JButton nested = findFirstButton((java.awt.Container) c, labelSubstring);
+				if (nested != null)
+				{
+					return nested;
+				}
+			}
+		}
+		return null;
+	}
+}


### PR DESCRIPTION
Partially addresses #503.

## Summary

Extracts the detail-view population path from `CollectionLogHelperPanel.showDetail(...)` into a dedicated `DetailViewBuilder` class, continuing the issue #503 god-class split alongside `PanelRebuildOrchestrator` (#513) and `SyncButtonController` (#515).

`DetailViewBuilder` is a plain (non-Guice) class, panel-constructed with its data collaborators (`PlayerCollectionState`, `RequirementsChecker`, `ItemManager`, `ClueCompletionEstimator`) and the two guidance callbacks (`activator` / `deactivator`). Its single `populate(target, item, source, guidanceActive, guidedSource, onBack)` method clears the supplied detail-view container, computes the per-source `obtained` / `locked` / `sourceObtained` / `sourceTotal` state, and pins a fresh `ItemDetailPanel` to `BorderLayout.NORTH` with all three button callbacks (back, guide-me, stop-guidance) wired through.

`showDetail` in the panel collapses from a ~32-line body to a 2-line delegation:

```java
detailViewBuilder.populate(detailView, item, source, guidanceActive, guidedSource, this::showListView);
showDetailView();
```

## LOC

| File | Before | After | Delta |
|---|---:|---:|---:|
| `CollectionLogHelperPanel.java` | 782 | 763 | -19 |
| `DetailViewBuilder.java` (new) | — | 136 | +136 |
| `DetailViewBuilderTest.java` (new) | — | 272 | +272 |

The remaining `showDetailView()` / `showListView()` helpers (4 LOC each) are deliberately left in the panel because they read/write panel-owned view-state (`cardLayout`, `inDetailView`, scroll helpers) rather than building the detail view. Pulling them out would couple the builder to view-state mutation instead of view construction.

## Behaviour preserved

- Same `ItemDetailPanel` constructor arguments and ordering.
- `isGuidingThis` still computed as `guidanceActive && guidedSource != null && guidedSource.getName().equals(source.getName())`.
- `detailView.removeAll()` still happens before each populate, so stale children from a previous showDetail are cleared.
- EDT discipline unchanged — no new threading wrappers introduced.

## Test plan

- [x] `./gradlew build` (compileJava + compileTestJava + test + jacocoTestCoverageVerification + lintDropRates + jacocoTestReport + check) — BUILD SUCCESSFUL.
- [x] `./gradlew test --tests com.collectionloghelper.ui.DetailViewBuilderTest` — 5/5 pass.
- [x] JaCoCo 45% coverage gate still passes (`jacocoTestCoverageVerification` task succeeded in full build).
- [x] New `DetailViewBuilderTest` covers:
  - `populateClearsTargetAndAddsItemDetailPanelToNorth` — stale child cleared, exactly one `ItemDetailPanel` child remains, pinned to `BorderLayout.NORTH`.
  - `populateCountsObtainedItemsAcrossSource` — verifies the source-items loop calls `isItemObtained` for every item id.
  - `populateRebindsBackCallbackToCallerSuppliedRunnable` — clicking the Back button on the produced `ItemDetailPanel` invokes the caller-supplied `onBack` Runnable.
  - `populateWiresGuidanceActivatorWithSourceAndItemId` — when not guiding, clicking the Guide Me button calls the activator with `(source, item.getItemId())` and does not call the deactivator.
  - `populateWiresGuidanceDeactivatorWhenGuidingThisSource` — when `guidanceActive=true` AND `guidedSource.name == source.name`, the button is in Stop Guidance mode and clicking it calls the deactivator exactly once and never the activator.
- [ ] Manual smoke: open plugin panel, click an item row, confirm detail view renders identically; click Back, confirm list returns; click Guide Me on an item, confirm guidance starts; click Stop Guidance, confirm guidance stops.