### PR TITLE
refactor: extract OverlaySourceApplier from GuidanceOverlayCoordinator (#503)

### DIFF
--- a/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
@@ -112,6 +112,7 @@ public class GuidanceOverlayCoordinator
 	private final GroundItemHighlightOverlay groundItemHighlightOverlay;
 	private final WidgetHighlightOverlay widgetHighlightOverlay;
 	private final OverlayStepApplier overlayStepApplier;
+	private final OverlaySourceApplier overlaySourceApplier;
 	private final WorldMapController worldMapController;
 	private final DynamicTargetManager dynamicTargetManager;
 	private final NpcTrackerHelper npcTrackerHelper;
@@ -182,6 +183,7 @@ public class GuidanceOverlayCoordinator
 		GroundItemHighlightOverlay groundItemHighlightOverlay,
 		WidgetHighlightOverlay widgetHighlightOverlay,
 		OverlayStepApplier overlayStepApplier,
+		OverlaySourceApplier overlaySourceApplier,
 		WorldMapController worldMapController,
 		DynamicTargetManager dynamicTargetManager,
 		NpcTrackerHelper npcTrackerHelper)
@@ -208,6 +210,7 @@ public class GuidanceOverlayCoordinator
 		this.groundItemHighlightOverlay = groundItemHighlightOverlay;
 		this.widgetHighlightOverlay = widgetHighlightOverlay;
 		this.overlayStepApplier = overlayStepApplier;
+		this.overlaySourceApplier = overlaySourceApplier;
 		this.worldMapController = worldMapController;
 		this.dynamicTargetManager = dynamicTargetManager;
 		this.npcTrackerHelper = npcTrackerHelper;
@@ -574,52 +577,20 @@ public class GuidanceOverlayCoordinator
 
 	/**
 	 * Applies a source's default location data to overlays (non-sequencer path).
+	 *
+	 * <p>Delegates to {@link OverlaySourceApplier} to keep this coordinator
+	 * focused on lifecycle/state ownership. The applier holds no mutable state
+	 * of its own; the {@code activeMapPoint} and {@code pendingShortestPathTarget}
+	 * fields stay owned here and are threaded through {@link OverlaySourceApplier.Input}
+	 * / {@link OverlaySourceApplier.Result}.</p>
 	 */
 	private void applySourceToOverlays(CollectionLogSource source)
 	{
-		WorldPoint worldPoint = source.getWorldPoint(requirementsChecker);
-		String displayName = source.getDisplayLocation(requirementsChecker);
-
-		guidanceOverlay.setTargetPoint(worldPoint);
-		guidanceOverlay.setTargetName(source.getName());
-		guidanceOverlay.setLocationDescription(displayName);
-		// Non-sequencer path: no step context, so no per-step item requirements.
-		guidanceOverlay.setRequiredItems(Collections.emptyList());
-		guidanceOverlay.setTravelTip(source.getTravelTip());
-		guidanceOverlay.setTargetNpcId(source.getNpcId());
-		guidanceOverlay.setInteractAction(source.getInteractAction());
-		dialogHighlightOverlay.setTargetDialogOptions(source.getDialogOptions());
-		dialogHighlightOverlay.setGuidanceActive(true);
-		guidanceMinimapOverlay.setTargetPoint(worldPoint);
-		worldMapRouteOverlay.setTargetPoint(worldPoint);
-		// Non-sequencer path: no step context, use generic TILE icon.
-		worldMapDestinationOverlay.setTarget(worldPoint, WorldMapDestinationOverlay.StepIconType.TILE);
-		// Register a CollectionLogWorldMapPoint for click-to-focus behaviour (#429).
-		// WorldMapDestinationOverlay suppresses its off-screen arrow while the map
-		// point is active to avoid a duplicate edge-snap arrow (#410).
-		if (activeMapPoint != null)
-		{
-			worldMapPointManager.remove(activeMapPoint);
-		}
-		activeMapPoint = new CollectionLogWorldMapPoint(worldPoint, displayName, collectionLogIcon);
-		worldMapPointManager.add(activeMapPoint);
-		worldMapDestinationOverlay.setMapPointActive(true);
-
-		clientThread.invokeLater(() ->
-		{
-			client.clearHintArrow();
-
-			if (worldMapController.shouldSetHintArrowTo(worldPoint))
-			{
-				client.setHintArrow(worldPoint);
-			}
-
-			if (config.useShortestPath())
-			{
-				eventBus.post(new PluginMessage("shortestpath", "clear"));
-				pendingShortestPathTarget = worldPoint;
-			}
-		});
+		OverlaySourceApplier.Result result = overlaySourceApplier.apply(source,
+			new OverlaySourceApplier.Input(activeMapPoint, collectionLogIcon),
+			worldMapController::shouldSetHintArrowTo,
+			wp -> pendingShortestPathTarget = wp);
+		activeMapPoint = result.activeMapPoint;
 	}
 
 	private void clearGuidanceOverlays()

--- a/src/main/java/com/collectionloghelper/guidance/OverlaySourceApplier.java
+++ b/src/main/java/com/collectionloghelper/guidance/OverlaySourceApplier.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.guidance;
+
+import com.collectionloghelper.CollectionLogHelperConfig;
+import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.data.RequirementsChecker;
+import com.collectionloghelper.overlay.CollectionLogWorldMapPoint;
+import com.collectionloghelper.overlay.DialogHighlightOverlay;
+import com.collectionloghelper.overlay.GuidanceMinimapOverlay;
+import com.collectionloghelper.overlay.GuidanceOverlay;
+import com.collectionloghelper.overlay.WorldMapDestinationOverlay;
+import com.collectionloghelper.overlay.WorldMapRouteOverlay;
+import java.awt.image.BufferedImage;
+import java.util.Collections;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.eventbus.EventBus;
+import net.runelite.client.events.PluginMessage;
+import net.runelite.client.ui.overlay.worldmap.WorldMapPointManager;
+
+/**
+ * Applies a {@link CollectionLogSource}'s default location data to all guidance
+ * overlays (the non-sequencer path). Used when guidance is activated for a
+ * single-step source that has no per-step {@code GuidanceStep} list.
+ *
+ * <p>Pure extraction from {@link GuidanceOverlayCoordinator}: this class holds
+ * no mutable state of its own. Mutable coordinator state that the source
+ * application touches (active world map point, pending shortest-path target)
+ * is passed in via {@link Input} and returned via {@link Result} so the
+ * coordinator remains the single owner of that state.</p>
+ *
+ * <p>Mirrors the structural pattern established by {@link OverlayStepApplier}.</p>
+ */
+@Slf4j
+@Singleton
+public class OverlaySourceApplier
+{
+	private final Client client;
+	private final ClientThread clientThread;
+	private final EventBus eventBus;
+	private final CollectionLogHelperConfig config;
+	private final RequirementsChecker requirementsChecker;
+	private final WorldMapPointManager worldMapPointManager;
+	private final GuidanceOverlay guidanceOverlay;
+	private final GuidanceMinimapOverlay guidanceMinimapOverlay;
+	private final DialogHighlightOverlay dialogHighlightOverlay;
+	private final WorldMapRouteOverlay worldMapRouteOverlay;
+	private final WorldMapDestinationOverlay worldMapDestinationOverlay;
+
+	@Inject
+	OverlaySourceApplier(
+		Client client,
+		ClientThread clientThread,
+		EventBus eventBus,
+		CollectionLogHelperConfig config,
+		RequirementsChecker requirementsChecker,
+		WorldMapPointManager worldMapPointManager,
+		GuidanceOverlay guidanceOverlay,
+		GuidanceMinimapOverlay guidanceMinimapOverlay,
+		DialogHighlightOverlay dialogHighlightOverlay,
+		WorldMapRouteOverlay worldMapRouteOverlay,
+		WorldMapDestinationOverlay worldMapDestinationOverlay)
+	{
+		this.client = client;
+		this.clientThread = clientThread;
+		this.eventBus = eventBus;
+		this.config = config;
+		this.requirementsChecker = requirementsChecker;
+		this.worldMapPointManager = worldMapPointManager;
+		this.guidanceOverlay = guidanceOverlay;
+		this.guidanceMinimapOverlay = guidanceMinimapOverlay;
+		this.dialogHighlightOverlay = dialogHighlightOverlay;
+		this.worldMapRouteOverlay = worldMapRouteOverlay;
+		this.worldMapDestinationOverlay = worldMapDestinationOverlay;
+	}
+
+	/**
+	 * Applies the given source's default location data to all overlays. Pure
+	 * extraction of {@code GuidanceOverlayCoordinator.applySourceToOverlays} --
+	 * no behavioral change. The coordinator's mutable state related to this
+	 * method is carried in {@link Input} and returned in {@link Result}.
+	 *
+	 * @param source the active collection log source
+	 * @param in coordinator-owned mutable state read by this apply pass
+	 * @param hintArrowPredicate delegate to {@code shouldSetHintArrowTo} on the coordinator
+	 * @param pendingShortestPathTargetSetter callback invoked on the client thread to assign
+	 *                                        the coordinator's {@code pendingShortestPathTarget}
+	 *                                        field (preserves original deferred-write semantics)
+	 * @return updated state to be written back onto the coordinator
+	 */
+	Result apply(
+		CollectionLogSource source,
+		Input in,
+		Predicate<WorldPoint> hintArrowPredicate,
+		Consumer<WorldPoint> pendingShortestPathTargetSetter)
+	{
+		WorldPoint worldPoint = source.getWorldPoint(requirementsChecker);
+		String displayName = source.getDisplayLocation(requirementsChecker);
+
+		guidanceOverlay.setTargetPoint(worldPoint);
+		guidanceOverlay.setTargetName(source.getName());
+		guidanceOverlay.setLocationDescription(displayName);
+		// Non-sequencer path: no step context, so no per-step item requirements.
+		guidanceOverlay.setRequiredItems(Collections.emptyList());
+		guidanceOverlay.setTravelTip(source.getTravelTip());
+		guidanceOverlay.setTargetNpcId(source.getNpcId());
+		guidanceOverlay.setInteractAction(source.getInteractAction());
+		dialogHighlightOverlay.setTargetDialogOptions(source.getDialogOptions());
+		dialogHighlightOverlay.setGuidanceActive(true);
+		guidanceMinimapOverlay.setTargetPoint(worldPoint);
+		worldMapRouteOverlay.setTargetPoint(worldPoint);
+		// Non-sequencer path: no step context, use generic TILE icon.
+		worldMapDestinationOverlay.setTarget(worldPoint, WorldMapDestinationOverlay.StepIconType.TILE);
+		// Register a CollectionLogWorldMapPoint for click-to-focus behaviour (#429).
+		// WorldMapDestinationOverlay suppresses its off-screen arrow while the map
+		// point is active to avoid a duplicate edge-snap arrow (#410).
+		CollectionLogWorldMapPoint updatedMapPoint = in.activeMapPoint;
+		if (updatedMapPoint != null)
+		{
+			worldMapPointManager.remove(updatedMapPoint);
+		}
+		updatedMapPoint = new CollectionLogWorldMapPoint(worldPoint, displayName, in.collectionLogIcon);
+		worldMapPointManager.add(updatedMapPoint);
+		worldMapDestinationOverlay.setMapPointActive(true);
+
+		final CollectionLogWorldMapPoint mapPointForReturn = updatedMapPoint;
+
+		clientThread.invokeLater(() ->
+		{
+			client.clearHintArrow();
+
+			if (hintArrowPredicate.test(worldPoint))
+			{
+				client.setHintArrow(worldPoint);
+			}
+
+			if (config.useShortestPath())
+			{
+				eventBus.post(new PluginMessage("shortestpath", "clear"));
+				pendingShortestPathTargetSetter.accept(worldPoint);
+			}
+		});
+
+		return new Result(mapPointForReturn);
+	}
+
+	/**
+	 * Coordinator-owned mutable state that this applier reads but does not own.
+	 */
+	static final class Input
+	{
+		@Nullable
+		final CollectionLogWorldMapPoint activeMapPoint;
+		@Nullable
+		final BufferedImage collectionLogIcon;
+
+		Input(
+			@Nullable CollectionLogWorldMapPoint activeMapPoint,
+			@Nullable BufferedImage collectionLogIcon)
+		{
+			this.activeMapPoint = activeMapPoint;
+			this.collectionLogIcon = collectionLogIcon;
+		}
+	}
+
+	/**
+	 * Updated state to be written back onto the coordinator after apply().
+	 */
+	static final class Result
+	{
+		@Nullable
+		final CollectionLogWorldMapPoint activeMapPoint;
+
+		Result(@Nullable CollectionLogWorldMapPoint activeMapPoint)
+		{
+			this.activeMapPoint = activeMapPoint;
+		}
+	}
+}

--- a/src/test/java/com/collectionloghelper/guidance/DynamicTargetEvaluatorDispatchTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/DynamicTargetEvaluatorDispatchTest.java
@@ -149,6 +149,7 @@ public class DynamicTargetEvaluatorDispatchTest
 		registry.register(STUB_KEY, (c, step) -> DYNAMIC_POINT);
 
 		OverlayStepApplier overlayStepApplier = newOverlayStepApplier();
+		OverlaySourceApplier overlaySourceApplier = newOverlaySourceApplier();
 		WorldMapController worldMapController = newWorldMapController();
 		DynamicTargetManager dynamicTargetManager = newDynamicTargetManager(worldMapController);
 		Constructor<GuidanceOverlayCoordinator> ctor =
@@ -175,6 +176,7 @@ public class DynamicTargetEvaluatorDispatchTest
 				GroundItemHighlightOverlay.class,
 				WidgetHighlightOverlay.class,
 				OverlayStepApplier.class,
+				OverlaySourceApplier.class,
 				WorldMapController.class,
 				DynamicTargetManager.class,
 				NpcTrackerHelper.class);
@@ -189,7 +191,8 @@ public class DynamicTargetEvaluatorDispatchTest
 			objectHighlightOverlay, itemHighlightOverlay,
 			worldMapRouteOverlay, worldMapDestinationOverlay,
 			groundItemHighlightOverlay, widgetHighlightOverlay,
-			overlayStepApplier, worldMapController, dynamicTargetManager, npcTrackerHelper);
+			overlayStepApplier, overlaySourceApplier, worldMapController,
+			dynamicTargetManager, npcTrackerHelper);
 
 		lenient().when(client.getLocalPlayer()).thenReturn(localPlayer);
 		lenient().when(localPlayer.getWorldLocation()).thenReturn(new WorldPoint(3200, 3200, 0));
@@ -325,6 +328,20 @@ public class DynamicTargetEvaluatorDispatchTest
 			objectHighlightOverlay, itemHighlightOverlay,
 			worldMapRouteOverlay, worldMapDestinationOverlay,
 			groundItemHighlightOverlay, widgetHighlightOverlay);
+	}
+
+	private OverlaySourceApplier newOverlaySourceApplier() throws Exception
+	{
+		Constructor<OverlaySourceApplier> ctor = OverlaySourceApplier.class.getDeclaredConstructor(
+			Client.class, ClientThread.class, EventBus.class, CollectionLogHelperConfig.class,
+			RequirementsChecker.class, WorldMapPointManager.class,
+			GuidanceOverlay.class, GuidanceMinimapOverlay.class, DialogHighlightOverlay.class,
+			WorldMapRouteOverlay.class, WorldMapDestinationOverlay.class);
+		ctor.setAccessible(true);
+		return ctor.newInstance(client, clientThread, eventBus, config,
+			requirementsChecker, worldMapPointManager,
+			guidanceOverlay, guidanceMinimapOverlay, dialogHighlightOverlay,
+			worldMapRouteOverlay, worldMapDestinationOverlay);
 	}
 
 	private static GuidanceStep stepWithEvaluator(String evaluatorKey)

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorDescriptionTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorDescriptionTest.java
@@ -144,6 +144,7 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 	public void setUp() throws Exception
 	{
 		OverlayStepApplier overlayStepApplier = newOverlayStepApplier();
+		OverlaySourceApplier overlaySourceApplier = newOverlaySourceApplier();
 		WorldMapController worldMapController = newWorldMapController();
 		Constructor<GuidanceOverlayCoordinator> ctor =
 			GuidanceOverlayCoordinator.class.getDeclaredConstructor(
@@ -169,6 +170,7 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 				GroundItemHighlightOverlay.class,
 				WidgetHighlightOverlay.class,
 				OverlayStepApplier.class,
+				OverlaySourceApplier.class,
 				WorldMapController.class,
 				DynamicTargetManager.class,
 				NpcTrackerHelper.class);
@@ -184,7 +186,8 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 			objectHighlightOverlay, itemHighlightOverlay,
 			worldMapRouteOverlay, worldMapDestinationOverlay,
 			groundItemHighlightOverlay, widgetHighlightOverlay,
-			overlayStepApplier, worldMapController, dynamicTargetManager, npcTrackerHelper);
+			overlayStepApplier, overlaySourceApplier, worldMapController,
+			dynamicTargetManager, npcTrackerHelper);
 
 		coordinator.setPanel(panel);
 
@@ -340,6 +343,20 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 			objectHighlightOverlay, itemHighlightOverlay,
 			worldMapRouteOverlay, worldMapDestinationOverlay,
 			groundItemHighlightOverlay, widgetHighlightOverlay);
+	}
+
+	private OverlaySourceApplier newOverlaySourceApplier() throws Exception
+	{
+		Constructor<OverlaySourceApplier> ctor = OverlaySourceApplier.class.getDeclaredConstructor(
+			Client.class, ClientThread.class, EventBus.class, CollectionLogHelperConfig.class,
+			RequirementsChecker.class, WorldMapPointManager.class,
+			GuidanceOverlay.class, GuidanceMinimapOverlay.class, DialogHighlightOverlay.class,
+			WorldMapRouteOverlay.class, WorldMapDestinationOverlay.class);
+		ctor.setAccessible(true);
+		return ctor.newInstance(client, clientThread, eventBus, config,
+			requirementsChecker, worldMapPointManager,
+			guidanceOverlay, guidanceMinimapOverlay, dialogHighlightOverlay,
+			worldMapRouteOverlay, worldMapDestinationOverlay);
 	}
 
 	private static CollectionLogSource sourceWithSteps(String name, GuidanceStep... steps)

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorMapPointTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorMapPointTest.java
@@ -130,6 +130,7 @@ public class GuidanceOverlayCoordinatorMapPointTest
 	public void setUp() throws Exception
 	{
 		OverlayStepApplier overlayStepApplier = newOverlayStepApplier();
+		OverlaySourceApplier overlaySourceApplier = newOverlaySourceApplier();
 		WorldMapController worldMapController = newWorldMapController();
 		Constructor<GuidanceOverlayCoordinator> ctor =
 			GuidanceOverlayCoordinator.class.getDeclaredConstructor(
@@ -155,6 +156,7 @@ public class GuidanceOverlayCoordinatorMapPointTest
 				GroundItemHighlightOverlay.class,
 				WidgetHighlightOverlay.class,
 				OverlayStepApplier.class,
+				OverlaySourceApplier.class,
 				WorldMapController.class,
 				DynamicTargetManager.class,
 				NpcTrackerHelper.class);
@@ -170,7 +172,8 @@ public class GuidanceOverlayCoordinatorMapPointTest
 			objectHighlightOverlay, itemHighlightOverlay,
 			worldMapRouteOverlay, worldMapDestinationOverlay,
 			groundItemHighlightOverlay, widgetHighlightOverlay,
-			overlayStepApplier, worldMapController, dynamicTargetManager, npcTrackerHelper);
+			overlayStepApplier, overlaySourceApplier, worldMapController,
+			dynamicTargetManager, npcTrackerHelper);
 
 		// Default stubs: no unmet requirements; buildRequirementRows called unconditionally
 		when(requirementsChecker.getUnmetRequirements(any())).thenReturn(Collections.emptyList());
@@ -299,6 +302,20 @@ public class GuidanceOverlayCoordinatorMapPointTest
 			objectHighlightOverlay, itemHighlightOverlay,
 			worldMapRouteOverlay, worldMapDestinationOverlay,
 			groundItemHighlightOverlay, widgetHighlightOverlay);
+	}
+
+	private OverlaySourceApplier newOverlaySourceApplier() throws Exception
+	{
+		Constructor<OverlaySourceApplier> ctor = OverlaySourceApplier.class.getDeclaredConstructor(
+			Client.class, ClientThread.class, EventBus.class, CollectionLogHelperConfig.class,
+			RequirementsChecker.class, WorldMapPointManager.class,
+			GuidanceOverlay.class, GuidanceMinimapOverlay.class, DialogHighlightOverlay.class,
+			WorldMapRouteOverlay.class, WorldMapDestinationOverlay.class);
+		ctor.setAccessible(true);
+		return ctor.newInstance(client, clientThread, eventBus, config,
+			requirementsChecker, worldMapPointManager,
+			guidanceOverlay, guidanceMinimapOverlay, dialogHighlightOverlay,
+			worldMapRouteOverlay, worldMapDestinationOverlay);
 	}
 
 	private static CollectionLogSource sourceAtCoords(

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorNpcIdTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorNpcIdTest.java
@@ -141,6 +141,7 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 	public void setUp() throws Exception
 	{
 		OverlayStepApplier overlayStepApplier = newOverlayStepApplier();
+		OverlaySourceApplier overlaySourceApplier = newOverlaySourceApplier();
 		WorldMapController worldMapController = newWorldMapController();
 		Constructor<GuidanceOverlayCoordinator> ctor =
 			GuidanceOverlayCoordinator.class.getDeclaredConstructor(
@@ -166,6 +167,7 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 				GroundItemHighlightOverlay.class,
 				WidgetHighlightOverlay.class,
 				OverlayStepApplier.class,
+				OverlaySourceApplier.class,
 				WorldMapController.class,
 				DynamicTargetManager.class,
 				NpcTrackerHelper.class);
@@ -181,7 +183,8 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 			objectHighlightOverlay, itemHighlightOverlay,
 			worldMapRouteOverlay, worldMapDestinationOverlay,
 			groundItemHighlightOverlay, widgetHighlightOverlay,
-			overlayStepApplier, worldMapController, dynamicTargetManager, npcTrackerHelper);
+			overlayStepApplier, overlaySourceApplier, worldMapController,
+			dynamicTargetManager, npcTrackerHelper);
 
 		when(requirementsChecker.getUnmetRequirements(any())).thenReturn(Collections.emptyList());
 		when(requirementsChecker.buildRequirementRows(any())).thenReturn(Collections.emptyList());
@@ -347,6 +350,20 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 			objectHighlightOverlay, itemHighlightOverlay,
 			worldMapRouteOverlay, worldMapDestinationOverlay,
 			groundItemHighlightOverlay, widgetHighlightOverlay);
+	}
+
+	private OverlaySourceApplier newOverlaySourceApplier() throws Exception
+	{
+		Constructor<OverlaySourceApplier> ctor = OverlaySourceApplier.class.getDeclaredConstructor(
+			Client.class, ClientThread.class, EventBus.class, CollectionLogHelperConfig.class,
+			RequirementsChecker.class, WorldMapPointManager.class,
+			GuidanceOverlay.class, GuidanceMinimapOverlay.class, DialogHighlightOverlay.class,
+			WorldMapRouteOverlay.class, WorldMapDestinationOverlay.class);
+		ctor.setAccessible(true);
+		return ctor.newInstance(client, clientThread, eventBus, config,
+			requirementsChecker, worldMapPointManager,
+			guidanceOverlay, guidanceMinimapOverlay, dialogHighlightOverlay,
+			worldMapRouteOverlay, worldMapDestinationOverlay);
 	}
 
 	private static CollectionLogSource sourceWithSteps(String name, GuidanceStep... steps)


### PR DESCRIPTION
## Summary

Wave 9 of #503: extract the `applySourceToOverlays` cluster from `GuidanceOverlayCoordinator` into a new `OverlaySourceApplier` Guice singleton. Pure structural extraction — no behavioral change.

Follows the established pattern from Wave 7 (`OverlayStepApplier`):
- `@Singleton @Inject` Guice component
- Holds no mutable state; coordinator-owned state (`activeMapPoint`, `pendingShortestPathTarget`) is threaded through `Input`/`Result` carriers
- Hint-arrow predicate and shortest-path setter passed as functional callbacks so the applier does not take a hard dependency on `WorldMapController` or the coordinator field

## LOC delta

- `GuidanceOverlayCoordinator.java`: 740 -> 711 (-29)
- `OverlaySourceApplier.java`: new (209 LOC, copyright header + 11-param ctor + Input/Result carriers)
- Coordinator still above the 600-LOC target — additional waves will continue.

## Test plan

- [x] `./gradlew build` passes
- [x] `./gradlew test` passes (all existing tests, including 4 reflection-based coordinator tests updated to inject the new singleton)
- [x] Public API of `GuidanceOverlayCoordinator` unchanged
- [x] `applySourceToOverlays` body unchanged — only relocated; same overlay setter sequence, same `clientThread.invokeLater` semantics for hint arrow + ShortestPath