### PR TITLE
refactor: extract NpcTrackerHelper from GuidanceOverlayCoordinator (#503)

### DIFF
--- a/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
@@ -67,7 +67,6 @@ import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.NPC;
 import net.runelite.api.Player;
-import net.runelite.api.WorldView;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.eventbus.EventBus;
@@ -82,8 +81,9 @@ import net.runelite.client.ui.overlay.worldmap.WorldMapPointManager;
  * applying step data to overlays, managing the world map arrow, and tracking
  * the guidance NPC. Extracted from CollectionLogHelperPlugin to reduce its size.
  *
- * <p>Thread safety: {@link #trackedGuidanceNpc} is volatile because it is
- * written on the client thread (via NpcSpawned/NpcDespawned and scanForTrackedNpc)
+ * <p>Thread safety: the tracked guidance NPC reference is owned by
+ * {@link NpcTrackerHelper}, which marks it volatile because it is written
+ * on the client thread (via NpcSpawned/NpcDespawned and scanForTrackedNpc)
  * but read on the EDT by overlay render methods.</p>
  */
 @Slf4j
@@ -114,18 +114,12 @@ public class GuidanceOverlayCoordinator
 	private final OverlayStepApplier overlayStepApplier;
 	private final WorldMapController worldMapController;
 	private final DynamicTargetManager dynamicTargetManager;
+	private final NpcTrackerHelper npcTrackerHelper;
 
 	// -- Guidance UI state (previously in plugin) --
 
 	private CollectionLogWorldMapPoint activeMapPoint;
 	private GuidanceInfoBox activeInfoBox;
-
-	/**
-	 * Tracked NPC for guidance overlay. Written on client thread via
-	 * NpcSpawned/NpcDespawned and scanForTrackedNpc, read on EDT by
-	 * overlay render. Must remain volatile.
-	 */
-	private volatile NPC trackedGuidanceNpc;
 
 	/**
 	 * The collection-log item ID that was active when guidance was last activated,
@@ -189,7 +183,8 @@ public class GuidanceOverlayCoordinator
 		WidgetHighlightOverlay widgetHighlightOverlay,
 		OverlayStepApplier overlayStepApplier,
 		WorldMapController worldMapController,
-		DynamicTargetManager dynamicTargetManager)
+		DynamicTargetManager dynamicTargetManager,
+		NpcTrackerHelper npcTrackerHelper)
 	{
 		this.client = client;
 		this.clientThread = clientThread;
@@ -215,6 +210,7 @@ public class GuidanceOverlayCoordinator
 		this.overlayStepApplier = overlayStepApplier;
 		this.worldMapController = worldMapController;
 		this.dynamicTargetManager = dynamicTargetManager;
+		this.npcTrackerHelper = npcTrackerHelper;
 	}
 
 	/**
@@ -367,7 +363,7 @@ public class GuidanceOverlayCoordinator
 	{
 		activeTargetItemId = null;
 		lastMessagedStepIndex = -1;
-		trackedGuidanceNpc = null;
+		npcTrackerHelper.clear();
 		if (activeInfoBox != null)
 		{
 			infoBoxManager.removeInfoBox(activeInfoBox);
@@ -441,34 +437,21 @@ public class GuidanceOverlayCoordinator
 	}
 
 	/**
-	 * Handles an NPC spawn event. If guidance is active and the NPC matches
-	 * the current step's target, begins tracking it.
+	 * Handles an NPC spawn event by delegating to {@link NpcTrackerHelper},
+	 * passing the current sequencer / step / target-item context.
 	 */
 	public void onNpcSpawned(NPC npc)
 	{
-		if (guidanceSequencer.isActive() && trackedGuidanceNpc == null)
-		{
-			GuidanceStep step = guidanceSequencer.getRawCurrentStep();
-			if (step != null && step.resolveNpcId(activeTargetItemId) > 0
-				&& npc.getId() == step.resolveNpcId(activeTargetItemId))
-			{
-				trackedGuidanceNpc = npc;
-				guidanceOverlay.setTrackedNpc(npc);
-			}
-		}
+		npcTrackerHelper.onNpcSpawned(npc, guidanceSequencer.isActive(),
+			guidanceSequencer.getRawCurrentStep(), activeTargetItemId);
 	}
 
 	/**
-	 * Handles an NPC despawn event. Clears tracking if the despawned NPC
-	 * was the currently tracked guidance NPC.
+	 * Handles an NPC despawn event by delegating to {@link NpcTrackerHelper}.
 	 */
 	public void onNpcDespawned(NPC npc)
 	{
-		if (npc == trackedGuidanceNpc)
-		{
-			trackedGuidanceNpc = null;
-			guidanceOverlay.setTrackedNpc(null);
-		}
+		npcTrackerHelper.onNpcDespawned(npc);
 	}
 
 	/**
@@ -641,7 +624,7 @@ public class GuidanceOverlayCoordinator
 
 	private void clearGuidanceOverlays()
 	{
-		trackedGuidanceNpc = null;
+		npcTrackerHelper.clear();
 		guidanceOverlay.clearTarget();
 		guidanceMinimapOverlay.clearTarget();
 		worldMapRouteOverlay.clearTarget();
@@ -662,41 +645,6 @@ public class GuidanceOverlayCoordinator
 	}
 
 	/**
-	 * Scans currently loaded NPCs to find a match for the given step's target NPC ID.
-	 * Called once when a new step activates to seed the tracked NPC reference.
-	 */
-	private void scanForTrackedNpc(GuidanceStep step)
-	{
-		trackedGuidanceNpc = null;
-		guidanceOverlay.setTrackedNpc(null);
-
-		final int resolvedNpcId = step == null ? 0 : step.resolveNpcId(activeTargetItemId);
-		if (resolvedNpcId <= 0)
-		{
-			return;
-		}
-
-		final int targetNpcId = resolvedNpcId;
-		clientThread.invokeLater(() ->
-		{
-			WorldView wv = client.getTopLevelWorldView();
-			if (wv == null)
-			{
-				return;
-			}
-			for (NPC npc : wv.npcs())
-			{
-				if (npc != null && npc.getId() == targetNpcId)
-				{
-					trackedGuidanceNpc = npc;
-					guidanceOverlay.setTrackedNpc(npc);
-					break;
-				}
-			}
-		});
-	}
-
-	/**
 	 * Callback from GuidanceSequencer when the current step changes.
 	 */
 	private void onStepChanged(GuidanceStep step)
@@ -705,7 +653,7 @@ public class GuidanceOverlayCoordinator
 		CollectionLogSource activeSource = guidanceSequencer.getActiveSource();
 		String sourceName = activeSource != null ? activeSource.getName() : "";
 		applyStepToOverlays(step, sourceName, activeSource);
-		scanForTrackedNpc(step);
+		npcTrackerHelper.scanForTrackedNpc(step, activeTargetItemId);
 
 		// Update InfoBox progress
 		if (activeInfoBox != null)

--- a/src/main/java/com/collectionloghelper/guidance/NpcTrackerHelper.java
+++ b/src/main/java/com/collectionloghelper/guidance/NpcTrackerHelper.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.guidance;
+
+import com.collectionloghelper.data.GuidanceStep;
+import com.collectionloghelper.overlay.GuidanceOverlay;
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.NPC;
+import net.runelite.api.WorldView;
+import net.runelite.client.callback.ClientThread;
+
+/**
+ * Owns the lifecycle of the currently tracked guidance NPC.
+ *
+ * <p>Extracted from {@link GuidanceOverlayCoordinator}: this helper holds
+ * the single mutable reference to the in-world NPC the guidance overlay
+ * is following, and exposes the lifecycle entry points the coordinator
+ * (and its event router) need:
+ * <ul>
+ *   <li>{@link #onNpcSpawned(NPC, boolean, GuidanceStep, Integer)} — promote
+ *       a newly spawned NPC to "tracked" when it matches the active step's
+ *       target NPC ID and nothing is currently tracked.</li>
+ *   <li>{@link #onNpcDespawned(NPC)} — clear tracking when the despawned
+ *       NPC is the one we were following.</li>
+ *   <li>{@link #scanForTrackedNpc(GuidanceStep, Integer)} — sweep the
+ *       active world view for a matching NPC when a new step activates,
+ *       so the overlay does not need to wait for a spawn event.</li>
+ *   <li>{@link #clear()} — drop tracking unconditionally (called by the
+ *       coordinator on guidance teardown).</li>
+ * </ul>
+ *
+ * <p>Thread safety: the underlying {@code trackedGuidanceNpc} reference is
+ * volatile because it is written on the client thread (via NpcSpawned /
+ * NpcDespawned and {@link #scanForTrackedNpc}) but read on the EDT by
+ * overlay render methods through {@link GuidanceOverlay#setTrackedNpc}.</p>
+ */
+@Slf4j
+@Singleton
+public class NpcTrackerHelper
+{
+	private final Client client;
+	private final ClientThread clientThread;
+	private final GuidanceOverlay guidanceOverlay;
+
+	/**
+	 * Tracked NPC for guidance overlay. Written on client thread via
+	 * NpcSpawned / NpcDespawned and {@link #scanForTrackedNpc}, read on
+	 * EDT by overlay render. Must remain volatile.
+	 */
+	private volatile NPC trackedGuidanceNpc;
+
+	@Inject
+	NpcTrackerHelper(Client client, ClientThread clientThread, GuidanceOverlay guidanceOverlay)
+	{
+		this.client = client;
+		this.clientThread = clientThread;
+		this.guidanceOverlay = guidanceOverlay;
+	}
+
+	/**
+	 * Handles an NPC spawn event.  When guidance is active, nothing is
+	 * currently tracked, and the spawned NPC matches the active step's
+	 * resolved target NPC ID, promotes the NPC to "tracked" and pushes it
+	 * into the guidance overlay.
+	 *
+	 * @param npc the spawned NPC
+	 * @param guidanceActive whether the sequencer currently has an active sequence
+	 * @param currentStep the active guidance step, or {@code null}
+	 * @param activeTargetItemId the active target item id used to resolve
+	 *                           per-item NPC overrides, or {@code null}
+	 */
+	public void onNpcSpawned(NPC npc, boolean guidanceActive,
+		@Nullable GuidanceStep currentStep, @Nullable Integer activeTargetItemId)
+	{
+		if (!guidanceActive || trackedGuidanceNpc != null || currentStep == null)
+		{
+			return;
+		}
+		int resolvedNpcId = currentStep.resolveNpcId(activeTargetItemId);
+		if (resolvedNpcId > 0 && npc.getId() == resolvedNpcId)
+		{
+			trackedGuidanceNpc = npc;
+			guidanceOverlay.setTrackedNpc(npc);
+		}
+	}
+
+	/**
+	 * Handles an NPC despawn event.  Clears tracking when the despawned NPC
+	 * is the one currently being tracked.
+	 */
+	public void onNpcDespawned(NPC npc)
+	{
+		if (npc == trackedGuidanceNpc)
+		{
+			trackedGuidanceNpc = null;
+			guidanceOverlay.setTrackedNpc(null);
+		}
+	}
+
+	/**
+	 * Scans the active world view for an NPC matching the given step's
+	 * resolved target NPC ID.  Called once when a new step activates to
+	 * seed the tracked NPC reference without waiting for a spawn event.
+	 *
+	 * <p>The scan itself runs on the client thread via
+	 * {@link ClientThread#invokeLater}; the synchronous prelude clears any
+	 * existing tracking so the overlay does not briefly point at a stale
+	 * NPC from the previous step.</p>
+	 */
+	public void scanForTrackedNpc(@Nullable GuidanceStep step, @Nullable Integer activeTargetItemId)
+	{
+		trackedGuidanceNpc = null;
+		guidanceOverlay.setTrackedNpc(null);
+
+		final int resolvedNpcId = step == null ? 0 : step.resolveNpcId(activeTargetItemId);
+		if (resolvedNpcId <= 0)
+		{
+			return;
+		}
+
+		final int targetNpcId = resolvedNpcId;
+		clientThread.invokeLater(() ->
+		{
+			WorldView wv = client.getTopLevelWorldView();
+			if (wv == null)
+			{
+				return;
+			}
+			for (NPC npc : wv.npcs())
+			{
+				if (npc != null && npc.getId() == targetNpcId)
+				{
+					trackedGuidanceNpc = npc;
+					guidanceOverlay.setTrackedNpc(npc);
+					break;
+				}
+			}
+		});
+	}
+
+	/**
+	 * Drops tracking unconditionally.  Called by the coordinator on guidance
+	 * teardown ({@code deactivateGuidance} / {@code clearGuidanceOverlays})
+	 * before the fresh scan that {@link #scanForTrackedNpc} performs for the
+	 * next step.
+	 *
+	 * <p>Does <em>not</em> push {@code setTrackedNpc(null)} to the overlay —
+	 * the coordinator already clears the overlay via
+	 * {@link GuidanceOverlay#clearTarget} on teardown, and
+	 * {@link #scanForTrackedNpc} applies its own overlay clear before the
+	 * new scan.</p>
+	 */
+	public void clear()
+	{
+		trackedGuidanceNpc = null;
+	}
+
+	/**
+	 * Returns the currently tracked NPC, or {@code null} when nothing is
+	 * being tracked.  Exposed primarily for tests; production overlay
+	 * rendering goes through {@link GuidanceOverlay} instead.
+	 */
+	@Nullable
+	public NPC getTrackedGuidanceNpc()
+	{
+		return trackedGuidanceNpc;
+	}
+}

--- a/src/test/java/com/collectionloghelper/guidance/DynamicTargetEvaluatorDispatchTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/DynamicTargetEvaluatorDispatchTest.java
@@ -176,8 +176,10 @@ public class DynamicTargetEvaluatorDispatchTest
 				WidgetHighlightOverlay.class,
 				OverlayStepApplier.class,
 				WorldMapController.class,
-				DynamicTargetManager.class);
+				DynamicTargetManager.class,
+				NpcTrackerHelper.class);
 		ctor.setAccessible(true);
+		NpcTrackerHelper npcTrackerHelper = newNpcTrackerHelper();
 		coordinator = ctor.newInstance(
 			client, clientThread, eventBus, config,
 			guidanceSequencer, requirementsChecker, travelCapabilities,
@@ -187,7 +189,7 @@ public class DynamicTargetEvaluatorDispatchTest
 			objectHighlightOverlay, itemHighlightOverlay,
 			worldMapRouteOverlay, worldMapDestinationOverlay,
 			groundItemHighlightOverlay, widgetHighlightOverlay,
-			overlayStepApplier, worldMapController, dynamicTargetManager);
+			overlayStepApplier, worldMapController, dynamicTargetManager, npcTrackerHelper);
 
 		lenient().when(client.getLocalPlayer()).thenReturn(localPlayer);
 		lenient().when(localPlayer.getWorldLocation()).thenReturn(new WorldPoint(3200, 3200, 0));
@@ -297,6 +299,14 @@ public class DynamicTargetEvaluatorDispatchTest
 		return ctor.newInstance(client, registry, worldMapPointManager,
 			guidanceOverlay, guidanceMinimapOverlay,
 			worldMapRouteOverlay, worldMapDestinationOverlay, worldMapController);
+	}
+
+	private NpcTrackerHelper newNpcTrackerHelper() throws Exception
+	{
+		Constructor<NpcTrackerHelper> ctor = NpcTrackerHelper.class.getDeclaredConstructor(
+			Client.class, ClientThread.class, GuidanceOverlay.class);
+		ctor.setAccessible(true);
+		return ctor.newInstance(client, clientThread, guidanceOverlay);
 	}
 
 	private OverlayStepApplier newOverlayStepApplier() throws Exception

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorDescriptionTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorDescriptionTest.java
@@ -170,9 +170,11 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 				WidgetHighlightOverlay.class,
 				OverlayStepApplier.class,
 				WorldMapController.class,
-				DynamicTargetManager.class);
+				DynamicTargetManager.class,
+				NpcTrackerHelper.class);
 		ctor.setAccessible(true);
 		DynamicTargetManager dynamicTargetManager = newDynamicTargetManager(worldMapController);
+		NpcTrackerHelper npcTrackerHelper = newNpcTrackerHelper();
 		coordinator = ctor.newInstance(
 			client, clientThread, eventBus, config,
 			guidanceSequencer, requirementsChecker, travelCapabilities,
@@ -182,7 +184,7 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 			objectHighlightOverlay, itemHighlightOverlay,
 			worldMapRouteOverlay, worldMapDestinationOverlay,
 			groundItemHighlightOverlay, widgetHighlightOverlay,
-			overlayStepApplier, worldMapController, dynamicTargetManager);
+			overlayStepApplier, worldMapController, dynamicTargetManager, npcTrackerHelper);
 
 		coordinator.setPanel(panel);
 
@@ -312,6 +314,14 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 		return ctor.newInstance(client, dynamicTargetEvaluatorRegistry, worldMapPointManager,
 			guidanceOverlay, guidanceMinimapOverlay,
 			worldMapRouteOverlay, worldMapDestinationOverlay, worldMapController);
+	}
+
+	private NpcTrackerHelper newNpcTrackerHelper() throws Exception
+	{
+		Constructor<NpcTrackerHelper> ctor = NpcTrackerHelper.class.getDeclaredConstructor(
+			Client.class, ClientThread.class, GuidanceOverlay.class);
+		ctor.setAccessible(true);
+		return ctor.newInstance(client, clientThread, guidanceOverlay);
 	}
 
 	private OverlayStepApplier newOverlayStepApplier() throws Exception

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorMapPointTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorMapPointTest.java
@@ -156,9 +156,11 @@ public class GuidanceOverlayCoordinatorMapPointTest
 				WidgetHighlightOverlay.class,
 				OverlayStepApplier.class,
 				WorldMapController.class,
-				DynamicTargetManager.class);
+				DynamicTargetManager.class,
+				NpcTrackerHelper.class);
 		ctor.setAccessible(true);
 		DynamicTargetManager dynamicTargetManager = newDynamicTargetManager(worldMapController);
+		NpcTrackerHelper npcTrackerHelper = newNpcTrackerHelper();
 		coordinator = ctor.newInstance(
 			client, clientThread, eventBus, config,
 			guidanceSequencer, requirementsChecker, travelCapabilities,
@@ -168,7 +170,7 @@ public class GuidanceOverlayCoordinatorMapPointTest
 			objectHighlightOverlay, itemHighlightOverlay,
 			worldMapRouteOverlay, worldMapDestinationOverlay,
 			groundItemHighlightOverlay, widgetHighlightOverlay,
-			overlayStepApplier, worldMapController, dynamicTargetManager);
+			overlayStepApplier, worldMapController, dynamicTargetManager, npcTrackerHelper);
 
 		// Default stubs: no unmet requirements; buildRequirementRows called unconditionally
 		when(requirementsChecker.getUnmetRequirements(any())).thenReturn(Collections.emptyList());
@@ -270,6 +272,14 @@ public class GuidanceOverlayCoordinatorMapPointTest
 		return ctor.newInstance(client, dynamicTargetEvaluatorRegistry, worldMapPointManager,
 			guidanceOverlay, guidanceMinimapOverlay,
 			worldMapRouteOverlay, worldMapDestinationOverlay, worldMapController);
+	}
+
+	private NpcTrackerHelper newNpcTrackerHelper() throws Exception
+	{
+		Constructor<NpcTrackerHelper> ctor = NpcTrackerHelper.class.getDeclaredConstructor(
+			Client.class, ClientThread.class, GuidanceOverlay.class);
+		ctor.setAccessible(true);
+		return ctor.newInstance(client, clientThread, guidanceOverlay);
 	}
 
 	/** Builds a minimal BOSSES source with coordinates but no guidance steps. */

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorNpcIdTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorNpcIdTest.java
@@ -167,9 +167,11 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 				WidgetHighlightOverlay.class,
 				OverlayStepApplier.class,
 				WorldMapController.class,
-				DynamicTargetManager.class);
+				DynamicTargetManager.class,
+				NpcTrackerHelper.class);
 		ctor.setAccessible(true);
 		DynamicTargetManager dynamicTargetManager = newDynamicTargetManager(worldMapController);
+		NpcTrackerHelper npcTrackerHelper = newNpcTrackerHelper();
 		coordinator = ctor.newInstance(
 			client, clientThread, eventBus, config,
 			guidanceSequencer, requirementsChecker, travelCapabilities,
@@ -179,7 +181,7 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 			objectHighlightOverlay, itemHighlightOverlay,
 			worldMapRouteOverlay, worldMapDestinationOverlay,
 			groundItemHighlightOverlay, widgetHighlightOverlay,
-			overlayStepApplier, worldMapController, dynamicTargetManager);
+			overlayStepApplier, worldMapController, dynamicTargetManager, npcTrackerHelper);
 
 		when(requirementsChecker.getUnmetRequirements(any())).thenReturn(Collections.emptyList());
 		when(requirementsChecker.buildRequirementRows(any())).thenReturn(Collections.emptyList());
@@ -319,6 +321,14 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 		return ctor.newInstance(client, dynamicTargetEvaluatorRegistry, worldMapPointManager,
 			guidanceOverlay, guidanceMinimapOverlay,
 			worldMapRouteOverlay, worldMapDestinationOverlay, worldMapController);
+	}
+
+	private NpcTrackerHelper newNpcTrackerHelper() throws Exception
+	{
+		Constructor<NpcTrackerHelper> ctor = NpcTrackerHelper.class.getDeclaredConstructor(
+			Client.class, ClientThread.class, GuidanceOverlay.class);
+		ctor.setAccessible(true);
+		return ctor.newInstance(client, clientThread, guidanceOverlay);
 	}
 
 	private OverlayStepApplier newOverlayStepApplier() throws Exception


### PR DESCRIPTION
Partially addresses #503.

## Summary

Extract the guidance NPC tracking cluster (`onNpcSpawned`, `onNpcDespawned`, `scanForTrackedNpc`, plus the `volatile NPC trackedGuidanceNpc` field) from `GuidanceOverlayCoordinator` into a new `@Singleton NpcTrackerHelper`. Matches the DI idiom used by the prior coordinator extractions (`OverlayStepApplier`, `WorldMapController`, `DynamicTargetManager`).

The coordinator now:
- Holds a `@Inject NpcTrackerHelper` field.
- Delegates `onNpcSpawned(NPC)` / `onNpcDespawned(NPC)` to the helper (public signatures preserved so `GuidanceEventRouter` wiring is unchanged).
- Calls `npcTrackerHelper.scanForTrackedNpc(step, activeTargetItemId)` from `onStepChanged`.
- Calls `npcTrackerHelper.clear()` from `clearGuidanceOverlays` and `deactivateGuidance`.
- No longer owns `trackedGuidanceNpc`; the helper owns it (still `volatile`, same thread-safety contract).
- Loses the now-unused `WorldView` import.

`GuidanceOverlayCoordinator`: 792 -> 740 LOC (-52).
`NpcTrackerHelper`: 194 LOC (new).

## Test plan

- [x] `./gradlew build` passes (compile, test, JaCoCo 45% gate, lintDropRates).
- [x] `./gradlew test` passes; no behavioural changes to coordinator-public API.
- [x] Updated 4 reflective-constructor tests to include `NpcTrackerHelper.class` in the coordinator ctor signature: `GuidanceOverlayCoordinatorMapPointTest`, `GuidanceOverlayCoordinatorNpcIdTest`, `GuidanceOverlayCoordinatorDescriptionTest`, `DynamicTargetEvaluatorDispatchTest`.
- [x] `Grep trackedGuidanceNpc` in coordinator source returns 0 hits (only a comment mentioning the historical write paths remains, accurate after the move).
- [x] Helper preserves `volatile` on `trackedGuidanceNpc` for the existing client-thread / EDT thread-safety contract.