### PR TITLE
refactor: extract CollectionStateChangeHandler from Plugin (#503)

### DIFF
--- a/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
@@ -37,6 +37,7 @@ import com.collectionloghelper.sync.LootSyncManager;
 import com.collectionloghelper.sync.TempleSyncOrchestrator;
 import com.collectionloghelper.efficiency.ScoredItem;
 import com.collectionloghelper.lifecycle.AuthoringLogger;
+import com.collectionloghelper.lifecycle.CollectionStateChangeHandler;
 import com.collectionloghelper.lifecycle.OverlayRegistry;
 import com.collectionloghelper.lifecycle.PlayerLocationResolver;
 import com.collectionloghelper.lifecycle.SceneEventRouter;
@@ -157,6 +158,9 @@ public class CollectionLogHelperPlugin extends Plugin
 	@Inject
 	private VarbitChangeRouter varbitChangeRouter;
 
+	@Inject
+	private CollectionStateChangeHandler collectionStateChangeHandler;
+
 
 	private CollectionLogHelperPanel panel;
 	private NavigationButton navButton;
@@ -231,7 +235,16 @@ public class CollectionLogHelperPlugin extends Plugin
 		// Wire coordinator with references it needs from the plugin
 		guidance.getGuidanceCoordinator().setPluginInstance(this);
 		guidance.getGuidanceCoordinator().setPanel(panel);
-		guidance.getGuidanceCoordinator().setOnSequenceCompleteCallback(this::onSequenceComplete);
+		collectionStateChangeHandler.setCallbacks(
+			() ->
+			{
+				pendingPanelRebuild = true;
+				rankedSourcesDirty = true;
+			},
+			this::getRankedSources,
+			this::activateGuidance);
+		guidance.getGuidanceCoordinator().setOnSequenceCompleteCallback(
+			collectionStateChangeHandler::handleSequenceComplete);
 		// Wire coordinator into resolver (post-construction, avoids circular injection)
 		guidance.getRequiredItemResolver().setCoordinator(guidance.getGuidanceCoordinator());
 
@@ -283,7 +296,7 @@ public class CollectionLogHelperPlugin extends Plugin
 				travelCapabilities.refreshQuestState();
 				travelCapabilities.refreshVarbits();
 				sync.getSyncStateCoordinator().setLastObtainedCount(data.getCollectionState().getTotalObtained());
-				rebuildSourcesWithMissingItems();
+				sourcesWithMissingItems = collectionStateChangeHandler.rebuildSourcesWithMissingItems();
 				if (panel != null)
 				{
 					panel.rebuild();
@@ -304,7 +317,7 @@ public class CollectionLogHelperPlugin extends Plugin
 				pendingRequirementsRefresh = true;
 				pendingTravelVarbitRefresh = true;
 			},
-			this::rebuildSourcesWithMissingItems,
+			() -> sourcesWithMissingItems = collectionStateChangeHandler.rebuildSourcesWithMissingItems(),
 			() ->
 			{
 				pendingPanelRebuild = true;
@@ -378,7 +391,7 @@ public class CollectionLogHelperPlugin extends Plugin
 				travelCapabilities.refreshVarbits();
 				data.getSlayerTaskState().refresh();
 				sync.getSyncStateCoordinator().setLastObtainedCount(data.getCollectionState().getTotalObtained());
-				rebuildSourcesWithMissingItems();
+				sourcesWithMissingItems = collectionStateChangeHandler.rebuildSourcesWithMissingItems();
 
 				// Rescan scene for tracked objects after scene (re)load
 				guidance.getObjectHighlightOverlay().rescanScene();
@@ -550,7 +563,7 @@ public class CollectionLogHelperPlugin extends Plugin
 				pendingPanelRebuild = true;
 				rankedSourcesDirty = true;
 			},
-			this::exportEfficiencyIfEnabled
+			collectionStateChangeHandler::exportEfficiencyIfEnabled
 		);
 		if (syncResult == SyncStateCoordinator.SyncTickResult.RANKED_DIRTY)
 		{
@@ -564,22 +577,6 @@ public class CollectionLogHelperPlugin extends Plugin
 			pendingPanelRebuild = false;
 			panel.rebuild();
 		}
-	}
-
-	private void exportEfficiencyIfEnabled()
-	{
-		if (!config.exportEfficiencyLog())
-		{
-			return;
-		}
-		java.io.File exportFile = data.getPluginDataManager().getFile("efficiency-export.txt");
-		if (exportFile == null)
-		{
-			// Fallback if player name not yet available
-			exportFile = new java.io.File(
-				net.runelite.client.RuneLite.RUNELITE_DIR, "collection-log-efficiency-export.txt");
-		}
-		efficiency.getCalculator().exportEfficiencyList(exportFile, client);
 	}
 
 	/**
@@ -668,47 +665,9 @@ public class CollectionLogHelperPlugin extends Plugin
 		return cachedRankedSources;
 	}
 
-	/**
-	 * Callback from coordinator when a guidance sequence completes.
-	 * Handles auto-advance to next source and panel rebuild.
-	 */
-	private void onSequenceComplete()
-	{
-		pendingPanelRebuild = true;
-		rankedSourcesDirty = true;
-		if (config.autoAdvanceGuidance())
-		{
-			// Auto-activate guidance for the next top efficiency pick.
-			// Pass the best-item target ID (B4.4) so per-item overrides
-			// (perItemRequiredItemIds, perItemStepDescription, perItemNpcId)
-			// activate automatically without the user right-clicking an item.
-			List<ScoredItem> ranked = getRankedSources();
-			ranked.stream()
-				.filter(s -> !s.isLocked())
-				.findFirst()
-				.ifPresent(topPick ->
-				{
-					Integer targetItemId = topPick.getBestItem() != null
-						? topPick.getBestItem().getItemId()
-						: null;
-					activateGuidance(topPick.getSource(), targetItemId);
-				});
-		}
-	}
-
 	public void deactivateGuidance()
 	{
 		guidance.getGuidanceCoordinator().deactivateGuidance();
-	}
-
-	/**
-	 * Rebuilds the cached set of source names that have at least one unobtained item.
-	 * Called when collection state changes to avoid per-menu-entry item scanning.
-	 */
-	private void rebuildSourcesWithMissingItems()
-	{
-		sourcesWithMissingItems = guidance.getGuidanceCoordinator().rebuildSourcesWithMissingItems(
-			data.getDatabase(), data.getCollectionState());
 	}
 
 	@Provides

--- a/src/main/java/com/collectionloghelper/lifecycle/CollectionStateChangeHandler.java
+++ b/src/main/java/com/collectionloghelper/lifecycle/CollectionStateChangeHandler.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.lifecycle;
+
+import com.collectionloghelper.CollectionLogHelperConfig;
+import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.di.DataModule;
+import com.collectionloghelper.di.EfficiencyModule;
+import com.collectionloghelper.di.GuidanceModule;
+import com.collectionloghelper.efficiency.ScoredItem;
+import java.io.File;
+import java.util.List;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.client.RuneLite;
+
+/**
+ * Owns the trio of collection-state lifecycle responsibilities that previously
+ * lived inline in {@link com.collectionloghelper.CollectionLogHelperPlugin}:
+ *
+ * <ol>
+ *   <li>{@link #handleSequenceComplete()} -- callback invoked by
+ *       {@code GuidanceOverlayCoordinator} when an active guidance sequence
+ *       finishes.  Flags a panel rebuild and ranked-source recompute, and
+ *       auto-activates guidance for the next top efficiency pick when
+ *       {@link CollectionLogHelperConfig#autoAdvanceGuidance()} is enabled.</li>
+ *   <li>{@link #rebuildSourcesWithMissingItems()} -- recomputes the cached set
+ *       of source names that still have unobtained items.  Returns the new
+ *       set so the plugin can assign it to its {@code sourcesWithMissingItems}
+ *       field (state ownership stays with the plugin to match
+ *       {@code shutDown}'s clear semantics).</li>
+ *   <li>{@link #exportEfficiencyIfEnabled()} -- writes the efficiency export
+ *       file when {@link CollectionLogHelperConfig#exportEfficiencyLog()} is
+ *       enabled.  Falls back to the global RuneLite directory if the
+ *       per-character data manager has not resolved a player name yet.</li>
+ * </ol>
+ *
+ * <p>The plugin wires three narrow callbacks once in {@code startUp()}:
+ * <ul>
+ *   <li>{@code onSequenceCompleteFlags} -- toggles {@code pendingPanelRebuild}
+ *       and {@code rankedSourcesDirty} on the plugin.</li>
+ *   <li>{@code rankedSourcesSupplier} -- returns the plugin's cached ranked
+ *       efficiency list so auto-advance picks the same top item the panel
+ *       would show.</li>
+ *   <li>{@code activateGuidanceCallback} -- delegates back to the plugin's
+ *       {@code activateGuidance(source, targetItemId)} so the client-thread
+ *       wrap stays in one place.</li>
+ * </ul>
+ *
+ * <p>Performance: {@link #handleSequenceComplete()} only fires when a guidance
+ * sequence completes (rare, user-driven).  Allocation discipline still holds
+ * on guard-fail paths -- when auto-advance is disabled the method returns
+ * after the flag callback with no allocations (see #527 / #523 lessons).
+ *
+ * <p>Part of issue #503 -- splitting {@code CollectionLogHelperPlugin} into
+ * focused collaborators (Wave 13).
+ */
+@Slf4j
+@Singleton
+public class CollectionStateChangeHandler
+{
+	private final Client client;
+	private final CollectionLogHelperConfig config;
+	private final DataModule data;
+	private final EfficiencyModule efficiency;
+	private final GuidanceModule guidance;
+
+	private Runnable onSequenceCompleteFlags;
+	private Supplier<List<ScoredItem>> rankedSourcesSupplier;
+	private BiConsumer<CollectionLogSource, Integer> activateGuidanceCallback;
+
+	@Inject
+	public CollectionStateChangeHandler(
+		Client client,
+		CollectionLogHelperConfig config,
+		DataModule data,
+		EfficiencyModule efficiency,
+		GuidanceModule guidance)
+	{
+		this.client = client;
+		this.config = config;
+		this.data = data;
+		this.efficiency = efficiency;
+		this.guidance = guidance;
+	}
+
+	/**
+	 * Wires plugin-owned callbacks. Called once from
+	 * {@code CollectionLogHelperPlugin.startUp()} after the plugin's private
+	 * state and panel are constructed. Kept off the constructor to avoid a
+	 * circular Guice dependency on the plugin itself.
+	 */
+	public void setCallbacks(
+		Runnable onSequenceCompleteFlags,
+		Supplier<List<ScoredItem>> rankedSourcesSupplier,
+		BiConsumer<CollectionLogSource, Integer> activateGuidanceCallback)
+	{
+		this.onSequenceCompleteFlags = onSequenceCompleteFlags;
+		this.rankedSourcesSupplier = rankedSourcesSupplier;
+		this.activateGuidanceCallback = activateGuidanceCallback;
+	}
+
+	/**
+	 * Callback invoked by {@code GuidanceOverlayCoordinator} when a guidance
+	 * sequence completes. Flags a panel rebuild and ranked-source recompute,
+	 * and -- if auto-advance is enabled -- activates guidance for the next
+	 * top efficiency pick (passing the best-item target id so per-item
+	 * overrides activate without requiring a user right-click).
+	 */
+	public void handleSequenceComplete()
+	{
+		if (onSequenceCompleteFlags != null)
+		{
+			onSequenceCompleteFlags.run();
+		}
+		if (!config.autoAdvanceGuidance())
+		{
+			return;
+		}
+		if (rankedSourcesSupplier == null || activateGuidanceCallback == null)
+		{
+			return;
+		}
+		List<ScoredItem> ranked = rankedSourcesSupplier.get();
+		if (ranked == null)
+		{
+			return;
+		}
+		ranked.stream()
+			.filter(s -> !s.isLocked())
+			.findFirst()
+			.ifPresent(topPick ->
+			{
+				Integer targetItemId = topPick.getBestItem() != null
+					? topPick.getBestItem().getItemId()
+					: null;
+				activateGuidanceCallback.accept(topPick.getSource(), targetItemId);
+			});
+	}
+
+	/**
+	 * Rebuilds and returns the set of source names that have at least one
+	 * unobtained item. The plugin assigns the result to its own
+	 * {@code sourcesWithMissingItems} field so the lifecycle reset in
+	 * {@code shutDown} retains its clear semantics.
+	 */
+	public Set<String> rebuildSourcesWithMissingItems()
+	{
+		return guidance.getGuidanceCoordinator().rebuildSourcesWithMissingItems(
+			data.getDatabase(), data.getCollectionState());
+	}
+
+	/**
+	 * Writes the efficiency export file when
+	 * {@link CollectionLogHelperConfig#exportEfficiencyLog()} is enabled.
+	 * No-op when the config is disabled. Falls back to the global RuneLite
+	 * directory if the per-character data manager has not resolved a player
+	 * name yet (login race condition).
+	 */
+	public void exportEfficiencyIfEnabled()
+	{
+		if (!config.exportEfficiencyLog())
+		{
+			return;
+		}
+		File exportFile = data.getPluginDataManager().getFile("efficiency-export.txt");
+		if (exportFile == null)
+		{
+			// Fallback if player name not yet available
+			exportFile = new File(
+				RuneLite.RUNELITE_DIR, "collection-log-efficiency-export.txt");
+		}
+		efficiency.getCalculator().exportEfficiencyList(exportFile, client);
+	}
+}

--- a/src/test/java/com/collectionloghelper/OnSequenceCompletePerItemTest.java
+++ b/src/test/java/com/collectionloghelper/OnSequenceCompletePerItemTest.java
@@ -27,15 +27,14 @@ package com.collectionloghelper;
 import com.collectionloghelper.data.CollectionLogCategory;
 import com.collectionloghelper.data.CollectionLogItem;
 import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.di.DataModule;
 import com.collectionloghelper.di.EfficiencyModule;
 import com.collectionloghelper.di.GuidanceModule;
-import com.collectionloghelper.efficiency.EfficiencyCalculator;
 import com.collectionloghelper.efficiency.ScoredItem;
-import com.collectionloghelper.guidance.GuidanceOverlayCoordinator;
-import com.collectionloghelper.lifecycle.PlayerLocationResolver;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
+import com.collectionloghelper.lifecycle.CollectionStateChangeHandler;
 import java.util.Collections;
+import java.util.List;
+import java.util.function.BiConsumer;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -44,22 +43,26 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * Tests for B4.4: {@code onSequenceComplete()} must pass the best-item target ID
- * from the top-ranked {@link ScoredItem} to
- * {@link CollectionLogHelperPlugin#activateGuidance(CollectionLogSource, Integer)}
+ * Tests for B4.4: {@code handleSequenceComplete()} must pass the best-item
+ * target ID from the top-ranked {@link ScoredItem} to the wired
+ * {@code activateGuidance} callback (which in production is
+ * {@link CollectionLogHelperPlugin#activateGuidance(CollectionLogSource, Integer)})
  * when auto-advancing guidance after a sequence completes.
  *
  * <p>This ensures per-item overrides ({@code perItemRequiredItemIds},
  * {@code perItemStepDescription}, {@code perItemNpcId}) activate automatically
  * without the user right-clicking on a specific item.
+ *
+ * <p>Wave 13 of #503 moved {@code onSequenceComplete} from
+ * {@link CollectionLogHelperPlugin} into
+ * {@link CollectionStateChangeHandler}, so these tests now drive the handler
+ * directly via its callback wiring.
  */
 @RunWith(MockitoJUnitRunner.class)
 public class OnSequenceCompletePerItemTest
@@ -67,107 +70,80 @@ public class OnSequenceCompletePerItemTest
 	private static final int BEST_ITEM_ID = 1234;
 
 	@Mock
-	private net.runelite.client.callback.ClientThread clientThread;
-
-	@Mock
-	private GuidanceOverlayCoordinator guidanceCoordinator;
+	private net.runelite.api.Client client;
 
 	@Mock
 	private CollectionLogHelperConfig config;
 
 	@Mock
-	private EfficiencyCalculator calculator;
+	private DataModule dataModule;
 
 	@Mock
-	private PlayerLocationResolver playerLocationResolver;
+	private EfficiencyModule efficiencyModule;
 
-	private CollectionLogHelperPlugin plugin;
+	@Mock
+	private GuidanceModule guidanceModule;
+
+	@Mock
+	@SuppressWarnings("unchecked")
+	private BiConsumer<CollectionLogSource, Integer> activateGuidanceCallback;
+
+	private CollectionStateChangeHandler handler;
+	private List<ScoredItem> rankedSources;
 
 	@Before
-	public void setUp() throws Exception
+	public void setUp()
 	{
-		plugin = new CollectionLogHelperPlugin();
-		injectField("clientThread", clientThread);
-		GuidanceModule guidanceModule = new GuidanceModule(
-			null, guidanceCoordinator, null, null, null, null, null, null);
-		injectField("guidance", guidanceModule);
-		injectField("config", config);
-		EfficiencyModule efficiencyModule = new EfficiencyModule(
-			calculator, null, null, null, null);
-		injectField("efficiency", efficiencyModule);
-		injectField("playerLocationResolver", playerLocationResolver);
-
-		// Make clientThread.invokeLater execute the runnable immediately so
-		// coordinator.activateGuidance is reachable within the same test call.
-		doAnswer(inv ->
-		{
-			Runnable r = inv.getArgument(0);
-			r.run();
-			return null;
-		}).when(clientThread).invokeLater(any(Runnable.class));
-
+		handler = new CollectionStateChangeHandler(
+			client, config, dataModule, efficiencyModule, guidanceModule);
+		rankedSources = Collections.emptyList();
+		handler.setCallbacks(
+			() -> { /* flag toggle no-op for this test */ },
+			() -> rankedSources,
+			activateGuidanceCallback);
 		when(config.autoAdvanceGuidance()).thenReturn(true);
 	}
 
 	/**
 	 * When the top-ranked {@code ScoredItem} has a non-null {@code bestItem},
-	 * {@code onSequenceComplete} must call
-	 * {@code coordinator.activateGuidance(source, location, bestItem.getItemId())}.
+	 * {@code handleSequenceComplete} must call
+	 * {@code activateGuidanceCallback.accept(source, bestItem.getItemId())}.
 	 */
 	@Test
-	public void onSequenceComplete_withBestItem_passesBestItemIdToCoordinator() throws Exception
+	public void onSequenceComplete_withBestItem_passesBestItemIdToCallback()
 	{
 		CollectionLogSource source = minimalSource("Test Source");
 		CollectionLogItem bestItem = new CollectionLogItem(
 			BEST_ITEM_ID, "Test Item", 1.0 / 128, false, null, 0, 0, false, false);
 		ScoredItem topPick = new ScoredItem(source, 100.0, 1, "Best", false, 100.0, bestItem, 100.0);
+		rankedSources = Collections.singletonList(topPick);
 
-		when(calculator.rankByEfficiency()).thenReturn(Collections.singletonList(topPick));
-
-		invokeOnSequenceComplete();
+		handler.handleSequenceComplete();
 
 		ArgumentCaptor<Integer> itemIdCaptor = ArgumentCaptor.forClass(Integer.class);
-		verify(guidanceCoordinator).activateGuidance(eq(source), any(), itemIdCaptor.capture());
+		verify(activateGuidanceCallback).accept(eq(source), itemIdCaptor.capture());
 		assertEquals(BEST_ITEM_ID, (int) itemIdCaptor.getValue());
 	}
 
 	/**
 	 * When the top-ranked {@code ScoredItem} has {@code bestItem == null},
-	 * {@code onSequenceComplete} must call
-	 * {@code coordinator.activateGuidance(source, location, null)} and must not throw.
+	 * {@code handleSequenceComplete} must call
+	 * {@code activateGuidanceCallback.accept(source, null)} and must not throw.
 	 */
 	@Test
-	public void onSequenceComplete_withNullBestItem_passesNullTargetIdToCoordinator() throws Exception
+	public void onSequenceComplete_withNullBestItem_passesNullTargetIdToCallback()
 	{
 		CollectionLogSource source = minimalSource("Null Best Item Source");
 		// bestItem is null — pure-guaranteed source or no specific item identified
 		ScoredItem topPick = new ScoredItem(source, 50.0, 2, "Some reason", false, 50.0, null, 0.0);
+		rankedSources = Collections.singletonList(topPick);
 
-		when(calculator.rankByEfficiency()).thenReturn(Collections.singletonList(topPick));
+		handler.handleSequenceComplete();
 
-		invokeOnSequenceComplete();
-
-		verify(guidanceCoordinator).activateGuidance(eq(source), any(), isNull());
+		verify(activateGuidanceCallback).accept(eq(source), isNull());
 	}
 
 	// ── helpers ───────────────────────────────────────────────────────────────
-
-	/**
-	 * Invokes the private {@code onSequenceComplete()} method via reflection.
-	 */
-	private void invokeOnSequenceComplete() throws Exception
-	{
-		Method m = CollectionLogHelperPlugin.class.getDeclaredMethod("onSequenceComplete");
-		m.setAccessible(true);
-		m.invoke(plugin);
-	}
-
-	private void injectField(String fieldName, Object value) throws Exception
-	{
-		Field field = CollectionLogHelperPlugin.class.getDeclaredField(fieldName);
-		field.setAccessible(true);
-		field.set(plugin, value);
-	}
 
 	private static CollectionLogSource minimalSource(String name)
 	{

--- a/src/test/java/com/collectionloghelper/lifecycle/CollectionStateChangeHandlerTest.java
+++ b/src/test/java/com/collectionloghelper/lifecycle/CollectionStateChangeHandlerTest.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.lifecycle;
+
+import com.collectionloghelper.CollectionLogHelperConfig;
+import com.collectionloghelper.data.CollectionLogCategory;
+import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.data.DropRateDatabase;
+import com.collectionloghelper.data.PlayerCollectionState;
+import com.collectionloghelper.data.PluginDataManager;
+import com.collectionloghelper.di.DataModule;
+import com.collectionloghelper.di.EfficiencyModule;
+import com.collectionloghelper.di.GuidanceModule;
+import com.collectionloghelper.efficiency.EfficiencyCalculator;
+import com.collectionloghelper.efficiency.ScoredItem;
+import com.collectionloghelper.guidance.GuidanceOverlayCoordinator;
+import java.io.File;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import net.runelite.api.Client;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link CollectionStateChangeHandler} -- the Wave 13 (#503)
+ * extraction that owns {@code onSequenceComplete},
+ * {@code rebuildSourcesWithMissingItems}, and
+ * {@code exportEfficiencyIfEnabled}.
+ *
+ * <p>The B4.4 per-item-target-id behaviour is covered separately by
+ * {@code OnSequenceCompletePerItemTest}; this file focuses on the
+ * happy-path/no-op contract for the other two methods plus allocation-free
+ * guard-fail behaviour.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class CollectionStateChangeHandlerTest
+{
+	@Mock private Client client;
+	@Mock private CollectionLogHelperConfig config;
+	@Mock private DataModule dataModule;
+	@Mock private EfficiencyModule efficiencyModule;
+	@Mock private GuidanceModule guidanceModule;
+
+	@Mock private GuidanceOverlayCoordinator coordinator;
+	@Mock private DropRateDatabase database;
+	@Mock private PlayerCollectionState collectionState;
+	@Mock private PluginDataManager pluginDataManager;
+	@Mock private EfficiencyCalculator calculator;
+
+	@Mock
+	@SuppressWarnings("unchecked")
+	private BiConsumer<CollectionLogSource, Integer> activateGuidanceCallback;
+
+	private CollectionStateChangeHandler handler;
+	private boolean flagsCalled;
+
+	@Before
+	public void setUp()
+	{
+		handler = new CollectionStateChangeHandler(
+			client, config, dataModule, efficiencyModule, guidanceModule);
+		flagsCalled = false;
+		handler.setCallbacks(
+			() -> flagsCalled = true,
+			Collections::emptyList,
+			activateGuidanceCallback);
+	}
+
+	// ── handleSequenceComplete ────────────────────────────────────────────────
+
+	@Test
+	public void handleSequenceComplete_alwaysFiresFlagCallback()
+	{
+		when(config.autoAdvanceGuidance()).thenReturn(false);
+		handler.handleSequenceComplete();
+		assertTrue("flag callback must always fire so the panel rebuilds", flagsCalled);
+	}
+
+	@Test
+	public void handleSequenceComplete_autoAdvanceDisabled_doesNotActivate()
+	{
+		when(config.autoAdvanceGuidance()).thenReturn(false);
+		handler.handleSequenceComplete();
+		verifyNoInteractions(activateGuidanceCallback);
+	}
+
+	@Test
+	public void handleSequenceComplete_autoAdvanceEnabled_emptyRanked_doesNotActivate()
+	{
+		when(config.autoAdvanceGuidance()).thenReturn(true);
+		// supplier already returns Collections.emptyList()
+		handler.handleSequenceComplete();
+		verifyNoInteractions(activateGuidanceCallback);
+		assertTrue(flagsCalled);
+	}
+
+	@Test
+	public void handleSequenceComplete_skipsLockedSources()
+	{
+		when(config.autoAdvanceGuidance()).thenReturn(true);
+		CollectionLogSource lockedSource = minimalSource("Locked Source");
+		CollectionLogSource unlockedSource = minimalSource("Unlocked Source");
+		ScoredItem locked = new ScoredItem(lockedSource, 100.0, 1, "L", true, 100.0, null, 100.0);
+		ScoredItem unlocked = new ScoredItem(unlockedSource, 50.0, 2, "U", false, 50.0, null, 50.0);
+		handler.setCallbacks(
+			() -> flagsCalled = true,
+			() -> java.util.Arrays.asList(locked, unlocked),
+			activateGuidanceCallback);
+		handler.handleSequenceComplete();
+		verify(activateGuidanceCallback).accept(unlockedSource, null);
+		verify(activateGuidanceCallback, never()).accept(lockedSource, null);
+	}
+
+	@Test
+	public void handleSequenceComplete_nullRankedSupplierResult_noActivation()
+	{
+		when(config.autoAdvanceGuidance()).thenReturn(true);
+		handler.setCallbacks(
+			() -> flagsCalled = true,
+			() -> null,
+			activateGuidanceCallback);
+		handler.handleSequenceComplete();
+		verifyNoInteractions(activateGuidanceCallback);
+	}
+
+	@Test
+	public void handleSequenceComplete_nullCallbacks_doNotNpe()
+	{
+		when(config.autoAdvanceGuidance()).thenReturn(true);
+		handler.setCallbacks(null, null, null);
+		// Must complete without throwing
+		handler.handleSequenceComplete();
+	}
+
+	// ── rebuildSourcesWithMissingItems ────────────────────────────────────────
+
+	@Test
+	public void rebuildSourcesWithMissingItems_delegatesToCoordinator()
+	{
+		when(guidanceModule.getGuidanceCoordinator()).thenReturn(coordinator);
+		when(dataModule.getDatabase()).thenReturn(database);
+		when(dataModule.getCollectionState()).thenReturn(collectionState);
+		Set<String> partitioned = new HashSet<>();
+		partitioned.add("Source A"); // incomplete
+		partitioned.add("Source C"); // incomplete
+		// (Sources B and D are complete and intentionally absent.)
+		when(coordinator.rebuildSourcesWithMissingItems(database, collectionState))
+			.thenReturn(partitioned);
+
+		Set<String> result = handler.rebuildSourcesWithMissingItems();
+
+		assertSame("handler must return the coordinator's set verbatim", partitioned, result);
+		assertEquals(2, result.size());
+		assertTrue("incomplete sources included", result.contains("Source A"));
+		assertTrue("incomplete sources included", result.contains("Source C"));
+		assertFalse("complete sources excluded", result.contains("Source B"));
+		assertFalse("complete sources excluded", result.contains("Source D"));
+	}
+
+	// ── exportEfficiencyIfEnabled ─────────────────────────────────────────────
+
+	@Test
+	public void exportEfficiencyIfEnabled_disabled_isNoOp()
+	{
+		when(config.exportEfficiencyLog()).thenReturn(false);
+		handler.exportEfficiencyIfEnabled();
+		// Disabled path must not touch data/efficiency modules at all
+		verify(dataModule, never()).getPluginDataManager();
+		verify(efficiencyModule, never()).getCalculator();
+	}
+
+	@Test
+	public void exportEfficiencyIfEnabled_enabled_writesToCharacterFile()
+	{
+		when(config.exportEfficiencyLog()).thenReturn(true);
+		when(dataModule.getPluginDataManager()).thenReturn(pluginDataManager);
+		File characterFile = new File("efficiency-export.txt");
+		when(pluginDataManager.getFile("efficiency-export.txt")).thenReturn(characterFile);
+		when(efficiencyModule.getCalculator()).thenReturn(calculator);
+
+		handler.exportEfficiencyIfEnabled();
+
+		verify(calculator).exportEfficiencyList(characterFile, client);
+	}
+
+	@Test
+	public void exportEfficiencyIfEnabled_enabled_fallsBackWhenPlayerNameUnavailable()
+	{
+		when(config.exportEfficiencyLog()).thenReturn(true);
+		when(dataModule.getPluginDataManager()).thenReturn(pluginDataManager);
+		when(pluginDataManager.getFile("efficiency-export.txt")).thenReturn(null);
+		when(efficiencyModule.getCalculator()).thenReturn(calculator);
+
+		handler.exportEfficiencyIfEnabled();
+
+		// Fallback path still invokes the calculator with some non-null file
+		verify(calculator).exportEfficiencyList(any(File.class), any());
+	}
+
+	// ── helpers ───────────────────────────────────────────────────────────────
+
+	private static CollectionLogSource minimalSource(String name)
+	{
+		return new CollectionLogSource(
+			name,
+			CollectionLogCategory.BOSSES,
+			0, 0, 0,
+			0, 0,
+			null, null, null, 0.0,
+			null, 0, false, 0,
+			null, 0, null, null,
+			null,
+			null, null, 0, null, 0,
+			Collections.emptyList()
+		, null);
+	}
+}


### PR DESCRIPTION
## Summary
- Wave 13 of the #503 god-class split. Extracts the `onSequenceComplete + rebuildSourcesWithMissingItems + exportEfficiencyIfEnabled` trio from `CollectionLogHelperPlugin` into a focused `lifecycle.CollectionStateChangeHandler` collaborator.
- `Plugin.java`: **719 -> 678 LOC** (-41). Plugin retains state ownership of `sourcesWithMissingItems`, `pendingPanelRebuild`, `rankedSourcesDirty`, and `cachedRankedSources`; the handler reads/writes those fields exclusively via three narrow callbacks wired once in `startUp()`.
- `GuidanceOverlayCoordinator.setOnSequenceCompleteCallback` now points at `collectionStateChangeHandler::handleSequenceComplete`, mirroring the Wave 11/12 (`SyncStateCoordinator`, `VarbitChangeRouter`) injection pattern.

## Refactor details
- New `@Singleton` Guice component injected via constructor (`Client`, `CollectionLogHelperConfig`, `DataModule`, `EfficiencyModule`, `GuidanceModule`).
- `setCallbacks(Runnable flags, Supplier<List<ScoredItem>> ranked, BiConsumer<CollectionLogSource, Integer> activate)` keeps the circular plugin dependency off the constructor.
- `handleSequenceComplete` short-circuits with no allocation when auto-advance is disabled (matches the #527 / #523 hot-path discipline used in `VarbitChangeRouter`).
- `rebuildSourcesWithMissingItems` returns the new `Set<String>` so the plugin's `shutDown` reset semantics for `sourcesWithMissingItems` are preserved.

## Test plan
- [x] `./gradlew build` passes (incl. JaCoCo coverage verification + drop-rate lint).
- [x] `./gradlew test` — 1267 tests, all green.
- [x] `OnSequenceCompletePerItemTest` rewritten to drive the handler directly (was using reflection against the deleted private `Plugin.onSequenceComplete`).
- [x] New `CollectionStateChangeHandlerTest` covers: flag-callback always fires, auto-advance disabled path is a no-op, empty/null ranked-sources path, locked-source skip, null-callback safety, coordinator partition delegation, export disabled no-op, and the player-name-unavailable fallback.

## Wave 14 candidate
Eta-2 flagged `onGameTick` (~85 LOC) as the next-biggest seam. Confirmed: lines 497-577 of the post-Wave-13 `Plugin.java` are an ~80 LOC tick-coalescer with five distinct responsibilities (debounced requirements / travel-varbit refresh, per-character data init, guidance coordinator tick, player-location resolve + sequencer dispatch, deferred slayer refresh, sync-tick delegation, and final panel rebuild). A `GameTickOrchestrator` extraction looks tractable and should land Plugin near the 600 LOC target.