### PR TITLE
perf: avoid per-tick allocations in DynamicTargetManager guard-fail path (#527)

### DIFF
--- a/src/main/java/com/collectionloghelper/guidance/DynamicTargetManager.java
+++ b/src/main/java/com/collectionloghelper/guidance/DynamicTargetManager.java
@@ -45,11 +45,10 @@ import net.runelite.client.ui.overlay.worldmap.WorldMapPointManager;
  *
  * <p>Pure extraction from {@link GuidanceOverlayCoordinator}: this manager
  * holds no mutable state of its own.  Coordinator state it needs to read
- * (active map point, current guidance step, sequencer activity, active
- * target item id, cached log icon) is passed in via the {@link Input}
- * carrier, and any state mutation the coordinator must apply (the new
- * active map point) is returned in {@link Result} so the coordinator
- * remains the single owner of guidance state.</p>
+ * (active map point, current guidance step, active target item id, cached
+ * log icon) is passed in as method arguments, and any state mutation the
+ * coordinator must apply (the new active map point) is returned directly
+ * so the coordinator remains the single owner of guidance state.</p>
  *
  * <p>Responsibilities:
  * <ul>
@@ -60,16 +59,22 @@ import net.runelite.client.ui.overlay.worldmap.WorldMapPointManager;
  *   <li>Pushing the new target into the four location-sensitive overlays
  *       (in-world, minimap, world-map route, world-map destination).</li>
  *   <li>Refreshing the world map point in {@link WorldMapPointManager} and
- *       reporting the new map point back via {@link Result}.</li>
+ *       returning the new map point to the coordinator.</li>
  *   <li>Re-applying the hint arrow via {@link WorldMapController} when
  *       {@code config.showHintArrow()} is enabled and the local player is
  *       on a compatible plane / world view.</li>
  * </ul>
  *
- * <p>Called on the client thread once per game tick.  Returns silently
- * (with {@link Result#unchanged(CollectionLogWorldMapPoint)}) when guidance
- * is inactive, the step has no evaluator key, the key is unregistered, or
- * the evaluator returns {@code null}.</p>
+ * <p>Called on the client thread once per game tick <em>only when guidance
+ * is active</em> (the coordinator guards the call site).  Returns
+ * {@code null} when the step has no evaluator key, the key is unregistered,
+ * or the evaluator returns {@code null}; the coordinator treats {@code null}
+ * as "no change" and keeps its existing active map point.</p>
+ *
+ * <p>This signature is allocation-free on guard-fail paths (issue #527):
+ * inactive ticks bypass the call entirely (Option 1 — coordinator-side
+ * guard), and the three active-tick guard-fails return a cached {@code null}
+ * sentinel without constructing any wrapper objects.</p>
  */
 @Slf4j
 @Singleton
@@ -108,44 +113,54 @@ public class DynamicTargetManager
 	/**
 	 * Dispatches the dynamic-target evaluator for the active step (when present)
 	 * and pushes the resulting world point to all location-sensitive overlays.
-	 * Returns a {@link Result} describing any change to the coordinator's
-	 * {@code activeMapPoint} so the caller can apply it without this manager
-	 * needing direct access to coordinator state.
+	 *
+	 * <p><b>Precondition:</b> the caller has already verified that guidance is
+	 * active; this method does not re-check {@code guidanceSequencer.isActive()}.
+	 * The {@code !guidanceActive} guard was lifted to the coordinator call site
+	 * to avoid per-tick allocations on inactive ticks (issue #527, Option 1).</p>
+	 *
+	 * @param currentStep         the active guidance step, may be {@code null}
+	 * @param activeMapPoint      the coordinator's current active map point, may be {@code null}
+	 * @param activeTargetItemId  the active target item id, may be {@code null}
+	 * @param collectionLogIcon   the cached log icon for the new map point, may be {@code null}
+	 * @return the new {@link CollectionLogWorldMapPoint} when the evaluator fired and
+	 *         produced a fresh target, or {@code null} when no change occurred (the
+	 *         coordinator should keep its existing {@code activeMapPoint}).
 	 */
-	public Result tick(Input input)
+	@Nullable
+	public CollectionLogWorldMapPoint tick(
+		@Nullable GuidanceStep currentStep,
+		@Nullable CollectionLogWorldMapPoint activeMapPoint,
+		@Nullable Integer activeTargetItemId,
+		@Nullable BufferedImage collectionLogIcon)
 	{
-		if (!input.guidanceActive)
+		if (currentStep == null || currentStep.getDynamicTargetEvaluator() == null)
 		{
-			return Result.unchanged(input.activeMapPoint);
+			return null;
 		}
-		GuidanceStep step = input.currentStep;
-		if (step == null || step.getDynamicTargetEvaluator() == null)
-		{
-			return Result.unchanged(input.activeMapPoint);
-		}
-		DynamicTargetEvaluator evaluator = registry.get(step.getDynamicTargetEvaluator());
+		DynamicTargetEvaluator evaluator = registry.get(currentStep.getDynamicTargetEvaluator());
 		if (evaluator == null)
 		{
-			return Result.unchanged(input.activeMapPoint);
+			return null;
 		}
-		WorldPoint dynamicPoint = evaluator.evaluate(client, step);
+		WorldPoint dynamicPoint = evaluator.evaluate(client, currentStep);
 		if (dynamicPoint == null)
 		{
-			return Result.unchanged(input.activeMapPoint);
+			return null;
 		}
 
 		guidanceOverlay.setTargetPoint(dynamicPoint);
 		guidanceMinimapOverlay.setTargetPoint(dynamicPoint);
 		worldMapRouteOverlay.setTargetPoint(dynamicPoint);
 		worldMapDestinationOverlay.setTarget(dynamicPoint,
-			worldMapController.resolveStepIconType(step, input.activeTargetItemId));
+			worldMapController.resolveStepIconType(currentStep, activeTargetItemId));
 
-		if (input.activeMapPoint != null)
+		if (activeMapPoint != null)
 		{
-			worldMapPointManager.remove(input.activeMapPoint);
+			worldMapPointManager.remove(activeMapPoint);
 		}
 		CollectionLogWorldMapPoint newMapPoint = new CollectionLogWorldMapPoint(dynamicPoint,
-			step.resolveDescription(input.activeTargetItemId), input.collectionLogIcon);
+			currentStep.resolveDescription(activeTargetItemId), collectionLogIcon);
 		worldMapPointManager.add(newMapPoint);
 		worldMapDestinationOverlay.setMapPointActive(true);
 
@@ -154,81 +169,6 @@ public class DynamicTargetManager
 			client.setHintArrow(dynamicPoint);
 		}
 
-		return Result.changed(newMapPoint);
-	}
-
-	/**
-	 * Inputs the coordinator passes to {@link #tick(Input)}.  Mirrors the
-	 * subset of coordinator state the dynamic-target dispatch reads.
-	 */
-	public static final class Input
-	{
-		private final boolean guidanceActive;
-		@Nullable
-		private final GuidanceStep currentStep;
-		@Nullable
-		private final CollectionLogWorldMapPoint activeMapPoint;
-		@Nullable
-		private final Integer activeTargetItemId;
-		@Nullable
-		private final BufferedImage collectionLogIcon;
-
-		public Input(boolean guidanceActive,
-			@Nullable GuidanceStep currentStep,
-			@Nullable CollectionLogWorldMapPoint activeMapPoint,
-			@Nullable Integer activeTargetItemId,
-			@Nullable BufferedImage collectionLogIcon)
-		{
-			this.guidanceActive = guidanceActive;
-			this.currentStep = currentStep;
-			this.activeMapPoint = activeMapPoint;
-			this.activeTargetItemId = activeTargetItemId;
-			this.collectionLogIcon = collectionLogIcon;
-		}
-	}
-
-	/**
-	 * Result of a single {@link #tick(Input)} call.  Carries the (possibly
-	 * new) active world map point so the coordinator can replace its own
-	 * reference without exposing internal fields to this manager.
-	 */
-	public static final class Result
-	{
-		private final boolean changed;
-		@Nullable
-		private final CollectionLogWorldMapPoint activeMapPoint;
-
-		private Result(boolean changed, @Nullable CollectionLogWorldMapPoint activeMapPoint)
-		{
-			this.changed = changed;
-			this.activeMapPoint = activeMapPoint;
-		}
-
-		static Result changed(CollectionLogWorldMapPoint newPoint)
-		{
-			return new Result(true, newPoint);
-		}
-
-		static Result unchanged(@Nullable CollectionLogWorldMapPoint existingPoint)
-		{
-			return new Result(false, existingPoint);
-		}
-
-		/** True when the evaluator fired and a new active map point was produced. */
-		public boolean isChanged()
-		{
-			return changed;
-		}
-
-		/**
-		 * The active world map point the coordinator should now hold.  When
-		 * {@link #isChanged()} is false this is the input's existing point
-		 * (echoed for caller convenience).
-		 */
-		@Nullable
-		public CollectionLogWorldMapPoint getActiveMapPoint()
-		{
-			return activeMapPoint;
-		}
+		return newMapPoint;
 	}
 }

--- a/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
@@ -404,9 +404,18 @@ public class GuidanceOverlayCoordinator
 		}
 
 		// Dynamic target evaluator dispatch (delegated to DynamicTargetManager).
-		activeMapPoint = dynamicTargetManager.tick(new DynamicTargetManager.Input(
-			guidanceSequencer.isActive(), guidanceSequencer.getRawCurrentStep(),
-			activeMapPoint, activeTargetItemId, collectionLogIcon)).getActiveMapPoint();
+		// The active-guidance guard is held here (#527) so inactive ticks
+		// skip the call entirely and allocate nothing on the hot path.
+		if (guidanceSequencer.isActive())
+		{
+			CollectionLogWorldMapPoint newMapPoint = dynamicTargetManager.tick(
+				guidanceSequencer.getRawCurrentStep(),
+				activeMapPoint, activeTargetItemId, collectionLogIcon);
+			if (newMapPoint != null)
+			{
+				activeMapPoint = newMapPoint;
+			}
+		}
 
 		// World map arrow rotation
 		worldMapController.updateArrow(activeMapPoint);

--- a/src/test/java/com/collectionloghelper/guidance/DynamicTargetManagerTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/DynamicTargetManagerTest.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.guidance;
+
+import com.collectionloghelper.CollectionLogHelperConfig;
+import com.collectionloghelper.data.CompletionCondition;
+import com.collectionloghelper.data.GuidanceStep;
+import com.collectionloghelper.guidance.dynamic.DynamicTargetEvaluatorRegistry;
+import com.collectionloghelper.overlay.CollectionLogWorldMapPoint;
+import com.collectionloghelper.overlay.GuidanceMinimapOverlay;
+import com.collectionloghelper.overlay.GuidanceOverlay;
+import com.collectionloghelper.overlay.WorldMapDestinationOverlay;
+import com.collectionloghelper.overlay.WorldMapRouteOverlay;
+import java.lang.reflect.Constructor;
+import net.runelite.api.Client;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.ui.overlay.worldmap.WorldMapPointManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for {@link DynamicTargetManager}.
+ *
+ * <p>Focused on the per-tick allocation discipline introduced for issue #527.
+ * The pre-#527 implementation allocated a fresh {@code Input} carrier and a
+ * fresh {@code Result} wrapper on every game tick — including the (very
+ * common) inactive-guidance and active-but-no-evaluator paths.  After the
+ * fix:</p>
+ *
+ * <ul>
+ *   <li>The coordinator owns the {@code !isActive()} guard, so the manager
+ *       is never invoked at all on inactive ticks.  (Verified at the
+ *       coordinator level by {@code DynamicTargetEvaluatorDispatchTest}.)</li>
+ *   <li>On active ticks, the three remaining guard-fail paths inside
+ *       {@link DynamicTargetManager#tick} return {@code null} without
+ *       constructing any wrapper objects, and without touching any of the
+ *       four overlay setters or the world-map-point manager.</li>
+ *   <li>On the happy path (evaluator returns a non-null point), the manager
+ *       still pushes the target to every location-sensitive overlay and
+ *       returns a fresh {@link CollectionLogWorldMapPoint}.</li>
+ * </ul>
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class DynamicTargetManagerTest
+{
+	private static final WorldPoint DYNAMIC_POINT = new WorldPoint(3200, 3200, 0);
+	private static final String STUB_KEY = "test_stub_evaluator";
+
+	@Mock
+	private Client client;
+	@Mock
+	private ClientThread clientThread;
+	@Mock
+	private CollectionLogHelperConfig config;
+	@Mock
+	private WorldMapPointManager worldMapPointManager;
+	@Mock
+	private GuidanceOverlay guidanceOverlay;
+	@Mock
+	private GuidanceMinimapOverlay guidanceMinimapOverlay;
+	@Mock
+	private WorldMapRouteOverlay worldMapRouteOverlay;
+	@Mock
+	private WorldMapDestinationOverlay worldMapDestinationOverlay;
+
+	private DynamicTargetEvaluatorRegistry registry;
+	private WorldMapController worldMapController;
+	private DynamicTargetManager manager;
+
+	@Before
+	public void setUp() throws Exception
+	{
+		registry = new DynamicTargetEvaluatorRegistry();
+		worldMapController = newWorldMapController();
+		manager = newManager();
+		lenient().when(config.showHintArrow()).thenReturn(false);
+	}
+
+	/**
+	 * Guard-fail path #1: step is null.  Manager must return {@code null}
+	 * (the cached "no change" sentinel) without touching any overlay.
+	 */
+	@Test
+	public void tick_nullStep_returnsNullAndAllocatesNothing()
+	{
+		CollectionLogWorldMapPoint result = manager.tick(null, null, null, null);
+
+		assertNull(result);
+		verifyNoOverlayInteractions();
+	}
+
+	/**
+	 * Guard-fail path #2: step has no {@code dynamicTargetEvaluator} key.
+	 * Manager must return {@code null} without touching any overlay.
+	 */
+	@Test
+	public void tick_stepWithoutEvaluatorKey_returnsNullAndAllocatesNothing()
+	{
+		GuidanceStep step = stepWithEvaluator(null);
+
+		CollectionLogWorldMapPoint result = manager.tick(step, null, null, null);
+
+		assertNull(result);
+		verifyNoOverlayInteractions();
+	}
+
+	/**
+	 * Guard-fail path #3: evaluator key is set but not registered.
+	 * Manager must return {@code null} without touching any overlay.
+	 */
+	@Test
+	public void tick_unregisteredEvaluatorKey_returnsNullAndAllocatesNothing()
+	{
+		GuidanceStep step = stepWithEvaluator("definitely_not_registered");
+
+		CollectionLogWorldMapPoint result = manager.tick(step, null, null, null);
+
+		assertNull(result);
+		verifyNoOverlayInteractions();
+	}
+
+	/**
+	 * Guard-fail path #4: registered evaluator returns {@code null}.
+	 * Manager must return {@code null} without touching any overlay.
+	 */
+	@Test
+	public void tick_evaluatorReturnsNull_returnsNullAndAllocatesNothing()
+	{
+		registry.register(STUB_KEY, (c, s) -> null);
+		GuidanceStep step = stepWithEvaluator(STUB_KEY);
+
+		CollectionLogWorldMapPoint result = manager.tick(step, null, null, null);
+
+		assertNull(result);
+		verifyNoOverlayInteractions();
+	}
+
+	/**
+	 * Happy path: evaluator returns a real {@link WorldPoint}.  Manager must
+	 * push the point to every location-sensitive overlay and return a fresh
+	 * {@link CollectionLogWorldMapPoint}.
+	 */
+	@Test
+	public void tick_evaluatorReturnsPoint_pushesToOverlaysAndReturnsNewMapPoint()
+	{
+		registry.register(STUB_KEY, (c, s) -> DYNAMIC_POINT);
+		GuidanceStep step = stepWithEvaluator(STUB_KEY);
+
+		CollectionLogWorldMapPoint result = manager.tick(step, null, null, null);
+
+		assertNotNull(result);
+		verify(guidanceOverlay).setTargetPoint(DYNAMIC_POINT);
+		verify(guidanceMinimapOverlay).setTargetPoint(DYNAMIC_POINT);
+		verify(worldMapRouteOverlay).setTargetPoint(DYNAMIC_POINT);
+		verify(worldMapDestinationOverlay).setMapPointActive(true);
+		verify(worldMapPointManager).add(result);
+	}
+
+	/**
+	 * Happy path with a pre-existing active map point: the old point must be
+	 * removed from the world-map-point manager before the new one is added.
+	 */
+	@Test
+	public void tick_evaluatorReturnsPoint_removesPreviousActiveMapPoint()
+	{
+		registry.register(STUB_KEY, (c, s) -> DYNAMIC_POINT);
+		GuidanceStep step = stepWithEvaluator(STUB_KEY);
+		CollectionLogWorldMapPoint previous = new CollectionLogWorldMapPoint(
+			new WorldPoint(1, 2, 0), "prev", null);
+
+		CollectionLogWorldMapPoint result = manager.tick(step, previous, null, null);
+
+		assertNotNull(result);
+		verify(worldMapPointManager).remove(previous);
+		verify(worldMapPointManager).add(result);
+	}
+
+	// ── Helpers ──────────────────────────────────────────────────────────────
+
+	private void verifyNoOverlayInteractions()
+	{
+		verify(guidanceOverlay, never()).setTargetPoint(any());
+		verify(guidanceMinimapOverlay, never()).setTargetPoint(any());
+		verify(worldMapRouteOverlay, never()).setTargetPoint(any());
+		verify(worldMapDestinationOverlay, never()).setMapPointActive(true);
+		verify(worldMapPointManager, never()).add(any());
+		verify(worldMapPointManager, never()).remove(any());
+	}
+
+	private static GuidanceStep stepWithEvaluator(String evaluatorKey)
+	{
+		return new GuidanceStep(
+			"Dynamic step",
+			null,  // perItemStepDescription
+			0, 0, 0,
+			0, null, null, null,
+			null, null,
+			null,  // perItemRequiredItemIds
+			null,
+			null /* perItemRecommendedItemIds */,
+			CompletionCondition.MANUAL,
+			0, 0, 0, 0,
+			null,  // completionNpcIds
+			null,  // worldMessage
+			0, null, null,
+			null, null,
+			null,
+			0, 0,
+			false,
+			0,     // objectMaxDistance
+			null,  // objectFilterTiles
+			null,  // highlightWidgetIds
+			0, 0,  // loopBackToStep, loopCount
+			null,  // skipIfHasAnyItemIds
+			null,  // dynamicItemObjectTiers
+			null,  // completionZone
+			null,  // conditionalAlternatives
+			null,  // section
+			null,  // waypoints
+			evaluatorKey  // dynamicTargetEvaluator
+		);
+	}
+
+	private WorldMapController newWorldMapController() throws Exception
+	{
+		Constructor<WorldMapController> ctor = WorldMapController.class.getDeclaredConstructor(
+			Client.class, ClientThread.class, CollectionLogHelperConfig.class);
+		ctor.setAccessible(true);
+		return ctor.newInstance(client, clientThread, config);
+	}
+
+	private DynamicTargetManager newManager() throws Exception
+	{
+		Constructor<DynamicTargetManager> ctor = DynamicTargetManager.class.getDeclaredConstructor(
+			Client.class, DynamicTargetEvaluatorRegistry.class, WorldMapPointManager.class,
+			GuidanceOverlay.class, GuidanceMinimapOverlay.class,
+			WorldMapRouteOverlay.class, WorldMapDestinationOverlay.class,
+			WorldMapController.class);
+		ctor.setAccessible(true);
+		return ctor.newInstance(client, registry, worldMapPointManager,
+			guidanceOverlay, guidanceMinimapOverlay,
+			worldMapRouteOverlay, worldMapDestinationOverlay, worldMapController);
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #527. PR #523 extracted `DynamicTargetManager` but introduced a per-tick allocation regression on guard-fail paths. Every game tick the coordinator allocated a fresh `Input` carrier and the manager allocated a fresh `Result` wrapper, even when guidance was inactive (the dominant case).

## Approach — both options from the issue, combined

**Option 1 (primary)** — lifted the `!isActive()` guard back to the coordinator call site. Inactive ticks now skip the manager entirely and allocate nothing.

**Option 2 (secondary)** — collapsed the manager API: `tick()` now takes its inputs as method arguments and returns `@Nullable CollectionLogWorldMapPoint` (`null` == "no change"). The `Input` and `Result` nested classes are deleted, so the three remaining active-tick guard-fails (`step == null` / unregistered evaluator / evaluator returns `null`) also allocate nothing.

Option 1 alone only handled the inactive-tick case; the active-tick guard-fails still happen frequently (any step that doesn't carry a `dynamicTargetEvaluator` key), so Option 2 covers the rest.

## Allocation profile

| Tick path | Before | After |
|---|---|---|
| Inactive guidance | 1 × `Input`, 1 × `Result` | **0** |
| Active, step has no evaluator | 1 × `Input`, 1 × `Result` | **0** |
| Active, evaluator key unregistered | 1 × `Input`, 1 × `Result` | **0** |
| Active, evaluator returns `null` | 1 × `Input`, 1 × `Result` | **0** |
| Happy path (new target produced) | 1 × `Input`, 1 × `Result`, 1 × `CollectionLogWorldMapPoint` | 1 × `CollectionLogWorldMapPoint` |

## Test plan

- [x] `./gradlew build` passes
- [x] `./gradlew test` passes (full suite)
- [x] New `DynamicTargetManagerTest` covers all four guard-fail paths (asserts `null` return + zero overlay interactions) plus two happy-path scenarios
- [x] Existing `DynamicTargetEvaluatorDispatchTest` unchanged and still green — continues to cover coordinator-side dispatch including the inactive-guidance no-op
- [ ] Manual smoke: start guidance, advance through a few steps with and without `dynamicTargetEvaluator` keys, confirm world map / minimap / hint arrow behaviour unchanged

Closes #527.