### PR TITLE
refactor: extract CollectionLogNetImportOrchestrator from Plugin (#503)

### DIFF
--- a/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
@@ -32,7 +32,7 @@ import com.collectionloghelper.di.DataModule;
 import com.collectionloghelper.di.EfficiencyModule;
 import com.collectionloghelper.di.GuidanceModule;
 import com.collectionloghelper.di.SyncModule;
-import com.collectionloghelper.sync.ImportResult;
+import com.collectionloghelper.sync.CollectionLogNetImportOrchestrator;
 import com.collectionloghelper.sync.LootSyncManager;
 import com.collectionloghelper.sync.TempleSyncOrchestrator;
 import com.collectionloghelper.efficiency.ScoredItem;
@@ -49,7 +49,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
@@ -146,6 +145,9 @@ public class CollectionLogHelperPlugin extends Plugin
 	private TempleSyncOrchestrator templeSyncOrchestrator;
 
 	@Inject
+	private CollectionLogNetImportOrchestrator collectionLogNetImportOrchestrator;
+
+	@Inject
 	private ChatEventHandler chatEventHandler;
 
 	@Inject
@@ -213,40 +215,11 @@ public class CollectionLogHelperPlugin extends Plugin
 			() -> clientThread.invokeLater(guidance.getGuidanceSequencer()::syncToCurrentState)
 		);
 
-		// Wire collectionlog.net import callback — fetches username from the logged-in player.
-		// Called from the EDT; submits async work and posts the result back via the panel method.
-		panel.setCollectionLogNetImportCallback(() ->
-		{
-			String username = client.getLocalPlayer() != null
-				? client.getLocalPlayer().getName()
-				: null;
-			if (username == null || username.isEmpty())
-			{
-				panel.onCollectionLogNetImportComplete("Log in first");
-				return;
-			}
-			Future<ImportResult> future =
-				sync.getCollectionLogNetImporter().importProfile(username);
-			// Poll the result on the shared daemon executor so the EDT is not blocked
-			httpResultExecutor.submit(() ->
-			{
-				try
-				{
-					ImportResult result = future.get();
-					panel.onCollectionLogNetImportComplete(result.toToastMessage());
-					if (result.isSuccess())
-					{
-						// Trigger a panel rebuild on the EDT
-						panel.rebuild();
-					}
-				}
-				catch (Exception e)
-				{
-					log.warn("collectionlog.net import result waiter failed", e);
-					panel.onCollectionLogNetImportComplete("collectionlog.net: error");
-				}
-			});
-		});
+		// Wire collectionlog.net import callback — delegates to the orchestrator
+		// which resolves the player name, dispatches the import, and posts the
+		// result back through the panel.
+		panel.setCollectionLogNetImportCallback(
+			() -> collectionLogNetImportOrchestrator.requestImport(panel, httpResultExecutor));
 
 		// Wire TempleOSRS KC sync button callback
 		panel.setTempleSyncCallback(() -> templeSyncOrchestrator.requestSync(panel, httpResultExecutor));

--- a/src/main/java/com/collectionloghelper/sync/CollectionLogNetImportOrchestrator.java
+++ b/src/main/java/com/collectionloghelper/sync/CollectionLogNetImportOrchestrator.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.sync;
+
+import com.collectionloghelper.di.SyncModule;
+import com.collectionloghelper.ui.CollectionLogHelperPanel;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+
+/**
+ * Orchestrates an end-to-end collectionlog.net profile import triggered from
+ * the panel "Import from collectionlog.net" button.
+ *
+ * <p>Owns the logic that previously lived inline in the plugin's
+ * {@code startUp} method (callback wired via
+ * {@link CollectionLogHelperPanel#setCollectionLogNetImportCallback(Runnable)}):
+ * <ul>
+ *   <li>Resolves the logged-in player's name from {@link Client}.</li>
+ *   <li>Submits the import to {@link CollectionLogNetImporter} and awaits the
+ *       result on the supplied {@link ExecutorService} so the EDT is never
+ *       blocked.</li>
+ *   <li>Posts the user-facing toast message back via
+ *       {@link CollectionLogHelperPanel#onCollectionLogNetImportComplete(String)}.</li>
+ *   <li>On success, triggers a panel rebuild so the new obtained-item state
+ *       renders immediately.</li>
+ * </ul>
+ *
+ * <p>The {@link CollectionLogHelperPanel} and {@link ExecutorService} are
+ * passed per-call rather than injected, because the panel is plugin-lifecycle
+ * owned (created in {@code startUp}) and the executor is a shared daemon
+ * lazily created by the plugin. This matches the pattern established by
+ * {@link TempleSyncOrchestrator} and {@link LootSyncManager}.
+ *
+ * <p>Part of issue #503 — splitting the {@code CollectionLogHelperPlugin}
+ * god-class into focused collaborators.
+ */
+@Slf4j
+@Singleton
+public class CollectionLogNetImportOrchestrator
+{
+	private static final String NOT_LOGGED_IN_MESSAGE = "Log in first";
+	private static final String GENERIC_ERROR_MESSAGE = "collectionlog.net: error";
+
+	private final Client client;
+	private final SyncModule sync;
+
+	@Inject
+	public CollectionLogNetImportOrchestrator(Client client, SyncModule sync)
+	{
+		this.client = client;
+		this.sync = sync;
+	}
+
+	/**
+	 * Initiates an asynchronous collectionlog.net profile import for the
+	 * currently logged-in player.
+	 *
+	 * <p>The import runs on the {@link CollectionLogNetImporter} background
+	 * executor; on completion the result is surfaced to the panel via the
+	 * supplied {@code resultExecutor}. If no player is logged in the panel is
+	 * notified immediately and no import is dispatched.
+	 *
+	 * <p>Fail-soft: any error during the result wait is logged and surfaced as
+	 * a generic toast; no exception reaches the caller.
+	 *
+	 * @param panel          the panel that owns the import button — used to
+	 *                       surface the completion message. Must be non-null
+	 *                       (the panel always owns the callback lifetime).
+	 * @param resultExecutor daemon executor used to wait on the import future
+	 *                       off the EDT/client thread.
+	 */
+	public void requestImport(CollectionLogHelperPanel panel, ExecutorService resultExecutor)
+	{
+		String username = client.getLocalPlayer() != null
+			? client.getLocalPlayer().getName()
+			: null;
+		if (username == null || username.isEmpty())
+		{
+			panel.onCollectionLogNetImportComplete(NOT_LOGGED_IN_MESSAGE);
+			return;
+		}
+
+		Future<ImportResult> future = sync.getCollectionLogNetImporter().importProfile(username);
+		// Poll the result on the shared daemon executor so the EDT is not blocked
+		resultExecutor.submit(() -> awaitResult(future, panel));
+	}
+
+	private void awaitResult(Future<ImportResult> future, CollectionLogHelperPanel panel)
+	{
+		try
+		{
+			ImportResult result = future.get();
+			panel.onCollectionLogNetImportComplete(result.toToastMessage());
+			if (result.isSuccess())
+			{
+				// Trigger a panel rebuild on the EDT
+				panel.rebuild();
+			}
+		}
+		catch (Exception e)
+		{
+			log.warn("collectionlog.net import result waiter failed", e);
+			panel.onCollectionLogNetImportComplete(GENERIC_ERROR_MESSAGE);
+		}
+	}
+}

--- a/src/test/java/com/collectionloghelper/sync/CollectionLogNetImportOrchestratorTest.java
+++ b/src/test/java/com/collectionloghelper/sync/CollectionLogNetImportOrchestratorTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.sync;
+
+import com.collectionloghelper.di.SyncModule;
+import com.collectionloghelper.ui.CollectionLogHelperPanel;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import net.runelite.api.Client;
+import net.runelite.api.Player;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link CollectionLogNetImportOrchestrator}.
+ *
+ * <p>Covers the observable paths previously inlined in the plugin:
+ * <ul>
+ *   <li>no local player — panel notified, importer never called</li>
+ *   <li>empty player name — panel notified, importer never called</li>
+ *   <li>successful import — panel toasted with success message and rebuilt</li>
+ *   <li>non-success result — panel toasted but no rebuild triggered</li>
+ *   <li>future fails — generic error message surfaced, no rebuild</li>
+ * </ul>
+ */
+public class CollectionLogNetImportOrchestratorTest
+{
+	private Client client;
+	private Player localPlayer;
+	private SyncModule sync;
+	private CollectionLogNetImporter importer;
+	private CollectionLogHelperPanel panel;
+	private ExecutorService resultExecutor;
+
+	private CollectionLogNetImportOrchestrator orchestrator;
+
+	@Before
+	public void setUp()
+	{
+		client = mock(Client.class);
+		localPlayer = mock(Player.class);
+		sync = mock(SyncModule.class);
+		importer = mock(CollectionLogNetImporter.class);
+		panel = mock(CollectionLogHelperPanel.class);
+		resultExecutor = mock(ExecutorService.class);
+
+		when(sync.getCollectionLogNetImporter()).thenReturn(importer);
+
+		// Run executor submissions inline so side-effects are observable after
+		// requestImport returns without waiting on a background thread.
+		doAnswer(inv ->
+		{
+			Runnable r = inv.getArgument(0);
+			r.run();
+			return null;
+		}).when(resultExecutor).submit(any(Runnable.class));
+
+		orchestrator = new CollectionLogNetImportOrchestrator(client, sync);
+	}
+
+	@Test
+	public void requestImport_noLocalPlayer_notifiesPanelAndSkips()
+	{
+		when(client.getLocalPlayer()).thenReturn(null);
+
+		orchestrator.requestImport(panel, resultExecutor);
+
+		verify(panel).onCollectionLogNetImportComplete("Log in first");
+		verify(importer, never()).importProfile(anyString());
+		verify(panel, never()).rebuild();
+	}
+
+	@Test
+	public void requestImport_emptyPlayerName_notifiesPanelAndSkips()
+	{
+		when(client.getLocalPlayer()).thenReturn(localPlayer);
+		when(localPlayer.getName()).thenReturn("");
+
+		orchestrator.requestImport(panel, resultExecutor);
+
+		verify(panel).onCollectionLogNetImportComplete("Log in first");
+		verify(importer, never()).importProfile(anyString());
+		verify(panel, never()).rebuild();
+	}
+
+	@Test
+	public void requestImport_successfulResultTriggersRebuild()
+	{
+		when(client.getLocalPlayer()).thenReturn(localPlayer);
+		when(localPlayer.getName()).thenReturn("Zezima");
+
+		ImportResult success = ImportResult.success(42);
+		when(importer.importProfile("Zezima"))
+			.thenReturn(CompletableFuture.completedFuture(success));
+
+		orchestrator.requestImport(panel, resultExecutor);
+
+		ArgumentCaptor<String> msg = ArgumentCaptor.forClass(String.class);
+		verify(panel).onCollectionLogNetImportComplete(msg.capture());
+		assertTrue("toast message should be non-empty", !msg.getValue().isEmpty());
+		verify(panel).rebuild();
+	}
+
+	@Test
+	public void requestImport_nonSuccessResultDoesNotRebuild()
+	{
+		when(client.getLocalPlayer()).thenReturn(localPlayer);
+		when(localPlayer.getName()).thenReturn("Zezima");
+
+		ImportResult notFound = ImportResult.userNotFound("Zezima");
+		when(importer.importProfile("Zezima"))
+			.thenReturn(CompletableFuture.completedFuture(notFound));
+
+		orchestrator.requestImport(panel, resultExecutor);
+
+		verify(panel).onCollectionLogNetImportComplete(notFound.toToastMessage());
+		verify(panel, never()).rebuild();
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void requestImport_futureFails_surfacesGenericError()
+	{
+		when(client.getLocalPlayer()).thenReturn(localPlayer);
+		when(localPlayer.getName()).thenReturn("Zezima");
+
+		Future<ImportResult> failing = mock(Future.class);
+		try
+		{
+			when(failing.get()).thenThrow(new ExecutionException(new RuntimeException("boom")));
+		}
+		catch (Exception e)
+		{
+			throw new AssertionError(e);
+		}
+		when(importer.importProfile("Zezima")).thenReturn(failing);
+
+		orchestrator.requestImport(panel, resultExecutor);
+
+		verify(panel).onCollectionLogNetImportComplete("collectionlog.net: error");
+		verify(panel, never()).rebuild();
+	}
+}


### PR DESCRIPTION
## Summary

Wave 11 of the #503 god-class breakdown. Extracts the collectionlog.net import callback wiring (player-name lookup + async dispatch + result handoff) from `CollectionLogHelperPlugin.startUp()` into a dedicated `@Singleton` orchestrator in `com.collectionloghelper.sync`.

Mirrors the Wave 9 `TempleSyncOrchestrator` pattern: the panel and the shared http-result executor are passed per-call so the plugin retains lifecycle ownership.

### LOC delta

- `CollectionLogHelperPlugin.java`: **780 -> 753** (-27)
- New: `CollectionLogNetImportOrchestrator.java` (~130 LOC incl. license + javadoc)
- New: `CollectionLogNetImportOrchestratorTest.java` (5 paths)

### Behaviour

No behavioural change. The new class re-creates the exact callback that previously lived inline:

1. Resolve `client.getLocalPlayer().getName()`; if null/empty toast `"Log in first"` and return.
2. Submit `CollectionLogNetImporter.importProfile(username)`.
3. On the supplied executor, await the future and forward the toast message to the panel.
4. If `result.isSuccess()`, call `panel.rebuild()`.
5. On any exception, log and surface `"collectionlog.net: error"`.

## Test plan

- [x] `./gradlew build` passes
- [x] `./gradlew test` passes
- [x] New `CollectionLogNetImportOrchestratorTest` covers: no local player, empty player name, success (rebuild triggered), non-success (no rebuild), future failure (generic error message)
- [ ] Manual smoke: click "Import from collectionlog.net" in the panel while logged in and confirm toast + obtained-item state updates
- [ ] Manual smoke: click the same button while logged out and confirm the "Log in first" toast