### PR TITLE
refactor: extract PlayerLocationResolver from Plugin (#503)

### DIFF
--- a/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
@@ -38,6 +38,7 @@ import com.collectionloghelper.sync.TempleSyncOrchestrator;
 import com.collectionloghelper.efficiency.ScoredItem;
 import com.collectionloghelper.lifecycle.AuthoringLogger;
 import com.collectionloghelper.lifecycle.OverlayRegistry;
+import com.collectionloghelper.lifecycle.PlayerLocationResolver;
 import com.collectionloghelper.lifecycle.SceneEventRouter;
 import com.collectionloghelper.lifecycle.SyncStateCoordinator;
 import com.collectionloghelper.ui.CollectionLogHelperPanel;
@@ -55,10 +56,6 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.NPC;
-import net.runelite.api.Player;
-import net.runelite.api.WorldEntity;
-import net.runelite.api.WorldView;
-import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.GameStateChanged;
@@ -151,6 +148,9 @@ public class CollectionLogHelperPlugin extends Plugin
 	@Inject
 	private ChatEventHandler chatEventHandler;
 
+	@Inject
+	private PlayerLocationResolver playerLocationResolver;
+
 
 	private CollectionLogHelperPanel panel;
 	private NavigationButton navButton;
@@ -168,12 +168,6 @@ public class CollectionLogHelperPlugin extends Plugin
 	 * leak that the ad-hoc {@code Executors.newSingleThreadExecutor()} pattern caused.
 	 */
 	private ExecutorService httpResultExecutor;
-
-	/**
-	 * Player location cached on the client thread each game tick.
-	 * Read by guidance sequencer and authoring log — volatile ensures visibility.
-	 */
-	private volatile WorldPoint cachedPlayerLocation;
 
 	private boolean slayerRefreshPending;
 
@@ -361,7 +355,7 @@ public class CollectionLogHelperPlugin extends Plugin
 		pendingPanelRebuild = false;
 		rankedSourcesDirty = true;
 		cachedRankedSources = null;
-		cachedPlayerLocation = null;
+		playerLocationResolver.reset();
 		guidance.getGuidanceOverlay().setShowCollectionLogReminder(false);
 		guidance.getGuidanceOverlay().setShowBankReminder(false);
 		data.getDataSyncState().reset();
@@ -435,7 +429,7 @@ public class CollectionLogHelperPlugin extends Plugin
 			sourcesWithMissingItems.clear();
 			slayerRefreshPending = false;
 			pendingTravelVarbitRefresh = false;
-			cachedPlayerLocation = null;
+			playerLocationResolver.reset();
 			guidance.getGuidanceOverlay().setShowCollectionLogReminder(false);
 			guidance.getGuidanceOverlay().setShowBankReminder(false);
 			data.getDataSyncState().reset();
@@ -582,20 +576,19 @@ public class CollectionLogHelperPlugin extends Plugin
 		guidance.getGuidanceCoordinator().tick();
 
 		// Cache player location for guidance sequencer and authoring log (client thread only).
-		// When sailing, the player is inside a WorldEntity whose inner WorldView
-		// returns boat-local coords.  Detect this and transform to real-world
-		// coordinates via WorldEntity.transformToMainWorld().
-		// Ref: LlemonDuck/sailing SailingUtil, RuneLite WorldEntity API
+		// PlayerLocationResolver handles instanced regions and non-top-level WorldViews
+		// (e.g. sailing boats), translating to overworld coords so ARRIVE_AT_TILE checks
+		// match the static JSON tile.
 		if (client.getLocalPlayer() != null)
 		{
-			cachedPlayerLocation = resolvePlayerWorldLocation();
-			authoringLogger.setPlayerLocation(cachedPlayerLocation);
+			WorldPoint playerLocation = playerLocationResolver.resolveAndCache();
+			authoringLogger.setPlayerLocation(playerLocation);
 
 			// Check ARRIVE_AT_TILE completion for guidance sequencer
 			if (guidance.getGuidanceSequencer().isActive())
 			{
-				guidance.getGuidanceSequencer().setPlayerLocation(cachedPlayerLocation);
-				guidance.getGuidanceSequencer().onPlayerMoved(cachedPlayerLocation);
+				guidance.getGuidanceSequencer().setPlayerLocation(playerLocation);
+				guidance.getGuidanceSequencer().onPlayerMoved(playerLocation);
 			}
 
 		}
@@ -686,7 +679,7 @@ public class CollectionLogHelperPlugin extends Plugin
 		// and related coordinator work require client-thread context.  Mirrors the
 		// step-advance / skip wrap added in commit c528d0ae.
 		clientThread.invokeLater(() -> guidance.getGuidanceCoordinator().activateGuidance(
-			source, cachedPlayerLocation, targetItemId));
+			source, playerLocationResolver.getCachedLocation(), targetItemId));
 	}
 
 	/**
@@ -777,85 +770,6 @@ public class CollectionLogHelperPlugin extends Plugin
 	{
 		sourcesWithMissingItems = guidance.getGuidanceCoordinator().rebuildSourcesWithMissingItems(
 			data.getDatabase(), data.getCollectionState());
-	}
-
-	/**
-	 * Resolve the player's real-world location, transforming local coordinates
-	 * back to template/overworld coordinates so they compare correctly against
-	 * the static {@code worldX/worldY} values in {@code drop_rates.json}.
-	 *
-	 * Three cases:
-	 * <ol>
-	 *   <li><b>Standard top-level world view</b> — return {@code getWorldLocation()}.</li>
-	 *   <li><b>Instanced region</b> (CoX/ToB/ToA, GWD, Vorkath, Royal Titans, many
-	 *       quest/clue rooms, etc.) — {@code getWorldLocation()} returns
-	 *       instance-template coords that don't match the static JSON tile.
-	 *       Translate via {@link WorldPoint#fromLocalInstance(Client, LocalPoint)}
-	 *       to recover the overworld coords.</li>
-	 *   <li><b>Sailing WorldEntity</b> — player is inside a non-top-level
-	 *       WorldView; map the local point back through
-	 *       {@code transformToMainWorld}.</li>
-	 * </ol>
-	 *
-	 * Falls back to plain {@code getWorldLocation()} on any error or when the
-	 * required API is unavailable.
-	 */
-	private WorldPoint resolvePlayerWorldLocation()
-	{
-		Player lp = client.getLocalPlayer();
-		if (lp == null)
-		{
-			return null;
-		}
-		WorldPoint fallback = lp.getWorldLocation();
-		try
-		{
-			WorldView playerView = lp.getWorldView();
-			if (playerView == null || playerView.isTopLevel())
-			{
-				// Top-level view — handle instanced regions by translating
-				// the player's local point back to the overworld template tile.
-				// Without this, ARRIVE_AT_TILE checks in instanced bosses
-				// (Royal Titans, raids, etc.) never match the JSON coords.
-				if (client.isInInstancedRegion())
-				{
-					LocalPoint localPoint = lp.getLocalLocation();
-					if (localPoint != null)
-					{
-						WorldPoint templatePoint = WorldPoint.fromLocalInstance(client, localPoint);
-						if (templatePoint != null)
-						{
-							return templatePoint;
-						}
-					}
-				}
-				return fallback;
-			}
-
-			// Player is inside a non-top-level WorldView (e.g. a sailing boat).
-			// Find the WorldEntity whose inner WorldView matches the player's.
-			WorldView topLevel = client.getTopLevelWorldView();
-			for (WorldEntity entity : topLevel.worldEntities())
-			{
-				if (entity.getWorldView() == playerView)
-				{
-					LocalPoint playerLocal = lp.getLocalLocation();
-					LocalPoint mainLocal = entity.transformToMainWorld(playerLocal);
-					if (mainLocal != null)
-					{
-						return WorldPoint.fromLocal(topLevel,
-							mainLocal.getX(), mainLocal.getY(),
-							topLevel.getPlane());
-					}
-					break;
-				}
-			}
-		}
-		catch (Exception e)
-		{
-			log.debug("Player-location resolution failed, using fallback", e);
-		}
-		return fallback;
 	}
 
 	@Provides

--- a/src/main/java/com/collectionloghelper/lifecycle/PlayerLocationResolver.java
+++ b/src/main/java/com/collectionloghelper/lifecycle/PlayerLocationResolver.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.lifecycle;
+
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.Player;
+import net.runelite.api.WorldEntity;
+import net.runelite.api.WorldView;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
+
+/**
+ * Resolves the local player's "real-world" {@link WorldPoint} on the client
+ * thread and caches the most recent result for cross-thread readers.
+ *
+ * <p>Most callers can just use {@code lp.getWorldLocation()}, but two cases
+ * require translation:
+ * <ul>
+ *   <li><b>Instanced regions</b> (raids, Royal Titans, etc.): the player's
+ *   raw world coords point inside the instance template — ARRIVE_AT_TILE
+ *   checks expect the underlying overworld tile. We translate via
+ *   {@link WorldPoint#fromLocalInstance(Client, LocalPoint)}.</li>
+ *   <li><b>Non-top-level WorldViews</b> (e.g. sailing boats): the player is
+ *   inside a {@link WorldEntity} whose inner {@link WorldView} returns
+ *   boat-local coordinates. We locate the matching entity and transform via
+ *   {@link WorldEntity#transformToMainWorld(LocalPoint)}.</li>
+ * </ul>
+ *
+ * <p>The cached value is {@code volatile} so guidance/authoring code reading
+ * from non-client threads observes the most recent client-thread write.
+ *
+ * <p>Extracted from {@code CollectionLogHelperPlugin} as part of #503 to keep
+ * the plugin class focused on RuneLite lifecycle wiring.
+ */
+@Slf4j
+@Singleton
+public class PlayerLocationResolver
+{
+	private final Client client;
+
+	/**
+	 * Player location cached on the client thread each game tick.
+	 * Read by guidance sequencer and authoring log — volatile ensures visibility.
+	 */
+	private volatile WorldPoint cachedLocation;
+
+	@Inject
+	public PlayerLocationResolver(Client client)
+	{
+		this.client = client;
+	}
+
+	/**
+	 * Resolves the player's real-world {@link WorldPoint}, updates the cache,
+	 * and returns the resolved value. Returns {@code null} if no local player
+	 * is present.
+	 *
+	 * <p>Must be called on the client thread.
+	 */
+	@Nullable
+	public WorldPoint resolveAndCache()
+	{
+		WorldPoint resolved = resolve();
+		cachedLocation = resolved;
+		return resolved;
+	}
+
+	/**
+	 * Returns the most recently cached player location, or {@code null} if none
+	 * has been resolved (or the cache has been {@link #reset()}).
+	 */
+	@Nullable
+	public WorldPoint getCachedLocation()
+	{
+		return cachedLocation;
+	}
+
+	/**
+	 * Clears the cached location. Invoked on logout / profile change so stale
+	 * coordinates do not leak across sessions.
+	 */
+	public void reset()
+	{
+		cachedLocation = null;
+	}
+
+	/**
+	 * Resolves the player's "real-world" {@link WorldPoint}, handling the
+	 * instanced-region and non-top-level WorldView cases described in the
+	 * class javadoc. Falls back to plain {@code getWorldLocation()} on any
+	 * error or when the required API is unavailable.
+	 */
+	@Nullable
+	private WorldPoint resolve()
+	{
+		Player lp = client.getLocalPlayer();
+		if (lp == null)
+		{
+			return null;
+		}
+		WorldPoint fallback = lp.getWorldLocation();
+		try
+		{
+			WorldView playerView = lp.getWorldView();
+			if (playerView == null || playerView.isTopLevel())
+			{
+				// Top-level view — handle instanced regions by translating
+				// the player's local point back to the overworld template tile.
+				// Without this, ARRIVE_AT_TILE checks in instanced bosses
+				// (Royal Titans, raids, etc.) never match the JSON coords.
+				if (client.isInInstancedRegion())
+				{
+					LocalPoint localPoint = lp.getLocalLocation();
+					if (localPoint != null)
+					{
+						WorldPoint templatePoint = WorldPoint.fromLocalInstance(client, localPoint);
+						if (templatePoint != null)
+						{
+							return templatePoint;
+						}
+					}
+				}
+				return fallback;
+			}
+
+			// Player is inside a non-top-level WorldView (e.g. a sailing boat).
+			// Find the WorldEntity whose inner WorldView matches the player's.
+			WorldView topLevel = client.getTopLevelWorldView();
+			for (WorldEntity entity : topLevel.worldEntities())
+			{
+				if (entity.getWorldView() == playerView)
+				{
+					LocalPoint playerLocal = lp.getLocalLocation();
+					LocalPoint mainLocal = entity.transformToMainWorld(playerLocal);
+					if (mainLocal != null)
+					{
+						return WorldPoint.fromLocal(topLevel,
+							mainLocal.getX(), mainLocal.getY(),
+							topLevel.getPlane());
+					}
+					break;
+				}
+			}
+		}
+		catch (Exception e)
+		{
+			log.debug("Player-location resolution failed, using fallback", e);
+		}
+		return fallback;
+	}
+}

--- a/src/test/java/com/collectionloghelper/OnSequenceCompletePerItemTest.java
+++ b/src/test/java/com/collectionloghelper/OnSequenceCompletePerItemTest.java
@@ -32,6 +32,7 @@ import com.collectionloghelper.di.GuidanceModule;
 import com.collectionloghelper.efficiency.EfficiencyCalculator;
 import com.collectionloghelper.efficiency.ScoredItem;
 import com.collectionloghelper.guidance.GuidanceOverlayCoordinator;
+import com.collectionloghelper.lifecycle.PlayerLocationResolver;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Collections;
@@ -77,6 +78,9 @@ public class OnSequenceCompletePerItemTest
 	@Mock
 	private EfficiencyCalculator calculator;
 
+	@Mock
+	private PlayerLocationResolver playerLocationResolver;
+
 	private CollectionLogHelperPlugin plugin;
 
 	@Before
@@ -91,6 +95,7 @@ public class OnSequenceCompletePerItemTest
 		EfficiencyModule efficiencyModule = new EfficiencyModule(
 			calculator, null, null, null, null);
 		injectField("efficiency", efficiencyModule);
+		injectField("playerLocationResolver", playerLocationResolver);
 
 		// Make clientThread.invokeLater execute the runnable immediately so
 		// coordinator.activateGuidance is reachable within the same test call.


### PR DESCRIPTION
## Summary

Wave 10 of the #503 god-class refactor. Extracts `resolvePlayerWorldLocation` and its companion `cachedPlayerLocation` volatile field out of `CollectionLogHelperPlugin` into a new Guice-managed `lifecycle/PlayerLocationResolver`.

The resolver owns the cache and exposes:
- `resolveAndCache()` — computes the player's real-world `WorldPoint` (handling instanced regions + non-top-level WorldViews like sailing boats), updates the cache, returns the value.
- `getCachedLocation()` — `@Nullable` volatile read for cross-thread callers.
- `reset()` — clears the cache on logout / profile change.

## LOC delta

`CollectionLogHelperPlugin.java`: **866 -> 780 (-86 LOC)**. Closer to the 600-LOC target for #503.

## Behavior

No behavior change. The resolver method body is the existing logic moved verbatim. The four removed `cachedPlayerLocation` reads/writes in Plugin now go through the resolver's `resolveAndCache()`, `getCachedLocation()`, and `reset()` (twice — on profile change and on login-screen state).

## Test plan

- [x] `./gradlew build` passes
- [x] `./gradlew test` passes (1210 tests)
- [x] `OnSequenceCompletePerItemTest` updated to inject the new `playerLocationResolver` mock so the captured runnable does not NPE
- [ ] Manual smoke: ARRIVE_AT_TILE auto-advance still works in an instanced region (e.g. Royal Titans)
- [ ] Manual smoke: location resolves correctly while sailing on a `WorldEntity`