### PR TITLE
refactor: extract GameStateRouter and PluginShutdownRoutine from Plugin (closes #503)

### DIFF
--- a/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
@@ -38,9 +38,11 @@ import com.collectionloghelper.sync.TempleSyncOrchestrator;
 import com.collectionloghelper.efficiency.ScoredItem;
 import com.collectionloghelper.lifecycle.AuthoringLogger;
 import com.collectionloghelper.lifecycle.CollectionStateChangeHandler;
+import com.collectionloghelper.lifecycle.GameStateRouter;
 import com.collectionloghelper.lifecycle.GameTickOrchestrator;
 import com.collectionloghelper.lifecycle.OverlayRegistry;
 import com.collectionloghelper.lifecycle.PlayerLocationResolver;
+import com.collectionloghelper.lifecycle.PluginShutdownRoutine;
 import com.collectionloghelper.lifecycle.SceneEventRouter;
 import com.collectionloghelper.lifecycle.VarbitChangeRouter;
 import com.collectionloghelper.ui.CollectionLogHelperPanel;
@@ -161,6 +163,12 @@ public class CollectionLogHelperPlugin extends Plugin
 
 	@Inject
 	private GameTickOrchestrator gameTickOrchestrator;
+
+	@Inject
+	private GameStateRouter gameStateRouter;
+
+	@Inject
+	private PluginShutdownRoutine pluginShutdownRoutine;
 
 
 	private CollectionLogHelperPanel panel;
@@ -304,6 +312,17 @@ public class CollectionLogHelperPlugin extends Plugin
 		chatEventHandler.setCallbacks(
 			this::getRankedSources,
 			this::markPanelRebuildAndRankedDirty);
+		gameStateRouter.setCallbacks(
+			() -> panel,
+			collectionStateChangeHandler::rebuildSourcesWithMissingItems,
+			set -> sourcesWithMissingItems = set,
+			() -> sourcesWithMissingItems.clear(),
+			() -> slayerRefreshPending = true,
+			() ->
+			{
+				slayerRefreshPending = false;
+				pendingTravelVarbitRefresh = false;
+			});
 		varbitChangeRouter.setCallbacks(
 			() ->
 			{
@@ -330,117 +349,21 @@ public class CollectionLogHelperPlugin extends Plugin
 	@Override
 	protected void shutDown() throws Exception
 	{
-		chatCommandManager.unregisterCommand("clh");
-		authoringLogger.close();
-		sync.getCollectionLogNetImporter().shutdown();
-		if (panel != null)
+		pluginShutdownRoutine.tearDown(panel, navButton, httpResultExecutor, () ->
 		{
-			panel.shutDown();
-		}
-		clientToolbar.removeNavigation(navButton);
-		overlayRegistry.unregisterAll();
-		eventBus.unregister(sceneEventRouter);
-		eventBus.unregister(guidance.getGuidanceEventRouter());
-		eventBus.unregister(guidance.getGuidanceMovementTracker());
-		eventBus.unregister(efficiency.getKillTimeTracker());
-		efficiency.getKillTimeTracker().reset();
-		deactivateGuidance();
-		sync.getSyncStateCoordinator().reset();
-		sync.getSourceKcStore().clear();
-		sync.getTempleOsrsKcSyncer().shutdown();
-		if (httpResultExecutor != null)
-		{
-			httpResultExecutor.shutdownNow();
-			httpResultExecutor = null;
-		}
-		sourcesWithMissingItems.clear();
-		pendingPanelRebuild = false;
-		rankedSourcesDirty = true;
-		cachedRankedSources = null;
-		playerLocationResolver.reset();
-		guidance.getGuidanceOverlay().setShowCollectionLogReminder(false);
-		guidance.getGuidanceOverlay().setShowBankReminder(false);
-		data.getDataSyncState().reset();
-		data.getPlayerBankState().reset();
-		data.getPlayerInventoryState().reset();
-		data.getSlayerTaskState().reset();
-		travelCapabilities.reset();
-		data.getCollectionState().clearState();
-		data.getPluginDataManager().reset();
-
+			sourcesWithMissingItems.clear();
+			pendingPanelRebuild = false;
+			rankedSourcesDirty = true;
+			cachedRankedSources = null;
+		});
+		httpResultExecutor = null;
 		log.info("Collection Log Helper stopped");
 	}
 
 	@Subscribe
 	public void onGameStateChanged(GameStateChanged event)
 	{
-		if (event.getGameState() == GameState.LOGGED_IN)
-		{
-			// LOGGED_IN fires multiple times during login/transitions.
-			// Only reset sync state on the first fire to avoid clearing
-			// collection log / bank sync flags mid-session.
-			sync.getSyncStateCoordinator().onGameStateLoggedIn();
-			slayerRefreshPending = true;
-			clientThread.invokeLater(() ->
-			{
-				data.getCollectionState().refreshVarps();
-				data.getCollectionState().loadObtainedItems();
-				data.getCollectionState().captureRecentItems();
-				requirementsChecker.refreshAccessibility(data.getDatabase().getAllSources());
-				travelCapabilities.refreshQuestState();
-				travelCapabilities.refreshVarbits();
-				data.getSlayerTaskState().refresh();
-				sync.getSyncStateCoordinator().setLastObtainedCount(data.getCollectionState().getTotalObtained());
-				sourcesWithMissingItems = collectionStateChangeHandler.rebuildSourcesWithMissingItems();
-
-				// Rescan scene for tracked objects after scene (re)load
-				guidance.getObjectHighlightOverlay().rescanScene();
-
-				// Per-character dir and cache-fresh check are handled in
-				// onGameTick once varps and player name are available.
-
-				if (panel != null)
-				{
-					if (data.getDataSyncState().isCollectionLogSynced()
-						&& data.getCollectionState().getTotalObtained() > 0)
-					{
-						panel.updateSyncStatus(CollectionLogHelperPanel.SyncState.SYNCED,
-							data.getCollectionState().getTotalObtained());
-					}
-					else
-					{
-						panel.updateSyncStatus(CollectionLogHelperPanel.SyncState.NOT_SYNCED, 0);
-					}
-					panel.updateDataSyncWarning();
-					if (data.getDataSyncState().isBankScanned())
-					{
-						panel.updateClueSummary(data.getPlayerBankState());
-					}
-					panel.rebuild();
-				}
-			});
-		}
-		else if (event.getGameState() == GameState.LOGIN_SCREEN)
-		{
-			data.getCollectionState().clearState();
-			requirementsChecker.clearCache();
-			efficiency.getClueEstimator().resetBucket();
-			data.getSlayerTaskState().reset();
-			sync.getSyncStateCoordinator().onGameStateLoginScreen();
-			sync.getSyncStateCoordinator().setLastObtainedCount(-1);
-			sourcesWithMissingItems.clear();
-			slayerRefreshPending = false;
-			pendingTravelVarbitRefresh = false;
-			playerLocationResolver.reset();
-			guidance.getGuidanceOverlay().setShowCollectionLogReminder(false);
-			guidance.getGuidanceOverlay().setShowBankReminder(false);
-			data.getDataSyncState().reset();
-			data.getPlayerBankState().reset();
-			data.getPlayerInventoryState().reset();
-			travelCapabilities.reset();
-			efficiency.getKillTimeTracker().reset();
-			data.getPluginDataManager().reset();
-		}
+		gameStateRouter.handle(event);
 	}
 
 	@Subscribe

--- a/src/main/java/com/collectionloghelper/lifecycle/GameStateRouter.java
+++ b/src/main/java/com/collectionloghelper/lifecycle/GameStateRouter.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.lifecycle;
+
+import com.collectionloghelper.data.PlayerTravelCapabilities;
+import com.collectionloghelper.data.RequirementsChecker;
+import com.collectionloghelper.di.DataModule;
+import com.collectionloghelper.di.EfficiencyModule;
+import com.collectionloghelper.di.GuidanceModule;
+import com.collectionloghelper.di.SyncModule;
+import com.collectionloghelper.ui.CollectionLogHelperPanel;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.GameState;
+import net.runelite.api.events.GameStateChanged;
+import net.runelite.client.callback.ClientThread;
+
+/**
+ * Processes {@link GameStateChanged} events. Mirrors the
+ * {@link VarbitChangeRouter} / {@code ChatEventHandler} extraction pattern --
+ * the plugin keeps the {@code @Subscribe} annotation and delegates the body
+ * to {@link #handle(GameStateChanged)}.
+ *
+ * <p>Two transitions matter:
+ * <ul>
+ *   <li>{@link GameState#LOGGED_IN} -- bootstraps cached varp/varbit state,
+ *       refreshes accessibility/travel/slayer caches, rebuilds the
+ *       sources-with-missing set, rescans the scene for tracked objects, and
+ *       refreshes the panel's sync-status indicators.</li>
+ *   <li>{@link GameState#LOGIN_SCREEN} -- clears per-character mutable state
+ *       (collection state, sync flags, slayer task, travel caps, kill-time
+ *       tracker, plugin data manager).</li>
+ * </ul>
+ *
+ * <p>All other transitions (LOADING, CONNECTION_LOST, HOPPING, etc.) are
+ * no-ops. The guard path is allocation-free: a single {@code ==} comparison
+ * against each enum constant, no lambda capture, no per-event {@code new}
+ * sites.
+ *
+ * <p>The LOGGED_IN bootstrap is dispatched to the client thread via the
+ * plugin-supplied {@link ClientThread} because it touches client-thread-only
+ * APIs ({@code refreshVarps}, {@code loadObtainedItems},
+ * {@code refreshAccessibility}, {@code refreshQuestState}). The lambda
+ * captured for {@link ClientThread#invokeLater} is the only per-event
+ * allocation on the LOGGED_IN path -- and only one per transition, not per
+ * tick.
+ *
+ * <p>Plugin callbacks keep state ownership in the plugin:
+ * <ul>
+ *   <li>{@code panelSupplier} -- returns the (nullable) panel so refresh
+ *       can short-circuit if startUp hasn't completed.</li>
+ *   <li>{@code missingItemsRebuilder} / {@code missingItemsApplier} --
+ *       rebuilds the sources-with-missing cache and writes the result back to
+ *       the plugin field.</li>
+ *   <li>{@code onLoggedInFlags} -- sets {@code slayerRefreshPending} on the
+ *       plugin.</li>
+ *   <li>{@code onLoginScreenFlags} -- clears the plugin's transient flags on
+ *       logout.</li>
+ * </ul>
+ *
+ * <p>Part of issue #503 -- splitting {@code CollectionLogHelperPlugin} into
+ * focused collaborators (Wave 15).
+ */
+@Slf4j
+@Singleton
+public class GameStateRouter
+{
+	private final ClientThread clientThread;
+	private final DataModule data;
+	private final EfficiencyModule efficiency;
+	private final GuidanceModule guidance;
+	private final SyncModule sync;
+	private final RequirementsChecker requirementsChecker;
+	private final PlayerTravelCapabilities travelCapabilities;
+	private final PlayerLocationResolver playerLocationResolver;
+
+	private Supplier<CollectionLogHelperPanel> panelSupplier;
+	private Consumer<Set<String>> missingItemsApplier;
+	private Supplier<Set<String>> missingItemsRebuilder;
+	private Runnable clearMissingItems;
+	private Runnable onLoggedInFlags;
+	private Runnable onLoginScreenFlags;
+
+	@Inject
+	public GameStateRouter(
+		ClientThread clientThread,
+		DataModule data,
+		EfficiencyModule efficiency,
+		GuidanceModule guidance,
+		SyncModule sync,
+		RequirementsChecker requirementsChecker,
+		PlayerTravelCapabilities travelCapabilities,
+		PlayerLocationResolver playerLocationResolver)
+	{
+		this.clientThread = clientThread;
+		this.data = data;
+		this.efficiency = efficiency;
+		this.guidance = guidance;
+		this.sync = sync;
+		this.requirementsChecker = requirementsChecker;
+		this.travelCapabilities = travelCapabilities;
+		this.playerLocationResolver = playerLocationResolver;
+	}
+
+	/**
+	 * Wires plugin-owned callbacks. Called once from
+	 * {@code CollectionLogHelperPlugin.startUp()}. Kept off the constructor to
+	 * avoid a circular Guice dependency on the plugin itself.
+	 *
+	 * @param panelSupplier returns the plugin's panel (nullable during startup races)
+	 * @param missingItemsRebuilder rebuilds and returns the new sources-with-missing set
+	 * @param missingItemsApplier assigns the rebuilt set back to the plugin field
+	 * @param onLoggedInFlags sets {@code slayerRefreshPending} on the plugin
+	 * @param onLoginScreenFlags clears the plugin's transient flags on logout
+	 */
+	public void setCallbacks(
+		Supplier<CollectionLogHelperPanel> panelSupplier,
+		Supplier<Set<String>> missingItemsRebuilder,
+		Consumer<Set<String>> missingItemsApplier,
+		Runnable clearMissingItems,
+		Runnable onLoggedInFlags,
+		Runnable onLoginScreenFlags)
+	{
+		this.panelSupplier = panelSupplier;
+		this.missingItemsRebuilder = missingItemsRebuilder;
+		this.missingItemsApplier = missingItemsApplier;
+		this.clearMissingItems = clearMissingItems;
+		this.onLoggedInFlags = onLoggedInFlags;
+		this.onLoginScreenFlags = onLoginScreenFlags;
+	}
+
+	/**
+	 * Handles a single {@link GameStateChanged} event. The LOGGED_IN bootstrap
+	 * is dispatched to the client thread; LOGIN_SCREEN reset runs inline (its
+	 * callees are thread-safe -- {@code clearState}, {@code clearCache}, and
+	 * the various {@code reset()} methods are pure state mutations on plugin-
+	 * managed objects).
+	 *
+	 * <p>All other game states are no-ops.
+	 */
+	public void handle(GameStateChanged event)
+	{
+		GameState gameState = event.getGameState();
+		if (gameState == GameState.LOGGED_IN)
+		{
+			handleLoggedIn();
+		}
+		else if (gameState == GameState.LOGIN_SCREEN)
+		{
+			handleLoginScreen();
+		}
+	}
+
+	private void handleLoggedIn()
+	{
+		// LOGGED_IN fires multiple times during login/transitions.
+		// Only reset sync state on the first fire to avoid clearing
+		// collection log / bank sync flags mid-session.
+		sync.getSyncStateCoordinator().onGameStateLoggedIn();
+		if (onLoggedInFlags != null)
+		{
+			onLoggedInFlags.run();
+		}
+		clientThread.invokeLater(() ->
+		{
+			data.getCollectionState().refreshVarps();
+			data.getCollectionState().loadObtainedItems();
+			data.getCollectionState().captureRecentItems();
+			requirementsChecker.refreshAccessibility(data.getDatabase().getAllSources());
+			travelCapabilities.refreshQuestState();
+			travelCapabilities.refreshVarbits();
+			data.getSlayerTaskState().refresh();
+			sync.getSyncStateCoordinator().setLastObtainedCount(data.getCollectionState().getTotalObtained());
+			if (missingItemsRebuilder != null && missingItemsApplier != null)
+			{
+				missingItemsApplier.accept(missingItemsRebuilder.get());
+			}
+
+			// Rescan scene for tracked objects after scene (re)load
+			guidance.getObjectHighlightOverlay().rescanScene();
+
+			// Per-character dir and cache-fresh check are handled in
+			// onGameTick once varps and player name are available.
+
+			CollectionLogHelperPanel panel = panelSupplier != null ? panelSupplier.get() : null;
+			if (panel != null)
+			{
+				if (data.getDataSyncState().isCollectionLogSynced()
+					&& data.getCollectionState().getTotalObtained() > 0)
+				{
+					panel.updateSyncStatus(CollectionLogHelperPanel.SyncState.SYNCED,
+						data.getCollectionState().getTotalObtained());
+				}
+				else
+				{
+					panel.updateSyncStatus(CollectionLogHelperPanel.SyncState.NOT_SYNCED, 0);
+				}
+				panel.updateDataSyncWarning();
+				if (data.getDataSyncState().isBankScanned())
+				{
+					panel.updateClueSummary(data.getPlayerBankState());
+				}
+				panel.rebuild();
+			}
+		});
+	}
+
+	private void handleLoginScreen()
+	{
+		data.getCollectionState().clearState();
+		requirementsChecker.clearCache();
+		efficiency.getClueEstimator().resetBucket();
+		data.getSlayerTaskState().reset();
+		sync.getSyncStateCoordinator().onGameStateLoginScreen();
+		sync.getSyncStateCoordinator().setLastObtainedCount(-1);
+		if (clearMissingItems != null)
+		{
+			clearMissingItems.run();
+		}
+		if (onLoginScreenFlags != null)
+		{
+			onLoginScreenFlags.run();
+		}
+		playerLocationResolver.reset();
+		guidance.getGuidanceOverlay().setShowCollectionLogReminder(false);
+		guidance.getGuidanceOverlay().setShowBankReminder(false);
+		data.getDataSyncState().reset();
+		data.getPlayerBankState().reset();
+		data.getPlayerInventoryState().reset();
+		travelCapabilities.reset();
+		efficiency.getKillTimeTracker().reset();
+		data.getPluginDataManager().reset();
+	}
+}

--- a/src/main/java/com/collectionloghelper/lifecycle/PluginShutdownRoutine.java
+++ b/src/main/java/com/collectionloghelper/lifecycle/PluginShutdownRoutine.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.lifecycle;
+
+import com.collectionloghelper.data.PlayerTravelCapabilities;
+import com.collectionloghelper.di.DataModule;
+import com.collectionloghelper.di.EfficiencyModule;
+import com.collectionloghelper.di.GuidanceModule;
+import com.collectionloghelper.di.SyncModule;
+import com.collectionloghelper.ui.CollectionLogHelperPanel;
+import java.util.concurrent.ExecutorService;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.chat.ChatCommandManager;
+import net.runelite.client.eventbus.EventBus;
+import net.runelite.client.ui.ClientToolbar;
+import net.runelite.client.ui.NavigationButton;
+
+/**
+ * Owns the symmetric teardown that previously lived inline in
+ * {@code CollectionLogHelperPlugin.shutDown()}. Mirrors the established
+ * lifecycle extraction pattern (Waves 11-14) -- the plugin retains state
+ * ownership; this routine sequences the teardown calls on the injected
+ * collaborators and lets the plugin clear its own private state via the
+ * supplied {@code clearPluginState} callback.
+ *
+ * <h2>Teardown order</h2>
+ * The order matches the pre-extraction shutDown body exactly:
+ * <ol>
+ *   <li>Unregister the {@code !clh} chat command.</li>
+ *   <li>Close the authoring logger file handle.</li>
+ *   <li>Shut down the collectionlog.net importer.</li>
+ *   <li>Tear down the panel (if it was constructed).</li>
+ *   <li>Remove the nav button from the client toolbar.</li>
+ *   <li>Unregister overlays.</li>
+ *   <li>Unregister event-bus listeners (scene router, guidance routers,
+ *       movement tracker, kill-time tracker).</li>
+ *   <li>Reset state on each collaborator
+ *       (kill-time tracker, guidance, sync coordinator, kc store, TempleOSRS
+ *       syncer, player location resolver, overlays, data sync state, bank
+ *       state, inventory state, slayer state, travel caps, collection state,
+ *       plugin data manager).</li>
+ *   <li>Shut down the shared HTTP result executor (if present).</li>
+ *   <li>Clear plugin-private state via the {@code clearPluginState}
+ *       callback -- the plugin owns {@code sourcesWithMissingItems},
+ *       {@code pendingPanelRebuild}, {@code rankedSourcesDirty}, and
+ *       {@code cachedRankedSources}.</li>
+ * </ol>
+ *
+ * <p>Part of issue #503 -- splitting {@code CollectionLogHelperPlugin} into
+ * focused collaborators (Wave 15).
+ */
+@Slf4j
+@Singleton
+public class PluginShutdownRoutine
+{
+	private final ChatCommandManager chatCommandManager;
+	private final AuthoringLogger authoringLogger;
+	private final SyncModule sync;
+	private final ClientToolbar clientToolbar;
+	private final OverlayRegistry overlayRegistry;
+	private final EventBus eventBus;
+	private final SceneEventRouter sceneEventRouter;
+	private final GuidanceModule guidance;
+	private final EfficiencyModule efficiency;
+	private final DataModule data;
+	private final PlayerTravelCapabilities travelCapabilities;
+	private final PlayerLocationResolver playerLocationResolver;
+
+	@Inject
+	public PluginShutdownRoutine(
+		ChatCommandManager chatCommandManager,
+		AuthoringLogger authoringLogger,
+		SyncModule sync,
+		ClientToolbar clientToolbar,
+		OverlayRegistry overlayRegistry,
+		EventBus eventBus,
+		SceneEventRouter sceneEventRouter,
+		GuidanceModule guidance,
+		EfficiencyModule efficiency,
+		DataModule data,
+		PlayerTravelCapabilities travelCapabilities,
+		PlayerLocationResolver playerLocationResolver)
+	{
+		this.chatCommandManager = chatCommandManager;
+		this.authoringLogger = authoringLogger;
+		this.sync = sync;
+		this.clientToolbar = clientToolbar;
+		this.overlayRegistry = overlayRegistry;
+		this.eventBus = eventBus;
+		this.sceneEventRouter = sceneEventRouter;
+		this.guidance = guidance;
+		this.efficiency = efficiency;
+		this.data = data;
+		this.travelCapabilities = travelCapabilities;
+		this.playerLocationResolver = playerLocationResolver;
+	}
+
+	/**
+	 * Performs the full plugin teardown. Called once from
+	 * {@code CollectionLogHelperPlugin.shutDown()}.
+	 *
+	 * @param panel the plugin's panel (may be {@code null} if {@code startUp}
+	 *              failed before constructing it)
+	 * @param navButton the plugin's nav button
+	 * @param httpResultExecutor the shared HTTP result executor (may be
+	 *                            {@code null} if {@code startUp} failed before
+	 *                            creating it)
+	 * @param clearPluginState callback that clears plugin-private state
+	 *                         ({@code sourcesWithMissingItems},
+	 *                         {@code pendingPanelRebuild},
+	 *                         {@code rankedSourcesDirty},
+	 *                         {@code cachedRankedSources}). Invoked exactly once.
+	 */
+	public void tearDown(
+		CollectionLogHelperPanel panel,
+		NavigationButton navButton,
+		ExecutorService httpResultExecutor,
+		Runnable clearPluginState)
+	{
+		chatCommandManager.unregisterCommand("clh");
+		authoringLogger.close();
+		sync.getCollectionLogNetImporter().shutdown();
+		if (panel != null)
+		{
+			panel.shutDown();
+		}
+		clientToolbar.removeNavigation(navButton);
+		overlayRegistry.unregisterAll();
+		eventBus.unregister(sceneEventRouter);
+		eventBus.unregister(guidance.getGuidanceEventRouter());
+		eventBus.unregister(guidance.getGuidanceMovementTracker());
+		eventBus.unregister(efficiency.getKillTimeTracker());
+		efficiency.getKillTimeTracker().reset();
+		guidance.getGuidanceCoordinator().deactivateGuidance();
+		sync.getSyncStateCoordinator().reset();
+		sync.getSourceKcStore().clear();
+		sync.getTempleOsrsKcSyncer().shutdown();
+		if (httpResultExecutor != null)
+		{
+			httpResultExecutor.shutdownNow();
+		}
+		if (clearPluginState != null)
+		{
+			clearPluginState.run();
+		}
+		playerLocationResolver.reset();
+		guidance.getGuidanceOverlay().setShowCollectionLogReminder(false);
+		guidance.getGuidanceOverlay().setShowBankReminder(false);
+		data.getDataSyncState().reset();
+		data.getPlayerBankState().reset();
+		data.getPlayerInventoryState().reset();
+		data.getSlayerTaskState().reset();
+		travelCapabilities.reset();
+		data.getCollectionState().clearState();
+		data.getPluginDataManager().reset();
+	}
+}

--- a/src/test/java/com/collectionloghelper/lifecycle/GameStateRouterTest.java
+++ b/src/test/java/com/collectionloghelper/lifecycle/GameStateRouterTest.java
@@ -1,0 +1,381 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ */
+package com.collectionloghelper.lifecycle;
+
+import com.collectionloghelper.data.DataSyncState;
+import com.collectionloghelper.efficiency.ClueCompletionEstimator;
+import com.collectionloghelper.data.DropRateDatabase;
+import com.collectionloghelper.data.PlayerBankState;
+import com.collectionloghelper.data.PlayerCollectionState;
+import com.collectionloghelper.data.PlayerInventoryState;
+import com.collectionloghelper.data.PlayerTravelCapabilities;
+import com.collectionloghelper.data.PluginDataManager;
+import com.collectionloghelper.data.RequirementsChecker;
+import com.collectionloghelper.data.SlayerTaskState;
+import com.collectionloghelper.di.DataModule;
+import com.collectionloghelper.di.EfficiencyModule;
+import com.collectionloghelper.di.GuidanceModule;
+import com.collectionloghelper.di.SyncModule;
+import com.collectionloghelper.overlay.GuidanceOverlay;
+import com.collectionloghelper.overlay.ObjectHighlightOverlay;
+import com.collectionloghelper.learning.KillTimeTracker;
+import com.collectionloghelper.ui.CollectionLogHelperPanel;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import net.runelite.api.GameState;
+import net.runelite.api.events.GameStateChanged;
+import net.runelite.client.callback.ClientThread;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link GameStateRouter} -- the Wave 15 (#503) extraction that
+ * owns the body of {@code CollectionLogHelperPlugin.onGameStateChanged}.
+ *
+ * <p>Covers:
+ * <ul>
+ *   <li>LOGGED_IN bootstrap dispatches client-thread work and refreshes the
+ *       collection / travel / slayer caches plus panel sync indicators.</li>
+ *   <li>LOGIN_SCREEN reset clears per-character state without dispatching to
+ *       the client thread.</li>
+ *   <li>All other transitions (LOADING, CONNECTION_LOST, HOPPING, STARTING)
+ *       are no-ops.</li>
+ *   <li>Null-callback safety on both transition handlers.</li>
+ * </ul>
+ */
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class GameStateRouterTest
+{
+	@Mock private ClientThread clientThread;
+	@Mock private DataModule dataModule;
+	@Mock private EfficiencyModule efficiencyModule;
+	@Mock private GuidanceModule guidanceModule;
+	@Mock private SyncModule syncModule;
+	@Mock private RequirementsChecker requirementsChecker;
+	@Mock private PlayerTravelCapabilities travelCapabilities;
+	@Mock private PlayerLocationResolver playerLocationResolver;
+
+	@Mock private PlayerCollectionState collectionState;
+	@Mock private DataSyncState dataSyncState;
+	@Mock private PlayerBankState playerBankState;
+	@Mock private PlayerInventoryState playerInventoryState;
+	@Mock private SlayerTaskState slayerTaskState;
+	@Mock private PluginDataManager pluginDataManager;
+	@Mock private DropRateDatabase database;
+	@Mock private ClueCompletionEstimator clueEstimator;
+	@Mock private KillTimeTracker killTimeTracker;
+	@Mock private GuidanceOverlay guidanceOverlay;
+	@Mock private ObjectHighlightOverlay objectHighlightOverlay;
+	@Mock private SyncStateCoordinator syncStateCoordinator;
+	@Mock private CollectionLogHelperPanel panel;
+
+	private GameStateRouter router;
+
+	// Plugin-owned state mirrors -- the router never touches these fields directly,
+	// only via the callbacks wired in setCallbacks().
+	private Set<String> sourcesWithMissingItems;
+	private boolean slayerRefreshPending;
+	private boolean pendingTravelVarbitRefresh;
+	private boolean missingItemsCleared;
+
+	@Before
+	public void setUp()
+	{
+		sourcesWithMissingItems = new HashSet<>();
+		sourcesWithMissingItems.add("seed");
+		slayerRefreshPending = false;
+		pendingTravelVarbitRefresh = true;
+		missingItemsCleared = false;
+
+		// Run clientThread.invokeLater inline so we can assert on the bootstrap body
+		doAnswer(inv ->
+		{
+			Runnable r = inv.getArgument(0);
+			r.run();
+			return null;
+		}).when(clientThread).invokeLater(any(Runnable.class));
+
+		router = new GameStateRouter(
+			clientThread, dataModule, efficiencyModule, guidanceModule, syncModule,
+			requirementsChecker, travelCapabilities, playerLocationResolver);
+		router.setCallbacks(
+			() -> panel,
+			() -> Collections.singleton("rebuilt-source"),
+			set -> sourcesWithMissingItems = set,
+			() ->
+			{
+				sourcesWithMissingItems.clear();
+				missingItemsCleared = true;
+			},
+			() -> slayerRefreshPending = true,
+			() ->
+			{
+				slayerRefreshPending = false;
+				pendingTravelVarbitRefresh = false;
+			});
+	}
+
+	// ── LOGGED_IN ───────────────────────────────────────────────────────────────
+
+	@Test
+	public void loggedIn_dispatchesBootstrapOnClientThread()
+	{
+		stubLoggedInBootstrap();
+
+		router.handle(gameStateEvent(GameState.LOGGED_IN));
+
+		verify(clientThread).invokeLater(any(Runnable.class));
+		// Bootstrap touched the canonical state-refresh sequence
+		verify(collectionState).refreshVarps();
+		verify(collectionState).loadObtainedItems();
+		verify(collectionState).captureRecentItems();
+		verify(requirementsChecker).refreshAccessibility(any());
+		verify(travelCapabilities).refreshQuestState();
+		verify(travelCapabilities).refreshVarbits();
+		verify(slayerTaskState).refresh();
+		verify(syncStateCoordinator).setLastObtainedCount(anyInt());
+		verify(objectHighlightOverlay).rescanScene();
+	}
+
+	@Test
+	public void loggedIn_flagsSlayerRefreshPending()
+	{
+		stubLoggedInBootstrap();
+
+		router.handle(gameStateEvent(GameState.LOGGED_IN));
+
+		assertTrue("slayerRefreshPending must be set so onGameTick refreshes Slayer", slayerRefreshPending);
+	}
+
+	@Test
+	public void loggedIn_appliesRebuiltMissingItemsSet()
+	{
+		stubLoggedInBootstrap();
+
+		router.handle(gameStateEvent(GameState.LOGGED_IN));
+
+		assertEquals(Collections.singleton("rebuilt-source"), sourcesWithMissingItems);
+	}
+
+	@Test
+	public void loggedIn_panelSyncedWhenLogSyncedAndCountPositive()
+	{
+		stubLoggedInBootstrap();
+		when(dataSyncState.isCollectionLogSynced()).thenReturn(true);
+		when(collectionState.getTotalObtained()).thenReturn(42);
+
+		router.handle(gameStateEvent(GameState.LOGGED_IN));
+
+		verify(panel).updateSyncStatus(eq(CollectionLogHelperPanel.SyncState.SYNCED), eq(42));
+		verify(panel, never()).updateSyncStatus(eq(CollectionLogHelperPanel.SyncState.NOT_SYNCED), anyInt());
+		verify(panel).rebuild();
+	}
+
+	@Test
+	public void loggedIn_panelNotSyncedWhenLogNotSynced()
+	{
+		stubLoggedInBootstrap();
+		when(dataSyncState.isCollectionLogSynced()).thenReturn(false);
+		when(collectionState.getTotalObtained()).thenReturn(0);
+
+		router.handle(gameStateEvent(GameState.LOGGED_IN));
+
+		verify(panel).updateSyncStatus(eq(CollectionLogHelperPanel.SyncState.NOT_SYNCED), eq(0));
+		verify(panel, never()).updateSyncStatus(eq(CollectionLogHelperPanel.SyncState.SYNCED), anyInt());
+	}
+
+	@Test
+	public void loggedIn_nullPanel_doesNotNpe()
+	{
+		stubLoggedInBootstrap();
+		router.setCallbacks(
+			() -> null,
+			() -> Collections.emptySet(),
+			set -> { },
+			() -> { },
+			() -> slayerRefreshPending = true,
+			() -> { });
+
+		router.handle(gameStateEvent(GameState.LOGGED_IN));
+		verifyNoInteractions(panel);
+	}
+
+	@Test
+	public void loggedIn_callsSyncCoordinatorOnGameStateLoggedIn()
+	{
+		stubLoggedInBootstrap();
+
+		router.handle(gameStateEvent(GameState.LOGGED_IN));
+
+		verify(syncStateCoordinator).onGameStateLoggedIn();
+	}
+
+	// ── LOGIN_SCREEN ────────────────────────────────────────────────────────────
+
+	@Test
+	public void loginScreen_clearsAllPerCharacterState()
+	{
+		stubLoginScreenReset();
+
+		router.handle(gameStateEvent(GameState.LOGIN_SCREEN));
+
+		verify(collectionState).clearState();
+		verify(requirementsChecker).clearCache();
+		verify(clueEstimator).resetBucket();
+		verify(slayerTaskState).reset();
+		verify(syncStateCoordinator).onGameStateLoginScreen();
+		verify(syncStateCoordinator).setLastObtainedCount(-1);
+		verify(playerLocationResolver).reset();
+		verify(guidanceOverlay).setShowCollectionLogReminder(false);
+		verify(guidanceOverlay).setShowBankReminder(false);
+		verify(dataSyncState).reset();
+		verify(playerBankState).reset();
+		verify(playerInventoryState).reset();
+		verify(travelCapabilities).reset();
+		verify(killTimeTracker).reset();
+		verify(pluginDataManager).reset();
+	}
+
+	@Test
+	public void loginScreen_clearsPluginTransientFlags()
+	{
+		stubLoginScreenReset();
+		slayerRefreshPending = true;
+		pendingTravelVarbitRefresh = true;
+
+		router.handle(gameStateEvent(GameState.LOGIN_SCREEN));
+
+		assertFalse("slayerRefreshPending must be cleared on logout", slayerRefreshPending);
+		assertFalse("pendingTravelVarbitRefresh must be cleared on logout", pendingTravelVarbitRefresh);
+	}
+
+	@Test
+	public void loginScreen_clearsMissingItemsSetInPlace()
+	{
+		stubLoginScreenReset();
+		Set<String> before = sourcesWithMissingItems;
+
+		router.handle(gameStateEvent(GameState.LOGIN_SCREEN));
+
+		assertTrue("clearMissingItems callback must fire on logout", missingItemsCleared);
+		// The clear() call mutates the seeded set in place -- reference unchanged
+		assertSame("missing-items reference must be the same plugin-owned set", before, sourcesWithMissingItems);
+		assertTrue("set must be empty after clear", sourcesWithMissingItems.isEmpty());
+	}
+
+	@Test
+	public void loginScreen_doesNotDispatchClientThread()
+	{
+		stubLoginScreenReset();
+
+		router.handle(gameStateEvent(GameState.LOGIN_SCREEN));
+
+		verifyNoInteractions(clientThread);
+	}
+
+	// ── No-op transitions ───────────────────────────────────────────────────────
+
+	@Test
+	public void loading_isNoOp()
+	{
+		router.handle(gameStateEvent(GameState.LOADING));
+		verifyNoInteractions(clientThread, collectionState, dataSyncState, syncStateCoordinator);
+		assertFalse(missingItemsCleared);
+	}
+
+	@Test
+	public void connectionLost_isNoOp()
+	{
+		router.handle(gameStateEvent(GameState.CONNECTION_LOST));
+		verifyNoInteractions(clientThread, collectionState, dataSyncState, syncStateCoordinator);
+	}
+
+	@Test
+	public void hopping_isNoOp()
+	{
+		router.handle(gameStateEvent(GameState.HOPPING));
+		verifyNoInteractions(clientThread, collectionState, dataSyncState, syncStateCoordinator);
+	}
+
+	@Test
+	public void starting_isNoOp()
+	{
+		router.handle(gameStateEvent(GameState.STARTING));
+		verifyNoInteractions(clientThread, collectionState, dataSyncState, syncStateCoordinator);
+	}
+
+	// ── Null callbacks ──────────────────────────────────────────────────────────
+
+	@Test
+	public void loggedIn_nullCallbacks_doNotNpe()
+	{
+		stubLoggedInBootstrap();
+		router.setCallbacks(null, null, null, null, null, null);
+
+		router.handle(gameStateEvent(GameState.LOGGED_IN));
+		// Reaches this line without an NPE
+	}
+
+	@Test
+	public void loginScreen_nullCallbacks_doNotNpe()
+	{
+		stubLoginScreenReset();
+		router.setCallbacks(null, null, null, null, null, null);
+
+		router.handle(gameStateEvent(GameState.LOGIN_SCREEN));
+		// Reaches this line without an NPE
+	}
+
+	// ── helpers ─────────────────────────────────────────────────────────────────
+
+	private void stubLoggedInBootstrap()
+	{
+		when(syncModule.getSyncStateCoordinator()).thenReturn(syncStateCoordinator);
+		when(dataModule.getCollectionState()).thenReturn(collectionState);
+		when(dataModule.getDatabase()).thenReturn(database);
+		when(database.getAllSources()).thenReturn(Collections.emptyList());
+		when(dataModule.getSlayerTaskState()).thenReturn(slayerTaskState);
+		when(dataModule.getDataSyncState()).thenReturn(dataSyncState);
+		when(dataModule.getPlayerBankState()).thenReturn(playerBankState);
+		when(guidanceModule.getObjectHighlightOverlay()).thenReturn(objectHighlightOverlay);
+	}
+
+	private static GameStateChanged gameStateEvent(GameState state)
+	{
+		GameStateChanged e = new GameStateChanged();
+		e.setGameState(state);
+		return e;
+	}
+
+	private void stubLoginScreenReset()
+	{
+		when(syncModule.getSyncStateCoordinator()).thenReturn(syncStateCoordinator);
+		when(dataModule.getCollectionState()).thenReturn(collectionState);
+		when(dataModule.getSlayerTaskState()).thenReturn(slayerTaskState);
+		when(dataModule.getDataSyncState()).thenReturn(dataSyncState);
+		when(dataModule.getPlayerBankState()).thenReturn(playerBankState);
+		when(dataModule.getPlayerInventoryState()).thenReturn(playerInventoryState);
+		when(dataModule.getPluginDataManager()).thenReturn(pluginDataManager);
+		when(efficiencyModule.getClueEstimator()).thenReturn(clueEstimator);
+		when(efficiencyModule.getKillTimeTracker()).thenReturn(killTimeTracker);
+		when(guidanceModule.getGuidanceOverlay()).thenReturn(guidanceOverlay);
+	}
+}

--- a/src/test/java/com/collectionloghelper/lifecycle/PluginShutdownRoutineTest.java
+++ b/src/test/java/com/collectionloghelper/lifecycle/PluginShutdownRoutineTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ */
+package com.collectionloghelper.lifecycle;
+
+import com.collectionloghelper.data.DataSyncState;
+import com.collectionloghelper.data.PlayerBankState;
+import com.collectionloghelper.data.PlayerCollectionState;
+import com.collectionloghelper.data.PlayerInventoryState;
+import com.collectionloghelper.data.PlayerTravelCapabilities;
+import com.collectionloghelper.data.PluginDataManager;
+import com.collectionloghelper.data.SlayerTaskState;
+import com.collectionloghelper.di.DataModule;
+import com.collectionloghelper.di.EfficiencyModule;
+import com.collectionloghelper.di.GuidanceModule;
+import com.collectionloghelper.di.SyncModule;
+import com.collectionloghelper.guidance.GuidanceMovementTracker;
+import com.collectionloghelper.guidance.GuidanceOverlayCoordinator;
+import com.collectionloghelper.learning.KillTimeTracker;
+import com.collectionloghelper.overlay.GuidanceOverlay;
+import com.collectionloghelper.sync.CollectionLogNetImporter;
+import com.collectionloghelper.sync.SourceKcStore;
+import com.collectionloghelper.sync.TempleOsrsKcSyncer;
+import com.collectionloghelper.ui.CollectionLogHelperPanel;
+import java.util.concurrent.ExecutorService;
+import net.runelite.client.chat.ChatCommandManager;
+import net.runelite.client.eventbus.EventBus;
+import net.runelite.client.ui.ClientToolbar;
+import net.runelite.client.ui.NavigationButton;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link PluginShutdownRoutine} -- the Wave 15 (#503) extraction
+ * that owns the body of {@code CollectionLogHelperPlugin.shutDown()}.
+ *
+ * <p>Covers the canonical teardown sequence, null-tolerance for the panel
+ * and executor (in case startUp failed early), and the plugin-private state
+ * clear callback.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class PluginShutdownRoutineTest
+{
+	@Mock private ChatCommandManager chatCommandManager;
+	@Mock private AuthoringLogger authoringLogger;
+	@Mock private SyncModule syncModule;
+	@Mock private ClientToolbar clientToolbar;
+	@Mock private OverlayRegistry overlayRegistry;
+	@Mock private EventBus eventBus;
+	@Mock private SceneEventRouter sceneEventRouter;
+	@Mock private GuidanceModule guidanceModule;
+	@Mock private EfficiencyModule efficiencyModule;
+	@Mock private DataModule dataModule;
+	@Mock private PlayerTravelCapabilities travelCapabilities;
+	@Mock private PlayerLocationResolver playerLocationResolver;
+
+	@Mock private CollectionLogNetImporter collectionLogNetImporter;
+	@Mock private SyncStateCoordinator syncStateCoordinator;
+	@Mock private SourceKcStore sourceKcStore;
+	@Mock private TempleOsrsKcSyncer templeOsrsKcSyncer;
+	@Mock private GuidanceEventRouter guidanceEventRouter;
+	@Mock private GuidanceMovementTracker guidanceMovementTracker;
+	@Mock private GuidanceOverlayCoordinator guidanceCoordinator;
+	@Mock private GuidanceOverlay guidanceOverlay;
+	@Mock private KillTimeTracker killTimeTracker;
+	@Mock private PlayerCollectionState collectionState;
+	@Mock private DataSyncState dataSyncState;
+	@Mock private PlayerBankState playerBankState;
+	@Mock private PlayerInventoryState playerInventoryState;
+	@Mock private SlayerTaskState slayerTaskState;
+	@Mock private PluginDataManager pluginDataManager;
+	@Mock private ExecutorService executor;
+	@Mock private CollectionLogHelperPanel panel;
+
+	private NavigationButton navButton;
+	private PluginShutdownRoutine routine;
+
+	@Before
+	public void setUp()
+	{
+		when(syncModule.getCollectionLogNetImporter()).thenReturn(collectionLogNetImporter);
+		when(syncModule.getSyncStateCoordinator()).thenReturn(syncStateCoordinator);
+		when(syncModule.getSourceKcStore()).thenReturn(sourceKcStore);
+		when(syncModule.getTempleOsrsKcSyncer()).thenReturn(templeOsrsKcSyncer);
+		when(guidanceModule.getGuidanceEventRouter()).thenReturn(guidanceEventRouter);
+		when(guidanceModule.getGuidanceMovementTracker()).thenReturn(guidanceMovementTracker);
+		when(guidanceModule.getGuidanceCoordinator()).thenReturn(guidanceCoordinator);
+		when(guidanceModule.getGuidanceOverlay()).thenReturn(guidanceOverlay);
+		when(efficiencyModule.getKillTimeTracker()).thenReturn(killTimeTracker);
+		when(dataModule.getCollectionState()).thenReturn(collectionState);
+		when(dataModule.getDataSyncState()).thenReturn(dataSyncState);
+		when(dataModule.getPlayerBankState()).thenReturn(playerBankState);
+		when(dataModule.getPlayerInventoryState()).thenReturn(playerInventoryState);
+		when(dataModule.getSlayerTaskState()).thenReturn(slayerTaskState);
+		when(dataModule.getPluginDataManager()).thenReturn(pluginDataManager);
+
+		// NavigationButton is final and cannot be mocked; construct a minimal real one
+		navButton = NavigationButton.builder()
+			.tooltip("test")
+			.icon(new java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_INT_ARGB))
+			.priority(1)
+			.panel(panel)
+			.build();
+
+		routine = new PluginShutdownRoutine(
+			chatCommandManager, authoringLogger, syncModule, clientToolbar, overlayRegistry,
+			eventBus, sceneEventRouter, guidanceModule, efficiencyModule, dataModule,
+			travelCapabilities, playerLocationResolver);
+	}
+
+	@Test
+	public void tearDown_unregistersChatCommand()
+	{
+		routine.tearDown(panel, navButton, executor, () -> { });
+		verify(chatCommandManager).unregisterCommand("clh");
+	}
+
+	@Test
+	public void tearDown_closesAuthoringLogger()
+	{
+		routine.tearDown(panel, navButton, executor, () -> { });
+		verify(authoringLogger).close();
+	}
+
+	@Test
+	public void tearDown_shutsDownCollectionLogNetImporter()
+	{
+		routine.tearDown(panel, navButton, executor, () -> { });
+		verify(collectionLogNetImporter).shutdown();
+	}
+
+	@Test
+	public void tearDown_shutsDownPanelWhenPresent()
+	{
+		routine.tearDown(panel, navButton, executor, () -> { });
+		verify(panel).shutDown();
+	}
+
+	@Test
+	public void tearDown_skipsPanelShutdownWhenNull()
+	{
+		routine.tearDown(null, navButton, executor, () -> { });
+		verify(panel, never()).shutDown();
+	}
+
+	@Test
+	public void tearDown_removesNavButton()
+	{
+		routine.tearDown(panel, navButton, executor, () -> { });
+		verify(clientToolbar).removeNavigation(navButton);
+	}
+
+	@Test
+	public void tearDown_unregistersAllOverlays()
+	{
+		routine.tearDown(panel, navButton, executor, () -> { });
+		verify(overlayRegistry).unregisterAll();
+	}
+
+	@Test
+	public void tearDown_unregistersEventBusListeners()
+	{
+		routine.tearDown(panel, navButton, executor, () -> { });
+		verify(eventBus).unregister(sceneEventRouter);
+		verify(eventBus).unregister(guidanceEventRouter);
+		verify(eventBus).unregister(guidanceMovementTracker);
+		verify(eventBus).unregister(killTimeTracker);
+	}
+
+	@Test
+	public void tearDown_resetsCollaboratorState()
+	{
+		routine.tearDown(panel, navButton, executor, () -> { });
+		verify(killTimeTracker).reset();
+		verify(guidanceCoordinator).deactivateGuidance();
+		verify(syncStateCoordinator).reset();
+		verify(sourceKcStore).clear();
+		verify(templeOsrsKcSyncer).shutdown();
+		verify(playerLocationResolver).reset();
+		verify(guidanceOverlay).setShowCollectionLogReminder(false);
+		verify(guidanceOverlay).setShowBankReminder(false);
+		verify(dataSyncState).reset();
+		verify(playerBankState).reset();
+		verify(playerInventoryState).reset();
+		verify(slayerTaskState).reset();
+		verify(travelCapabilities).reset();
+		verify(collectionState).clearState();
+		verify(pluginDataManager).reset();
+	}
+
+	@Test
+	public void tearDown_shutsDownExecutorWhenPresent()
+	{
+		routine.tearDown(panel, navButton, executor, () -> { });
+		verify(executor).shutdownNow();
+	}
+
+	@Test
+	public void tearDown_skipsExecutorWhenNull()
+	{
+		routine.tearDown(panel, navButton, null, () -> { });
+		verify(executor, never()).shutdownNow();
+	}
+
+	@Test
+	public void tearDown_invokesClearPluginStateCallback()
+	{
+		boolean[] called = {false};
+		routine.tearDown(panel, navButton, executor, () -> called[0] = true);
+		assertTrue("clearPluginState callback must fire once", called[0]);
+	}
+
+	@Test
+	public void tearDown_tolerantOfNullClearCallback()
+	{
+		// Must not NPE
+		routine.tearDown(panel, navButton, executor, null);
+	}
+
+	@Test
+	public void tearDown_chatCommandUnregisterPrecedesEventBusUnregister()
+	{
+		// The original shutDown body unregisters the chat command first so any
+		// in-flight !clh handler doesn't fire mid-teardown. Lock the order.
+		routine.tearDown(panel, navButton, executor, () -> { });
+		InOrder order = inOrder(chatCommandManager, eventBus);
+		order.verify(chatCommandManager).unregisterCommand("clh");
+		order.verify(eventBus).unregister(sceneEventRouter);
+	}
+}


### PR DESCRIPTION
## Summary

Wave 15 of the #503 plugin split. `CollectionLogHelperPlugin.java` drops from **628 to 551 LOC** (delta **-77**), landing firmly under the 600 LOC architectural target. Closes #503.

Two collaborators extracted (Option C from the wave plan -- `startUp` was too entangled with field assignments and method references to ship safely in one PR; deferred to a follow-up if needed):

- **`lifecycle/GameStateRouter`** owns the LOGGED_IN bootstrap + LOGIN_SCREEN reset body (~67 LOC removed from Plugin). Mirrors `VarbitChangeRouter` / `ChatEventHandler` -- the plugin keeps the `@Subscribe` annotation and delegates the body. Allocation-free on all no-op transitions (LOADING, CONNECTION_LOST, HOPPING, STARTING, etc.). Only the LOGGED_IN bootstrap allocates one lambda for client-thread dispatch, matching pre-extraction behaviour.

- **`lifecycle/PluginShutdownRoutine`** owns the symmetric teardown body (~40 LOC removed) and preserves the exact ordering of the original `shutDown()`: chat command unregister -> authoring logger close -> sync importer shutdown -> panel shutdown -> nav button removal -> overlay unregister -> event bus unregister -> collaborator resets -> executor shutdown -> plugin-private state clear.

Plugin retains state ownership; both collaborators use the established `setCallbacks()` / param-passing pattern from Waves 11-14.

### Plugin LOC delta

| Before | After | Delta |
|--------|-------|-------|
| 628    | 551   | -77   |

### Allocation analysis (`onGameStateChanged`)

Fires on every game-state transition (login, scene load, hop, disconnect). Not per-tick but common.

- **No-op path (LOADING / CONNECTION_LOST / HOPPING / STARTING / etc.):** Two `==` comparisons against enum constants. Zero allocations, zero method dispatches beyond `event.getGameState()`.
- **LOGIN_SCREEN path:** Inline state resets via injected collaborator references. No per-event allocations -- all callees mutate existing state.
- **LOGGED_IN path:** One `Runnable` lambda allocated for `clientThread.invokeLater(...)`. This matches pre-extraction behaviour exactly (the original plugin body already allocated this lambda per LOGGED_IN fire).

The `setCallbacks` lambdas are allocated once during `startUp()` and stored as fields on `GameStateRouter`, so the hot guard-fail path never allocates a `Supplier`/`Runnable`.

## Test plan

- [x] `./gradlew build` passes
- [x] `./gradlew test` passes (1325+ tests)
- [x] `GameStateRouterTest` covers LOGGED_IN bootstrap (client-thread dispatch, panel sync indicators, missing-items rebuild), LOGIN_SCREEN reset (in-place clear, transient flag clear, no client-thread dispatch), no-op transitions, null-callback safety
- [x] `PluginShutdownRoutineTest` covers full teardown sequence, null panel and null executor tolerance, chat-command-before-event-bus ordering, plugin-private state callback invocation