### PR TITLE
refactor: extract DynamicTargetManager from GuidanceOverlayCoordinator (#503)

### DIFF
--- a/src/main/java/com/collectionloghelper/guidance/DynamicTargetManager.java
+++ b/src/main/java/com/collectionloghelper/guidance/DynamicTargetManager.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.guidance;
+
+import com.collectionloghelper.data.GuidanceStep;
+import com.collectionloghelper.guidance.dynamic.DynamicTargetEvaluatorRegistry;
+import com.collectionloghelper.overlay.CollectionLogWorldMapPoint;
+import com.collectionloghelper.overlay.GuidanceMinimapOverlay;
+import com.collectionloghelper.overlay.GuidanceOverlay;
+import com.collectionloghelper.overlay.WorldMapDestinationOverlay;
+import com.collectionloghelper.overlay.WorldMapRouteOverlay;
+import java.awt.image.BufferedImage;
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.ui.overlay.worldmap.WorldMapPointManager;
+
+/**
+ * Owns the per-tick dynamic-target evaluator dispatch for guidance.
+ *
+ * <p>Pure extraction from {@link GuidanceOverlayCoordinator}: this manager
+ * holds no mutable state of its own.  Coordinator state it needs to read
+ * (active map point, current guidance step, sequencer activity, active
+ * target item id, cached log icon) is passed in via the {@link Input}
+ * carrier, and any state mutation the coordinator must apply (the new
+ * active map point) is returned in {@link Result} so the coordinator
+ * remains the single owner of guidance state.</p>
+ *
+ * <p>Responsibilities:
+ * <ul>
+ *   <li>Looking up the {@link DynamicTargetEvaluator} registered under the
+ *       step's {@code dynamicTargetEvaluator} key.</li>
+ *   <li>Evaluating it against the live client and current step to obtain
+ *       a fresh {@link WorldPoint} target.</li>
+ *   <li>Pushing the new target into the four location-sensitive overlays
+ *       (in-world, minimap, world-map route, world-map destination).</li>
+ *   <li>Refreshing the world map point in {@link WorldMapPointManager} and
+ *       reporting the new map point back via {@link Result}.</li>
+ *   <li>Re-applying the hint arrow via {@link WorldMapController} when
+ *       {@code config.showHintArrow()} is enabled and the local player is
+ *       on a compatible plane / world view.</li>
+ * </ul>
+ *
+ * <p>Called on the client thread once per game tick.  Returns silently
+ * (with {@link Result#unchanged(CollectionLogWorldMapPoint)}) when guidance
+ * is inactive, the step has no evaluator key, the key is unregistered, or
+ * the evaluator returns {@code null}.</p>
+ */
+@Slf4j
+@Singleton
+public class DynamicTargetManager
+{
+	private final Client client;
+	private final DynamicTargetEvaluatorRegistry registry;
+	private final WorldMapPointManager worldMapPointManager;
+	private final GuidanceOverlay guidanceOverlay;
+	private final GuidanceMinimapOverlay guidanceMinimapOverlay;
+	private final WorldMapRouteOverlay worldMapRouteOverlay;
+	private final WorldMapDestinationOverlay worldMapDestinationOverlay;
+	private final WorldMapController worldMapController;
+
+	@Inject
+	DynamicTargetManager(
+		Client client,
+		DynamicTargetEvaluatorRegistry registry,
+		WorldMapPointManager worldMapPointManager,
+		GuidanceOverlay guidanceOverlay,
+		GuidanceMinimapOverlay guidanceMinimapOverlay,
+		WorldMapRouteOverlay worldMapRouteOverlay,
+		WorldMapDestinationOverlay worldMapDestinationOverlay,
+		WorldMapController worldMapController)
+	{
+		this.client = client;
+		this.registry = registry;
+		this.worldMapPointManager = worldMapPointManager;
+		this.guidanceOverlay = guidanceOverlay;
+		this.guidanceMinimapOverlay = guidanceMinimapOverlay;
+		this.worldMapRouteOverlay = worldMapRouteOverlay;
+		this.worldMapDestinationOverlay = worldMapDestinationOverlay;
+		this.worldMapController = worldMapController;
+	}
+
+	/**
+	 * Dispatches the dynamic-target evaluator for the active step (when present)
+	 * and pushes the resulting world point to all location-sensitive overlays.
+	 * Returns a {@link Result} describing any change to the coordinator's
+	 * {@code activeMapPoint} so the caller can apply it without this manager
+	 * needing direct access to coordinator state.
+	 */
+	public Result tick(Input input)
+	{
+		if (!input.guidanceActive)
+		{
+			return Result.unchanged(input.activeMapPoint);
+		}
+		GuidanceStep step = input.currentStep;
+		if (step == null || step.getDynamicTargetEvaluator() == null)
+		{
+			return Result.unchanged(input.activeMapPoint);
+		}
+		DynamicTargetEvaluator evaluator = registry.get(step.getDynamicTargetEvaluator());
+		if (evaluator == null)
+		{
+			return Result.unchanged(input.activeMapPoint);
+		}
+		WorldPoint dynamicPoint = evaluator.evaluate(client, step);
+		if (dynamicPoint == null)
+		{
+			return Result.unchanged(input.activeMapPoint);
+		}
+
+		guidanceOverlay.setTargetPoint(dynamicPoint);
+		guidanceMinimapOverlay.setTargetPoint(dynamicPoint);
+		worldMapRouteOverlay.setTargetPoint(dynamicPoint);
+		worldMapDestinationOverlay.setTarget(dynamicPoint,
+			worldMapController.resolveStepIconType(step, input.activeTargetItemId));
+
+		if (input.activeMapPoint != null)
+		{
+			worldMapPointManager.remove(input.activeMapPoint);
+		}
+		CollectionLogWorldMapPoint newMapPoint = new CollectionLogWorldMapPoint(dynamicPoint,
+			step.resolveDescription(input.activeTargetItemId), input.collectionLogIcon);
+		worldMapPointManager.add(newMapPoint);
+		worldMapDestinationOverlay.setMapPointActive(true);
+
+		if (worldMapController.shouldSetHintArrowTo(dynamicPoint))
+		{
+			client.setHintArrow(dynamicPoint);
+		}
+
+		return Result.changed(newMapPoint);
+	}
+
+	/**
+	 * Inputs the coordinator passes to {@link #tick(Input)}.  Mirrors the
+	 * subset of coordinator state the dynamic-target dispatch reads.
+	 */
+	public static final class Input
+	{
+		private final boolean guidanceActive;
+		@Nullable
+		private final GuidanceStep currentStep;
+		@Nullable
+		private final CollectionLogWorldMapPoint activeMapPoint;
+		@Nullable
+		private final Integer activeTargetItemId;
+		@Nullable
+		private final BufferedImage collectionLogIcon;
+
+		public Input(boolean guidanceActive,
+			@Nullable GuidanceStep currentStep,
+			@Nullable CollectionLogWorldMapPoint activeMapPoint,
+			@Nullable Integer activeTargetItemId,
+			@Nullable BufferedImage collectionLogIcon)
+		{
+			this.guidanceActive = guidanceActive;
+			this.currentStep = currentStep;
+			this.activeMapPoint = activeMapPoint;
+			this.activeTargetItemId = activeTargetItemId;
+			this.collectionLogIcon = collectionLogIcon;
+		}
+	}
+
+	/**
+	 * Result of a single {@link #tick(Input)} call.  Carries the (possibly
+	 * new) active world map point so the coordinator can replace its own
+	 * reference without exposing internal fields to this manager.
+	 */
+	public static final class Result
+	{
+		private final boolean changed;
+		@Nullable
+		private final CollectionLogWorldMapPoint activeMapPoint;
+
+		private Result(boolean changed, @Nullable CollectionLogWorldMapPoint activeMapPoint)
+		{
+			this.changed = changed;
+			this.activeMapPoint = activeMapPoint;
+		}
+
+		static Result changed(CollectionLogWorldMapPoint newPoint)
+		{
+			return new Result(true, newPoint);
+		}
+
+		static Result unchanged(@Nullable CollectionLogWorldMapPoint existingPoint)
+		{
+			return new Result(false, existingPoint);
+		}
+
+		/** True when the evaluator fired and a new active map point was produced. */
+		public boolean isChanged()
+		{
+			return changed;
+		}
+
+		/**
+		 * The active world map point the coordinator should now hold.  When
+		 * {@link #isChanged()} is false this is the input's existing point
+		 * (echoed for caller convenience).
+		 */
+		@Nullable
+		public CollectionLogWorldMapPoint getActiveMapPoint()
+		{
+			return activeMapPoint;
+		}
+	}
+}

--- a/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
@@ -37,7 +37,6 @@ import com.collectionloghelper.data.PlayerInventoryState;
 import com.collectionloghelper.data.PlayerTravelCapabilities;
 import com.collectionloghelper.data.RequirementRow;
 import com.collectionloghelper.data.RequirementsChecker;
-import com.collectionloghelper.guidance.dynamic.DynamicTargetEvaluatorRegistry;
 import com.collectionloghelper.overlay.CollectionLogWorldMapPoint;
 import com.collectionloghelper.overlay.DialogHighlightOverlay;
 import com.collectionloghelper.overlay.GroundItemHighlightOverlay;
@@ -96,7 +95,6 @@ public class GuidanceOverlayCoordinator
 	private final EventBus eventBus;
 	private final CollectionLogHelperConfig config;
 	private final GuidanceSequencer guidanceSequencer;
-	private final DynamicTargetEvaluatorRegistry dynamicTargetEvaluatorRegistry;
 	private final RequirementsChecker requirementsChecker;
 	private final PlayerTravelCapabilities travelCapabilities;
 	private final PlayerInventoryState playerInventoryState;
@@ -115,6 +113,7 @@ public class GuidanceOverlayCoordinator
 	private final WidgetHighlightOverlay widgetHighlightOverlay;
 	private final OverlayStepApplier overlayStepApplier;
 	private final WorldMapController worldMapController;
+	private final DynamicTargetManager dynamicTargetManager;
 
 	// -- Guidance UI state (previously in plugin) --
 
@@ -172,7 +171,6 @@ public class GuidanceOverlayCoordinator
 		EventBus eventBus,
 		CollectionLogHelperConfig config,
 		GuidanceSequencer guidanceSequencer,
-		DynamicTargetEvaluatorRegistry dynamicTargetEvaluatorRegistry,
 		RequirementsChecker requirementsChecker,
 		PlayerTravelCapabilities travelCapabilities,
 		PlayerInventoryState playerInventoryState,
@@ -190,14 +188,14 @@ public class GuidanceOverlayCoordinator
 		GroundItemHighlightOverlay groundItemHighlightOverlay,
 		WidgetHighlightOverlay widgetHighlightOverlay,
 		OverlayStepApplier overlayStepApplier,
-		WorldMapController worldMapController)
+		WorldMapController worldMapController,
+		DynamicTargetManager dynamicTargetManager)
 	{
 		this.client = client;
 		this.clientThread = clientThread;
 		this.eventBus = eventBus;
 		this.config = config;
 		this.guidanceSequencer = guidanceSequencer;
-		this.dynamicTargetEvaluatorRegistry = dynamicTargetEvaluatorRegistry;
 		this.requirementsChecker = requirementsChecker;
 		this.travelCapabilities = travelCapabilities;
 		this.playerInventoryState = playerInventoryState;
@@ -216,6 +214,7 @@ public class GuidanceOverlayCoordinator
 		this.widgetHighlightOverlay = widgetHighlightOverlay;
 		this.overlayStepApplier = overlayStepApplier;
 		this.worldMapController = worldMapController;
+		this.dynamicTargetManager = dynamicTargetManager;
 	}
 
 	/**
@@ -432,63 +431,13 @@ public class GuidanceOverlayCoordinator
 			eventBus.post(new PluginMessage("shortestpath", "path", data));
 		}
 
-		// Dynamic target evaluator dispatch: update overlays each tick when the
-		// active step has a dynamicTargetEvaluator key.
-		tickDynamicTargetEvaluator();
+		// Dynamic target evaluator dispatch (delegated to DynamicTargetManager).
+		activeMapPoint = dynamicTargetManager.tick(new DynamicTargetManager.Input(
+			guidanceSequencer.isActive(), guidanceSequencer.getRawCurrentStep(),
+			activeMapPoint, activeTargetItemId, collectionLogIcon)).getActiveMapPoint();
 
 		// World map arrow rotation
 		worldMapController.updateArrow(activeMapPoint);
-	}
-
-	/**
-	 * If the currently active guidance step has a non-null
-	 * {@link com.collectionloghelper.data.GuidanceStep#getDynamicTargetEvaluator()}
-	 * key, looks up the evaluator in the registry and calls it to obtain the
-	 * current target {@link WorldPoint}.  When the evaluator returns a non-null
-	 * point, pushes it to all location-sensitive overlays (minimap, world map,
-	 * overlay, hint arrow).  Returns silently when guidance is inactive, the
-	 * step carries no evaluator key, the key is unknown, or the evaluator
-	 * returns {@code null}.
-	 *
-	 * <p>Called on the client thread once per game tick via {@link #tick()}.
-	 */
-	private void tickDynamicTargetEvaluator()
-	{
-		if (!guidanceSequencer.isActive())
-		{
-			return;
-		}
-		GuidanceStep step = guidanceSequencer.getRawCurrentStep();
-		if (step == null || step.getDynamicTargetEvaluator() == null)
-		{
-			return;
-		}
-		DynamicTargetEvaluator evaluator = dynamicTargetEvaluatorRegistry.get(step.getDynamicTargetEvaluator());
-		if (evaluator == null)
-		{
-			return;
-		}
-		WorldPoint dynamicPoint = evaluator.evaluate(client, step);
-		if (dynamicPoint == null)
-		{
-			return;
-		}
-		guidanceOverlay.setTargetPoint(dynamicPoint);
-		guidanceMinimapOverlay.setTargetPoint(dynamicPoint);
-		worldMapRouteOverlay.setTargetPoint(dynamicPoint);
-		worldMapDestinationOverlay.setTarget(dynamicPoint, worldMapController.resolveStepIconType(step, activeTargetItemId));
-		if (activeMapPoint != null)
-		{
-			worldMapPointManager.remove(activeMapPoint);
-		}
-		activeMapPoint = new CollectionLogWorldMapPoint(dynamicPoint,
-			step.resolveDescription(activeTargetItemId), collectionLogIcon);
-		worldMapPointManager.add(activeMapPoint);
-		worldMapDestinationOverlay.setMapPointActive(true);
-		if (worldMapController.shouldSetHintArrowTo(dynamicPoint))
-		{
-			client.setHintArrow(dynamicPoint);
-		}
 	}
 
 	/**

--- a/src/test/java/com/collectionloghelper/guidance/DynamicTargetEvaluatorDispatchTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/DynamicTargetEvaluatorDispatchTest.java
@@ -150,6 +150,7 @@ public class DynamicTargetEvaluatorDispatchTest
 
 		OverlayStepApplier overlayStepApplier = newOverlayStepApplier();
 		WorldMapController worldMapController = newWorldMapController();
+		DynamicTargetManager dynamicTargetManager = newDynamicTargetManager(worldMapController);
 		Constructor<GuidanceOverlayCoordinator> ctor =
 			GuidanceOverlayCoordinator.class.getDeclaredConstructor(
 				Client.class,
@@ -157,7 +158,6 @@ public class DynamicTargetEvaluatorDispatchTest
 				EventBus.class,
 				CollectionLogHelperConfig.class,
 				GuidanceSequencer.class,
-				DynamicTargetEvaluatorRegistry.class,
 				RequirementsChecker.class,
 				PlayerTravelCapabilities.class,
 				PlayerInventoryState.class,
@@ -175,18 +175,19 @@ public class DynamicTargetEvaluatorDispatchTest
 				GroundItemHighlightOverlay.class,
 				WidgetHighlightOverlay.class,
 				OverlayStepApplier.class,
-				WorldMapController.class);
+				WorldMapController.class,
+				DynamicTargetManager.class);
 		ctor.setAccessible(true);
 		coordinator = ctor.newInstance(
 			client, clientThread, eventBus, config,
-			guidanceSequencer, registry, requirementsChecker, travelCapabilities,
+			guidanceSequencer, requirementsChecker, travelCapabilities,
 			playerInventoryState, itemManager, requiredItemResolver,
 			worldMapPointManager, infoBoxManager,
 			guidanceOverlay, guidanceMinimapOverlay, dialogHighlightOverlay,
 			objectHighlightOverlay, itemHighlightOverlay,
 			worldMapRouteOverlay, worldMapDestinationOverlay,
 			groundItemHighlightOverlay, widgetHighlightOverlay,
-			overlayStepApplier, worldMapController);
+			overlayStepApplier, worldMapController, dynamicTargetManager);
 
 		lenient().when(client.getLocalPlayer()).thenReturn(localPlayer);
 		lenient().when(localPlayer.getWorldLocation()).thenReturn(new WorldPoint(3200, 3200, 0));
@@ -282,6 +283,20 @@ public class DynamicTargetEvaluatorDispatchTest
 			Client.class, ClientThread.class, CollectionLogHelperConfig.class);
 		ctor.setAccessible(true);
 		return ctor.newInstance(client, clientThread, config);
+	}
+
+	private DynamicTargetManager newDynamicTargetManager(WorldMapController worldMapController)
+		throws Exception
+	{
+		Constructor<DynamicTargetManager> ctor = DynamicTargetManager.class.getDeclaredConstructor(
+			Client.class, DynamicTargetEvaluatorRegistry.class, WorldMapPointManager.class,
+			GuidanceOverlay.class, GuidanceMinimapOverlay.class,
+			WorldMapRouteOverlay.class, WorldMapDestinationOverlay.class,
+			WorldMapController.class);
+		ctor.setAccessible(true);
+		return ctor.newInstance(client, registry, worldMapPointManager,
+			guidanceOverlay, guidanceMinimapOverlay,
+			worldMapRouteOverlay, worldMapDestinationOverlay, worldMapController);
 	}
 
 	private OverlayStepApplier newOverlayStepApplier() throws Exception

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorDescriptionTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorDescriptionTest.java
@@ -152,7 +152,6 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 				EventBus.class,
 				CollectionLogHelperConfig.class,
 				GuidanceSequencer.class,
-				DynamicTargetEvaluatorRegistry.class,
 				RequirementsChecker.class,
 				PlayerTravelCapabilities.class,
 				PlayerInventoryState.class,
@@ -170,18 +169,20 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 				GroundItemHighlightOverlay.class,
 				WidgetHighlightOverlay.class,
 				OverlayStepApplier.class,
-				WorldMapController.class);
+				WorldMapController.class,
+				DynamicTargetManager.class);
 		ctor.setAccessible(true);
+		DynamicTargetManager dynamicTargetManager = newDynamicTargetManager(worldMapController);
 		coordinator = ctor.newInstance(
 			client, clientThread, eventBus, config,
-			guidanceSequencer, dynamicTargetEvaluatorRegistry, requirementsChecker, travelCapabilities,
+			guidanceSequencer, requirementsChecker, travelCapabilities,
 			playerInventoryState, itemManager, requiredItemResolver,
 			worldMapPointManager, infoBoxManager,
 			guidanceOverlay, guidanceMinimapOverlay, dialogHighlightOverlay,
 			objectHighlightOverlay, itemHighlightOverlay,
 			worldMapRouteOverlay, worldMapDestinationOverlay,
 			groundItemHighlightOverlay, widgetHighlightOverlay,
-			overlayStepApplier, worldMapController);
+			overlayStepApplier, worldMapController, dynamicTargetManager);
 
 		coordinator.setPanel(panel);
 
@@ -297,6 +298,20 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 			Client.class, ClientThread.class, CollectionLogHelperConfig.class);
 		ctor.setAccessible(true);
 		return ctor.newInstance(client, clientThread, config);
+	}
+
+	private DynamicTargetManager newDynamicTargetManager(WorldMapController worldMapController)
+		throws Exception
+	{
+		Constructor<DynamicTargetManager> ctor = DynamicTargetManager.class.getDeclaredConstructor(
+			Client.class, DynamicTargetEvaluatorRegistry.class, WorldMapPointManager.class,
+			GuidanceOverlay.class, GuidanceMinimapOverlay.class,
+			WorldMapRouteOverlay.class, WorldMapDestinationOverlay.class,
+			WorldMapController.class);
+		ctor.setAccessible(true);
+		return ctor.newInstance(client, dynamicTargetEvaluatorRegistry, worldMapPointManager,
+			guidanceOverlay, guidanceMinimapOverlay,
+			worldMapRouteOverlay, worldMapDestinationOverlay, worldMapController);
 	}
 
 	private OverlayStepApplier newOverlayStepApplier() throws Exception

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorMapPointTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorMapPointTest.java
@@ -138,7 +138,6 @@ public class GuidanceOverlayCoordinatorMapPointTest
 				EventBus.class,
 				CollectionLogHelperConfig.class,
 				GuidanceSequencer.class,
-				DynamicTargetEvaluatorRegistry.class,
 				RequirementsChecker.class,
 				PlayerTravelCapabilities.class,
 				PlayerInventoryState.class,
@@ -156,18 +155,20 @@ public class GuidanceOverlayCoordinatorMapPointTest
 				GroundItemHighlightOverlay.class,
 				WidgetHighlightOverlay.class,
 				OverlayStepApplier.class,
-				WorldMapController.class);
+				WorldMapController.class,
+				DynamicTargetManager.class);
 		ctor.setAccessible(true);
+		DynamicTargetManager dynamicTargetManager = newDynamicTargetManager(worldMapController);
 		coordinator = ctor.newInstance(
 			client, clientThread, eventBus, config,
-			guidanceSequencer, dynamicTargetEvaluatorRegistry, requirementsChecker, travelCapabilities,
+			guidanceSequencer, requirementsChecker, travelCapabilities,
 			playerInventoryState, itemManager, requiredItemResolver,
 			worldMapPointManager, infoBoxManager,
 			guidanceOverlay, guidanceMinimapOverlay, dialogHighlightOverlay,
 			objectHighlightOverlay, itemHighlightOverlay,
 			worldMapRouteOverlay, worldMapDestinationOverlay,
 			groundItemHighlightOverlay, widgetHighlightOverlay,
-			overlayStepApplier, worldMapController);
+			overlayStepApplier, worldMapController, dynamicTargetManager);
 
 		// Default stubs: no unmet requirements; buildRequirementRows called unconditionally
 		when(requirementsChecker.getUnmetRequirements(any())).thenReturn(Collections.emptyList());
@@ -255,6 +256,20 @@ public class GuidanceOverlayCoordinatorMapPointTest
 			Client.class, ClientThread.class, CollectionLogHelperConfig.class);
 		ctor.setAccessible(true);
 		return ctor.newInstance(client, clientThread, config);
+	}
+
+	private DynamicTargetManager newDynamicTargetManager(WorldMapController worldMapController)
+		throws Exception
+	{
+		Constructor<DynamicTargetManager> ctor = DynamicTargetManager.class.getDeclaredConstructor(
+			Client.class, DynamicTargetEvaluatorRegistry.class, WorldMapPointManager.class,
+			GuidanceOverlay.class, GuidanceMinimapOverlay.class,
+			WorldMapRouteOverlay.class, WorldMapDestinationOverlay.class,
+			WorldMapController.class);
+		ctor.setAccessible(true);
+		return ctor.newInstance(client, dynamicTargetEvaluatorRegistry, worldMapPointManager,
+			guidanceOverlay, guidanceMinimapOverlay,
+			worldMapRouteOverlay, worldMapDestinationOverlay, worldMapController);
 	}
 
 	/** Builds a minimal BOSSES source with coordinates but no guidance steps. */

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorNpcIdTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorNpcIdTest.java
@@ -149,7 +149,6 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 				EventBus.class,
 				CollectionLogHelperConfig.class,
 				GuidanceSequencer.class,
-				DynamicTargetEvaluatorRegistry.class,
 				RequirementsChecker.class,
 				PlayerTravelCapabilities.class,
 				PlayerInventoryState.class,
@@ -167,18 +166,20 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 				GroundItemHighlightOverlay.class,
 				WidgetHighlightOverlay.class,
 				OverlayStepApplier.class,
-				WorldMapController.class);
+				WorldMapController.class,
+				DynamicTargetManager.class);
 		ctor.setAccessible(true);
+		DynamicTargetManager dynamicTargetManager = newDynamicTargetManager(worldMapController);
 		coordinator = ctor.newInstance(
 			client, clientThread, eventBus, config,
-			guidanceSequencer, dynamicTargetEvaluatorRegistry, requirementsChecker, travelCapabilities,
+			guidanceSequencer, requirementsChecker, travelCapabilities,
 			playerInventoryState, itemManager, requiredItemResolver,
 			worldMapPointManager, infoBoxManager,
 			guidanceOverlay, guidanceMinimapOverlay, dialogHighlightOverlay,
 			objectHighlightOverlay, itemHighlightOverlay,
 			worldMapRouteOverlay, worldMapDestinationOverlay,
 			groundItemHighlightOverlay, widgetHighlightOverlay,
-			overlayStepApplier, worldMapController);
+			overlayStepApplier, worldMapController, dynamicTargetManager);
 
 		when(requirementsChecker.getUnmetRequirements(any())).thenReturn(Collections.emptyList());
 		when(requirementsChecker.buildRequirementRows(any())).thenReturn(Collections.emptyList());
@@ -304,6 +305,20 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 			Client.class, ClientThread.class, CollectionLogHelperConfig.class);
 		ctor.setAccessible(true);
 		return ctor.newInstance(client, clientThread, config);
+	}
+
+	private DynamicTargetManager newDynamicTargetManager(WorldMapController worldMapController)
+		throws Exception
+	{
+		Constructor<DynamicTargetManager> ctor = DynamicTargetManager.class.getDeclaredConstructor(
+			Client.class, DynamicTargetEvaluatorRegistry.class, WorldMapPointManager.class,
+			GuidanceOverlay.class, GuidanceMinimapOverlay.class,
+			WorldMapRouteOverlay.class, WorldMapDestinationOverlay.class,
+			WorldMapController.class);
+		ctor.setAccessible(true);
+		return ctor.newInstance(client, dynamicTargetEvaluatorRegistry, worldMapPointManager,
+			guidanceOverlay, guidanceMinimapOverlay,
+			worldMapRouteOverlay, worldMapDestinationOverlay, worldMapController);
 	}
 
 	private OverlayStepApplier newOverlayStepApplier() throws Exception


### PR DESCRIPTION
## Summary

Partially addresses #503.

Extracts the per-tick dynamic-target evaluator dispatch out of `GuidanceOverlayCoordinator` into a new `DynamicTargetManager`, continuing the coordinator decomposition started by #510 (`OverlayStepApplier`) and #520 (`WorldMapController`).

- `DynamicTargetManager` is `@Singleton`, constructor `@Inject`, stateless — coordinator state it needs is passed in via a static `Input` carrier and any state mutation (the new `activeMapPoint`) is returned in a `Result` so the coordinator remains the sole owner of guidance state.
- The `DynamicTargetEvaluatorRegistry` dependency moves with the dispatch logic; `GuidanceOverlayCoordinator` no longer imports or references it.
- `tick()` in the coordinator now builds `DynamicTargetManager.Input`, calls `manager.tick(input)`, and assigns the result's `activeMapPoint`.

LOC: `GuidanceOverlayCoordinator` 843 -> 792 (-51). `DynamicTargetManager` is 234 LOC.

## Test plan

- [x] `./gradlew build` (compileJava + compileTestJava + test + jacocoTestCoverageVerification + lintDropRates) passes locally.
- [x] All 1200 tests green; previously-affected reflective-constructor tests now wire the new ctor signature.
- [x] JaCoCo 45% coverage gate holds.
- [x] No production behaviour change: the same overlay setters and `WorldMapPointManager.add/remove` calls fire in the same order for the same inputs.
- [x] `DynamicTargetEvaluatorDispatchTest` (the behavioural test for this seam) passes against the new wiring — exercises `tick_*` paths for active/inactive, null/unknown key, null-evaluator-result.