### PR TITLE
refactor: extract SelectorControlsPanel from Panel (#503)

### DIFF
--- a/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
@@ -323,10 +323,21 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 
 	public void setMode(Mode mode)
 	{
-		currentMode = mode;
+		// Route programmatic mode changes through the selector listener so the
+		// mode-controller lifecycle hooks (onModeDeactivated / onModeActivated)
+		// fire just like a user-driven selection. Mutating currentMode here
+		// before calling setSelectedMode(...) would cause the listener to see
+		// previous == next and short-circuit the dispatcher, silently breaking
+		// the contract for any controller that overrides those hooks.
+		if (mode == currentMode)
+		{
+			// Same-mode call: the combo listener won't fire, so apply the
+			// visibility + rebuild side effects directly.
+			updateControlVisibility();
+			rebuild();
+			return;
+		}
 		selectorControls.setSelectedMode(mode);
-		updateControlVisibility();
-		rebuild();
 	}
 
 	private void onModeSelected(Mode mode)

--- a/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
@@ -67,24 +67,18 @@ import java.awt.CardLayout;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
-import java.awt.event.ItemEvent;
 import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
-import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JProgressBar;
 import javax.swing.JScrollPane;
-import javax.swing.JTextField;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
-import javax.swing.Timer;
-import javax.swing.event.DocumentEvent;
-import javax.swing.event.DocumentListener;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
@@ -142,11 +136,7 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 	private final ClueSummaryView clueSummaryView;
 	private final SyncButtonController syncButtonController;
 
-	private final JComboBox<Mode> modeSelector;
-	private final JComboBox<AfkFilter> afkFilterSelector;
-	private final JComboBox<EfficientSortMode> sortSelector;
-	private final JComboBox<CollectionLogCategory> categorySelector;
-	private final JTextField searchField;
+	private final SelectorControlsPanel selectorControls;
 	private final JLabel completionLabel;
 	private final JProgressBar completionProgressBar;
 	private final JPanel listContainer;
@@ -159,8 +149,6 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 	private final SlayerStrategyView slayerStrategyView;
 	private final StepProgressView stepProgressView;
 	private final QuickGuidePanelView quickGuidePanelView;
-
-	private final Timer searchDebounceTimer;
 
 	private final Map<Mode, PanelModeController> modeControllers = new EnumMap<>(Mode.class);
 	private final PanelModeDispatcher<Mode> modeDispatcher = new PanelModeDispatcher<>(modeControllers);
@@ -259,95 +247,22 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 
 		controlsPanel.add(Box.createVerticalStrut(4));
 
-		modeSelector = new JComboBox<>(Mode.values());
-		modeSelector.setMaximumSize(new Dimension(Integer.MAX_VALUE, 28));
-		modeSelector.addItemListener(e ->
-		{
-			if (e.getStateChange() == ItemEvent.SELECTED)
+		selectorControls = new SelectorControlsPanel(
+			config,
+			currentMode,
+			this::onModeSelected,
+			afkFilter ->
 			{
-				Mode previous = currentMode;
-				currentMode = (Mode) e.getItem();
-				modeDispatcher.switchMode(previous, currentMode);
-				updateControlVisibility();
-				inDetailView = false;
+				afkFilterUpdater.accept(afkFilter);
 				rebuild();
-				resetScrollPosition();
-			}
-		});
-		controlsPanel.add(modeSelector);
-
-		afkFilterSelector = new JComboBox<>(AfkFilter.values());
-		afkFilterSelector.setSelectedItem(config.afkFilter());
-		afkFilterSelector.setMaximumSize(new Dimension(Integer.MAX_VALUE, 28));
-		afkFilterSelector.setVisible(currentMode == Mode.EFFICIENT || currentMode == Mode.PET_HUNT);
-		afkFilterSelector.addItemListener(e ->
-		{
-			if (e.getStateChange() == ItemEvent.SELECTED)
+			},
+			sortMode ->
 			{
-				AfkFilter selected = (AfkFilter) e.getItem();
-				afkFilterUpdater.accept(selected);
+				sortModeUpdater.accept(sortMode);
 				rebuild();
-			}
-		});
-		controlsPanel.add(afkFilterSelector);
-
-		sortSelector = new JComboBox<>(EfficientSortMode.values());
-		sortSelector.setSelectedItem(config.efficientSortMode());
-		sortSelector.setMaximumSize(new Dimension(Integer.MAX_VALUE, 28));
-		sortSelector.setVisible(currentMode == Mode.EFFICIENT);
-		sortSelector.addItemListener(e ->
-		{
-			if (e.getStateChange() == ItemEvent.SELECTED)
-			{
-				EfficientSortMode selected = (EfficientSortMode) sortSelector.getSelectedItem();
-				if (selected != null)
-				{
-					sortModeUpdater.accept(selected);
-				}
-				rebuild();
-			}
-		});
-		controlsPanel.add(sortSelector);
-
-		categorySelector = new JComboBox<>(CollectionLogCategory.values());
-		categorySelector.setMaximumSize(new Dimension(Integer.MAX_VALUE, 28));
-		categorySelector.setVisible(false);
-		categorySelector.addItemListener(e ->
-		{
-			if (e.getStateChange() == ItemEvent.SELECTED)
-			{
-				rebuild();
-			}
-		});
-		controlsPanel.add(categorySelector);
-
-		searchField = new JTextField();
-		searchField.setMaximumSize(new Dimension(Integer.MAX_VALUE, 28));
-		searchField.setVisible(false);
-		searchField.setToolTipText("Search by item name or source name");
-		searchDebounceTimer = new Timer(200, e -> rebuild());
-		searchDebounceTimer.setRepeats(false);
-		searchField.getDocument().addDocumentListener(new DocumentListener()
-		{
-			@Override
-			public void insertUpdate(DocumentEvent e)
-			{
-				searchDebounceTimer.restart();
-			}
-
-			@Override
-			public void removeUpdate(DocumentEvent e)
-			{
-				searchDebounceTimer.restart();
-			}
-
-			@Override
-			public void changedUpdate(DocumentEvent e)
-			{
-				searchDebounceTimer.restart();
-			}
-		});
-		controlsPanel.add(searchField);
+			},
+			this::rebuild);
+		controlsPanel.add(selectorControls);
 
 		add(controlsPanel, BorderLayout.NORTH);
 
@@ -409,9 +324,20 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 	public void setMode(Mode mode)
 	{
 		currentMode = mode;
-		modeSelector.setSelectedItem(mode);
+		selectorControls.setSelectedMode(mode);
 		updateControlVisibility();
 		rebuild();
+	}
+
+	private void onModeSelected(Mode mode)
+	{
+		Mode previous = currentMode;
+		currentMode = mode;
+		modeDispatcher.switchMode(previous, currentMode);
+		updateControlVisibility();
+		inDetailView = false;
+		rebuild();
+		resetScrollPosition();
 	}
 
 	public void updateCompletionHeader()
@@ -486,7 +412,7 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 
 	public void shutDown()
 	{
-		searchDebounceTimer.stop();
+		selectorControls.shutDown();
 	}
 
 	/**
@@ -721,11 +647,7 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 
 	private void updateControlVisibility()
 	{
-		afkFilterSelector.setVisible(currentMode == Mode.EFFICIENT || currentMode == Mode.PET_HUNT
-			|| currentMode == Mode.CATEGORY_FOCUS);
-		sortSelector.setVisible(currentMode == Mode.EFFICIENT);
-		categorySelector.setVisible(currentMode == Mode.CATEGORY_FOCUS);
-		searchField.setVisible(currentMode == Mode.SEARCH);
+		selectorControls.updateVisibility(currentMode);
 	}
 
 	// ── PanelShellContext implementation ────────────────────────────────────
@@ -739,25 +661,25 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 	@Override
 	public void switchToCategoryFocus(CollectionLogCategory category)
 	{
-		categorySelector.setSelectedItem(category);
-		modeSelector.setSelectedItem(Mode.CATEGORY_FOCUS);
+		selectorControls.setSelectedCategory(category);
+		selectorControls.setSelectedMode(Mode.CATEGORY_FOCUS);
 	}
 
 	@Override
 	public String getSearchQuery()
 	{
-		return searchField.getText() == null ? "" : searchField.getText().toLowerCase().trim();
+		return selectorControls.getSearchQuery();
 	}
 
 	@Override
 	public EfficientSortMode getEfficientSortMode()
 	{
-		return (EfficientSortMode) sortSelector.getSelectedItem();
+		return selectorControls.getSelectedSortMode();
 	}
 
 	@Override
 	public CollectionLogCategory getSelectedCategory()
 	{
-		return (CollectionLogCategory) categorySelector.getSelectedItem();
+		return selectorControls.getSelectedCategory();
 	}
 }

--- a/src/main/java/com/collectionloghelper/ui/SelectorControlsPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/SelectorControlsPanel.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.ui;
+
+import com.collectionloghelper.AfkFilter;
+import com.collectionloghelper.CollectionLogHelperConfig;
+import com.collectionloghelper.EfficientSortMode;
+import com.collectionloghelper.data.CollectionLogCategory;
+import com.collectionloghelper.ui.CollectionLogHelperPanel.Mode;
+import java.awt.Dimension;
+import java.awt.event.ItemEvent;
+import java.util.function.Consumer;
+import javax.swing.BoxLayout;
+import javax.swing.JComboBox;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.Timer;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+
+/**
+ * Owns the five selector widgets shown in the panel's control header:
+ * mode, AFK-filter, sort-mode, category, and search-text. Extracted from
+ * {@link CollectionLogHelperPanel} as part of the issue #503 god-class split.
+ *
+ * <p>This class encapsulates widget construction, listener wiring, the
+ * search-field debounce timer, and the visibility rules that decide which
+ * selectors are shown for the current {@link Mode}. The owning panel keeps
+ * authority over the {@code currentMode} field; this class only reports
+ * changes via callbacks supplied at construction time.</p>
+ *
+ * <p>It is intentionally not a Guice {@code @Singleton} — it is constructed
+ * inside the panel and bound to that panel's lifecycle (its debounce timer is
+ * stopped via {@link #shutDown()}).</p>
+ */
+public class SelectorControlsPanel extends JPanel
+{
+	private static final int SELECTOR_HEIGHT = 28;
+	private static final int SEARCH_DEBOUNCE_MS = 200;
+
+	private final JComboBox<Mode> modeSelector;
+	private final JComboBox<AfkFilter> afkFilterSelector;
+	private final JComboBox<EfficientSortMode> sortSelector;
+	private final JComboBox<CollectionLogCategory> categorySelector;
+	private final JTextField searchField;
+	private final Timer searchDebounceTimer;
+
+	/**
+	 * Constructs the selector controls and wires up listeners. Callbacks are
+	 * invoked directly when the corresponding selector changes; the search
+	 * field's changes are debounced.
+	 *
+	 * @param config                  plugin config used to seed initial
+	 *                                AFK-filter and sort-mode selections
+	 * @param initialMode             mode used to seed initial visibility — the
+	 *                                caller still owns {@code currentMode}
+	 * @param onModeChanged           invoked when the user picks a new mode
+	 * @param onAfkFilterChanged      invoked when the AFK filter changes
+	 * @param onSortChanged           invoked when the sort mode changes
+	 * @param onSearchOrFilterChanged invoked when the category or search field
+	 *                                changes — both call this so the panel can
+	 *                                rebuild
+	 */
+	public SelectorControlsPanel(CollectionLogHelperConfig config,
+		Mode initialMode,
+		Consumer<Mode> onModeChanged,
+		Consumer<AfkFilter> onAfkFilterChanged,
+		Consumer<EfficientSortMode> onSortChanged,
+		Runnable onSearchOrFilterChanged)
+	{
+		setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+		setOpaque(false);
+
+		modeSelector = new JComboBox<>(Mode.values());
+		modeSelector.setMaximumSize(new Dimension(Integer.MAX_VALUE, SELECTOR_HEIGHT));
+		modeSelector.addItemListener(e ->
+		{
+			if (e.getStateChange() == ItemEvent.SELECTED)
+			{
+				onModeChanged.accept((Mode) e.getItem());
+			}
+		});
+		add(modeSelector);
+
+		afkFilterSelector = new JComboBox<>(AfkFilter.values());
+		afkFilterSelector.setSelectedItem(config.afkFilter());
+		afkFilterSelector.setMaximumSize(new Dimension(Integer.MAX_VALUE, SELECTOR_HEIGHT));
+		afkFilterSelector.setVisible(initialMode == Mode.EFFICIENT || initialMode == Mode.PET_HUNT);
+		afkFilterSelector.addItemListener(e ->
+		{
+			if (e.getStateChange() == ItemEvent.SELECTED)
+			{
+				onAfkFilterChanged.accept((AfkFilter) e.getItem());
+			}
+		});
+		add(afkFilterSelector);
+
+		sortSelector = new JComboBox<>(EfficientSortMode.values());
+		sortSelector.setSelectedItem(config.efficientSortMode());
+		sortSelector.setMaximumSize(new Dimension(Integer.MAX_VALUE, SELECTOR_HEIGHT));
+		sortSelector.setVisible(initialMode == Mode.EFFICIENT);
+		sortSelector.addItemListener(e ->
+		{
+			if (e.getStateChange() == ItemEvent.SELECTED)
+			{
+				EfficientSortMode selected = (EfficientSortMode) sortSelector.getSelectedItem();
+				if (selected != null)
+				{
+					onSortChanged.accept(selected);
+				}
+			}
+		});
+		add(sortSelector);
+
+		categorySelector = new JComboBox<>(CollectionLogCategory.values());
+		categorySelector.setMaximumSize(new Dimension(Integer.MAX_VALUE, SELECTOR_HEIGHT));
+		categorySelector.setVisible(false);
+		categorySelector.addItemListener(e ->
+		{
+			if (e.getStateChange() == ItemEvent.SELECTED)
+			{
+				onSearchOrFilterChanged.run();
+			}
+		});
+		add(categorySelector);
+
+		searchField = new JTextField();
+		searchField.setMaximumSize(new Dimension(Integer.MAX_VALUE, SELECTOR_HEIGHT));
+		searchField.setVisible(false);
+		searchField.setToolTipText("Search by item name or source name");
+		searchDebounceTimer = new Timer(SEARCH_DEBOUNCE_MS, e -> onSearchOrFilterChanged.run());
+		searchDebounceTimer.setRepeats(false);
+		searchField.getDocument().addDocumentListener(new DocumentListener()
+		{
+			@Override
+			public void insertUpdate(DocumentEvent e)
+			{
+				searchDebounceTimer.restart();
+			}
+
+			@Override
+			public void removeUpdate(DocumentEvent e)
+			{
+				searchDebounceTimer.restart();
+			}
+
+			@Override
+			public void changedUpdate(DocumentEvent e)
+			{
+				searchDebounceTimer.restart();
+			}
+		});
+		add(searchField);
+	}
+
+	/**
+	 * Updates which selectors are visible based on the current mode. AFK filter
+	 * is shown for EFFICIENT, PET_HUNT, and CATEGORY_FOCUS modes; sort selector
+	 * is shown only in EFFICIENT; category selector only in CATEGORY_FOCUS;
+	 * search field only in SEARCH.
+	 */
+	public void updateVisibility(Mode currentMode)
+	{
+		afkFilterSelector.setVisible(currentMode == Mode.EFFICIENT || currentMode == Mode.PET_HUNT
+			|| currentMode == Mode.CATEGORY_FOCUS);
+		sortSelector.setVisible(currentMode == Mode.EFFICIENT);
+		categorySelector.setVisible(currentMode == Mode.CATEGORY_FOCUS);
+		searchField.setVisible(currentMode == Mode.SEARCH);
+	}
+
+	/** Programmatically selects the given mode in the mode combo. */
+	public void setSelectedMode(Mode mode)
+	{
+		modeSelector.setSelectedItem(mode);
+	}
+
+	/** Programmatically selects the given category in the category combo. */
+	public void setSelectedCategory(CollectionLogCategory category)
+	{
+		categorySelector.setSelectedItem(category);
+	}
+
+	/** Returns the lower-cased, trimmed search query, or empty string. */
+	public String getSearchQuery()
+	{
+		return searchField.getText() == null ? "" : searchField.getText().toLowerCase().trim();
+	}
+
+	/** Returns the currently selected sort mode (may be {@code null}). */
+	public EfficientSortMode getSelectedSortMode()
+	{
+		return (EfficientSortMode) sortSelector.getSelectedItem();
+	}
+
+	/** Returns the currently selected category (may be {@code null}). */
+	public CollectionLogCategory getSelectedCategory()
+	{
+		return (CollectionLogCategory) categorySelector.getSelectedItem();
+	}
+
+	/** Stops the search-debounce timer. Call from panel shutdown. */
+	public void shutDown()
+	{
+		searchDebounceTimer.stop();
+	}
+}

--- a/src/test/java/com/collectionloghelper/ui/SelectorControlsPanelTest.java
+++ b/src/test/java/com/collectionloghelper/ui/SelectorControlsPanelTest.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.ui;
+
+import com.collectionloghelper.AfkFilter;
+import com.collectionloghelper.CollectionLogHelperConfig;
+import com.collectionloghelper.EfficientSortMode;
+import com.collectionloghelper.data.CollectionLogCategory;
+import com.collectionloghelper.ui.CollectionLogHelperPanel.Mode;
+import java.awt.Component;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.swing.JComboBox;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link SelectorControlsPanel}: the helper that owns the
+ * mode, AFK-filter, sort-mode, category, and search selectors. Extracted
+ * from {@link CollectionLogHelperPanel} as part of issue #503 god-class
+ * splits.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class SelectorControlsPanelTest
+{
+	@Mock
+	private CollectionLogHelperConfig config;
+
+	@Before
+	public void seedConfig()
+	{
+		when(config.afkFilter()).thenReturn(AfkFilter.OFF);
+		when(config.efficientSortMode()).thenReturn(EfficientSortMode.EFFICIENCY);
+	}
+
+	private SelectorControlsPanel newPanel(Mode initialMode,
+		AtomicReference<Mode> modeSink,
+		AtomicReference<AfkFilter> afkSink,
+		AtomicReference<EfficientSortMode> sortSink,
+		AtomicInteger rebuildCount)
+	{
+		return new SelectorControlsPanel(
+			config,
+			initialMode,
+			modeSink::set,
+			afkSink::set,
+			sortSink::set,
+			rebuildCount::incrementAndGet);
+	}
+
+	@Test
+	public void initialVisibility_efficient_showsAfkAndSort() throws Exception
+	{
+		SwingUtilities.invokeAndWait(() ->
+		{
+			SelectorControlsPanel panel = newPanel(Mode.EFFICIENT,
+				new AtomicReference<>(), new AtomicReference<>(),
+				new AtomicReference<>(), new AtomicInteger());
+
+			assertTrue(findCombo(panel, Mode.class).isVisible());
+			assertTrue(findCombo(panel, AfkFilter.class).isVisible());
+			assertTrue(findCombo(panel, EfficientSortMode.class).isVisible());
+			assertFalse(findCombo(panel, CollectionLogCategory.class).isVisible());
+			assertFalse(findField(panel).isVisible());
+		});
+	}
+
+	@Test
+	public void updateVisibility_searchMode_showsOnlySearchField() throws Exception
+	{
+		SwingUtilities.invokeAndWait(() ->
+		{
+			SelectorControlsPanel panel = newPanel(Mode.EFFICIENT,
+				new AtomicReference<>(), new AtomicReference<>(),
+				new AtomicReference<>(), new AtomicInteger());
+
+			panel.updateVisibility(Mode.SEARCH);
+
+			assertFalse(findCombo(panel, AfkFilter.class).isVisible());
+			assertFalse(findCombo(panel, EfficientSortMode.class).isVisible());
+			assertFalse(findCombo(panel, CollectionLogCategory.class).isVisible());
+			assertTrue(findField(panel).isVisible());
+		});
+	}
+
+	@Test
+	public void updateVisibility_categoryFocus_showsCategoryAndAfk() throws Exception
+	{
+		SwingUtilities.invokeAndWait(() ->
+		{
+			SelectorControlsPanel panel = newPanel(Mode.EFFICIENT,
+				new AtomicReference<>(), new AtomicReference<>(),
+				new AtomicReference<>(), new AtomicInteger());
+
+			panel.updateVisibility(Mode.CATEGORY_FOCUS);
+
+			assertTrue(findCombo(panel, AfkFilter.class).isVisible());
+			assertFalse(findCombo(panel, EfficientSortMode.class).isVisible());
+			assertTrue(findCombo(panel, CollectionLogCategory.class).isVisible());
+			assertFalse(findField(panel).isVisible());
+		});
+	}
+
+	@Test
+	public void selectMode_invokesModeChangedCallback() throws Exception
+	{
+		AtomicReference<Mode> sink = new AtomicReference<>();
+		SwingUtilities.invokeAndWait(() ->
+		{
+			SelectorControlsPanel panel = newPanel(Mode.EFFICIENT,
+				sink, new AtomicReference<>(), new AtomicReference<>(),
+				new AtomicInteger());
+
+			findCombo(panel, Mode.class).setSelectedItem(Mode.SEARCH);
+		});
+		assertEquals(Mode.SEARCH, sink.get());
+	}
+
+	@Test
+	public void selectAfkFilter_invokesAfkChangedCallback() throws Exception
+	{
+		AtomicReference<AfkFilter> sink = new AtomicReference<>();
+		SwingUtilities.invokeAndWait(() ->
+		{
+			SelectorControlsPanel panel = newPanel(Mode.EFFICIENT,
+				new AtomicReference<>(), sink, new AtomicReference<>(),
+				new AtomicInteger());
+
+			findCombo(panel, AfkFilter.class).setSelectedItem(AfkFilter.AFK);
+		});
+		assertEquals(AfkFilter.AFK, sink.get());
+	}
+
+	@Test
+	public void selectSortMode_invokesSortChangedCallback() throws Exception
+	{
+		AtomicReference<EfficientSortMode> sink = new AtomicReference<>();
+		SwingUtilities.invokeAndWait(() ->
+		{
+			SelectorControlsPanel panel = newPanel(Mode.EFFICIENT,
+				new AtomicReference<>(), new AtomicReference<>(),
+				sink, new AtomicInteger());
+
+			findCombo(panel, EfficientSortMode.class).setSelectedItem(EfficientSortMode.KILL_TIME);
+		});
+		assertEquals(EfficientSortMode.KILL_TIME, sink.get());
+	}
+
+	@Test
+	public void selectCategory_invokesRebuildCallback() throws Exception
+	{
+		AtomicInteger rebuilds = new AtomicInteger();
+		SwingUtilities.invokeAndWait(() ->
+		{
+			SelectorControlsPanel panel = newPanel(Mode.EFFICIENT,
+				new AtomicReference<>(), new AtomicReference<>(),
+				new AtomicReference<>(), rebuilds);
+
+			JComboBox<CollectionLogCategory> combo = findCombo(panel, CollectionLogCategory.class);
+			CollectionLogCategory initial = (CollectionLogCategory) combo.getSelectedItem();
+			CollectionLogCategory next = null;
+			for (int i = 0; i < combo.getItemCount(); i++)
+			{
+				if (combo.getItemAt(i) != initial)
+				{
+					next = combo.getItemAt(i);
+					break;
+				}
+			}
+			assertNotNull(next);
+			combo.setSelectedItem(next);
+		});
+		assertEquals(1, rebuilds.get());
+	}
+
+	@Test
+	public void getSearchQuery_returnsLowerCasedTrimmed() throws Exception
+	{
+		AtomicReference<String> observed = new AtomicReference<>();
+		SwingUtilities.invokeAndWait(() ->
+		{
+			SelectorControlsPanel panel = newPanel(Mode.SEARCH,
+				new AtomicReference<>(), new AtomicReference<>(),
+				new AtomicReference<>(), new AtomicInteger());
+
+			findField(panel).setText("  Slayer Helm  ");
+			observed.set(panel.getSearchQuery());
+			panel.shutDown();
+		});
+		assertEquals("slayer helm", observed.get());
+	}
+
+	@Test
+	public void setSelectedMode_updatesCombo() throws Exception
+	{
+		SwingUtilities.invokeAndWait(() ->
+		{
+			SelectorControlsPanel panel = newPanel(Mode.EFFICIENT,
+				new AtomicReference<>(), new AtomicReference<>(),
+				new AtomicReference<>(), new AtomicInteger());
+
+			panel.setSelectedMode(Mode.STATISTICS);
+
+			assertEquals(Mode.STATISTICS, findCombo(panel, Mode.class).getSelectedItem());
+		});
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T> JComboBox<T> findCombo(SelectorControlsPanel panel, Class<T> itemType)
+	{
+		for (Component c : panel.getComponents())
+		{
+			if (c instanceof JComboBox)
+			{
+				JComboBox<?> combo = (JComboBox<?>) c;
+				if (combo.getItemCount() > 0 && itemType.isInstance(combo.getItemAt(0)))
+				{
+					return (JComboBox<T>) combo;
+				}
+			}
+		}
+		throw new AssertionError("JComboBox for " + itemType.getSimpleName() + " not found");
+	}
+
+	private static JTextField findField(SelectorControlsPanel panel)
+	{
+		for (Component c : panel.getComponents())
+		{
+			if (c instanceof JTextField)
+			{
+				return (JTextField) c;
+			}
+		}
+		throw new AssertionError("JTextField not found");
+	}
+}

--- a/src/test/java/com/collectionloghelper/ui/SelectorControlsPanelTest.java
+++ b/src/test/java/com/collectionloghelper/ui/SelectorControlsPanelTest.java
@@ -29,7 +29,11 @@ import com.collectionloghelper.CollectionLogHelperConfig;
 import com.collectionloghelper.EfficientSortMode;
 import com.collectionloghelper.data.CollectionLogCategory;
 import com.collectionloghelper.ui.CollectionLogHelperPanel.Mode;
+import com.collectionloghelper.ui.mode.PanelModeController;
+import com.collectionloghelper.ui.mode.PanelModeDispatcher;
 import java.awt.Component;
+import java.util.EnumMap;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.swing.JComboBox;
@@ -236,6 +240,128 @@ public class SelectorControlsPanelTest
 
 			assertEquals(Mode.STATISTICS, findCombo(panel, Mode.class).getSelectedItem());
 		});
+	}
+
+	/**
+	 * Regression guard for the PR #531 HIGH finding: a programmatic mode change
+	 * via {@link SelectorControlsPanel#setSelectedMode(Mode)} must fire the
+	 * {@code onModeChanged} callback so the owning panel can route the
+	 * transition through {@code PanelModeDispatcher.switchMode(...)} and fire
+	 * the controller lifecycle hooks. If the callback is skipped, lifecycle
+	 * hooks are silently dropped on programmatic transitions.
+	 */
+	@Test
+	public void setSelectedMode_firesModeChangedCallback_forDifferentMode() throws Exception
+	{
+		AtomicReference<Mode> sink = new AtomicReference<>();
+		SwingUtilities.invokeAndWait(() ->
+		{
+			SelectorControlsPanel panel = newPanel(Mode.EFFICIENT,
+				sink, new AtomicReference<>(), new AtomicReference<>(),
+				new AtomicInteger());
+
+			panel.setSelectedMode(Mode.SEARCH);
+		});
+		assertEquals(Mode.SEARCH, sink.get());
+	}
+
+	/**
+	 * Companion check: a no-op programmatic selection (already-selected mode)
+	 * must NOT fire the callback. The owning panel relies on this to know the
+	 * dispatcher would short-circuit anyway, and handles the same-mode side
+	 * effects (visibility + rebuild) directly.
+	 */
+	@Test
+	public void setSelectedMode_doesNotFireCallback_forSameMode() throws Exception
+	{
+		AtomicReference<Mode> sink = new AtomicReference<>();
+		SwingUtilities.invokeAndWait(() ->
+		{
+			SelectorControlsPanel panel = newPanel(Mode.EFFICIENT,
+				sink, new AtomicReference<>(), new AtomicReference<>(),
+				new AtomicInteger());
+
+			panel.setSelectedMode(Mode.EFFICIENT);
+		});
+		assertEquals(null, sink.get());
+	}
+
+	/**
+	 * End-to-end regression guard for PR #531 HIGH: simulates the owning
+	 * panel's wiring (selector → listener → {@link PanelModeDispatcher}) with
+	 * recording-fake controllers, and verifies that a programmatic transition
+	 * fires {@code onModeDeactivated()} on the leaving controller exactly once
+	 * and {@code onModeActivated()} on the entering controller exactly once.
+	 * Before the fix, {@code panel.setMode(...)} mutated {@code currentMode}
+	 * before dispatching, so the listener saw {@code previous == next} and the
+	 * dispatcher short-circuited — both hooks fired zero times.
+	 */
+	@Test
+	public void setSelectedMode_firesLifecycleHooksThroughDispatcher() throws Exception
+	{
+		RecordingController efficientController = new RecordingController();
+		RecordingController searchController = new RecordingController();
+
+		Map<Mode, PanelModeController> controllers = new EnumMap<>(Mode.class);
+		controllers.put(Mode.EFFICIENT, efficientController);
+		controllers.put(Mode.SEARCH, searchController);
+		PanelModeDispatcher<Mode> dispatcher = new PanelModeDispatcher<>(controllers);
+
+		AtomicReference<Mode> currentMode = new AtomicReference<>(Mode.EFFICIENT);
+		// Mirror the panel's onModeSelected listener: capture previous, write
+		// next, then dispatch.
+		java.util.function.Consumer<Mode> listener = nextMode ->
+		{
+			Mode previous = currentMode.get();
+			currentMode.set(nextMode);
+			dispatcher.switchMode(previous, nextMode);
+		};
+
+		SwingUtilities.invokeAndWait(() ->
+		{
+			SelectorControlsPanel panel = new SelectorControlsPanel(
+				config,
+				Mode.EFFICIENT,
+				listener,
+				afk -> { },
+				sort -> { },
+				() -> { });
+
+			// Mimic panel.setMode(Mode.SEARCH) under the fixed implementation:
+			// no pre-mutation, route entirely through the selector.
+			panel.setSelectedMode(Mode.SEARCH);
+		});
+
+		assertEquals(Mode.SEARCH, currentMode.get());
+		assertEquals(1, efficientController.deactivatedCount);
+		assertEquals(0, efficientController.activatedCount);
+		assertEquals(1, searchController.activatedCount);
+		assertEquals(0, searchController.deactivatedCount);
+	}
+
+	/** Recording-fake controller used by the end-to-end lifecycle test. */
+	private static final class RecordingController implements PanelModeController
+	{
+		int activatedCount = 0;
+		int deactivatedCount = 0;
+
+		@Override
+		public void buildView()
+		{
+			// No-op for the lifecycle test.
+		}
+
+		@Override
+		public void onModeActivated()
+		{
+			activatedCount++;
+		}
+
+		@Override
+		public void onModeDeactivated()
+		{
+			deactivatedCount++;
+		}
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
## Summary

Wave 10 of the #503 god-class split. Moves the five selector widgets (mode, AFK-filter, sort-mode, category, search) plus their listeners, visibility rules, and the search debounce timer out of `CollectionLogHelperPanel` into a dedicated `SelectorControlsPanel`.

- Panel keeps authority over `currentMode`; the selector panel reports changes via callbacks supplied at construction.
- Sibling of `PanelRebuildOrchestrator`, `SyncButtonController`, `ListContainerScrollPane`, `DetailViewBuilder`. Panel-constructed (not @Singleton), bound to panel lifecycle.
- `CollectionLogHelperPanel.java`: 763 -> 685 LOC (-78).
- New `SelectorControlsPanel.java`: 228 LOC.
- New `SelectorControlsPanelTest.java`: 9 unit tests covering initial visibility, visibility transitions, callback invocations, query normalization, and programmatic mode selection.

## Test plan

- [x] `./gradlew compileJava` clean
- [x] `./gradlew test` passes (1219 tests)
- [x] `./gradlew build` passes
- [x] New `SelectorControlsPanelTest` covers visibility rules per mode, all five change callbacks, search-query trimming/lower-casing, and programmatic selection
- [x] Public API of `CollectionLogHelperPanel` unchanged (`setMode`, `getSearchQuery`, `getEfficientSortMode`, `getSelectedCategory`, `switchToCategoryFocus`, `shutDown` preserved)