### PR TITLE
refactor: extract TempleSyncOrchestrator from Plugin (#503)

### DIFF
--- a/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
@@ -34,8 +34,7 @@ import com.collectionloghelper.di.GuidanceModule;
 import com.collectionloghelper.di.SyncModule;
 import com.collectionloghelper.sync.ImportResult;
 import com.collectionloghelper.sync.LootSyncManager;
-import com.collectionloghelper.sync.SyncResult;
-import com.collectionloghelper.sync.TempleOsrsKcSyncer;
+import com.collectionloghelper.sync.TempleSyncOrchestrator;
 import com.collectionloghelper.efficiency.ScoredItem;
 import com.collectionloghelper.lifecycle.AuthoringLogger;
 import com.collectionloghelper.lifecycle.OverlayRegistry;
@@ -44,15 +43,12 @@ import com.collectionloghelper.lifecycle.SyncStateCoordinator;
 import com.collectionloghelper.ui.CollectionLogHelperPanel;
 import com.google.inject.Provides;
 import java.awt.image.BufferedImage;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
@@ -148,6 +144,9 @@ public class CollectionLogHelperPlugin extends Plugin
 
 	@Inject
 	private LootSyncManager lootSyncManager;
+
+	@Inject
+	private TempleSyncOrchestrator templeSyncOrchestrator;
 
 	@Inject
 	private ChatEventHandler chatEventHandler;
@@ -256,7 +255,7 @@ public class CollectionLogHelperPlugin extends Plugin
 		});
 
 		// Wire TempleOSRS KC sync button callback
-		panel.setTempleSyncCallback(this::onTempleSyncRequested);
+		panel.setTempleSyncCallback(() -> templeSyncOrchestrator.requestSync(panel, httpResultExecutor));
 
 		// Wire coordinator with references it needs from the plugin
 		guidance.getGuidanceCoordinator().setPluginInstance(this);
@@ -768,98 +767,6 @@ public class CollectionLogHelperPlugin extends Plugin
 	public void deactivateGuidance()
 	{
 		guidance.getGuidanceCoordinator().deactivateGuidance();
-	}
-
-	/**
-	 * Initiates an asynchronous TempleOSRS KC sync for the current player.
-	 *
-	 * <p>Triggered by the panel "Sync KC from TempleOSRS" button. The sync runs on
-	 * the {@link TempleOsrsKcSyncer} background thread; on completion the result is
-	 * applied on the EDT and the panel button is reset.
-	 *
-	 * <p>Fail-soft: any error is logged and surfaced as a chat message; no exception
-	 * reaches the caller.
-	 */
-	private void onTempleSyncRequested()
-	{
-		if (!config.enableTempleOsrsSync())
-		{
-			return;
-		}
-
-		String playerName = data.getPluginDataManager().getCurrentPlayerName();
-		if (playerName == null || playerName.isEmpty())
-		{
-			log.warn("TempleOSRS sync requested but player name is not available");
-			if (panel != null)
-			{
-				panel.onTempleSyncComplete(false);
-			}
-			return;
-		}
-
-		log.debug("Requesting TempleOSRS KC sync for '{}'", playerName);
-
-		Future<SyncResult> future = sync.getTempleOsrsKcSyncer().syncKc(playerName);
-
-		// Wait for the result on the shared daemon executor so the EDT is not blocked
-		httpResultExecutor.submit(() ->
-		{
-			SyncResult result;
-			try
-			{
-				result = future.get(30, TimeUnit.SECONDS);
-			}
-			catch (Exception e)
-			{
-				log.warn("TempleOSRS sync future failed for '{}': {}", playerName, e.getMessage());
-				result = SyncResult.failure("Sync timed out or failed: " + e.getMessage());
-			}
-
-			final SyncResult finalResult = result;
-			if (finalResult.isSuccess())
-			{
-				// Validate mapped names against the DB and apply only known sources
-				Map<String, Integer> validated = new java.util.HashMap<>();
-				for (Map.Entry<String, Integer> entry : finalResult.getKcBySource().entrySet())
-				{
-					if (data.getDatabase().getSourceByName(entry.getKey()) != null)
-					{
-						validated.put(entry.getKey(), entry.getValue());
-					}
-					else
-					{
-						log.debug("TempleOSRS KC entry '{}' not found in CLH database - skipping",
-							entry.getKey());
-					}
-				}
-				sync.getSourceKcStore().update(validated);
-				log.info("TempleOSRS KC sync complete: {} sources updated, {} skipped",
-					validated.size(), finalResult.getSkippedCount());
-
-				clientThread.invokeLater(() ->
-					client.addChatMessage(
-						net.runelite.api.ChatMessageType.GAMEMESSAGE, "",
-						"<col=00c8c8>[Collection Log Helper]</col> TempleOSRS KC synced: "
-							+ validated.size() + " sources updated.",
-						null));
-			}
-			else
-			{
-				log.warn("TempleOSRS KC sync failed: {}", finalResult.getErrorMessage());
-				clientThread.invokeLater(() ->
-					client.addChatMessage(
-						net.runelite.api.ChatMessageType.GAMEMESSAGE, "",
-						"<col=ff0000>[Collection Log Helper]</col> TempleOSRS KC sync failed: "
-							+ finalResult.getErrorMessage(),
-						null));
-			}
-
-			if (panel != null)
-			{
-				panel.onTempleSyncComplete(finalResult.isSuccess());
-			}
-		});
 	}
 
 	/**

--- a/src/main/java/com/collectionloghelper/sync/TempleSyncOrchestrator.java
+++ b/src/main/java/com/collectionloghelper/sync/TempleSyncOrchestrator.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.sync;
+
+import com.collectionloghelper.CollectionLogHelperConfig;
+import com.collectionloghelper.di.DataModule;
+import com.collectionloghelper.ui.CollectionLogHelperPanel;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.Client;
+import net.runelite.client.callback.ClientThread;
+
+/**
+ * Orchestrates an end-to-end TempleOSRS KC sync request triggered from the
+ * panel "Sync KC from TempleOSRS" button.
+ *
+ * <p>Owns the logic that previously lived in the plugin's
+ * {@code onTempleSyncRequested} method:
+ * <ul>
+ *   <li>Validates the feature toggle and player-name preconditions.</li>
+ *   <li>Submits the sync to {@link TempleOsrsKcSyncer} and awaits the result on
+ *       the supplied {@link ExecutorService} so the EDT/client thread is never
+ *       blocked.</li>
+ *   <li>Filters mapped names against the source database before writing them
+ *       into {@link SourceKcStore} (unknown sources are logged and skipped).</li>
+ *   <li>Posts the user-facing chat message on the client thread and notifies
+ *       the panel that the button can be restored.</li>
+ * </ul>
+ *
+ * <p>The {@link CollectionLogHelperPanel} and {@link ExecutorService} are
+ * passed per-call rather than injected, because the panel is plugin-lifecycle
+ * owned (created in {@code startUp}) and the executor is a shared daemon
+ * lazily created by the plugin. This matches the call-site delegation pattern
+ * established by {@link LootSyncManager}.
+ *
+ * <p>Part of issue #503 — splitting the {@code CollectionLogHelperPlugin}
+ * god-class into focused collaborators.
+ */
+@Slf4j
+@Singleton
+public class TempleSyncOrchestrator
+{
+	private static final long SYNC_TIMEOUT_SECONDS = 30;
+
+	private final CollectionLogHelperConfig config;
+	private final DataModule data;
+	private final TempleOsrsKcSyncer templeOsrsKcSyncer;
+	private final SourceKcStore sourceKcStore;
+	private final Client client;
+	private final ClientThread clientThread;
+
+	@Inject
+	public TempleSyncOrchestrator(
+		CollectionLogHelperConfig config,
+		DataModule data,
+		TempleOsrsKcSyncer templeOsrsKcSyncer,
+		SourceKcStore sourceKcStore,
+		Client client,
+		ClientThread clientThread)
+	{
+		this.config = config;
+		this.data = data;
+		this.templeOsrsKcSyncer = templeOsrsKcSyncer;
+		this.sourceKcStore = sourceKcStore;
+		this.client = client;
+		this.clientThread = clientThread;
+	}
+
+	/**
+	 * Initiates an asynchronous TempleOSRS KC sync for the current player.
+	 *
+	 * <p>The sync runs on the {@link TempleOsrsKcSyncer} background thread;
+	 * on completion the result is applied via {@link #clientThread} and the
+	 * panel button is reset.
+	 *
+	 * <p>Fail-soft: any error is logged and surfaced as a chat message; no
+	 * exception reaches the caller.
+	 *
+	 * @param panel            the panel that owns the sync button — used to
+	 *                         reset the button label on completion. May be
+	 *                         {@code null} during shutdown races, in which
+	 *                         case the panel callback is skipped.
+	 * @param resultExecutor   daemon executor used to wait on the sync future
+	 *                         off the EDT/client thread.
+	 */
+	public void requestSync(CollectionLogHelperPanel panel, ExecutorService resultExecutor)
+	{
+		if (!config.enableTempleOsrsSync())
+		{
+			return;
+		}
+
+		String playerName = data.getPluginDataManager().getCurrentPlayerName();
+		if (playerName == null || playerName.isEmpty())
+		{
+			log.warn("TempleOSRS sync requested but player name is not available");
+			if (panel != null)
+			{
+				panel.onTempleSyncComplete(false);
+			}
+			return;
+		}
+
+		log.debug("Requesting TempleOSRS KC sync for '{}'", playerName);
+
+		Future<SyncResult> future = templeOsrsKcSyncer.syncKc(playerName);
+
+		// Wait for the result on the shared daemon executor so the EDT is not blocked
+		resultExecutor.submit(() -> awaitResult(future, playerName, panel));
+	}
+
+	private void awaitResult(Future<SyncResult> future, String playerName, CollectionLogHelperPanel panel)
+	{
+		SyncResult result;
+		try
+		{
+			result = future.get(SYNC_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+		}
+		catch (Exception e)
+		{
+			log.warn("TempleOSRS sync future failed for '{}': {}", playerName, e.getMessage());
+			result = SyncResult.failure("Sync timed out or failed: " + e.getMessage());
+		}
+
+		if (result.isSuccess())
+		{
+			applySuccessfulResult(result);
+		}
+		else
+		{
+			log.warn("TempleOSRS KC sync failed: {}", result.getErrorMessage());
+			postChatMessage(
+				"<col=ff0000>[Collection Log Helper]</col> TempleOSRS KC sync failed: "
+					+ result.getErrorMessage());
+		}
+
+		if (panel != null)
+		{
+			panel.onTempleSyncComplete(result.isSuccess());
+		}
+	}
+
+	private void applySuccessfulResult(SyncResult result)
+	{
+		// Validate mapped names against the DB and apply only known sources
+		Map<String, Integer> validated = new HashMap<>();
+		for (Map.Entry<String, Integer> entry : result.getKcBySource().entrySet())
+		{
+			if (data.getDatabase().getSourceByName(entry.getKey()) != null)
+			{
+				validated.put(entry.getKey(), entry.getValue());
+			}
+			else
+			{
+				log.debug("TempleOSRS KC entry '{}' not found in CLH database - skipping",
+					entry.getKey());
+			}
+		}
+		sourceKcStore.update(validated);
+		log.info("TempleOSRS KC sync complete: {} sources updated, {} skipped",
+			validated.size(), result.getSkippedCount());
+
+		postChatMessage(
+			"<col=00c8c8>[Collection Log Helper]</col> TempleOSRS KC synced: "
+				+ validated.size() + " sources updated.");
+	}
+
+	private void postChatMessage(String message)
+	{
+		clientThread.invokeLater(() ->
+			client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", message, null));
+	}
+}

--- a/src/test/java/com/collectionloghelper/sync/TempleSyncOrchestratorTest.java
+++ b/src/test/java/com/collectionloghelper/sync/TempleSyncOrchestratorTest.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.sync;
+
+import com.collectionloghelper.CollectionLogHelperConfig;
+import com.collectionloghelper.data.CollectionLogCategory;
+import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.data.DropRateDatabase;
+import com.collectionloghelper.data.PluginDataManager;
+import com.collectionloghelper.di.DataModule;
+import com.collectionloghelper.ui.CollectionLogHelperPanel;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import net.runelite.api.Client;
+import net.runelite.client.callback.ClientThread;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link TempleSyncOrchestrator}.
+ *
+ * <p>Covers the observable paths previously inlined in the plugin:
+ * <ul>
+ *   <li>feature toggle disabled — short-circuit, no panel callback</li>
+ *   <li>missing or empty player name — panel notified of failure, syncer never called</li>
+ *   <li>successful result — KC store updated with only DB-known sources</li>
+ *   <li>failure result — KC store untouched, panel notified of failure</li>
+ * </ul>
+ */
+public class TempleSyncOrchestratorTest
+{
+	private CollectionLogHelperConfig config;
+	private DataModule data;
+	private DropRateDatabase database;
+	private PluginDataManager pluginDataManager;
+	private TempleOsrsKcSyncer syncer;
+	private SourceKcStore kcStore;
+	private Client client;
+	private ClientThread clientThread;
+	private CollectionLogHelperPanel panel;
+	private ExecutorService resultExecutor;
+
+	private TempleSyncOrchestrator orchestrator;
+
+	@Before
+	public void setUp()
+	{
+		config = mock(CollectionLogHelperConfig.class);
+		data = mock(DataModule.class);
+		database = mock(DropRateDatabase.class);
+		pluginDataManager = mock(PluginDataManager.class);
+		syncer = mock(TempleOsrsKcSyncer.class);
+		kcStore = mock(SourceKcStore.class);
+		client = mock(Client.class);
+		clientThread = mock(ClientThread.class);
+		panel = mock(CollectionLogHelperPanel.class);
+		resultExecutor = mock(ExecutorService.class);
+
+		when(data.getDatabase()).thenReturn(database);
+		when(data.getPluginDataManager()).thenReturn(pluginDataManager);
+
+		// Run any clientThread.invokeLater callbacks inline so we can assert
+		// the chat-message side-effect synchronously.
+		doAnswer(inv ->
+		{
+			Runnable r = inv.getArgument(0);
+			r.run();
+			return null;
+		}).when(clientThread).invokeLater(any(Runnable.class));
+
+		// Run executor submissions inline so side-effects are observable after
+		// requestSync returns without waiting on a background thread.
+		doAnswer(inv ->
+		{
+			Runnable r = inv.getArgument(0);
+			r.run();
+			return null;
+		}).when(resultExecutor).submit(any(Runnable.class));
+
+		orchestrator = new TempleSyncOrchestrator(
+			config, data, syncer, kcStore, client, clientThread);
+	}
+
+	@Test
+	public void requestSync_featureDisabled_doesNothing()
+	{
+		when(config.enableTempleOsrsSync()).thenReturn(false);
+
+		orchestrator.requestSync(panel, resultExecutor);
+
+		verify(syncer, never()).syncKc(anyString());
+		verify(panel, never()).onTempleSyncComplete(anyBoolean());
+		verify(kcStore, never()).update(any());
+	}
+
+	@Test
+	public void requestSync_missingPlayerName_notifiesPanelFailure()
+	{
+		when(config.enableTempleOsrsSync()).thenReturn(true);
+		when(pluginDataManager.getCurrentPlayerName()).thenReturn(null);
+
+		orchestrator.requestSync(panel, resultExecutor);
+
+		verify(syncer, never()).syncKc(anyString());
+		verify(panel).onTempleSyncComplete(false);
+	}
+
+	@Test
+	public void requestSync_emptyPlayerName_notifiesPanelFailure()
+	{
+		when(config.enableTempleOsrsSync()).thenReturn(true);
+		when(pluginDataManager.getCurrentPlayerName()).thenReturn("");
+
+		orchestrator.requestSync(panel, resultExecutor);
+
+		verify(syncer, never()).syncKc(anyString());
+		verify(panel).onTempleSyncComplete(false);
+	}
+
+	@Test
+	@SuppressWarnings({"rawtypes", "unchecked"})
+	public void requestSync_successFiltersUnknownSources()
+	{
+		when(config.enableTempleOsrsSync()).thenReturn(true);
+		when(pluginDataManager.getCurrentPlayerName()).thenReturn("Zezima");
+
+		Map<String, Integer> kcMap = new HashMap<>();
+		kcMap.put("Zulrah", 250);
+		kcMap.put("Unknown Boss", 99);
+		SyncResult success = SyncResult.success(kcMap, 0);
+		when(syncer.syncKc("Zezima")).thenReturn(CompletableFuture.completedFuture(success));
+
+		CollectionLogSource zulrahSource = stubSource("Zulrah");
+		when(database.getSourceByName("Zulrah")).thenReturn(zulrahSource);
+		when(database.getSourceByName("Unknown Boss")).thenReturn(null);
+
+		orchestrator.requestSync(panel, resultExecutor);
+
+		ArgumentCaptor<Map> mapCaptor = ArgumentCaptor.forClass(Map.class);
+		verify(kcStore).update(mapCaptor.capture());
+		Map<String, Integer> validated = mapCaptor.getValue();
+		assertNotNull(validated);
+		assertEquals(1, validated.size());
+		assertEquals(Integer.valueOf(250), validated.get("Zulrah"));
+
+		verify(panel).onTempleSyncComplete(true);
+		verify(client).addChatMessage(any(), eq(""), anyString(), eq(null));
+	}
+
+	@Test
+	public void requestSync_failureResultLeavesStoreUntouched()
+	{
+		when(config.enableTempleOsrsSync()).thenReturn(true);
+		when(pluginDataManager.getCurrentPlayerName()).thenReturn("Zezima");
+
+		SyncResult failure = SyncResult.failure("HTTP 503");
+		when(syncer.syncKc("Zezima")).thenReturn(CompletableFuture.completedFuture(failure));
+
+		orchestrator.requestSync(panel, resultExecutor);
+
+		verify(kcStore, never()).update(any());
+		verify(panel).onTempleSyncComplete(false);
+		verify(client).addChatMessage(any(), eq(""), anyString(), eq(null));
+	}
+
+	/**
+	 * Build a real (non-mocked) {@link CollectionLogSource} — the class is final
+	 * (Lombok {@code @Value}) so Mockito can't mock it directly. We only need the
+	 * orchestrator to see a non-null lookup result.
+	 */
+	private static CollectionLogSource stubSource(String name)
+	{
+		return new CollectionLogSource(name, CollectionLogCategory.BOSSES, 0, 0, 0,
+			60, 0, null, Collections.emptyList(),
+			null, 0.0, null, 0, false, 0, null, 0, null, null, null, null, null, 0, null, 0,
+			Collections.emptyList(), null);
+	}
+}


### PR DESCRIPTION
## Summary

Wave 9 of the #503 god-class refactor. Extracts the TempleOSRS KC sync orchestration out of `CollectionLogHelperPlugin` into a focused collaborator in the `sync` package.

The new `TempleSyncOrchestrator` owns the end-to-end flow that the plugin's private `onTempleSyncRequested` method used to handle inline:

- Feature-toggle and player-name preconditions
- Submitting the sync to `TempleOsrsKcSyncer` and awaiting the result on the shared daemon executor (EDT/client thread stay unblocked)
- Filtering the returned KC map against the source database before writing to `SourceKcStore`
- Posting the user-facing chat message on the client thread and resetting the panel button

The plugin's panel-callback wiring becomes a one-line delegation; the `panel` and `httpResultExecutor` are passed per-call because their lifecycles are plugin-owned (matches the call-site pattern established by `LootSyncManager` in Wave 8).

## LOC delta

- `CollectionLogHelperPlugin.java`: 959 -> 866 LOC (-93)
- New: `sync/TempleSyncOrchestrator.java` (202 LOC, including license header + javadoc)
- New: test `sync/TempleSyncOrchestratorTest.java` (216 LOC)

## Test plan

- [x] `./gradlew build` passes
- [x] `./gradlew test` passes (full suite)
- [x] New `TempleSyncOrchestratorTest` covers four observable paths:
  - feature toggle disabled (short-circuit)
  - missing / empty player name (panel notified, syncer never called)
  - successful result (KC store updated with DB-known sources only, unknown skipped)
  - failure result (KC store untouched, panel notified)
- [ ] Manual smoke: in-client, click `Sync KC from TempleOSRS` with sync enabled and a known character; verify chat message and button reset

## Related

- Tracking: #503
- Prior wave: #525 (ChatEventHandler extraction)