### PR TITLE
refactor: extract StepChangeHandler from GuidanceOverlayCoordinator (#503)

### DIFF
--- a/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
@@ -117,6 +117,7 @@ public class GuidanceOverlayCoordinator
 	private final WorldMapController worldMapController;
 	private final DynamicTargetManager dynamicTargetManager;
 	private final NpcTrackerHelper npcTrackerHelper;
+	private final StepChangeHandler stepChangeHandler;
 
 	// -- Guidance UI state (previously in plugin) --
 
@@ -188,7 +189,8 @@ public class GuidanceOverlayCoordinator
 		OverlayDeactivator overlayDeactivator,
 		WorldMapController worldMapController,
 		DynamicTargetManager dynamicTargetManager,
-		NpcTrackerHelper npcTrackerHelper)
+		NpcTrackerHelper npcTrackerHelper,
+		StepChangeHandler stepChangeHandler)
 	{
 		this.client = client;
 		this.clientThread = clientThread;
@@ -217,6 +219,7 @@ public class GuidanceOverlayCoordinator
 		this.worldMapController = worldMapController;
 		this.dynamicTargetManager = dynamicTargetManager;
 		this.npcTrackerHelper = npcTrackerHelper;
+		this.stepChangeHandler = stepChangeHandler;
 	}
 
 	/**
@@ -573,6 +576,10 @@ public class GuidanceOverlayCoordinator
 
 	/**
 	 * Callback from GuidanceSequencer when the current step changes.
+	 * Performs the overlay clear + apply + NPC-tracker scan locally (those
+	 * paths mutate coordinator-owned state such as {@code lastMessagedStepIndex}
+	 * and {@code activeMapPoint}), then delegates the InfoBox/panel
+	 * progress refresh to {@link StepChangeHandler}.
 	 */
 	private void onStepChanged(GuidanceStep step)
 	{
@@ -582,55 +589,8 @@ public class GuidanceOverlayCoordinator
 		applyStepToOverlays(step, sourceName, activeSource);
 		npcTrackerHelper.scanForTrackedNpc(step, activeTargetItemId);
 
-		// Update InfoBox progress
-		if (activeInfoBox != null)
-		{
-			int current = guidanceSequencer.getCurrentIndex() + 1;
-			int total = guidanceSequencer.getTotalSteps();
-			activeInfoBox.setStepText(current + "/" + total);
-			String tooltip = step.getDescription();
-			if (guidanceSequencer.getCumulativeTrackThreshold() > 0)
-			{
-				tooltip += "\n" + guidanceSequencer.getCumulativeActionCount()
-					+ "/" + guidanceSequencer.getCumulativeTrackThreshold()
-					+ " actions tracked";
-			}
-			activeInfoBox.setTooltipText(tooltip);
-			if (current == total)
-			{
-				activeInfoBox.setTextColor(java.awt.Color.GREEN);
-			}
-		}
-
-		if (panel != null)
-		{
-			final int current = guidanceSequencer.getCurrentIndex() + 1;
-			final int total = guidanceSequencer.getTotalSteps();
-			final String desc = step.resolveDescription(activeTargetItemId);
-			final boolean isManual = step.getCompletionCondition() == CompletionCondition.MANUAL;
-			final GuidanceStep rawStep = guidanceSequencer.getRawCurrentStep();
-			final CollectionLogSource stepChangeSource = guidanceSequencer.getActiveSource();
-			final List<GuidanceStep> sourceSteps = stepChangeSource != null
-				&& stepChangeSource.getGuidanceSteps() != null
-				? stepChangeSource.getGuidanceSteps() : Collections.emptyList();
-
-			// Push description + step progress to the panel immediately (safe from any thread
-			// because showStep dispatches to the EDT). Required-item resolution is deferred
-			// to the client thread because RequiredItemResolver.resolve() calls
-			// ItemManager.getItemComposition, which asserts caller-is-client-thread. See
-			// cha-ndler/collection-log-helper#388 for the original trace.
-			panel.updateStepProgress(current, total, desc, isManual,
-				Collections.emptyList(), Collections.emptyList(), sourceSteps);
-			clientThread.invokeLater(() ->
-			{
-				final List<RequiredItemDisplay> resolvedItems =
-					requiredItemResolver.resolve(rawStep);
-				final List<RequiredItemDisplay> resolvedRecommended =
-					requiredItemResolver.resolveRecommended(rawStep);
-				panel.updateStepProgress(current, total, desc, isManual,
-					resolvedItems, resolvedRecommended, sourceSteps);
-			});
-		}
+		stepChangeHandler.handle(step,
+			new StepChangeHandler.Input(activeInfoBox, panel, activeTargetItemId));
 	}
 
 	/**

--- a/src/main/java/com/collectionloghelper/guidance/StepChangeHandler.java
+++ b/src/main/java/com/collectionloghelper/guidance/StepChangeHandler.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.guidance;
+
+import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.data.CompletionCondition;
+import com.collectionloghelper.data.GuidanceStep;
+import com.collectionloghelper.overlay.GuidanceInfoBox;
+import com.collectionloghelper.ui.CollectionLogHelperPanel;
+import java.awt.Color;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.callback.ClientThread;
+
+/**
+ * Handles the InfoBox progress refresh + panel step-progress push that
+ * {@link GuidanceOverlayCoordinator} performs each time the sequencer
+ * advances to a new step. Pure extraction of the second half of
+ * {@code GuidanceOverlayCoordinator.onStepChanged} (the overlay/NPC-tracker
+ * portion stays in the coordinator because it mutates coordinator-owned
+ * state such as {@code lastMessagedStepIndex} and {@code activeMapPoint}).
+ *
+ * <p>No state of its own: collaborators are injected and the coordinator
+ * threads its mutable view of the world through {@link Input}. The
+ * {@code activeInfoBox} is mutated in-place via {@code setStepText} /
+ * {@code setTooltipText} / {@code setTextColor}, so no result-write-back
+ * is needed.</p>
+ *
+ * <p>Performance note: {@code onStepChanged} fires on guidance step
+ * transitions (not per-tick) but can fire multiple times in rapid
+ * succession during fast-skip / cascade. The guard-fail paths
+ * ({@code activeInfoBox == null}, {@code panel == null}) allocate nothing.</p>
+ */
+@Slf4j
+@Singleton
+public class StepChangeHandler
+{
+	private final ClientThread clientThread;
+	private final GuidanceSequencer guidanceSequencer;
+	private final RequiredItemResolver requiredItemResolver;
+
+	@Inject
+	StepChangeHandler(
+		ClientThread clientThread,
+		GuidanceSequencer guidanceSequencer,
+		RequiredItemResolver requiredItemResolver)
+	{
+		this.clientThread = clientThread;
+		this.guidanceSequencer = guidanceSequencer;
+		this.requiredItemResolver = requiredItemResolver;
+	}
+
+	/**
+	 * Refreshes the InfoBox progress text/tooltip/colour and pushes a panel
+	 * step-progress update for the given step. Pure extraction -- no
+	 * behavioural change.
+	 *
+	 * @param step the new current step (must not be null; the sequencer
+	 *             never invokes the step-changed callback with a null step)
+	 * @param in coordinator-owned mutable refs (active InfoBox, panel,
+	 *           active-target-item id) consumed by this handler
+	 */
+	void handle(GuidanceStep step, Input in)
+	{
+		// Update InfoBox progress (mutates in.activeInfoBox in-place;
+		// no field reassignment needed back on the coordinator).
+		if (in.activeInfoBox != null)
+		{
+			int current = guidanceSequencer.getCurrentIndex() + 1;
+			int total = guidanceSequencer.getTotalSteps();
+			in.activeInfoBox.setStepText(current + "/" + total);
+			String tooltip = step.getDescription();
+			if (guidanceSequencer.getCumulativeTrackThreshold() > 0)
+			{
+				tooltip += "\n" + guidanceSequencer.getCumulativeActionCount()
+					+ "/" + guidanceSequencer.getCumulativeTrackThreshold()
+					+ " actions tracked";
+			}
+			in.activeInfoBox.setTooltipText(tooltip);
+			if (current == total)
+			{
+				in.activeInfoBox.setTextColor(Color.GREEN);
+			}
+		}
+
+		if (in.panel != null)
+		{
+			final int current = guidanceSequencer.getCurrentIndex() + 1;
+			final int total = guidanceSequencer.getTotalSteps();
+			final String desc = step.resolveDescription(in.activeTargetItemId);
+			final boolean isManual = step.getCompletionCondition() == CompletionCondition.MANUAL;
+			final GuidanceStep rawStep = guidanceSequencer.getRawCurrentStep();
+			final CollectionLogSource stepChangeSource = guidanceSequencer.getActiveSource();
+			final List<GuidanceStep> sourceSteps = stepChangeSource != null
+				&& stepChangeSource.getGuidanceSteps() != null
+				? stepChangeSource.getGuidanceSteps() : Collections.emptyList();
+
+			// Push description + step progress to the panel immediately (safe from any thread
+			// because showStep dispatches to the EDT). Required-item resolution is deferred
+			// to the client thread because RequiredItemResolver.resolve() calls
+			// ItemManager.getItemComposition, which asserts caller-is-client-thread. See
+			// cha-ndler/collection-log-helper#388 for the original trace.
+			in.panel.updateStepProgress(current, total, desc, isManual,
+				Collections.emptyList(), Collections.emptyList(), sourceSteps);
+			final CollectionLogHelperPanel panelRef = in.panel;
+			clientThread.invokeLater(() ->
+			{
+				final List<RequiredItemDisplay> resolvedItems =
+					requiredItemResolver.resolve(rawStep);
+				final List<RequiredItemDisplay> resolvedRecommended =
+					requiredItemResolver.resolveRecommended(rawStep);
+				panelRef.updateStepProgress(current, total, desc, isManual,
+					resolvedItems, resolvedRecommended, sourceSteps);
+			});
+		}
+	}
+
+	/**
+	 * Coordinator-owned mutable refs this handler reads but does not own.
+	 * No result type: {@code activeInfoBox} is mutated in-place via setters,
+	 * not replaced.
+	 */
+	static final class Input
+	{
+		@Nullable
+		final GuidanceInfoBox activeInfoBox;
+		@Nullable
+		final CollectionLogHelperPanel panel;
+		@Nullable
+		final Integer activeTargetItemId;
+
+		Input(
+			@Nullable GuidanceInfoBox activeInfoBox,
+			@Nullable CollectionLogHelperPanel panel,
+			@Nullable Integer activeTargetItemId)
+		{
+			this.activeInfoBox = activeInfoBox;
+			this.panel = panel;
+			this.activeTargetItemId = activeTargetItemId;
+		}
+	}
+}

--- a/src/test/java/com/collectionloghelper/guidance/DynamicTargetEvaluatorDispatchTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/DynamicTargetEvaluatorDispatchTest.java
@@ -154,6 +154,7 @@ public class DynamicTargetEvaluatorDispatchTest
 		DynamicTargetManager dynamicTargetManager = newDynamicTargetManager(worldMapController);
 		NpcTrackerHelper npcTrackerHelper = newNpcTrackerHelper();
 		OverlayDeactivator overlayDeactivator = newOverlayDeactivator(npcTrackerHelper);
+		StepChangeHandler stepChangeHandler = newStepChangeHandler();
 		Constructor<GuidanceOverlayCoordinator> ctor =
 			GuidanceOverlayCoordinator.class.getDeclaredConstructor(
 				Client.class,
@@ -182,7 +183,8 @@ public class DynamicTargetEvaluatorDispatchTest
 				OverlayDeactivator.class,
 				WorldMapController.class,
 				DynamicTargetManager.class,
-				NpcTrackerHelper.class);
+				NpcTrackerHelper.class,
+				StepChangeHandler.class);
 		ctor.setAccessible(true);
 		coordinator = ctor.newInstance(
 			client, clientThread, eventBus, config,
@@ -194,7 +196,7 @@ public class DynamicTargetEvaluatorDispatchTest
 			worldMapRouteOverlay, worldMapDestinationOverlay,
 			groundItemHighlightOverlay, widgetHighlightOverlay,
 			overlayStepApplier, overlaySourceApplier, overlayDeactivator,
-			worldMapController, dynamicTargetManager, npcTrackerHelper);
+			worldMapController, dynamicTargetManager, npcTrackerHelper, stepChangeHandler);
 
 		lenient().when(client.getLocalPlayer()).thenReturn(localPlayer);
 		lenient().when(localPlayer.getWorldLocation()).thenReturn(new WorldPoint(3200, 3200, 0));
@@ -312,6 +314,14 @@ public class DynamicTargetEvaluatorDispatchTest
 			Client.class, ClientThread.class, GuidanceOverlay.class);
 		ctor.setAccessible(true);
 		return ctor.newInstance(client, clientThread, guidanceOverlay);
+	}
+
+	private StepChangeHandler newStepChangeHandler() throws Exception
+	{
+		Constructor<StepChangeHandler> ctor = StepChangeHandler.class.getDeclaredConstructor(
+			ClientThread.class, GuidanceSequencer.class, RequiredItemResolver.class);
+		ctor.setAccessible(true);
+		return ctor.newInstance(clientThread, guidanceSequencer, requiredItemResolver);
 	}
 
 	private OverlayStepApplier newOverlayStepApplier() throws Exception

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorDescriptionTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorDescriptionTest.java
@@ -148,6 +148,7 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 		WorldMapController worldMapController = newWorldMapController();
 		NpcTrackerHelper npcTrackerHelper = newNpcTrackerHelper();
 		OverlayDeactivator overlayDeactivator = newOverlayDeactivator(npcTrackerHelper);
+		StepChangeHandler stepChangeHandler = newStepChangeHandler();
 		Constructor<GuidanceOverlayCoordinator> ctor =
 			GuidanceOverlayCoordinator.class.getDeclaredConstructor(
 				Client.class,
@@ -176,7 +177,8 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 				OverlayDeactivator.class,
 				WorldMapController.class,
 				DynamicTargetManager.class,
-				NpcTrackerHelper.class);
+				NpcTrackerHelper.class,
+				StepChangeHandler.class);
 		ctor.setAccessible(true);
 		DynamicTargetManager dynamicTargetManager = newDynamicTargetManager(worldMapController);
 		coordinator = ctor.newInstance(
@@ -189,7 +191,7 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 			worldMapRouteOverlay, worldMapDestinationOverlay,
 			groundItemHighlightOverlay, widgetHighlightOverlay,
 			overlayStepApplier, overlaySourceApplier, overlayDeactivator,
-			worldMapController, dynamicTargetManager, npcTrackerHelper);
+			worldMapController, dynamicTargetManager, npcTrackerHelper, stepChangeHandler);
 
 		coordinator.setPanel(panel);
 
@@ -327,6 +329,14 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 			Client.class, ClientThread.class, GuidanceOverlay.class);
 		ctor.setAccessible(true);
 		return ctor.newInstance(client, clientThread, guidanceOverlay);
+	}
+
+	private StepChangeHandler newStepChangeHandler() throws Exception
+	{
+		Constructor<StepChangeHandler> ctor = StepChangeHandler.class.getDeclaredConstructor(
+			ClientThread.class, GuidanceSequencer.class, RequiredItemResolver.class);
+		ctor.setAccessible(true);
+		return ctor.newInstance(clientThread, guidanceSequencer, requiredItemResolver);
 	}
 
 	private OverlayStepApplier newOverlayStepApplier() throws Exception

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorMapPointTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorMapPointTest.java
@@ -134,6 +134,7 @@ public class GuidanceOverlayCoordinatorMapPointTest
 		WorldMapController worldMapController = newWorldMapController();
 		NpcTrackerHelper npcTrackerHelper = newNpcTrackerHelper();
 		OverlayDeactivator overlayDeactivator = newOverlayDeactivator(npcTrackerHelper);
+		StepChangeHandler stepChangeHandler = newStepChangeHandler();
 		Constructor<GuidanceOverlayCoordinator> ctor =
 			GuidanceOverlayCoordinator.class.getDeclaredConstructor(
 				Client.class,
@@ -162,7 +163,8 @@ public class GuidanceOverlayCoordinatorMapPointTest
 				OverlayDeactivator.class,
 				WorldMapController.class,
 				DynamicTargetManager.class,
-				NpcTrackerHelper.class);
+				NpcTrackerHelper.class,
+				StepChangeHandler.class);
 		ctor.setAccessible(true);
 		DynamicTargetManager dynamicTargetManager = newDynamicTargetManager(worldMapController);
 		coordinator = ctor.newInstance(
@@ -175,7 +177,7 @@ public class GuidanceOverlayCoordinatorMapPointTest
 			worldMapRouteOverlay, worldMapDestinationOverlay,
 			groundItemHighlightOverlay, widgetHighlightOverlay,
 			overlayStepApplier, overlaySourceApplier, overlayDeactivator,
-			worldMapController, dynamicTargetManager, npcTrackerHelper);
+			worldMapController, dynamicTargetManager, npcTrackerHelper, stepChangeHandler);
 
 		// Default stubs: no unmet requirements; buildRequirementRows called unconditionally
 		when(requirementsChecker.getUnmetRequirements(any())).thenReturn(Collections.emptyList());
@@ -285,6 +287,14 @@ public class GuidanceOverlayCoordinatorMapPointTest
 			Client.class, ClientThread.class, GuidanceOverlay.class);
 		ctor.setAccessible(true);
 		return ctor.newInstance(client, clientThread, guidanceOverlay);
+	}
+
+	private StepChangeHandler newStepChangeHandler() throws Exception
+	{
+		Constructor<StepChangeHandler> ctor = StepChangeHandler.class.getDeclaredConstructor(
+			ClientThread.class, GuidanceSequencer.class, RequiredItemResolver.class);
+		ctor.setAccessible(true);
+		return ctor.newInstance(clientThread, guidanceSequencer, requiredItemResolver);
 	}
 
 	/** Builds a minimal BOSSES source with coordinates but no guidance steps. */

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorNpcIdTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorNpcIdTest.java
@@ -145,6 +145,7 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 		WorldMapController worldMapController = newWorldMapController();
 		NpcTrackerHelper npcTrackerHelper = newNpcTrackerHelper();
 		OverlayDeactivator overlayDeactivator = newOverlayDeactivator(npcTrackerHelper);
+		StepChangeHandler stepChangeHandler = newStepChangeHandler();
 		Constructor<GuidanceOverlayCoordinator> ctor =
 			GuidanceOverlayCoordinator.class.getDeclaredConstructor(
 				Client.class,
@@ -173,7 +174,8 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 				OverlayDeactivator.class,
 				WorldMapController.class,
 				DynamicTargetManager.class,
-				NpcTrackerHelper.class);
+				NpcTrackerHelper.class,
+				StepChangeHandler.class);
 		ctor.setAccessible(true);
 		DynamicTargetManager dynamicTargetManager = newDynamicTargetManager(worldMapController);
 		coordinator = ctor.newInstance(
@@ -186,7 +188,7 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 			worldMapRouteOverlay, worldMapDestinationOverlay,
 			groundItemHighlightOverlay, widgetHighlightOverlay,
 			overlayStepApplier, overlaySourceApplier, overlayDeactivator,
-			worldMapController, dynamicTargetManager, npcTrackerHelper);
+			worldMapController, dynamicTargetManager, npcTrackerHelper, stepChangeHandler);
 
 		when(requirementsChecker.getUnmetRequirements(any())).thenReturn(Collections.emptyList());
 		when(requirementsChecker.buildRequirementRows(any())).thenReturn(Collections.emptyList());
@@ -334,6 +336,14 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 			Client.class, ClientThread.class, GuidanceOverlay.class);
 		ctor.setAccessible(true);
 		return ctor.newInstance(client, clientThread, guidanceOverlay);
+	}
+
+	private StepChangeHandler newStepChangeHandler() throws Exception
+	{
+		Constructor<StepChangeHandler> ctor = StepChangeHandler.class.getDeclaredConstructor(
+			ClientThread.class, GuidanceSequencer.class, RequiredItemResolver.class);
+		ctor.setAccessible(true);
+		return ctor.newInstance(clientThread, guidanceSequencer, requiredItemResolver);
 	}
 
 	private OverlayStepApplier newOverlayStepApplier() throws Exception


### PR DESCRIPTION
## Summary
- Extracts the InfoBox progress refresh + panel step-progress push from `GuidanceOverlayCoordinator.onStepChanged` into a new `StepChangeHandler` Guice singleton (sibling under `com.collectionloghelper.guidance`).
- Pure extraction: no behavioural change. The overlay clear + apply + NPC-tracker scan stays in the coordinator because those paths mutate coordinator-owned state (`activeMapPoint`, `lastMessagedStepIndex`).
- `activeInfoBox` is mutated in-place via `setStepText` / `setTooltipText` / `setTextColor`, so the handler needs no result-write-back -- only an `Input` carrying `(activeInfoBox, panel, activeTargetItemId)`.

## LOC impact
- `GuidanceOverlayCoordinator.java`: **667 -> 627** (-40). New file `StepChangeHandler.java` at 168 LOC.
- Wave 11 of #503. Falls short of the 600 target by 27; the extracted seam was ~47 LOC honest, not the ~60 originally predicted.

## Performance
- `onStepChanged` fires on step transitions (not per-tick) but can fire repeatedly during fast-skip / cascade. Both guard-fail branches (`activeInfoBox == null`, `panel == null`) allocate nothing -- the only allocations are the `Input` record per call and the existing `Collections.emptyList()` literals.

## Test plan
- [x] `./gradlew build` -- BUILD SUCCESSFUL
- [x] `./gradlew test` -- all green, including the four reflectively-instantiated coordinator tests (`GuidanceOverlayCoordinatorMapPointTest`, `GuidanceOverlayCoordinatorNpcIdTest`, `GuidanceOverlayCoordinatorDescriptionTest`, `DynamicTargetEvaluatorDispatchTest`)
- [x] Coordinator constructor signature extended with `StepChangeHandler`; tests inject a constructor-built singleton via the existing `newXxx` helper pattern