### PR TITLE
refactor: extract OverlayDeactivator from GuidanceOverlayCoordinator (#503)

### DIFF
--- a/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
@@ -113,6 +113,7 @@ public class GuidanceOverlayCoordinator
 	private final WidgetHighlightOverlay widgetHighlightOverlay;
 	private final OverlayStepApplier overlayStepApplier;
 	private final OverlaySourceApplier overlaySourceApplier;
+	private final OverlayDeactivator overlayDeactivator;
 	private final WorldMapController worldMapController;
 	private final DynamicTargetManager dynamicTargetManager;
 	private final NpcTrackerHelper npcTrackerHelper;
@@ -184,6 +185,7 @@ public class GuidanceOverlayCoordinator
 		WidgetHighlightOverlay widgetHighlightOverlay,
 		OverlayStepApplier overlayStepApplier,
 		OverlaySourceApplier overlaySourceApplier,
+		OverlayDeactivator overlayDeactivator,
 		WorldMapController worldMapController,
 		DynamicTargetManager dynamicTargetManager,
 		NpcTrackerHelper npcTrackerHelper)
@@ -211,6 +213,7 @@ public class GuidanceOverlayCoordinator
 		this.widgetHighlightOverlay = widgetHighlightOverlay;
 		this.overlayStepApplier = overlayStepApplier;
 		this.overlaySourceApplier = overlaySourceApplier;
+		this.overlayDeactivator = overlayDeactivator;
 		this.worldMapController = worldMapController;
 		this.dynamicTargetManager = dynamicTargetManager;
 		this.npcTrackerHelper = npcTrackerHelper;
@@ -366,45 +369,11 @@ public class GuidanceOverlayCoordinator
 	{
 		activeTargetItemId = null;
 		lastMessagedStepIndex = -1;
-		npcTrackerHelper.clear();
-		if (activeInfoBox != null)
-		{
-			infoBoxManager.removeInfoBox(activeInfoBox);
-			activeInfoBox = null;
-		}
-		guidanceSequencer.stopSequence();
-		guidanceOverlay.clearTarget();
-		guidanceMinimapOverlay.clearTarget();
-		worldMapRouteOverlay.clearTarget();
-		worldMapDestinationOverlay.clearTarget();
-		worldMapDestinationOverlay.setMapPointActive(false);
-		dialogHighlightOverlay.clear();
-		objectHighlightOverlay.clearTarget();
-		itemHighlightOverlay.clearTarget();
-		groundItemHighlightOverlay.clearTargets();
-		widgetHighlightOverlay.clearHighlights();
-		activeMapPoint = null;
-		pendingShortestPathTarget = null;
-		worldMapPointManager.removeIf(CollectionLogWorldMapPoint.class::isInstance);
-
-		clientThread.invokeLater(() ->
-		{
-			client.clearHintArrow();
-
-			if (config.useShortestPath())
-			{
-				eventBus.post(new PluginMessage("shortestpath", "clear"));
-			}
-		});
-
-		if (panel != null)
-		{
-			panel.hideClueGuidance();
-			panel.hideStepProgress();
-			panel.setGuidanceState(false, null, null);
-		}
-
-		log.debug("Guidance deactivated");
+		OverlayDeactivator.Result result = overlayDeactivator.deactivate(
+			new OverlayDeactivator.Input(activeInfoBox, pendingShortestPathTarget, panel));
+		activeMapPoint = result.activeMapPoint;
+		activeInfoBox = result.activeInfoBox;
+		pendingShortestPathTarget = result.pendingShortestPathTarget;
 	}
 
 	/**
@@ -595,24 +564,11 @@ public class GuidanceOverlayCoordinator
 
 	private void clearGuidanceOverlays()
 	{
-		npcTrackerHelper.clear();
-		guidanceOverlay.clearTarget();
-		guidanceMinimapOverlay.clearTarget();
-		worldMapRouteOverlay.clearTarget();
-		worldMapDestinationOverlay.clearTarget();
-		worldMapDestinationOverlay.setMapPointActive(false);
-		dialogHighlightOverlay.clear();
-		objectHighlightOverlay.clearTarget();
-		itemHighlightOverlay.clearTarget();
-		groundItemHighlightOverlay.clearTargets();
-		widgetHighlightOverlay.clearHighlights();
-		clientThread.invokeLater(() -> client.clearHintArrow());
-		activeMapPoint = null;
-		worldMapPointManager.removeIf(CollectionLogWorldMapPoint.class::isInstance);
-		if (panel != null)
-		{
-			panel.hideClueGuidance();
-		}
+		OverlayDeactivator.Result result = overlayDeactivator.clearOverlays(
+			new OverlayDeactivator.Input(activeInfoBox, pendingShortestPathTarget, panel));
+		activeMapPoint = result.activeMapPoint;
+		activeInfoBox = result.activeInfoBox;
+		pendingShortestPathTarget = result.pendingShortestPathTarget;
 	}
 
 	/**

--- a/src/main/java/com/collectionloghelper/guidance/OverlayDeactivator.java
+++ b/src/main/java/com/collectionloghelper/guidance/OverlayDeactivator.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.guidance;
+
+import com.collectionloghelper.CollectionLogHelperConfig;
+import com.collectionloghelper.overlay.CollectionLogWorldMapPoint;
+import com.collectionloghelper.overlay.DialogHighlightOverlay;
+import com.collectionloghelper.overlay.GroundItemHighlightOverlay;
+import com.collectionloghelper.overlay.GuidanceInfoBox;
+import com.collectionloghelper.overlay.GuidanceMinimapOverlay;
+import com.collectionloghelper.overlay.GuidanceOverlay;
+import com.collectionloghelper.overlay.ItemHighlightOverlay;
+import com.collectionloghelper.overlay.ObjectHighlightOverlay;
+import com.collectionloghelper.overlay.WidgetHighlightOverlay;
+import com.collectionloghelper.overlay.WorldMapDestinationOverlay;
+import com.collectionloghelper.overlay.WorldMapRouteOverlay;
+import com.collectionloghelper.ui.CollectionLogHelperPanel;
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.eventbus.EventBus;
+import net.runelite.client.events.PluginMessage;
+import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
+import net.runelite.client.ui.overlay.worldmap.WorldMapPointManager;
+
+/**
+ * Handles the overlay deactivation cluster from {@link GuidanceOverlayCoordinator}:
+ * the partial between-step {@code clearGuidanceOverlays} pass and the full
+ * {@code deactivateGuidance} pass that tears down all guidance state.
+ *
+ * <p>Pure extraction: this class holds no mutable guidance state of its own.
+ * Coordinator-owned mutable state (active world-map point, active InfoBox,
+ * pending shortest-path target, panel reference) is passed in via {@link Input}
+ * and returned via {@link Result} so the coordinator remains the single owner
+ * of that state.</p>
+ *
+ * <p>Mirrors the structural pattern established by {@link OverlaySourceApplier}.</p>
+ */
+@Slf4j
+@Singleton
+public class OverlayDeactivator
+{
+	private final Client client;
+	private final ClientThread clientThread;
+	private final EventBus eventBus;
+	private final CollectionLogHelperConfig config;
+	private final WorldMapPointManager worldMapPointManager;
+	private final InfoBoxManager infoBoxManager;
+	private final GuidanceOverlay guidanceOverlay;
+	private final GuidanceMinimapOverlay guidanceMinimapOverlay;
+	private final DialogHighlightOverlay dialogHighlightOverlay;
+	private final ObjectHighlightOverlay objectHighlightOverlay;
+	private final ItemHighlightOverlay itemHighlightOverlay;
+	private final WorldMapRouteOverlay worldMapRouteOverlay;
+	private final WorldMapDestinationOverlay worldMapDestinationOverlay;
+	private final GroundItemHighlightOverlay groundItemHighlightOverlay;
+	private final WidgetHighlightOverlay widgetHighlightOverlay;
+	private final NpcTrackerHelper npcTrackerHelper;
+	private final GuidanceSequencer guidanceSequencer;
+
+	@Inject
+	OverlayDeactivator(
+		Client client,
+		ClientThread clientThread,
+		EventBus eventBus,
+		CollectionLogHelperConfig config,
+		WorldMapPointManager worldMapPointManager,
+		InfoBoxManager infoBoxManager,
+		GuidanceOverlay guidanceOverlay,
+		GuidanceMinimapOverlay guidanceMinimapOverlay,
+		DialogHighlightOverlay dialogHighlightOverlay,
+		ObjectHighlightOverlay objectHighlightOverlay,
+		ItemHighlightOverlay itemHighlightOverlay,
+		WorldMapRouteOverlay worldMapRouteOverlay,
+		WorldMapDestinationOverlay worldMapDestinationOverlay,
+		GroundItemHighlightOverlay groundItemHighlightOverlay,
+		WidgetHighlightOverlay widgetHighlightOverlay,
+		NpcTrackerHelper npcTrackerHelper,
+		GuidanceSequencer guidanceSequencer)
+	{
+		this.client = client;
+		this.clientThread = clientThread;
+		this.eventBus = eventBus;
+		this.config = config;
+		this.worldMapPointManager = worldMapPointManager;
+		this.infoBoxManager = infoBoxManager;
+		this.guidanceOverlay = guidanceOverlay;
+		this.guidanceMinimapOverlay = guidanceMinimapOverlay;
+		this.dialogHighlightOverlay = dialogHighlightOverlay;
+		this.objectHighlightOverlay = objectHighlightOverlay;
+		this.itemHighlightOverlay = itemHighlightOverlay;
+		this.worldMapRouteOverlay = worldMapRouteOverlay;
+		this.worldMapDestinationOverlay = worldMapDestinationOverlay;
+		this.groundItemHighlightOverlay = groundItemHighlightOverlay;
+		this.widgetHighlightOverlay = widgetHighlightOverlay;
+		this.npcTrackerHelper = npcTrackerHelper;
+		this.guidanceSequencer = guidanceSequencer;
+	}
+
+	/**
+	 * Clears guidance overlays between sequencer steps. Pure extraction of
+	 * {@code GuidanceOverlayCoordinator.clearGuidanceOverlays} -- no behavioural
+	 * change. Sequencer state, InfoBox, and {@code activeTargetItemId} are
+	 * preserved (only a partial reset for the step transition).
+	 *
+	 * @param in coordinator-owned mutable state read by this clear pass
+	 * @return updated state to be written back onto the coordinator
+	 */
+	Result clearOverlays(Input in)
+	{
+		npcTrackerHelper.clear();
+		guidanceOverlay.clearTarget();
+		guidanceMinimapOverlay.clearTarget();
+		worldMapRouteOverlay.clearTarget();
+		worldMapDestinationOverlay.clearTarget();
+		worldMapDestinationOverlay.setMapPointActive(false);
+		dialogHighlightOverlay.clear();
+		objectHighlightOverlay.clearTarget();
+		itemHighlightOverlay.clearTarget();
+		groundItemHighlightOverlay.clearTargets();
+		widgetHighlightOverlay.clearHighlights();
+		clientThread.invokeLater(() -> client.clearHintArrow());
+		worldMapPointManager.removeIf(CollectionLogWorldMapPoint.class::isInstance);
+		if (in.panel != null)
+		{
+			in.panel.hideClueGuidance();
+		}
+		// activeInfoBox and pendingShortestPathTarget unchanged by the partial clear.
+		return new Result(null, in.activeInfoBox, in.pendingShortestPathTarget);
+	}
+
+	/**
+	 * Fully deactivates guidance: clears all overlays, stops the sequencer,
+	 * removes the InfoBox, posts the ShortestPath "clear" message, and resets
+	 * the panel state. Pure extraction of
+	 * {@code GuidanceOverlayCoordinator.deactivateGuidance} -- no behavioural
+	 * change.
+	 *
+	 * @param in coordinator-owned mutable state read by this deactivate pass
+	 * @return updated state to be written back onto the coordinator
+	 */
+	Result deactivate(Input in)
+	{
+		npcTrackerHelper.clear();
+		GuidanceInfoBox infoBox = in.activeInfoBox;
+		if (infoBox != null)
+		{
+			infoBoxManager.removeInfoBox(infoBox);
+			infoBox = null;
+		}
+		guidanceSequencer.stopSequence();
+		guidanceOverlay.clearTarget();
+		guidanceMinimapOverlay.clearTarget();
+		worldMapRouteOverlay.clearTarget();
+		worldMapDestinationOverlay.clearTarget();
+		worldMapDestinationOverlay.setMapPointActive(false);
+		dialogHighlightOverlay.clear();
+		objectHighlightOverlay.clearTarget();
+		itemHighlightOverlay.clearTarget();
+		groundItemHighlightOverlay.clearTargets();
+		widgetHighlightOverlay.clearHighlights();
+		worldMapPointManager.removeIf(CollectionLogWorldMapPoint.class::isInstance);
+
+		clientThread.invokeLater(() ->
+		{
+			client.clearHintArrow();
+
+			if (config.useShortestPath())
+			{
+				eventBus.post(new PluginMessage("shortestpath", "clear"));
+			}
+		});
+
+		if (in.panel != null)
+		{
+			in.panel.hideClueGuidance();
+			in.panel.hideStepProgress();
+			in.panel.setGuidanceState(false, null, null);
+		}
+
+		log.debug("Guidance deactivated");
+		return new Result(null, infoBox, null);
+	}
+
+	/**
+	 * Coordinator-owned mutable state that this deactivator reads but does not own.
+	 */
+	static final class Input
+	{
+		@Nullable
+		final GuidanceInfoBox activeInfoBox;
+		@Nullable
+		final WorldPoint pendingShortestPathTarget;
+		@Nullable
+		final CollectionLogHelperPanel panel;
+
+		Input(
+			@Nullable GuidanceInfoBox activeInfoBox,
+			@Nullable WorldPoint pendingShortestPathTarget,
+			@Nullable CollectionLogHelperPanel panel)
+		{
+			this.activeInfoBox = activeInfoBox;
+			this.pendingShortestPathTarget = pendingShortestPathTarget;
+			this.panel = panel;
+		}
+	}
+
+	/**
+	 * Updated state to be written back onto the coordinator after a clear or
+	 * deactivate pass.
+	 */
+	static final class Result
+	{
+		@Nullable
+		final CollectionLogWorldMapPoint activeMapPoint;
+		@Nullable
+		final GuidanceInfoBox activeInfoBox;
+		@Nullable
+		final WorldPoint pendingShortestPathTarget;
+
+		Result(
+			@Nullable CollectionLogWorldMapPoint activeMapPoint,
+			@Nullable GuidanceInfoBox activeInfoBox,
+			@Nullable WorldPoint pendingShortestPathTarget)
+		{
+			this.activeMapPoint = activeMapPoint;
+			this.activeInfoBox = activeInfoBox;
+			this.pendingShortestPathTarget = pendingShortestPathTarget;
+		}
+	}
+}

--- a/src/test/java/com/collectionloghelper/guidance/DynamicTargetEvaluatorDispatchTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/DynamicTargetEvaluatorDispatchTest.java
@@ -152,6 +152,8 @@ public class DynamicTargetEvaluatorDispatchTest
 		OverlaySourceApplier overlaySourceApplier = newOverlaySourceApplier();
 		WorldMapController worldMapController = newWorldMapController();
 		DynamicTargetManager dynamicTargetManager = newDynamicTargetManager(worldMapController);
+		NpcTrackerHelper npcTrackerHelper = newNpcTrackerHelper();
+		OverlayDeactivator overlayDeactivator = newOverlayDeactivator(npcTrackerHelper);
 		Constructor<GuidanceOverlayCoordinator> ctor =
 			GuidanceOverlayCoordinator.class.getDeclaredConstructor(
 				Client.class,
@@ -177,11 +179,11 @@ public class DynamicTargetEvaluatorDispatchTest
 				WidgetHighlightOverlay.class,
 				OverlayStepApplier.class,
 				OverlaySourceApplier.class,
+				OverlayDeactivator.class,
 				WorldMapController.class,
 				DynamicTargetManager.class,
 				NpcTrackerHelper.class);
 		ctor.setAccessible(true);
-		NpcTrackerHelper npcTrackerHelper = newNpcTrackerHelper();
 		coordinator = ctor.newInstance(
 			client, clientThread, eventBus, config,
 			guidanceSequencer, requirementsChecker, travelCapabilities,
@@ -191,8 +193,8 @@ public class DynamicTargetEvaluatorDispatchTest
 			objectHighlightOverlay, itemHighlightOverlay,
 			worldMapRouteOverlay, worldMapDestinationOverlay,
 			groundItemHighlightOverlay, widgetHighlightOverlay,
-			overlayStepApplier, overlaySourceApplier, worldMapController,
-			dynamicTargetManager, npcTrackerHelper);
+			overlayStepApplier, overlaySourceApplier, overlayDeactivator,
+			worldMapController, dynamicTargetManager, npcTrackerHelper);
 
 		lenient().when(client.getLocalPlayer()).thenReturn(localPlayer);
 		lenient().when(localPlayer.getWorldLocation()).thenReturn(new WorldPoint(3200, 3200, 0));
@@ -342,6 +344,26 @@ public class DynamicTargetEvaluatorDispatchTest
 			requirementsChecker, worldMapPointManager,
 			guidanceOverlay, guidanceMinimapOverlay, dialogHighlightOverlay,
 			worldMapRouteOverlay, worldMapDestinationOverlay);
+	}
+
+	private OverlayDeactivator newOverlayDeactivator(NpcTrackerHelper npcTrackerHelper) throws Exception
+	{
+		Constructor<OverlayDeactivator> ctor = OverlayDeactivator.class.getDeclaredConstructor(
+			Client.class, ClientThread.class, EventBus.class, CollectionLogHelperConfig.class,
+			WorldMapPointManager.class, InfoBoxManager.class,
+			GuidanceOverlay.class, GuidanceMinimapOverlay.class, DialogHighlightOverlay.class,
+			ObjectHighlightOverlay.class, ItemHighlightOverlay.class,
+			WorldMapRouteOverlay.class, WorldMapDestinationOverlay.class,
+			GroundItemHighlightOverlay.class, WidgetHighlightOverlay.class,
+			NpcTrackerHelper.class, GuidanceSequencer.class);
+		ctor.setAccessible(true);
+		return ctor.newInstance(client, clientThread, eventBus, config,
+			worldMapPointManager, infoBoxManager,
+			guidanceOverlay, guidanceMinimapOverlay, dialogHighlightOverlay,
+			objectHighlightOverlay, itemHighlightOverlay,
+			worldMapRouteOverlay, worldMapDestinationOverlay,
+			groundItemHighlightOverlay, widgetHighlightOverlay,
+			npcTrackerHelper, guidanceSequencer);
 	}
 
 	private static GuidanceStep stepWithEvaluator(String evaluatorKey)

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorDescriptionTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorDescriptionTest.java
@@ -146,6 +146,8 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 		OverlayStepApplier overlayStepApplier = newOverlayStepApplier();
 		OverlaySourceApplier overlaySourceApplier = newOverlaySourceApplier();
 		WorldMapController worldMapController = newWorldMapController();
+		NpcTrackerHelper npcTrackerHelper = newNpcTrackerHelper();
+		OverlayDeactivator overlayDeactivator = newOverlayDeactivator(npcTrackerHelper);
 		Constructor<GuidanceOverlayCoordinator> ctor =
 			GuidanceOverlayCoordinator.class.getDeclaredConstructor(
 				Client.class,
@@ -171,12 +173,12 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 				WidgetHighlightOverlay.class,
 				OverlayStepApplier.class,
 				OverlaySourceApplier.class,
+				OverlayDeactivator.class,
 				WorldMapController.class,
 				DynamicTargetManager.class,
 				NpcTrackerHelper.class);
 		ctor.setAccessible(true);
 		DynamicTargetManager dynamicTargetManager = newDynamicTargetManager(worldMapController);
-		NpcTrackerHelper npcTrackerHelper = newNpcTrackerHelper();
 		coordinator = ctor.newInstance(
 			client, clientThread, eventBus, config,
 			guidanceSequencer, requirementsChecker, travelCapabilities,
@@ -186,8 +188,8 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 			objectHighlightOverlay, itemHighlightOverlay,
 			worldMapRouteOverlay, worldMapDestinationOverlay,
 			groundItemHighlightOverlay, widgetHighlightOverlay,
-			overlayStepApplier, overlaySourceApplier, worldMapController,
-			dynamicTargetManager, npcTrackerHelper);
+			overlayStepApplier, overlaySourceApplier, overlayDeactivator,
+			worldMapController, dynamicTargetManager, npcTrackerHelper);
 
 		coordinator.setPanel(panel);
 
@@ -357,6 +359,26 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 			requirementsChecker, worldMapPointManager,
 			guidanceOverlay, guidanceMinimapOverlay, dialogHighlightOverlay,
 			worldMapRouteOverlay, worldMapDestinationOverlay);
+	}
+
+	private OverlayDeactivator newOverlayDeactivator(NpcTrackerHelper npcTrackerHelper) throws Exception
+	{
+		Constructor<OverlayDeactivator> ctor = OverlayDeactivator.class.getDeclaredConstructor(
+			Client.class, ClientThread.class, EventBus.class, CollectionLogHelperConfig.class,
+			WorldMapPointManager.class, InfoBoxManager.class,
+			GuidanceOverlay.class, GuidanceMinimapOverlay.class, DialogHighlightOverlay.class,
+			ObjectHighlightOverlay.class, ItemHighlightOverlay.class,
+			WorldMapRouteOverlay.class, WorldMapDestinationOverlay.class,
+			GroundItemHighlightOverlay.class, WidgetHighlightOverlay.class,
+			NpcTrackerHelper.class, GuidanceSequencer.class);
+		ctor.setAccessible(true);
+		return ctor.newInstance(client, clientThread, eventBus, config,
+			worldMapPointManager, infoBoxManager,
+			guidanceOverlay, guidanceMinimapOverlay, dialogHighlightOverlay,
+			objectHighlightOverlay, itemHighlightOverlay,
+			worldMapRouteOverlay, worldMapDestinationOverlay,
+			groundItemHighlightOverlay, widgetHighlightOverlay,
+			npcTrackerHelper, guidanceSequencer);
 	}
 
 	private static CollectionLogSource sourceWithSteps(String name, GuidanceStep... steps)

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorMapPointTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorMapPointTest.java
@@ -132,6 +132,8 @@ public class GuidanceOverlayCoordinatorMapPointTest
 		OverlayStepApplier overlayStepApplier = newOverlayStepApplier();
 		OverlaySourceApplier overlaySourceApplier = newOverlaySourceApplier();
 		WorldMapController worldMapController = newWorldMapController();
+		NpcTrackerHelper npcTrackerHelper = newNpcTrackerHelper();
+		OverlayDeactivator overlayDeactivator = newOverlayDeactivator(npcTrackerHelper);
 		Constructor<GuidanceOverlayCoordinator> ctor =
 			GuidanceOverlayCoordinator.class.getDeclaredConstructor(
 				Client.class,
@@ -157,12 +159,12 @@ public class GuidanceOverlayCoordinatorMapPointTest
 				WidgetHighlightOverlay.class,
 				OverlayStepApplier.class,
 				OverlaySourceApplier.class,
+				OverlayDeactivator.class,
 				WorldMapController.class,
 				DynamicTargetManager.class,
 				NpcTrackerHelper.class);
 		ctor.setAccessible(true);
 		DynamicTargetManager dynamicTargetManager = newDynamicTargetManager(worldMapController);
-		NpcTrackerHelper npcTrackerHelper = newNpcTrackerHelper();
 		coordinator = ctor.newInstance(
 			client, clientThread, eventBus, config,
 			guidanceSequencer, requirementsChecker, travelCapabilities,
@@ -172,8 +174,8 @@ public class GuidanceOverlayCoordinatorMapPointTest
 			objectHighlightOverlay, itemHighlightOverlay,
 			worldMapRouteOverlay, worldMapDestinationOverlay,
 			groundItemHighlightOverlay, widgetHighlightOverlay,
-			overlayStepApplier, overlaySourceApplier, worldMapController,
-			dynamicTargetManager, npcTrackerHelper);
+			overlayStepApplier, overlaySourceApplier, overlayDeactivator,
+			worldMapController, dynamicTargetManager, npcTrackerHelper);
 
 		// Default stubs: no unmet requirements; buildRequirementRows called unconditionally
 		when(requirementsChecker.getUnmetRequirements(any())).thenReturn(Collections.emptyList());
@@ -316,6 +318,26 @@ public class GuidanceOverlayCoordinatorMapPointTest
 			requirementsChecker, worldMapPointManager,
 			guidanceOverlay, guidanceMinimapOverlay, dialogHighlightOverlay,
 			worldMapRouteOverlay, worldMapDestinationOverlay);
+	}
+
+	private OverlayDeactivator newOverlayDeactivator(NpcTrackerHelper npcTrackerHelper) throws Exception
+	{
+		Constructor<OverlayDeactivator> ctor = OverlayDeactivator.class.getDeclaredConstructor(
+			Client.class, ClientThread.class, EventBus.class, CollectionLogHelperConfig.class,
+			WorldMapPointManager.class, InfoBoxManager.class,
+			GuidanceOverlay.class, GuidanceMinimapOverlay.class, DialogHighlightOverlay.class,
+			ObjectHighlightOverlay.class, ItemHighlightOverlay.class,
+			WorldMapRouteOverlay.class, WorldMapDestinationOverlay.class,
+			GroundItemHighlightOverlay.class, WidgetHighlightOverlay.class,
+			NpcTrackerHelper.class, GuidanceSequencer.class);
+		ctor.setAccessible(true);
+		return ctor.newInstance(client, clientThread, eventBus, config,
+			worldMapPointManager, infoBoxManager,
+			guidanceOverlay, guidanceMinimapOverlay, dialogHighlightOverlay,
+			objectHighlightOverlay, itemHighlightOverlay,
+			worldMapRouteOverlay, worldMapDestinationOverlay,
+			groundItemHighlightOverlay, widgetHighlightOverlay,
+			npcTrackerHelper, guidanceSequencer);
 	}
 
 	private static CollectionLogSource sourceAtCoords(

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorNpcIdTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorNpcIdTest.java
@@ -143,6 +143,8 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 		OverlayStepApplier overlayStepApplier = newOverlayStepApplier();
 		OverlaySourceApplier overlaySourceApplier = newOverlaySourceApplier();
 		WorldMapController worldMapController = newWorldMapController();
+		NpcTrackerHelper npcTrackerHelper = newNpcTrackerHelper();
+		OverlayDeactivator overlayDeactivator = newOverlayDeactivator(npcTrackerHelper);
 		Constructor<GuidanceOverlayCoordinator> ctor =
 			GuidanceOverlayCoordinator.class.getDeclaredConstructor(
 				Client.class,
@@ -168,12 +170,12 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 				WidgetHighlightOverlay.class,
 				OverlayStepApplier.class,
 				OverlaySourceApplier.class,
+				OverlayDeactivator.class,
 				WorldMapController.class,
 				DynamicTargetManager.class,
 				NpcTrackerHelper.class);
 		ctor.setAccessible(true);
 		DynamicTargetManager dynamicTargetManager = newDynamicTargetManager(worldMapController);
-		NpcTrackerHelper npcTrackerHelper = newNpcTrackerHelper();
 		coordinator = ctor.newInstance(
 			client, clientThread, eventBus, config,
 			guidanceSequencer, requirementsChecker, travelCapabilities,
@@ -183,8 +185,8 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 			objectHighlightOverlay, itemHighlightOverlay,
 			worldMapRouteOverlay, worldMapDestinationOverlay,
 			groundItemHighlightOverlay, widgetHighlightOverlay,
-			overlayStepApplier, overlaySourceApplier, worldMapController,
-			dynamicTargetManager, npcTrackerHelper);
+			overlayStepApplier, overlaySourceApplier, overlayDeactivator,
+			worldMapController, dynamicTargetManager, npcTrackerHelper);
 
 		when(requirementsChecker.getUnmetRequirements(any())).thenReturn(Collections.emptyList());
 		when(requirementsChecker.buildRequirementRows(any())).thenReturn(Collections.emptyList());
@@ -364,6 +366,26 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 			requirementsChecker, worldMapPointManager,
 			guidanceOverlay, guidanceMinimapOverlay, dialogHighlightOverlay,
 			worldMapRouteOverlay, worldMapDestinationOverlay);
+	}
+
+	private OverlayDeactivator newOverlayDeactivator(NpcTrackerHelper npcTrackerHelper) throws Exception
+	{
+		Constructor<OverlayDeactivator> ctor = OverlayDeactivator.class.getDeclaredConstructor(
+			Client.class, ClientThread.class, EventBus.class, CollectionLogHelperConfig.class,
+			WorldMapPointManager.class, InfoBoxManager.class,
+			GuidanceOverlay.class, GuidanceMinimapOverlay.class, DialogHighlightOverlay.class,
+			ObjectHighlightOverlay.class, ItemHighlightOverlay.class,
+			WorldMapRouteOverlay.class, WorldMapDestinationOverlay.class,
+			GroundItemHighlightOverlay.class, WidgetHighlightOverlay.class,
+			NpcTrackerHelper.class, GuidanceSequencer.class);
+		ctor.setAccessible(true);
+		return ctor.newInstance(client, clientThread, eventBus, config,
+			worldMapPointManager, infoBoxManager,
+			guidanceOverlay, guidanceMinimapOverlay, dialogHighlightOverlay,
+			objectHighlightOverlay, itemHighlightOverlay,
+			worldMapRouteOverlay, worldMapDestinationOverlay,
+			groundItemHighlightOverlay, widgetHighlightOverlay,
+			npcTrackerHelper, guidanceSequencer);
 	}
 
 	private static CollectionLogSource sourceWithSteps(String name, GuidanceStep... steps)


### PR DESCRIPTION
## Summary

Wave 10 of the GuidanceOverlayCoordinator decomposition (#503). Extracts the overlay deactivation cluster into a new `OverlayDeactivator` helper that follows the Input/Result carrier pattern established by `OverlaySourceApplier` (#529).

- `clearGuidanceOverlays()` (partial between-step clear) and `deactivateGuidance()` (full teardown) now delegate to `OverlayDeactivator.clearOverlays(Input)` and `OverlayDeactivator.deactivate(Input)` respectively.
- Coordinator-owned mutable state (`activeMapPoint`, `activeInfoBox`, `pendingShortestPathTarget`) flows in via `Input` and out via `Result`, so the coordinator remains the single owner of that state.
- Pure extraction. Behaviour preserved exactly (same overlay calls, same order, same client-thread deferral, same ShortestPath plugin-message dispatch).

## LOC delta

`GuidanceOverlayCoordinator.java`: **711 -> 667 (-44 LOC)**.

Closer to the 600-LOC target. Remaining seam highlighted as Wave 11 candidate: the `onStepChanged` cluster (~60 LOC at the bottom of the file), which is genuinely stateful and will need careful Input/Result discipline.

## Test plan

- [x] `./gradlew build` passes
- [x] `./gradlew test` passes (covered by `build`)
- [x] Reflection-based coordinator tests updated to inject the new singleton through the package-private constructor:
  - [x] `GuidanceOverlayCoordinatorMapPointTest`
  - [x] `GuidanceOverlayCoordinatorNpcIdTest`
  - [x] `GuidanceOverlayCoordinatorDescriptionTest`
  - [x] `DynamicTargetEvaluatorDispatchTest`
- [ ] Manual smoke: start guidance for a multi-step source, step through, then stop guidance; verify overlays clear, hint arrow clears, ShortestPath "clear" fires, and panel resets.
- [ ] Manual smoke: start guidance for a single-step source and stop guidance; verify the InfoBox is removed and `activeMapPoint` is unregistered from `WorldMapPointManager`.