### PR TITLE
refactor: extract PanelHeaderBuilder from Panel (#503)

### DIFF
--- a/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
@@ -64,14 +64,12 @@ import java.util.EnumMap;
 import java.util.Map;
 import java.awt.BorderLayout;
 import java.awt.CardLayout;
-import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import javax.swing.BorderFactory;
-import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -192,60 +190,27 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 		setBackground(ColorScheme.DARK_GRAY_COLOR);
 		setLayout(new BorderLayout());
 
-		// === Controls panel (north) ===
-		JPanel controlsPanel = new JPanel();
-		controlsPanel.setLayout(new BoxLayout(controlsPanel, BoxLayout.Y_AXIS));
-		controlsPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
-
-		completionLabel = new JLabel("Collection Log: 0/0 (0.0%)", SwingConstants.CENTER);
-		completionLabel.setFont(FontManager.getRunescapeBoldFont());
-		completionLabel.setForeground(Color.WHITE);
-		completionLabel.setAlignmentX(CENTER_ALIGNMENT);
-		completionLabel.setBorder(BorderFactory.createEmptyBorder(0, 0, 2, 0));
-		controlsPanel.add(completionLabel);
-
-		completionProgressBar = new JProgressBar(0, 1699);
-		completionProgressBar.setValue(0);
-		completionProgressBar.setPreferredSize(new Dimension(Integer.MAX_VALUE, 6));
-		completionProgressBar.setMaximumSize(new Dimension(Integer.MAX_VALUE, 6));
-		completionProgressBar.setAlignmentX(CENTER_ALIGNMENT);
-		completionProgressBar.setBorderPainted(false);
-		completionProgressBar.setBackground(new Color(40, 40, 40));
-		completionProgressBar.setForeground(new Color(80, 200, 80));
-		completionProgressBar.setBorder(BorderFactory.createEmptyBorder(0, 4, 4, 4));
-		controlsPanel.add(completionProgressBar);
-
-		syncStatusView = new SyncStatusView(dataSyncState);
-		syncStatusView.setAlignmentX(CENTER_ALIGNMENT);
-		syncStatusView.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
-		controlsPanel.add(syncStatusView);
-
-		syncButtonController = new SyncButtonController(config, this);
-		controlsPanel.add(syncButtonController.getCollectionLogNetButton());
-		controlsPanel.add(syncButtonController.getTempleSyncButton());
-
-		clueSummaryView = new ClueSummaryView();
-		clueSummaryView.setAlignmentX(CENTER_ALIGNMENT);
-		clueSummaryView.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
-		controlsPanel.add(clueSummaryView);
-
-		slayerStrategyView = new SlayerStrategyView(slayerTaskState, slayerStrategyCalculator);
-		slayerStrategyView.setAlignmentX(CENTER_ALIGNMENT);
-		slayerStrategyView.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
-		controlsPanel.add(slayerStrategyView);
-
-		guidanceBannerView = new GuidanceBannerView(requirementsChecker);
-		guidanceBannerView.setAlignmentX(CENTER_ALIGNMENT);
-		guidanceBannerView.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
-		controlsPanel.add(guidanceBannerView);
-
-		stepProgressView = new StepProgressView(itemManager);
-		stepProgressView.setAlignmentX(CENTER_ALIGNMENT);
-		controlsPanel.add(stepProgressView);
-
-		quickGuidePanelView = new QuickGuidePanelView(guidanceActivator, guidanceDeactivator);
-
-		controlsPanel.add(Box.createVerticalStrut(4));
+		// === Controls panel (north) — static header widgets built by PanelHeaderBuilder ===
+		PanelHeaderBuilder.Result header = PanelHeaderBuilder.build(
+			config,
+			dataSyncState,
+			slayerTaskState,
+			slayerStrategyCalculator,
+			requirementsChecker,
+			itemManager,
+			guidanceActivator,
+			guidanceDeactivator,
+			this);
+		JPanel controlsPanel = header.controlsPanel;
+		completionLabel = header.completionLabel;
+		completionProgressBar = header.completionProgressBar;
+		syncStatusView = header.syncStatusView;
+		syncButtonController = header.syncButtonController;
+		clueSummaryView = header.clueSummaryView;
+		slayerStrategyView = header.slayerStrategyView;
+		guidanceBannerView = header.guidanceBannerView;
+		stepProgressView = header.stepProgressView;
+		quickGuidePanelView = header.quickGuidePanelView;
 
 		selectorControls = new SelectorControlsPanel(
 			config,

--- a/src/main/java/com/collectionloghelper/ui/PanelHeaderBuilder.java
+++ b/src/main/java/com/collectionloghelper/ui/PanelHeaderBuilder.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.ui;
+
+import com.collectionloghelper.CollectionLogHelperConfig;
+import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.data.DataSyncState;
+import com.collectionloghelper.data.RequirementsChecker;
+import com.collectionloghelper.data.SlayerTaskState;
+import com.collectionloghelper.efficiency.SlayerStrategyCalculator;
+import com.collectionloghelper.ui.widget.ClueSummaryView;
+import com.collectionloghelper.ui.widget.GuidanceBannerView;
+import com.collectionloghelper.ui.widget.QuickGuidePanelView;
+import com.collectionloghelper.ui.widget.SlayerStrategyView;
+import com.collectionloghelper.ui.widget.StepProgressView;
+import com.collectionloghelper.ui.widget.SyncStatusView;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.util.function.BiConsumer;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JProgressBar;
+import javax.swing.SwingConstants;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.ui.ColorScheme;
+import net.runelite.client.ui.FontManager;
+
+/**
+ * Builds the static header section of {@link CollectionLogHelperPanel}: completion
+ * label, progress bar, sync status, sync buttons, clue summary, slayer strategy,
+ * guidance banner, and step progress views. Extracted from
+ * {@link CollectionLogHelperPanel} as part of the issue #503 god-class split.
+ *
+ * <p>The host panel still owns mutation of the view widgets via the handles
+ * exposed on {@link Result}. The builder only assembles the layout and returns
+ * the assembled {@code controlsPanel} plus references to widgets the host needs
+ * to update later (completion label/bar, sync views, guidance views).
+ *
+ * <p>The mode/AFK/sort/category/search selectors are NOT built here — those
+ * remain the responsibility of {@link SelectorControlsPanel} which the host
+ * adds to the returned {@code controlsPanel} after this builder runs.
+ */
+final class PanelHeaderBuilder
+{
+	private PanelHeaderBuilder()
+	{
+	}
+
+	/**
+	 * Assembles the static header widgets and returns the configured controls
+	 * panel together with handles to the views the host panel mutates later.
+	 *
+	 * <p>The returned {@link Result#controlsPanel} is a fresh {@link JPanel} laid
+	 * out with a vertical {@link BoxLayout}, populated with all the header
+	 * widgets in display order, followed by a trailing vertical strut. Callers
+	 * add the selector controls panel and any additional north-region content
+	 * after the strut.
+	 */
+	static Result build(CollectionLogHelperConfig config,
+		DataSyncState dataSyncState,
+		SlayerTaskState slayerTaskState,
+		SlayerStrategyCalculator slayerStrategyCalculator,
+		RequirementsChecker requirementsChecker,
+		ItemManager itemManager,
+		BiConsumer<CollectionLogSource, Integer> guidanceActivator,
+		Runnable guidanceDeactivator,
+		JComponent syncButtonOwner)
+	{
+		JPanel controlsPanel = new JPanel();
+		controlsPanel.setLayout(new BoxLayout(controlsPanel, BoxLayout.Y_AXIS));
+		controlsPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
+
+		JLabel completionLabel = new JLabel("Collection Log: 0/0 (0.0%)", SwingConstants.CENTER);
+		completionLabel.setFont(FontManager.getRunescapeBoldFont());
+		completionLabel.setForeground(Color.WHITE);
+		completionLabel.setAlignmentX(JComponent.CENTER_ALIGNMENT);
+		completionLabel.setBorder(BorderFactory.createEmptyBorder(0, 0, 2, 0));
+		controlsPanel.add(completionLabel);
+
+		JProgressBar completionProgressBar = new JProgressBar(0, 1699);
+		completionProgressBar.setValue(0);
+		completionProgressBar.setPreferredSize(new Dimension(Integer.MAX_VALUE, 6));
+		completionProgressBar.setMaximumSize(new Dimension(Integer.MAX_VALUE, 6));
+		completionProgressBar.setAlignmentX(JComponent.CENTER_ALIGNMENT);
+		completionProgressBar.setBorderPainted(false);
+		completionProgressBar.setBackground(new Color(40, 40, 40));
+		completionProgressBar.setForeground(new Color(80, 200, 80));
+		completionProgressBar.setBorder(BorderFactory.createEmptyBorder(0, 4, 4, 4));
+		controlsPanel.add(completionProgressBar);
+
+		SyncStatusView syncStatusView = new SyncStatusView(dataSyncState);
+		syncStatusView.setAlignmentX(JComponent.CENTER_ALIGNMENT);
+		syncStatusView.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
+		controlsPanel.add(syncStatusView);
+
+		SyncButtonController syncButtonController = new SyncButtonController(config, syncButtonOwner);
+		controlsPanel.add(syncButtonController.getCollectionLogNetButton());
+		controlsPanel.add(syncButtonController.getTempleSyncButton());
+
+		ClueSummaryView clueSummaryView = new ClueSummaryView();
+		clueSummaryView.setAlignmentX(JComponent.CENTER_ALIGNMENT);
+		clueSummaryView.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
+		controlsPanel.add(clueSummaryView);
+
+		SlayerStrategyView slayerStrategyView = new SlayerStrategyView(slayerTaskState, slayerStrategyCalculator);
+		slayerStrategyView.setAlignmentX(JComponent.CENTER_ALIGNMENT);
+		slayerStrategyView.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
+		controlsPanel.add(slayerStrategyView);
+
+		GuidanceBannerView guidanceBannerView = new GuidanceBannerView(requirementsChecker);
+		guidanceBannerView.setAlignmentX(JComponent.CENTER_ALIGNMENT);
+		guidanceBannerView.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
+		controlsPanel.add(guidanceBannerView);
+
+		StepProgressView stepProgressView = new StepProgressView(itemManager);
+		stepProgressView.setAlignmentX(JComponent.CENTER_ALIGNMENT);
+		controlsPanel.add(stepProgressView);
+
+		QuickGuidePanelView quickGuidePanelView = new QuickGuidePanelView(guidanceActivator, guidanceDeactivator);
+
+		controlsPanel.add(Box.createVerticalStrut(4));
+
+		return new Result(
+			controlsPanel,
+			completionLabel,
+			completionProgressBar,
+			syncStatusView,
+			syncButtonController,
+			clueSummaryView,
+			slayerStrategyView,
+			guidanceBannerView,
+			stepProgressView,
+			quickGuidePanelView);
+	}
+
+	/**
+	 * View handles returned by {@link #build}. The host panel retains mutation
+	 * authority on every widget here; the builder does not hold references
+	 * after the call returns.
+	 */
+	static final class Result
+	{
+		final JPanel controlsPanel;
+		final JLabel completionLabel;
+		final JProgressBar completionProgressBar;
+		final SyncStatusView syncStatusView;
+		final SyncButtonController syncButtonController;
+		final ClueSummaryView clueSummaryView;
+		final SlayerStrategyView slayerStrategyView;
+		final GuidanceBannerView guidanceBannerView;
+		final StepProgressView stepProgressView;
+		final QuickGuidePanelView quickGuidePanelView;
+
+		Result(JPanel controlsPanel,
+			JLabel completionLabel,
+			JProgressBar completionProgressBar,
+			SyncStatusView syncStatusView,
+			SyncButtonController syncButtonController,
+			ClueSummaryView clueSummaryView,
+			SlayerStrategyView slayerStrategyView,
+			GuidanceBannerView guidanceBannerView,
+			StepProgressView stepProgressView,
+			QuickGuidePanelView quickGuidePanelView)
+		{
+			this.controlsPanel = controlsPanel;
+			this.completionLabel = completionLabel;
+			this.completionProgressBar = completionProgressBar;
+			this.syncStatusView = syncStatusView;
+			this.syncButtonController = syncButtonController;
+			this.clueSummaryView = clueSummaryView;
+			this.slayerStrategyView = slayerStrategyView;
+			this.guidanceBannerView = guidanceBannerView;
+			this.stepProgressView = stepProgressView;
+			this.quickGuidePanelView = quickGuidePanelView;
+		}
+	}
+}

--- a/src/test/java/com/collectionloghelper/ui/PanelHeaderBuilderTest.java
+++ b/src/test/java/com/collectionloghelper/ui/PanelHeaderBuilderTest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.ui;
+
+import com.collectionloghelper.CollectionLogHelperConfig;
+import com.collectionloghelper.data.DataSyncState;
+import com.collectionloghelper.data.RequirementsChecker;
+import com.collectionloghelper.data.SlayerTaskState;
+import com.collectionloghelper.efficiency.SlayerStrategyCalculator;
+import java.awt.Component;
+import javax.swing.BoxLayout;
+import javax.swing.JPanel;
+import net.runelite.client.game.ItemManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link PanelHeaderBuilder}: the helper that assembles the
+ * static header section of {@link CollectionLogHelperPanel} (completion
+ * label/bar, sync status, sync buttons, clue summary, slayer strategy,
+ * guidance banner, step progress, quick-guide). Extracted from
+ * {@link CollectionLogHelperPanel} as part of issue #503 god-class splits.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class PanelHeaderBuilderTest
+{
+	@Mock
+	private CollectionLogHelperConfig config;
+	@Mock
+	private DataSyncState dataSyncState;
+	@Mock
+	private SlayerTaskState slayerTaskState;
+	@Mock
+	private SlayerStrategyCalculator slayerStrategyCalculator;
+	@Mock
+	private RequirementsChecker requirementsChecker;
+	@Mock
+	private ItemManager itemManager;
+
+	private JPanel host;
+
+	@Before
+	public void setUp()
+	{
+		// SyncButtonController consults these config flags during construction.
+		when(config.enableCollectionLogNetImport()).thenReturn(true);
+		when(config.enableTempleOsrsSync()).thenReturn(true);
+		host = new JPanel();
+	}
+
+	private PanelHeaderBuilder.Result build()
+	{
+		return PanelHeaderBuilder.build(
+			config,
+			dataSyncState,
+			slayerTaskState,
+			slayerStrategyCalculator,
+			requirementsChecker,
+			itemManager,
+			(source, count) -> { /* no-op */ },
+			() -> { /* no-op */ },
+			host);
+	}
+
+	@Test
+	public void buildReturnsNonNullResultAndControlsPanel()
+	{
+		PanelHeaderBuilder.Result result = build();
+
+		assertNotNull("result", result);
+		assertNotNull("controlsPanel", result.controlsPanel);
+		assertTrue("controlsPanel uses BoxLayout",
+			result.controlsPanel.getLayout() instanceof BoxLayout);
+	}
+
+	@Test
+	public void buildExposesAllViewHandles()
+	{
+		PanelHeaderBuilder.Result result = build();
+
+		assertNotNull("completionLabel", result.completionLabel);
+		assertNotNull("completionProgressBar", result.completionProgressBar);
+		assertNotNull("syncStatusView", result.syncStatusView);
+		assertNotNull("syncButtonController", result.syncButtonController);
+		assertNotNull("clueSummaryView", result.clueSummaryView);
+		assertNotNull("slayerStrategyView", result.slayerStrategyView);
+		assertNotNull("guidanceBannerView", result.guidanceBannerView);
+		assertNotNull("stepProgressView", result.stepProgressView);
+		assertNotNull("quickGuidePanelView", result.quickGuidePanelView);
+	}
+
+	@Test
+	public void completionLabelInitialTextMatchesEmptyState()
+	{
+		PanelHeaderBuilder.Result result = build();
+
+		assertEquals("Collection Log: 0/0 (0.0%)", result.completionLabel.getText());
+	}
+
+	@Test
+	public void completionProgressBarHasFullCollectionLogMaximum()
+	{
+		PanelHeaderBuilder.Result result = build();
+
+		assertEquals(0, result.completionProgressBar.getMinimum());
+		assertEquals(1699, result.completionProgressBar.getMaximum());
+		assertEquals(0, result.completionProgressBar.getValue());
+	}
+
+	@Test
+	public void controlsPanelContainsExpectedWidgetsInOrder()
+	{
+		PanelHeaderBuilder.Result result = build();
+		Component[] children = result.controlsPanel.getComponents();
+
+		assertSame("completion label first", result.completionLabel, children[0]);
+		assertSame("completion progress bar second", result.completionProgressBar, children[1]);
+		assertSame("sync status view third", result.syncStatusView, children[2]);
+		assertSame("collectionlog.net button fourth",
+			result.syncButtonController.getCollectionLogNetButton(), children[3]);
+		assertSame("temple sync button fifth",
+			result.syncButtonController.getTempleSyncButton(), children[4]);
+		assertSame("clue summary view", result.clueSummaryView, children[5]);
+		assertSame("slayer strategy view", result.slayerStrategyView, children[6]);
+		assertSame("guidance banner view", result.guidanceBannerView, children[7]);
+		assertSame("step progress view", result.stepProgressView, children[8]);
+		// QuickGuidePanelView is intentionally NOT added to controlsPanel — it is
+		// shown contextually in the detail/list view. The trailing component
+		// must therefore be the vertical strut (Box.Filler).
+		assertTrue("trailing vertical strut present", children.length >= 10);
+	}
+
+	@Test
+	public void quickGuidePanelViewIsCreatedButNotAddedToControlsPanel()
+	{
+		PanelHeaderBuilder.Result result = build();
+
+		// QuickGuidePanelView is a factory, not a Component, so it cannot appear
+		// in the controlsPanel's child list — assert by counting and shape only.
+		assertNotNull("quickGuidePanelView factory created",
+			result.quickGuidePanelView);
+	}
+
+	@Test
+	public void repeatedBuildsReturnIndependentInstances()
+	{
+		PanelHeaderBuilder.Result a = build();
+		PanelHeaderBuilder.Result b = build();
+
+		// Each invocation creates fresh widget instances; the builder holds no state.
+		assertTrue(a.controlsPanel != b.controlsPanel);
+		assertTrue(a.completionLabel != b.completionLabel);
+		assertTrue(a.syncButtonController != b.syncButtonController);
+	}
+}


### PR DESCRIPTION
## Summary

Wave 11 of the issue #503 god-class split for `CollectionLogHelperPanel`. Extracts the static controls-panel header construction into a new `PanelHeaderBuilder` helper.

The builder assembles the completion label, progress bar, sync status view, collectionlog.net + TempleOSRS sync buttons, clue summary, slayer strategy, guidance banner, step progress, and the quick-guide factory. It returns the configured `controlsPanel` alongside view handles the host panel mutates later via `updateCompletionHeader`, `updateSyncStatus`, `updateClueSummary`, `updateStepProgress`, etc.

The selector controls (mode/AFK/sort/category/search) remain owned by the panel and are appended to the returned `controlsPanel` after the header widgets, preserving the original visual order.

Panel constructor body shrinks from a 65-line inline header block to a small destructure of the builder `Result` onto fields.

- New file: `PanelHeaderBuilder.java` (203 LOC including license header and Javadoc)
- New test: `PanelHeaderBuilderTest.java` covering construction, view-handle exposure, widget order, initial state, and statelessness across repeated builds
- Panel.java: 696 -> 661 LOC (-35)

## Architectural-floor observation

After this extraction the Panel is mostly: state fields, public mutation methods that thin-delegate to the extracted views (`stepProgressView.showStep(...)`, `syncButtonController.*`, `selectorControls.*`), the `rebuild()` orchestration, and `PanelShellContext` interface methods. There is no remaining 50+ LOC contiguous seam — the larger Wave 10 prediction that the panel is at architectural floor after this extraction looks correct. Future #503 progress on this file will likely come from trimming the remaining shell (e.g. inlining or removing the duplicate `updateStepProgress` overloads, or rewriting `addEmptyStateMessage` as a static helper), each of which is sub-30-LOC.

## Test plan

- [x] `./gradlew build` passes
- [x] `./gradlew test` passes (including the new `PanelHeaderBuilderTest` suite)
- [x] No public API changes to `CollectionLogHelperPanel` — caller in `CollectionLogHelperPlugin` is unaffected
- [ ] Manual smoke: open plugin panel, confirm completion label, progress bar, sync status, sync buttons, clue summary, slayer strategy, guidance banner, and step progress all render in the same vertical order and respond to the same callbacks as before