### PR TITLE
refactor: extract VarbitChangeRouter from Plugin (#503)

### DIFF
--- a/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
@@ -41,6 +41,7 @@ import com.collectionloghelper.lifecycle.OverlayRegistry;
 import com.collectionloghelper.lifecycle.PlayerLocationResolver;
 import com.collectionloghelper.lifecycle.SceneEventRouter;
 import com.collectionloghelper.lifecycle.SyncStateCoordinator;
+import com.collectionloghelper.lifecycle.VarbitChangeRouter;
 import com.collectionloghelper.ui.CollectionLogHelperPanel;
 import com.google.inject.Provides;
 import java.awt.image.BufferedImage;
@@ -152,6 +153,9 @@ public class CollectionLogHelperPlugin extends Plugin
 
 	@Inject
 	private PlayerLocationResolver playerLocationResolver;
+
+	@Inject
+	private VarbitChangeRouter varbitChangeRouter;
 
 
 	private CollectionLogHelperPanel panel;
@@ -294,6 +298,18 @@ public class CollectionLogHelperPlugin extends Plugin
 				pendingPanelRebuild = true;
 				rankedSourcesDirty = true;
 			});
+		varbitChangeRouter.setCallbacks(
+			() ->
+			{
+				pendingRequirementsRefresh = true;
+				pendingTravelVarbitRefresh = true;
+			},
+			this::rebuildSourcesWithMissingItems,
+			() ->
+			{
+				pendingPanelRebuild = true;
+				rankedSourcesDirty = true;
+			});
 		chatCommandManager.registerCommand("clh", chatEventHandler::onClhCommand);
 		log.info("Collection Log Helper started");
 	}
@@ -429,57 +445,7 @@ public class CollectionLogHelperPlugin extends Plugin
 	@Subscribe
 	public void onVarbitChanged(VarbitChanged event)
 	{
-		// Runs on the client thread — safe to call client API
-		data.getCollectionState().refreshVarps();
-
-		// Authoring: log varbit changes (throttle to 1 per tick to avoid spam)
-		if (config.guidanceAuthoring() && client.getTickCount() != authoringLogger.getLastVarbitLogTick())
-		{
-			authoringLogger.setLastVarbitLogTick(client.getTickCount());
-			authoringLogger.log("VARBIT_CHANGED varbitId=%d value=%d",
-				event.getVarbitId(), event.getValue());
-		}
-
-		// Forward varbit change to guidance sequencer for VARBIT_AT_LEAST completion
-		guidance.getGuidanceSequencer().onVarbitChanged(event.getVarbitId(), event.getValue());
-
-		// Refresh Slayer task state and rebuild if the task changed
-		boolean wasActive = data.getSlayerTaskState().isTaskActive();
-		String oldCreature = data.getSlayerTaskState().getCreatureName();
-		int oldRemaining = data.getSlayerTaskState().getRemaining();
-		data.getSlayerTaskState().refresh();
-
-		boolean slayerChanged = wasActive != data.getSlayerTaskState().isTaskActive()
-			|| (data.getSlayerTaskState().getCreatureName() != null
-				&& !data.getSlayerTaskState().getCreatureName().equals(oldCreature))
-			|| data.getSlayerTaskState().getRemaining() != oldRemaining;
-
-		// Flag requirements and travel capabilities for refresh on next game tick (debounced).
-		// Quest states are varbits that fire hundreds of times during login,
-		// so we can't call refreshAccessibility() here — it scans all sources.
-		pendingRequirementsRefresh = true;
-		pendingTravelVarbitRefresh = true;
-
-		// Don't trigger rebuilds mid-scan; the settle logic in onGameTick
-		// will fire a single rebuild once script 4100 stops firing.
-		if (sync.getSyncStateCoordinator().isScriptScanActive())
-		{
-			return;
-		}
-
-		int currentCount = data.getCollectionState().getTotalObtained();
-		if (currentCount != sync.getSyncStateCoordinator().getLastObtainedCount())
-		{
-			sync.getSyncStateCoordinator().onCollectionStateChanged(currentCount);
-			rebuildSourcesWithMissingItems();
-			slayerChanged = true; // rebuild anyway
-		}
-
-		if (slayerChanged)
-		{
-			pendingPanelRebuild = true;
-			rankedSourcesDirty = true;
-		}
+		varbitChangeRouter.handle(event);
 	}
 
 	@Subscribe

--- a/src/main/java/com/collectionloghelper/lifecycle/VarbitChangeRouter.java
+++ b/src/main/java/com/collectionloghelper/lifecycle/VarbitChangeRouter.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.lifecycle;
+
+import com.collectionloghelper.CollectionLogHelperConfig;
+import com.collectionloghelper.di.DataModule;
+import com.collectionloghelper.di.GuidanceModule;
+import com.collectionloghelper.di.SyncModule;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.events.VarbitChanged;
+
+/**
+ * Processes {@link VarbitChanged} events on the client thread.
+ *
+ * <p>Owns the body that previously lived inline in
+ * {@code CollectionLogHelperPlugin.onVarbitChanged}. The plugin keeps the
+ * {@code @Subscribe} annotation (so the RuneLite event bus discovers it via
+ * the existing {@code eventBus.register(plugin)} call in {@code startUp}) and
+ * delegates to {@link #handle(VarbitChanged)}.
+ *
+ * <p>Five responsibilities are kept here:
+ * <ol>
+ *   <li>Refresh the cached varp snapshot.</li>
+ *   <li>Throttled authoring-log line (one per tick).</li>
+ *   <li>Forward to {@code GuidanceSequencer.onVarbitChanged}.</li>
+ *   <li>Detect Slayer task deltas (active / creature / remaining).</li>
+ *   <li>Gate the obtained-count delta on the script-scan flag and forward
+ *       to {@link SyncStateCoordinator}.</li>
+ * </ol>
+ *
+ * <p>Three narrow callbacks back to the plugin keep the per-tick refresh
+ * flags and rebuild triggers where they live today, without leaking those
+ * fields into this collaborator:
+ * <ul>
+ *   <li>{@code flagRefreshes} -- set both
+ *       {@code pendingRequirementsRefresh} and
+ *       {@code pendingTravelVarbitRefresh} on the plugin.</li>
+ *   <li>{@code onCollectionStateChanged} -- rebuild the sources-with-missing
+ *       cache when the obtained-item count moves.</li>
+ *   <li>{@code onSlayerTaskChanged} -- flag a panel rebuild + ranked-source
+ *       recompute when the Slayer task delta fires.</li>
+ * </ul>
+ *
+ * <p>Performance: {@link VarbitChanged} fires extremely frequently in OSRS
+ * (hundreds of times during login alone). The no-op / guard-fail path
+ * allocates nothing -- there are no per-event {@code new} sites and no
+ * lambdas captured here.
+ *
+ * <p>Part of issue #503 -- splitting {@code CollectionLogHelperPlugin} into
+ * focused collaborators (Wave 12).
+ */
+@Slf4j
+@Singleton
+public class VarbitChangeRouter
+{
+	private final Client client;
+	private final CollectionLogHelperConfig config;
+	private final DataModule data;
+	private final GuidanceModule guidance;
+	private final SyncModule sync;
+	private final AuthoringLogger authoringLogger;
+
+	private Runnable flagRefreshes;
+	private Runnable onCollectionStateChanged;
+	private Runnable onSlayerTaskChanged;
+
+	@Inject
+	VarbitChangeRouter(
+		Client client,
+		CollectionLogHelperConfig config,
+		DataModule data,
+		GuidanceModule guidance,
+		SyncModule sync,
+		AuthoringLogger authoringLogger)
+	{
+		this.client = client;
+		this.config = config;
+		this.data = data;
+		this.guidance = guidance;
+		this.sync = sync;
+		this.authoringLogger = authoringLogger;
+	}
+
+	/**
+	 * Wires the callbacks back to the plugin's per-tick refresh flags and
+	 * rebuild triggers. Called once from {@code CollectionLogHelperPlugin.startUp()}
+	 * after the plugin's private state is ready. Kept off the constructor to
+	 * avoid a circular Guice dependency on the plugin itself.
+	 */
+	public void setCallbacks(
+		Runnable flagRefreshes,
+		Runnable onCollectionStateChanged,
+		Runnable onSlayerTaskChanged)
+	{
+		this.flagRefreshes = flagRefreshes;
+		this.onCollectionStateChanged = onCollectionStateChanged;
+		this.onSlayerTaskChanged = onSlayerTaskChanged;
+	}
+
+	/**
+	 * Handles a single {@link VarbitChanged} event. Runs on the client thread,
+	 * so client-API access is safe.
+	 */
+	public void handle(VarbitChanged event)
+	{
+		// Runs on the client thread -- safe to call client API
+		data.getCollectionState().refreshVarps();
+
+		// Authoring: log varbit changes (throttle to 1 per tick to avoid spam)
+		if (config.guidanceAuthoring() && client.getTickCount() != authoringLogger.getLastVarbitLogTick())
+		{
+			authoringLogger.setLastVarbitLogTick(client.getTickCount());
+			authoringLogger.log("VARBIT_CHANGED varbitId=%d value=%d",
+				event.getVarbitId(), event.getValue());
+		}
+
+		// Forward varbit change to guidance sequencer for VARBIT_AT_LEAST completion
+		guidance.getGuidanceSequencer().onVarbitChanged(event.getVarbitId(), event.getValue());
+
+		// Refresh Slayer task state and rebuild if the task changed
+		boolean wasActive = data.getSlayerTaskState().isTaskActive();
+		String oldCreature = data.getSlayerTaskState().getCreatureName();
+		int oldRemaining = data.getSlayerTaskState().getRemaining();
+		data.getSlayerTaskState().refresh();
+
+		boolean slayerChanged = wasActive != data.getSlayerTaskState().isTaskActive()
+			|| (data.getSlayerTaskState().getCreatureName() != null
+				&& !data.getSlayerTaskState().getCreatureName().equals(oldCreature))
+			|| data.getSlayerTaskState().getRemaining() != oldRemaining;
+
+		// Flag requirements and travel capabilities for refresh on next game tick (debounced).
+		// Quest states are varbits that fire hundreds of times during login,
+		// so we can't call refreshAccessibility() here -- it scans all sources.
+		if (flagRefreshes != null)
+		{
+			flagRefreshes.run();
+		}
+
+		// Don't trigger rebuilds mid-scan; the settle logic in onGameTick
+		// will fire a single rebuild once script 4100 stops firing.
+		if (sync.getSyncStateCoordinator().isScriptScanActive())
+		{
+			return;
+		}
+
+		int currentCount = data.getCollectionState().getTotalObtained();
+		if (currentCount != sync.getSyncStateCoordinator().getLastObtainedCount())
+		{
+			sync.getSyncStateCoordinator().onCollectionStateChanged(currentCount);
+			if (onCollectionStateChanged != null)
+			{
+				onCollectionStateChanged.run();
+			}
+			slayerChanged = true; // rebuild anyway
+		}
+
+		if (slayerChanged && onSlayerTaskChanged != null)
+		{
+			onSlayerTaskChanged.run();
+		}
+	}
+}

--- a/src/test/java/com/collectionloghelper/lifecycle/VarbitChangeRouterTest.java
+++ b/src/test/java/com/collectionloghelper/lifecycle/VarbitChangeRouterTest.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ */
+package com.collectionloghelper.lifecycle;
+
+import com.collectionloghelper.CollectionLogHelperConfig;
+import com.collectionloghelper.data.PlayerCollectionState;
+import com.collectionloghelper.data.SlayerTaskState;
+import com.collectionloghelper.di.DataModule;
+import com.collectionloghelper.di.GuidanceModule;
+import com.collectionloghelper.di.SyncModule;
+import com.collectionloghelper.guidance.GuidanceSequencer;
+import net.runelite.api.Client;
+import net.runelite.api.events.VarbitChanged;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class VarbitChangeRouterTest
+{
+	@Mock private Client client;
+	@Mock private CollectionLogHelperConfig config;
+	@Mock private DataModule dataModule;
+	@Mock private GuidanceModule guidanceModule;
+	@Mock private SyncModule syncModule;
+	@Mock private AuthoringLogger authoringLogger;
+	@Mock private PlayerCollectionState collectionState;
+	@Mock private SlayerTaskState slayerTaskState;
+	@Mock private GuidanceSequencer guidanceSequencer;
+	@Mock private SyncStateCoordinator syncStateCoordinator;
+
+	private VarbitChangeRouter router;
+	private boolean flagRefreshesCalled;
+	private boolean onCollectionStateChangedCalled;
+	private boolean onSlayerTaskChangedCalled;
+
+	@Before
+	public void setUp()
+	{
+		when(dataModule.getCollectionState()).thenReturn(collectionState);
+		when(dataModule.getSlayerTaskState()).thenReturn(slayerTaskState);
+		when(guidanceModule.getGuidanceSequencer()).thenReturn(guidanceSequencer);
+		when(syncModule.getSyncStateCoordinator()).thenReturn(syncStateCoordinator);
+		router = new VarbitChangeRouter(client, config, dataModule, guidanceModule, syncModule, authoringLogger);
+		flagRefreshesCalled = false;
+		onCollectionStateChangedCalled = false;
+		onSlayerTaskChangedCalled = false;
+		router.setCallbacks(
+			() -> flagRefreshesCalled = true,
+			() -> onCollectionStateChangedCalled = true,
+			() -> onSlayerTaskChangedCalled = true);
+	}
+
+	private VarbitChanged makeEvent(int varbitId, int value)
+	{
+		VarbitChanged e = new VarbitChanged();
+		e.setVarbitId(varbitId);
+		e.setValue(value);
+		return e;
+	}
+
+	@Test
+	public void unrelatedVarbit_stillFlagsRefreshes_andForwardsToSequencer()
+	{
+		when(slayerTaskState.isTaskActive()).thenReturn(false);
+		when(slayerTaskState.getCreatureName()).thenReturn(null);
+		when(slayerTaskState.getRemaining()).thenReturn(0);
+		when(syncStateCoordinator.isScriptScanActive()).thenReturn(false);
+		when(collectionState.getTotalObtained()).thenReturn(100);
+		when(syncStateCoordinator.getLastObtainedCount()).thenReturn(100);
+		router.handle(makeEvent(9999, 0));
+		verify(collectionState).refreshVarps();
+		verify(guidanceSequencer).onVarbitChanged(9999, 0);
+		verify(slayerTaskState).refresh();
+		assertTrue("flagRefreshes should always fire", flagRefreshesCalled);
+		assertFalse("no collection-state delta", onCollectionStateChangedCalled);
+		assertFalse("no slayer delta", onSlayerTaskChangedCalled);
+	}
+
+	@Test
+	public void authoringLog_firesOnceWhenTickAdvances()
+	{
+		when(config.guidanceAuthoring()).thenReturn(true);
+		when(client.getTickCount()).thenReturn(42);
+		when(authoringLogger.getLastVarbitLogTick()).thenReturn(41);
+		when(slayerTaskState.isTaskActive()).thenReturn(false);
+		when(slayerTaskState.getCreatureName()).thenReturn(null);
+		when(slayerTaskState.getRemaining()).thenReturn(0);
+		when(syncStateCoordinator.isScriptScanActive()).thenReturn(true);
+		router.handle(makeEvent(123, 4));
+		verify(authoringLogger).setLastVarbitLogTick(42);
+		verify(authoringLogger).log(anyString(), any(), any());
+	}
+
+	@Test
+	public void authoringLog_doesNotFireOnSameTick()
+	{
+		when(config.guidanceAuthoring()).thenReturn(true);
+		when(client.getTickCount()).thenReturn(42);
+		when(authoringLogger.getLastVarbitLogTick()).thenReturn(42);
+		when(slayerTaskState.isTaskActive()).thenReturn(false);
+		when(slayerTaskState.getCreatureName()).thenReturn(null);
+		when(slayerTaskState.getRemaining()).thenReturn(0);
+		when(syncStateCoordinator.isScriptScanActive()).thenReturn(true);
+		router.handle(makeEvent(123, 4));
+		verify(authoringLogger, never()).setLastVarbitLogTick(anyInt());
+		verify(authoringLogger, never()).log(anyString(), any(), any());
+	}
+
+	@Test
+	public void authoringLog_doesNotFireWhenAuthoringDisabled()
+	{
+		when(config.guidanceAuthoring()).thenReturn(false);
+		when(slayerTaskState.isTaskActive()).thenReturn(false);
+		when(slayerTaskState.getCreatureName()).thenReturn(null);
+		when(slayerTaskState.getRemaining()).thenReturn(0);
+		when(syncStateCoordinator.isScriptScanActive()).thenReturn(true);
+		router.handle(makeEvent(123, 4));
+		verify(authoringLogger, never()).log(anyString(), any(), any());
+	}
+
+	@Test
+	public void slayerTask_activeToInactive_triggersSlayerCallback()
+	{
+		when(slayerTaskState.isTaskActive()).thenReturn(true, false);
+		when(slayerTaskState.getCreatureName()).thenReturn("GreaterDemon", "GreaterDemon");
+		when(slayerTaskState.getRemaining()).thenReturn(50, 50);
+		when(syncStateCoordinator.isScriptScanActive()).thenReturn(false);
+		when(collectionState.getTotalObtained()).thenReturn(100);
+		when(syncStateCoordinator.getLastObtainedCount()).thenReturn(100);
+		router.handle(makeEvent(1, 0));
+		assertTrue(onSlayerTaskChangedCalled);
+		assertFalse(onCollectionStateChangedCalled);
+	}
+
+	@Test
+	public void slayerTask_creatureChange_triggersSlayerCallback()
+	{
+		when(slayerTaskState.isTaskActive()).thenReturn(true, true);
+		when(slayerTaskState.getCreatureName()).thenReturn("GreaterDemon", "BlackDemon");
+		when(slayerTaskState.getRemaining()).thenReturn(50, 50);
+		when(syncStateCoordinator.isScriptScanActive()).thenReturn(false);
+		when(collectionState.getTotalObtained()).thenReturn(100);
+		when(syncStateCoordinator.getLastObtainedCount()).thenReturn(100);
+		router.handle(makeEvent(2, 0));
+		assertTrue(onSlayerTaskChangedCalled);
+	}
+
+	@Test
+	public void slayerTask_remainingChange_triggersSlayerCallback()
+	{
+		when(slayerTaskState.isTaskActive()).thenReturn(true, true);
+		when(slayerTaskState.getCreatureName()).thenReturn("GreaterDemon", "GreaterDemon");
+		when(slayerTaskState.getRemaining()).thenReturn(50, 49);
+		when(syncStateCoordinator.isScriptScanActive()).thenReturn(false);
+		when(collectionState.getTotalObtained()).thenReturn(100);
+		when(syncStateCoordinator.getLastObtainedCount()).thenReturn(100);
+		router.handle(makeEvent(3, 0));
+		assertTrue(onSlayerTaskChangedCalled);
+	}
+
+	@Test
+	public void slayerTask_noChange_noSlayerCallback()
+	{
+		when(slayerTaskState.isTaskActive()).thenReturn(true, true);
+		when(slayerTaskState.getCreatureName()).thenReturn("GreaterDemon", "GreaterDemon");
+		when(slayerTaskState.getRemaining()).thenReturn(50, 50);
+		when(syncStateCoordinator.isScriptScanActive()).thenReturn(false);
+		when(collectionState.getTotalObtained()).thenReturn(100);
+		when(syncStateCoordinator.getLastObtainedCount()).thenReturn(100);
+		router.handle(makeEvent(4, 0));
+		assertFalse(onSlayerTaskChangedCalled);
+	}
+
+	@Test
+	public void scriptScanActive_shortCircuitsBeforeObtainedCheck()
+	{
+		when(slayerTaskState.isTaskActive()).thenReturn(false);
+		when(slayerTaskState.getCreatureName()).thenReturn(null);
+		when(slayerTaskState.getRemaining()).thenReturn(0);
+		when(syncStateCoordinator.isScriptScanActive()).thenReturn(true);
+		router.handle(makeEvent(5, 0));
+		assertTrue(flagRefreshesCalled);
+		assertFalse(onCollectionStateChangedCalled);
+		assertFalse(onSlayerTaskChangedCalled);
+		verify(collectionState, never()).getTotalObtained();
+		verify(syncStateCoordinator, never()).onCollectionStateChanged(anyInt());
+	}
+
+	@Test
+	public void obtainedCountDelta_firesCollectionAndSlayerCallbacks()
+	{
+		when(slayerTaskState.isTaskActive()).thenReturn(false);
+		when(slayerTaskState.getCreatureName()).thenReturn(null);
+		when(slayerTaskState.getRemaining()).thenReturn(0);
+		when(syncStateCoordinator.isScriptScanActive()).thenReturn(false);
+		when(collectionState.getTotalObtained()).thenReturn(101);
+		when(syncStateCoordinator.getLastObtainedCount()).thenReturn(100);
+		router.handle(makeEvent(6, 0));
+		verify(syncStateCoordinator).onCollectionStateChanged(101);
+		assertTrue("obtained-count callback should fire", onCollectionStateChangedCalled);
+		assertTrue("slayer callback fires (new item forces rebuild)", onSlayerTaskChangedCalled);
+	}
+
+	@Test
+	public void obtainedCountUnchanged_noCollectionCallback()
+	{
+		when(slayerTaskState.isTaskActive()).thenReturn(false);
+		when(slayerTaskState.getCreatureName()).thenReturn(null);
+		when(slayerTaskState.getRemaining()).thenReturn(0);
+		when(syncStateCoordinator.isScriptScanActive()).thenReturn(false);
+		when(collectionState.getTotalObtained()).thenReturn(100);
+		when(syncStateCoordinator.getLastObtainedCount()).thenReturn(100);
+		router.handle(makeEvent(7, 0));
+		verify(syncStateCoordinator, never()).onCollectionStateChanged(anyInt());
+		assertFalse(onCollectionStateChangedCalled);
+		assertFalse(onSlayerTaskChangedCalled);
+	}
+
+	@Test
+	public void nullCallbacks_doNotNpe()
+	{
+		router.setCallbacks(null, null, null);
+		when(slayerTaskState.isTaskActive()).thenReturn(false);
+		when(slayerTaskState.getCreatureName()).thenReturn(null);
+		when(slayerTaskState.getRemaining()).thenReturn(0);
+		when(syncStateCoordinator.isScriptScanActive()).thenReturn(false);
+		when(collectionState.getTotalObtained()).thenReturn(101);
+		when(syncStateCoordinator.getLastObtainedCount()).thenReturn(100);
+		router.handle(makeEvent(8, 0));
+		verify(syncStateCoordinator).onCollectionStateChanged(101);
+	}
+
+	@Test
+	public void sequencerForward_alwaysHappens()
+	{
+		when(slayerTaskState.isTaskActive()).thenReturn(false);
+		when(slayerTaskState.getCreatureName()).thenReturn(null);
+		when(slayerTaskState.getRemaining()).thenReturn(0);
+		when(syncStateCoordinator.isScriptScanActive()).thenReturn(true);
+		router.handle(makeEvent(555, 7));
+		verify(guidanceSequencer, times(1)).onVarbitChanged(555, 7);
+	}
+}


### PR DESCRIPTION
## Summary

Wave 12 of the #503 god-class split. Extracts the body of `CollectionLogHelperPlugin.onVarbitChanged` into a focused `VarbitChangeRouter` collaborator under `com.collectionloghelper.lifecycle`, mirroring the `ChatEventHandler` pattern from #525.

The plugin keeps the `@Subscribe` annotation (so the RuneLite event bus still discovers the handler via `eventBus.register(plugin)`); the body becomes a single `varbitChangeRouter.handle(event)` delegation.

Three narrow `Runnable` callbacks keep the per-tick refresh flags and rebuild triggers as plugin-owned state without leaking those fields into the router:
- `flagRefreshes` — sets `pendingRequirementsRefresh` + `pendingTravelVarbitRefresh`
- `onCollectionStateChanged` — calls `rebuildSourcesWithMissingItems()`
- `onSlayerTaskChanged` — sets `pendingPanelRebuild` + `rankedSourcesDirty`

## LOC delta

- `CollectionLogHelperPlugin.java`: **753 -> 719** (-34 net)
- New `VarbitChangeRouter.java`: 187 LOC (license + javadoc + class)
- New `VarbitChangeRouterTest.java`: 257 LOC

## Performance note

`VarbitChanged` fires extremely frequently in OSRS (hundreds of times during login alone, see #527 / #523 lesson). The no-op / guard-fail path stays allocation-free — no per-event `new` sites, no captured lambdas, no boxing. The `setCallbacks` Runnables are wired once in `startUp()`.

## Test plan

- [x] `./gradlew build` passes
- [x] `./gradlew test` passes (full suite)
- [x] New `VarbitChangeRouterTest` covers:
  - Slayer-task delta detection (active->inactive, creature change, remaining change, no-change)
  - Authoring-log throttle (tick advance fires, same tick suppresses, disabled config suppresses)
  - Script-scan guard short-circuits before obtained-count check
  - Obtained-count delta fires collection-state + slayer callbacks
  - Null-callback safety (no NPE if `setCallbacks` not yet wired)
  - Sequencer forwarding always happens, even mid-scan
- [ ] In-game smoke: log in, complete a Slayer task, verify panel rebuild fires
- [ ] In-game smoke: enable `guidanceAuthoring`, verify one `VARBIT_CHANGED` log line per tick
