### PR TITLE
refactor: extract DynamicItemObjectTierResolver from GuidanceOverlayCoordinator (#503)

### DIFF
--- a/src/main/java/com/collectionloghelper/guidance/DynamicItemObjectTierResolver.java
+++ b/src/main/java/com/collectionloghelper/guidance/DynamicItemObjectTierResolver.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.guidance;
+
+import com.collectionloghelper.data.GuidanceStep;
+import com.collectionloghelper.data.ItemObjectTier;
+import com.collectionloghelper.data.PlayerInventoryState;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ * Pure tier-resolution half of the dynamic item-to-object override that
+ * {@link GuidanceOverlayCoordinator} applies on step change and on inventory
+ * change. Given a {@link GuidanceStep} that carries
+ * {@link GuidanceStep#getDynamicItemObjectTiers()}, scans the player's
+ * inventory and returns the matched object-id / item-id / action / tooltip
+ * snapshot, or {@link Result#EMPTY} when no tier matches.
+ *
+ * <p>Extracted from {@code GuidanceOverlayCoordinator.applyDynamicItemObjectOverlays}
+ * so the tier-resolution logic is independently testable and the per-tick
+ * (overlay refresh) no-op path allocates nothing -- {@link Result#EMPTY} is a
+ * cached singleton returned whenever the step has no dynamic tiers or none of
+ * the tiers' items are present in inventory.</p>
+ *
+ * <p>The overlay-mutation half stays on the coordinator because that class
+ * owns the overlay collaborators and the no-match branch is a no-op there
+ * (no setters fire).</p>
+ *
+ * @see GuidanceOverlayCoordinator
+ * @see ItemObjectTier
+ */
+@Singleton
+public class DynamicItemObjectTierResolver
+{
+	private final PlayerInventoryState playerInventoryState;
+
+	@Inject
+	DynamicItemObjectTierResolver(PlayerInventoryState playerInventoryState)
+	{
+		this.playerInventoryState = playerInventoryState;
+	}
+
+	/**
+	 * Walks {@code step.getDynamicItemObjectTiers()} and collects every tier
+	 * whose item set intersects the current inventory. Mirrors the original
+	 * inline loop: at most one match per tier (avoid duplicate items), tooltip
+	 * derived from the first matching tier (or the step description when
+	 * multiple tiers match), action derived from the first matching tier's
+	 * {@code interactAction} (falling back to the step's
+	 * {@code objectInteractAction}).
+	 *
+	 * @param step the current raw guidance step, or {@code null}
+	 * @return matched object-id / item-id / action / tooltip snapshot, or
+	 *         {@link Result#EMPTY} when the step has no dynamic tiers or
+	 *         nothing in inventory matches.  Never returns {@code null}.
+	 */
+	Result resolve(@Nullable GuidanceStep step)
+	{
+		if (step == null
+			|| step.getDynamicItemObjectTiers() == null
+			|| step.getDynamicItemObjectTiers().isEmpty())
+		{
+			return Result.EMPTY;
+		}
+
+		Set<Integer> matchedObjectIds = null;
+		List<Integer> matchedItemIds = null;
+		String tooltipText = null;
+		String action = null;
+
+		for (ItemObjectTier tier : step.getDynamicItemObjectTiers())
+		{
+			if (tier.getItemIds() == null)
+			{
+				continue;
+			}
+			for (int itemId : tier.getItemIds())
+			{
+				if (playerInventoryState.hasItem(itemId))
+				{
+					if (matchedObjectIds == null)
+					{
+						matchedObjectIds = new HashSet<>();
+						matchedItemIds = new ArrayList<>();
+					}
+					if (tier.getObjectIds() != null && !tier.getObjectIds().isEmpty())
+					{
+						matchedObjectIds.addAll(tier.getObjectIds());
+					}
+					matchedItemIds.add(itemId);
+					if (action == null)
+					{
+						action = tier.getInteractAction() != null
+							? tier.getInteractAction()
+							: step.getObjectInteractAction();
+					}
+					if (tooltipText == null)
+					{
+						tooltipText = tier.getName() != null
+							? (action + " " + tier.getName())
+							: step.getDescription();
+					}
+					break; // Only match first key per tier (avoid duplicates)
+				}
+			}
+		}
+
+		if (matchedObjectIds == null || matchedObjectIds.isEmpty())
+		{
+			return Result.EMPTY;
+		}
+
+		// When multiple tiers matched, the merged tooltip uses the step
+		// description instead of the first tier's "<action> <tierName>" form.
+		String finalTooltip = matchedItemIds.size() > 1 ? step.getDescription() : tooltipText;
+		return new Result(matchedObjectIds, matchedItemIds, action, finalTooltip);
+	}
+
+	/**
+	 * Snapshot returned by {@link #resolve(GuidanceStep)}. {@link #EMPTY} is a
+	 * cached singleton used for every no-op path; callers MUST check
+	 * {@link #hasMatch()} before touching the collection getters.
+	 */
+	static final class Result
+	{
+		/** Cached singleton used for the no-op path (no allocation). */
+		static final Result EMPTY = new Result(
+			Collections.emptySet(), Collections.emptyList(), null, null);
+
+		private final Set<Integer> objectIds;
+		private final List<Integer> itemIds;
+		@Nullable
+		private final String action;
+		@Nullable
+		private final String tooltipText;
+
+		Result(
+			Set<Integer> objectIds,
+			List<Integer> itemIds,
+			@Nullable String action,
+			@Nullable String tooltipText)
+		{
+			this.objectIds = objectIds;
+			this.itemIds = itemIds;
+			this.action = action;
+			this.tooltipText = tooltipText;
+		}
+
+		/** True when at least one tier matched the inventory. */
+		boolean hasMatch()
+		{
+			return !objectIds.isEmpty();
+		}
+
+		Set<Integer> getObjectIds()
+		{
+			return objectIds;
+		}
+
+		List<Integer> getItemIds()
+		{
+			return itemIds;
+		}
+
+		@Nullable
+		String getAction()
+		{
+			return action;
+		}
+
+		@Nullable
+		String getTooltipText()
+		{
+			return tooltipText;
+		}
+	}
+}

--- a/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
@@ -31,7 +31,6 @@ import com.collectionloghelper.data.CollectionLogSource;
 import com.collectionloghelper.data.CompletionCondition;
 import com.collectionloghelper.data.DropRateDatabase;
 import com.collectionloghelper.data.GuidanceStep;
-import com.collectionloghelper.data.ItemObjectTier;
 import com.collectionloghelper.data.PlayerCollectionState;
 import com.collectionloghelper.data.PlayerInventoryState;
 import com.collectionloghelper.data.PlayerTravelCapabilities;
@@ -50,7 +49,6 @@ import com.collectionloghelper.overlay.WorldMapDestinationOverlay;
 import com.collectionloghelper.overlay.WorldMapRouteOverlay;
 import com.collectionloghelper.ui.CollectionLogHelperPanel;
 import java.awt.image.BufferedImage;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -118,6 +116,7 @@ public class GuidanceOverlayCoordinator
 	private final DynamicTargetManager dynamicTargetManager;
 	private final NpcTrackerHelper npcTrackerHelper;
 	private final StepChangeHandler stepChangeHandler;
+	private final DynamicItemObjectTierResolver dynamicItemObjectTierResolver;
 
 	// -- Guidance UI state (previously in plugin) --
 
@@ -190,7 +189,8 @@ public class GuidanceOverlayCoordinator
 		WorldMapController worldMapController,
 		DynamicTargetManager dynamicTargetManager,
 		NpcTrackerHelper npcTrackerHelper,
-		StepChangeHandler stepChangeHandler)
+		StepChangeHandler stepChangeHandler,
+		DynamicItemObjectTierResolver dynamicItemObjectTierResolver)
 	{
 		this.client = client;
 		this.clientThread = clientThread;
@@ -220,6 +220,7 @@ public class GuidanceOverlayCoordinator
 		this.dynamicTargetManager = dynamicTargetManager;
 		this.npcTrackerHelper = npcTrackerHelper;
 		this.stepChangeHandler = stepChangeHandler;
+		this.dynamicItemObjectTierResolver = dynamicItemObjectTierResolver;
 	}
 
 	/**
@@ -486,64 +487,27 @@ public class GuidanceOverlayCoordinator
 
 	/**
 	 * Dynamically overrides overlays when the current step has dynamicItemObjectTiers.
-	 * Scans inventory for the lowest tier with matching items, then highlights
-	 * that tier's objects and the matching item. Called on step change and on
-	 * inventory change while a guidance sequence is active.
+	 * Delegates the tier-scan / inventory-match to
+	 * {@link DynamicItemObjectTierResolver}; the coordinator only owns the overlay
+	 * setter calls (we hold the overlay collaborators). The resolver returns
+	 * {@link DynamicItemObjectTierResolver.Result#EMPTY} as a cached singleton on
+	 * the no-match path, so this method allocates nothing per overlay refresh tick
+	 * when no tier matches.
+	 *
+	 * <p>Called on step change ({@link #applyStepToOverlays}) and on inventory
+	 * change while a guidance sequence is active
+	 * ({@link #onItemContainerChanged()}).</p>
 	 */
 	private void applyDynamicItemObjectOverlays()
 	{
-		GuidanceStep step = guidanceSequencer.getRawCurrentStep();
-		if (step == null || step.getDynamicItemObjectTiers() == null
-			|| step.getDynamicItemObjectTiers().isEmpty())
+		DynamicItemObjectTierResolver.Result result =
+			dynamicItemObjectTierResolver.resolve(guidanceSequencer.getRawCurrentStep());
+		if (result.hasMatch())
 		{
-			return;
-		}
-
-		// Collect ALL matching tiers so multiple keys highlight multiple chests
-		Set<Integer> matchedObjectIds = new HashSet<>();
-		List<Integer> matchedItemIds = new ArrayList<>();
-		String tooltipText = null;
-		String action = null;
-
-		for (ItemObjectTier tier : step.getDynamicItemObjectTiers())
-		{
-			if (tier.getItemIds() == null)
-			{
-				continue;
-			}
-			for (int itemId : tier.getItemIds())
-			{
-				if (playerInventoryState.hasItem(itemId))
-				{
-					if (tier.getObjectIds() != null && !tier.getObjectIds().isEmpty())
-					{
-						matchedObjectIds.addAll(tier.getObjectIds());
-					}
-					matchedItemIds.add(itemId);
-					if (action == null)
-					{
-						action = tier.getInteractAction() != null
-							? tier.getInteractAction()
-							: step.getObjectInteractAction();
-					}
-					if (tooltipText == null)
-					{
-						tooltipText = tier.getName() != null
-							? (action + " " + tier.getName())
-							: step.getDescription();
-					}
-					break; // Only match first key per tier (avoid duplicates)
-				}
-			}
-		}
-
-		if (!matchedObjectIds.isEmpty())
-		{
-			objectHighlightOverlay.setTargetObjectIds(matchedObjectIds);
-			objectHighlightOverlay.setObjectInteractAction(action);
-			objectHighlightOverlay.setTooltipText(
-				matchedItemIds.size() > 1 ? step.getDescription() : tooltipText);
-			itemHighlightOverlay.setTargetItemIds(matchedItemIds);
+			objectHighlightOverlay.setTargetObjectIds(result.getObjectIds());
+			objectHighlightOverlay.setObjectInteractAction(result.getAction());
+			objectHighlightOverlay.setTooltipText(result.getTooltipText());
+			itemHighlightOverlay.setTargetItemIds(result.getItemIds());
 		}
 	}
 

--- a/src/test/java/com/collectionloghelper/guidance/DynamicItemObjectTierResolverTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/DynamicItemObjectTierResolverTest.java
@@ -1,0 +1,301 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.guidance;
+
+import com.collectionloghelper.data.CompletionCondition;
+import com.collectionloghelper.data.GuidanceStep;
+import com.collectionloghelper.data.ItemObjectTier;
+import com.collectionloghelper.data.PlayerInventoryState;
+import java.lang.reflect.Constructor;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link DynamicItemObjectTierResolver}. Pins the tier-resolution
+ * contract extracted from {@code GuidanceOverlayCoordinator.applyDynamicItemObjectOverlays}:
+ *
+ * <ul>
+ *   <li>No tiers configured -- {@link DynamicItemObjectTierResolver.Result#EMPTY}
+ *       singleton (no allocation, no inventory probes).</li>
+ *   <li>Single tier with required item present -- result mirrors that tier's
+ *       object/item ids and uses the tier-specific tooltip ({@code "<action> <name>"}).</li>
+ *   <li>Multiple tiers matching -- object/item ids merged; tooltip falls back to
+ *       the step description (matches legacy 2-tier branch).</li>
+ *   <li>No tier's items in inventory -- {@link DynamicItemObjectTierResolver.Result#EMPTY}.</li>
+ * </ul>
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class DynamicItemObjectTierResolverTest
+{
+	private static final String STEP_DESC = "Loot the chest";
+
+	@Mock
+	private PlayerInventoryState playerInventoryState;
+
+	private DynamicItemObjectTierResolver resolver;
+
+	@Before
+	public void setUp() throws Exception
+	{
+		Constructor<DynamicItemObjectTierResolver> ctor =
+			DynamicItemObjectTierResolver.class.getDeclaredConstructor(PlayerInventoryState.class);
+		ctor.setAccessible(true);
+		resolver = ctor.newInstance(playerInventoryState);
+	}
+
+	@Test
+	public void resolve_nullStep_returnsEmptySingletonAndProbesNothing()
+	{
+		DynamicItemObjectTierResolver.Result result = resolver.resolve(null);
+
+		assertSame("null step must return the EMPTY singleton (no allocation)",
+			DynamicItemObjectTierResolver.Result.EMPTY, result);
+		assertFalse(result.hasMatch());
+		verifyNoInteractions(playerInventoryState);
+	}
+
+	@Test
+	public void resolve_stepWithoutDynamicTiers_returnsEmptySingleton()
+	{
+		GuidanceStep step = stepWithTiers(null);
+
+		DynamicItemObjectTierResolver.Result result = resolver.resolve(step);
+
+		assertSame(DynamicItemObjectTierResolver.Result.EMPTY, result);
+		verifyNoInteractions(playerInventoryState);
+	}
+
+	@Test
+	public void resolve_stepWithEmptyTiersList_returnsEmptySingleton()
+	{
+		GuidanceStep step = stepWithTiers(Collections.emptyList());
+
+		DynamicItemObjectTierResolver.Result result = resolver.resolve(step);
+
+		assertSame(DynamicItemObjectTierResolver.Result.EMPTY, result);
+		verifyNoInteractions(playerInventoryState);
+	}
+
+	@Test
+	public void resolve_singleTierItemPresent_returnsTierObjectsAndTooltip()
+	{
+		ItemObjectTier bronze = new ItemObjectTier(
+			"Bronze",
+			Arrays.asList(101, 102),
+			Arrays.asList(2001, 2002),
+			"Open");
+		GuidanceStep step = stepWithTiers(Collections.singletonList(bronze));
+		when(playerInventoryState.hasItem(101)).thenReturn(true);
+
+		DynamicItemObjectTierResolver.Result result = resolver.resolve(step);
+
+		assertTrue(result.hasMatch());
+		assertEquals(2, result.getObjectIds().size());
+		assertTrue(result.getObjectIds().containsAll(Arrays.asList(2001, 2002)));
+		assertEquals(Collections.singletonList(101), result.getItemIds());
+		assertEquals("Open", result.getAction());
+		assertEquals("Open Bronze", result.getTooltipText());
+	}
+
+	@Test
+	public void resolve_singleTierFirstItemMatches_breaksAfterFirstKey()
+	{
+		// Tier has two item IDs; first matches in inventory. Loop must break after
+		// the first match (legacy "Only match first key per tier (avoid duplicates)").
+		ItemObjectTier tier = new ItemObjectTier(
+			"Steel",
+			Arrays.asList(201, 202),
+			Collections.singletonList(3001),
+			"Use");
+		GuidanceStep step = stepWithTiers(Collections.singletonList(tier));
+		when(playerInventoryState.hasItem(201)).thenReturn(true);
+
+		DynamicItemObjectTierResolver.Result result = resolver.resolve(step);
+
+		assertTrue(result.hasMatch());
+		assertEquals(Collections.singletonList(201), result.getItemIds());
+	}
+
+	@Test
+	public void resolve_multipleTiersMatching_mergesObjectsAndUsesStepDescription()
+	{
+		// Bronze + Steel both have a matching item -- merged object set, tooltip
+		// falls back to step description (legacy: matchedItemIds.size() > 1).
+		ItemObjectTier bronze = new ItemObjectTier(
+			"Bronze",
+			Collections.singletonList(101),
+			Collections.singletonList(2001),
+			"Open");
+		ItemObjectTier steel = new ItemObjectTier(
+			"Steel",
+			Collections.singletonList(201),
+			Collections.singletonList(3001),
+			"Open");
+		GuidanceStep step = stepWithTiers(Arrays.asList(bronze, steel));
+		when(playerInventoryState.hasItem(101)).thenReturn(true);
+		when(playerInventoryState.hasItem(201)).thenReturn(true);
+
+		DynamicItemObjectTierResolver.Result result = resolver.resolve(step);
+
+		assertTrue(result.hasMatch());
+		assertEquals(2, result.getObjectIds().size());
+		assertTrue(result.getObjectIds().containsAll(Arrays.asList(2001, 3001)));
+		assertEquals(Arrays.asList(101, 201), result.getItemIds());
+		assertEquals("Open", result.getAction());
+		// Multi-tier match: tooltip falls back to step description, not "<action> <name>"
+		assertEquals(STEP_DESC, result.getTooltipText());
+	}
+
+	@Test
+	public void resolve_noTierItemInInventory_returnsEmptySingleton()
+	{
+		ItemObjectTier tier = new ItemObjectTier(
+			"Bronze",
+			Collections.singletonList(101),
+			Collections.singletonList(2001),
+			"Open");
+		GuidanceStep step = stepWithTiers(Collections.singletonList(tier));
+		// hasItem(101) is false by default -- nothing matches.
+
+		DynamicItemObjectTierResolver.Result result = resolver.resolve(step);
+
+		assertSame("no-match path must return the EMPTY singleton (no allocation)",
+			DynamicItemObjectTierResolver.Result.EMPTY, result);
+		assertFalse(result.hasMatch());
+	}
+
+	@Test
+	public void resolve_tierWithNullItemIds_isSkipped()
+	{
+		// Defensive: a malformed tier with null itemIds must not throw and must
+		// not prevent later tiers from matching.
+		ItemObjectTier malformed = new ItemObjectTier("Empty", null, null, null);
+		ItemObjectTier good = new ItemObjectTier(
+			"Steel",
+			Collections.singletonList(201),
+			Collections.singletonList(3001),
+			"Use");
+		GuidanceStep step = stepWithTiers(Arrays.asList(malformed, good));
+		when(playerInventoryState.hasItem(201)).thenReturn(true);
+
+		DynamicItemObjectTierResolver.Result result = resolver.resolve(step);
+
+		assertTrue(result.hasMatch());
+		assertEquals(Collections.singletonList(3001),
+			Arrays.asList(result.getObjectIds().toArray(new Integer[0])));
+		assertEquals(Collections.singletonList(201), result.getItemIds());
+	}
+
+	@Test
+	public void resolve_tierActionNull_fallsBackToStepObjectInteractAction()
+	{
+		// Tier has no interactAction -- falls back to step.objectInteractAction.
+		ItemObjectTier tier = new ItemObjectTier(
+			"Gold",
+			Collections.singletonList(301),
+			Collections.singletonList(4001),
+			null);
+		GuidanceStep step = stepWithTiersAndAction(
+			Collections.singletonList(tier), "Search");
+		when(playerInventoryState.hasItem(301)).thenReturn(true);
+
+		DynamicItemObjectTierResolver.Result result = resolver.resolve(step);
+
+		assertTrue(result.hasMatch());
+		assertEquals("Search", result.getAction());
+		assertEquals("Search Gold", result.getTooltipText());
+	}
+
+	@Test
+	public void resultEmpty_isAllocationFreeNoOp()
+	{
+		// The EMPTY singleton invariants the coordinator relies on: hasMatch=false
+		// short-circuits before any overlay setter fires, and the getters return
+		// non-null empty collections so a misuse can't throw NPE.
+		DynamicItemObjectTierResolver.Result empty = DynamicItemObjectTierResolver.Result.EMPTY;
+
+		assertFalse(empty.hasMatch());
+		assertTrue(empty.getObjectIds().isEmpty());
+		assertTrue(empty.getItemIds().isEmpty());
+		assertNull(empty.getAction());
+		assertNull(empty.getTooltipText());
+	}
+
+	// -- helpers --
+
+	private static GuidanceStep stepWithTiers(List<ItemObjectTier> tiers)
+	{
+		return stepWithTiersAndAction(tiers, "Open");
+	}
+
+	private static GuidanceStep stepWithTiersAndAction(
+		List<ItemObjectTier> tiers, String objectInteractAction)
+	{
+		return new GuidanceStep(
+			STEP_DESC,
+			null,           // perItemStepDescription
+			0, 0, 0,       // worldX, worldY, worldPlane
+			0, null, null, null, // npcId, perItemNpcId, interactAction, dialogOptions
+			null, null,     // travelTip, requiredItemIds
+			null,           // perItemRequiredItemIds
+			null,           // recommendedItemIds
+			null,           // perItemRecommendedItemIds
+			CompletionCondition.MANUAL,
+			0, 0, 0, 0,    // completionItemId, completionItemCount, completionDistance, completionNpcId
+			null,           // completionNpcIds
+			null,           // worldMessage
+			0, null, objectInteractAction,  // objectId, objectIds, objectInteractAction
+			null, null,     // highlightItemIds, groundItemIds
+			null,           // completionChatPattern
+			0, 0,           // completionVarbitId, completionVarbitValue
+			false,          // useItemOnObject
+			0,              // objectMaxDistance
+			null,           // objectFilterTiles
+			null,           // highlightWidgetIds
+			0, 0,           // loopBackToStep, loopCount
+			null,           // skipIfHasAnyItemIds
+			tiers,          // dynamicItemObjectTiers
+			null,           // completionZone
+			null,           // conditionalAlternatives
+			null,           // section
+			null,           // waypoints
+			null            // dynamicTargetEvaluator
+		);
+	}
+}

--- a/src/test/java/com/collectionloghelper/guidance/DynamicTargetEvaluatorDispatchTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/DynamicTargetEvaluatorDispatchTest.java
@@ -155,6 +155,7 @@ public class DynamicTargetEvaluatorDispatchTest
 		NpcTrackerHelper npcTrackerHelper = newNpcTrackerHelper();
 		OverlayDeactivator overlayDeactivator = newOverlayDeactivator(npcTrackerHelper);
 		StepChangeHandler stepChangeHandler = newStepChangeHandler();
+		DynamicItemObjectTierResolver dynamicItemObjectTierResolver = newDynamicItemObjectTierResolver();
 		Constructor<GuidanceOverlayCoordinator> ctor =
 			GuidanceOverlayCoordinator.class.getDeclaredConstructor(
 				Client.class,
@@ -184,7 +185,8 @@ public class DynamicTargetEvaluatorDispatchTest
 				WorldMapController.class,
 				DynamicTargetManager.class,
 				NpcTrackerHelper.class,
-				StepChangeHandler.class);
+				StepChangeHandler.class,
+				DynamicItemObjectTierResolver.class);
 		ctor.setAccessible(true);
 		coordinator = ctor.newInstance(
 			client, clientThread, eventBus, config,
@@ -196,7 +198,8 @@ public class DynamicTargetEvaluatorDispatchTest
 			worldMapRouteOverlay, worldMapDestinationOverlay,
 			groundItemHighlightOverlay, widgetHighlightOverlay,
 			overlayStepApplier, overlaySourceApplier, overlayDeactivator,
-			worldMapController, dynamicTargetManager, npcTrackerHelper, stepChangeHandler);
+			worldMapController, dynamicTargetManager, npcTrackerHelper, stepChangeHandler,
+			dynamicItemObjectTierResolver);
 
 		lenient().when(client.getLocalPlayer()).thenReturn(localPlayer);
 		lenient().when(localPlayer.getWorldLocation()).thenReturn(new WorldPoint(3200, 3200, 0));
@@ -322,6 +325,14 @@ public class DynamicTargetEvaluatorDispatchTest
 			ClientThread.class, GuidanceSequencer.class, RequiredItemResolver.class);
 		ctor.setAccessible(true);
 		return ctor.newInstance(clientThread, guidanceSequencer, requiredItemResolver);
+	}
+
+	private DynamicItemObjectTierResolver newDynamicItemObjectTierResolver() throws Exception
+	{
+		Constructor<DynamicItemObjectTierResolver> ctor =
+			DynamicItemObjectTierResolver.class.getDeclaredConstructor(PlayerInventoryState.class);
+		ctor.setAccessible(true);
+		return ctor.newInstance(playerInventoryState);
 	}
 
 	private OverlayStepApplier newOverlayStepApplier() throws Exception

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorDescriptionTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorDescriptionTest.java
@@ -149,6 +149,7 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 		NpcTrackerHelper npcTrackerHelper = newNpcTrackerHelper();
 		OverlayDeactivator overlayDeactivator = newOverlayDeactivator(npcTrackerHelper);
 		StepChangeHandler stepChangeHandler = newStepChangeHandler();
+		DynamicItemObjectTierResolver dynamicItemObjectTierResolver = newDynamicItemObjectTierResolver();
 		Constructor<GuidanceOverlayCoordinator> ctor =
 			GuidanceOverlayCoordinator.class.getDeclaredConstructor(
 				Client.class,
@@ -178,7 +179,8 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 				WorldMapController.class,
 				DynamicTargetManager.class,
 				NpcTrackerHelper.class,
-				StepChangeHandler.class);
+				StepChangeHandler.class,
+				DynamicItemObjectTierResolver.class);
 		ctor.setAccessible(true);
 		DynamicTargetManager dynamicTargetManager = newDynamicTargetManager(worldMapController);
 		coordinator = ctor.newInstance(
@@ -191,7 +193,8 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 			worldMapRouteOverlay, worldMapDestinationOverlay,
 			groundItemHighlightOverlay, widgetHighlightOverlay,
 			overlayStepApplier, overlaySourceApplier, overlayDeactivator,
-			worldMapController, dynamicTargetManager, npcTrackerHelper, stepChangeHandler);
+			worldMapController, dynamicTargetManager, npcTrackerHelper, stepChangeHandler,
+			dynamicItemObjectTierResolver);
 
 		coordinator.setPanel(panel);
 
@@ -337,6 +340,14 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 			ClientThread.class, GuidanceSequencer.class, RequiredItemResolver.class);
 		ctor.setAccessible(true);
 		return ctor.newInstance(clientThread, guidanceSequencer, requiredItemResolver);
+	}
+
+	private DynamicItemObjectTierResolver newDynamicItemObjectTierResolver() throws Exception
+	{
+		Constructor<DynamicItemObjectTierResolver> ctor =
+			DynamicItemObjectTierResolver.class.getDeclaredConstructor(PlayerInventoryState.class);
+		ctor.setAccessible(true);
+		return ctor.newInstance(playerInventoryState);
 	}
 
 	private OverlayStepApplier newOverlayStepApplier() throws Exception

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorMapPointTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorMapPointTest.java
@@ -135,6 +135,7 @@ public class GuidanceOverlayCoordinatorMapPointTest
 		NpcTrackerHelper npcTrackerHelper = newNpcTrackerHelper();
 		OverlayDeactivator overlayDeactivator = newOverlayDeactivator(npcTrackerHelper);
 		StepChangeHandler stepChangeHandler = newStepChangeHandler();
+		DynamicItemObjectTierResolver dynamicItemObjectTierResolver = newDynamicItemObjectTierResolver();
 		Constructor<GuidanceOverlayCoordinator> ctor =
 			GuidanceOverlayCoordinator.class.getDeclaredConstructor(
 				Client.class,
@@ -164,7 +165,8 @@ public class GuidanceOverlayCoordinatorMapPointTest
 				WorldMapController.class,
 				DynamicTargetManager.class,
 				NpcTrackerHelper.class,
-				StepChangeHandler.class);
+				StepChangeHandler.class,
+				DynamicItemObjectTierResolver.class);
 		ctor.setAccessible(true);
 		DynamicTargetManager dynamicTargetManager = newDynamicTargetManager(worldMapController);
 		coordinator = ctor.newInstance(
@@ -177,7 +179,8 @@ public class GuidanceOverlayCoordinatorMapPointTest
 			worldMapRouteOverlay, worldMapDestinationOverlay,
 			groundItemHighlightOverlay, widgetHighlightOverlay,
 			overlayStepApplier, overlaySourceApplier, overlayDeactivator,
-			worldMapController, dynamicTargetManager, npcTrackerHelper, stepChangeHandler);
+			worldMapController, dynamicTargetManager, npcTrackerHelper, stepChangeHandler,
+			dynamicItemObjectTierResolver);
 
 		// Default stubs: no unmet requirements; buildRequirementRows called unconditionally
 		when(requirementsChecker.getUnmetRequirements(any())).thenReturn(Collections.emptyList());
@@ -295,6 +298,14 @@ public class GuidanceOverlayCoordinatorMapPointTest
 			ClientThread.class, GuidanceSequencer.class, RequiredItemResolver.class);
 		ctor.setAccessible(true);
 		return ctor.newInstance(clientThread, guidanceSequencer, requiredItemResolver);
+	}
+
+	private DynamicItemObjectTierResolver newDynamicItemObjectTierResolver() throws Exception
+	{
+		Constructor<DynamicItemObjectTierResolver> ctor =
+			DynamicItemObjectTierResolver.class.getDeclaredConstructor(PlayerInventoryState.class);
+		ctor.setAccessible(true);
+		return ctor.newInstance(playerInventoryState);
 	}
 
 	/** Builds a minimal BOSSES source with coordinates but no guidance steps. */

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorNpcIdTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorNpcIdTest.java
@@ -146,6 +146,7 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 		NpcTrackerHelper npcTrackerHelper = newNpcTrackerHelper();
 		OverlayDeactivator overlayDeactivator = newOverlayDeactivator(npcTrackerHelper);
 		StepChangeHandler stepChangeHandler = newStepChangeHandler();
+		DynamicItemObjectTierResolver dynamicItemObjectTierResolver = newDynamicItemObjectTierResolver();
 		Constructor<GuidanceOverlayCoordinator> ctor =
 			GuidanceOverlayCoordinator.class.getDeclaredConstructor(
 				Client.class,
@@ -175,7 +176,8 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 				WorldMapController.class,
 				DynamicTargetManager.class,
 				NpcTrackerHelper.class,
-				StepChangeHandler.class);
+				StepChangeHandler.class,
+				DynamicItemObjectTierResolver.class);
 		ctor.setAccessible(true);
 		DynamicTargetManager dynamicTargetManager = newDynamicTargetManager(worldMapController);
 		coordinator = ctor.newInstance(
@@ -188,7 +190,8 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 			worldMapRouteOverlay, worldMapDestinationOverlay,
 			groundItemHighlightOverlay, widgetHighlightOverlay,
 			overlayStepApplier, overlaySourceApplier, overlayDeactivator,
-			worldMapController, dynamicTargetManager, npcTrackerHelper, stepChangeHandler);
+			worldMapController, dynamicTargetManager, npcTrackerHelper, stepChangeHandler,
+			dynamicItemObjectTierResolver);
 
 		when(requirementsChecker.getUnmetRequirements(any())).thenReturn(Collections.emptyList());
 		when(requirementsChecker.buildRequirementRows(any())).thenReturn(Collections.emptyList());
@@ -344,6 +347,14 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 			ClientThread.class, GuidanceSequencer.class, RequiredItemResolver.class);
 		ctor.setAccessible(true);
 		return ctor.newInstance(clientThread, guidanceSequencer, requiredItemResolver);
+	}
+
+	private DynamicItemObjectTierResolver newDynamicItemObjectTierResolver() throws Exception
+	{
+		Constructor<DynamicItemObjectTierResolver> ctor =
+			DynamicItemObjectTierResolver.class.getDeclaredConstructor(PlayerInventoryState.class);
+		ctor.setAccessible(true);
+		return ctor.newInstance(playerInventoryState);
 	}
 
 	private OverlayStepApplier newOverlayStepApplier() throws Exception


### PR DESCRIPTION
## Summary

Wave 12 of #503: extract the tier-resolution half of `applyDynamicItemObjectOverlays` into a new `DynamicItemObjectTierResolver` so the inventory-scan logic is independently testable and the per-tick no-op path is allocation-free. The coordinator keeps the overlay-mutation half (it owns the overlay collaborators).

- `GuidanceOverlayCoordinator.java`: **627 -- 591 LOC** (-36), landing under the 600 target for #503.
- New `DynamicItemObjectTierResolver` returns a cached `Result.EMPTY` singleton when no tier matches, preserving the critical overlay-refresh hot path (#527 / #523 allocation-free lesson).
- The four reflection-based coordinator tests (`MapPointTest`, `NpcIdTest`, `DescriptionTest`, `DynamicTargetEvaluatorDispatchTest`) are updated to inject the new singleton through the package-private constructor.
- New `DynamicItemObjectTierResolverTest` covers: null step, null/empty tiers, single tier with item present, single-tier first-match-breaks-loop, multi-tier merge with step-description fallback, no-match returns `EMPTY`, malformed tier (null itemIds) is skipped, tier action falls back to `step.objectInteractAction`, and `EMPTY` singleton invariants.

## Test plan

- [x] `./gradlew build` passes
- [x] `./gradlew test` passes
- [x] New `DynamicItemObjectTierResolverTest` executes 10 test methods covering all reviewer-requested cases
- [x] Coordinator behaviour unchanged: same 4 overlay setters fire on match, no setter fires on no-match
- [x] No allocation on the no-op path (`Result.EMPTY` singleton)