### PR TITLE
feat(ux): replace Skip/Reset/Sync text buttons with icon controls + tooltips (#547)

### DIFF
--- a/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
@@ -224,10 +224,14 @@ public class CollectionLogHelperPlugin extends Plugin
 		// so overlay rescans fire in the same game-frame as auto-completion
 		// events. Reset and Sync require RequirementsChecker / inventory state
 		// that are client-thread-only, matching the pattern established in
-		// commits c528d0ae and cha-ndler/collection-log-helper#409.
+		// commits c528d0ae and cha-ndler/collection-log-helper#409. The Stop
+		// icon (#547) delegates to the same deactivateGuidance() entry point
+		// already used by the Quick Guide panel header, so behavior is identical
+		// to the existing "Deactivate" affordance — only the surface is new.
 		panel.setStepCallbacks(
 			() -> clientThread.invokeLater(guidance.getGuidanceSequencer()::advanceStep),
 			() -> clientThread.invokeLater(guidance.getGuidanceSequencer()::skipStep),
+			() -> clientThread.invokeLater(this::deactivateGuidance),
 			() -> clientThread.invokeLater(guidance.getGuidanceSequencer()::restartFromStep0),
 			() -> clientThread.invokeLater(guidance.getGuidanceSequencer()::syncToCurrentState)
 		);

--- a/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
@@ -603,6 +603,17 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 		stepProgressView.setCallbacks(advancer, skipper, resetter, syncer);
 	}
 
+	/**
+	 * Sets callbacks for all five icon-driven step-control buttons (#547):
+	 * Next Step, Skip, Stop (deactivate guidance), Restart, and Sync.
+	 * Any callback may be {@code null}.
+	 */
+	public void setStepCallbacks(Runnable advancer, Runnable skipper, Runnable stopper,
+		Runnable resetter, Runnable syncer)
+	{
+		stepProgressView.setCallbacks(advancer, skipper, stopper, resetter, syncer);
+	}
+
 	public void hideClueGuidance()
 	{
 		guidanceBannerView.hideClueGuidance();

--- a/src/main/java/com/collectionloghelper/ui/widget/StepControlIcons.java
+++ b/src/main/java/com/collectionloghelper/ui/widget/StepControlIcons.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.ui.widget;
+
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.geom.Path2D;
+import java.awt.image.BufferedImage;
+
+/**
+ * Programmatic media-control style glyphs rendered with Java2D for the
+ * active-guidance step-control button row (#547).
+ *
+ * <p>Glyphs are drawn at runtime instead of shipped as PNG assets so that:
+ * <ul>
+ *   <li>no third-party icon-set license needs to ride along with the plugin
+ *       jar (Material Icons / Feather / etc.);</li>
+ *   <li>colour can be themed without keeping multiple PNG variants in sync;</li>
+ *   <li>the icon row scales cleanly with the existing button preferred-size
+ *       contract (28x28 click target, 16x16 glyph inside).</li>
+ * </ul>
+ *
+ * <p>Each public factory returns a freshly-allocated {@link BufferedImage}.
+ * Two passes (idle / hover) are typically prepared once at construction time
+ * by the caller and swapped via {@link javax.swing.JButton#setIcon}.
+ */
+final class StepControlIcons
+{
+	/** Standard glyph canvas size — matches the 16x16 sprite slot used by the row. */
+	static final int GLYPH_SIZE = 16;
+
+	private StepControlIcons()
+	{
+	}
+
+	/**
+	 * Skip-next glyph — a right-pointing triangle followed by a thin vertical bar,
+	 * matching the familiar media-player "next track" symbol. Used for "Skip to
+	 * next step".
+	 */
+	static BufferedImage skipNext(Color color)
+	{
+		BufferedImage img = blank();
+		Graphics2D g = prepare(img, color);
+		try
+		{
+			Path2D.Float tri = new Path2D.Float();
+			tri.moveTo(3f, 3f);
+			tri.lineTo(3f, 13f);
+			tri.lineTo(11f, 8f);
+			tri.closePath();
+			g.fill(tri);
+			// Trailing vertical bar
+			g.fillRect(12, 3, 2, 10);
+		}
+		finally
+		{
+			g.dispose();
+		}
+		return img;
+	}
+
+	/**
+	 * Stop glyph — a filled square. Used for "Stop guidance — clear all overlays".
+	 */
+	static BufferedImage stop(Color color)
+	{
+		BufferedImage img = blank();
+		Graphics2D g = prepare(img, color);
+		try
+		{
+			g.fillRect(3, 3, 10, 10);
+		}
+		finally
+		{
+			g.dispose();
+		}
+		return img;
+	}
+
+	/**
+	 * Restart glyph — circular arrow pointing back to its start position.
+	 * Used for "Restart this task from the first step".
+	 */
+	static BufferedImage restart(Color color)
+	{
+		BufferedImage img = blank();
+		Graphics2D g = prepare(img, color);
+		try
+		{
+			g.setStroke(new BasicStroke(1.6f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
+			// Open arc, leaving a gap at the top-right for the arrowhead
+			g.drawArc(3, 3, 10, 10, 60, 270);
+			// Arrowhead at the open end of the arc
+			Path2D.Float head = new Path2D.Float();
+			head.moveTo(8f, 1f);
+			head.lineTo(11.5f, 4f);
+			head.lineTo(8f, 6f);
+			head.closePath();
+			g.fill(head);
+		}
+		finally
+		{
+			g.dispose();
+		}
+		return img;
+	}
+
+	/**
+	 * Sync glyph — two opposing curved arrows in a closed loop, distinct from
+	 * the single-arrow {@link #restart(Color)} glyph. Used for "Sync collection-log
+	 * state".
+	 */
+	static BufferedImage sync(Color color)
+	{
+		BufferedImage img = blank();
+		Graphics2D g = prepare(img, color);
+		try
+		{
+			g.setStroke(new BasicStroke(1.4f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
+			// Two opposing arcs to suggest a bidirectional refresh
+			g.drawArc(3, 3, 10, 10, 20, 150);
+			g.drawArc(3, 3, 10, 10, 200, 150);
+			// Top-right arrowhead pointing down-right
+			Path2D.Float h1 = new Path2D.Float();
+			h1.moveTo(13f, 2.5f);
+			h1.lineTo(13.5f, 6.5f);
+			h1.lineTo(10f, 4.5f);
+			h1.closePath();
+			g.fill(h1);
+			// Bottom-left arrowhead pointing up-left
+			Path2D.Float h2 = new Path2D.Float();
+			h2.moveTo(3f, 13.5f);
+			h2.lineTo(2.5f, 9.5f);
+			h2.lineTo(6f, 11.5f);
+			h2.closePath();
+			g.fill(h2);
+		}
+		finally
+		{
+			g.dispose();
+		}
+		return img;
+	}
+
+	private static BufferedImage blank()
+	{
+		return new BufferedImage(GLYPH_SIZE, GLYPH_SIZE, BufferedImage.TYPE_INT_ARGB);
+	}
+
+	private static Graphics2D prepare(BufferedImage img, Color color)
+	{
+		Graphics2D g = img.createGraphics();
+		g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+		g.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
+		g.setColor(color);
+		return g;
+	}
+}

--- a/src/main/java/com/collectionloghelper/ui/widget/StepProgressView.java
+++ b/src/main/java/com/collectionloghelper/ui/widget/StepProgressView.java
@@ -257,6 +257,10 @@ public class StepProgressView extends JPanel
 			BorderFactory.createLineBorder(STOP_ICON_IDLE_COLOR, 1),
 			BorderFactory.createEmptyBorder(2, 2, 2, 2)
 		));
+		// buildIconButton() disables border painting for the clean icon-only look used
+		// by the other controls. The Stop button needs the red border to render so the
+		// destructive affordance is visually distinct, so re-enable border painting here.
+		stopButton.setBorderPainted(true);
 		stepButtonRow.add(stopButton);
 
 		stepButtonRow.add(Box.createHorizontalStrut(4));

--- a/src/main/java/com/collectionloghelper/ui/widget/StepProgressView.java
+++ b/src/main/java/com/collectionloghelper/ui/widget/StepProgressView.java
@@ -27,9 +27,12 @@ package com.collectionloghelper.ui.widget;
 import com.collectionloghelper.data.GuidanceStep;
 import com.collectionloghelper.guidance.RequiredItemDisplay;
 import java.awt.Color;
+import java.awt.Cursor;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.Graphics2D;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
 import java.util.Collections;
 import java.util.HashMap;
@@ -123,6 +126,7 @@ public class StepProgressView extends JPanel
 	private final JPanel sectionsPanel;
 	private final JButton nextStepButton;
 	private final JButton skipStepButton;
+	private final JButton stopButton;
 	private final JButton resetButton;
 	private final JButton syncButton;
 
@@ -134,6 +138,7 @@ public class StepProgressView extends JPanel
 
 	private Runnable stepAdvancer;
 	private Runnable stepSkipper;
+	private Runnable stepStopper;
 	private Runnable stepResetter;
 	private Runnable stepSyncer;
 
@@ -210,53 +215,141 @@ public class StepProgressView extends JPanel
 
 		stepButtonRow.add(Box.createHorizontalStrut(4));
 
-		skipStepButton = new JButton("Skip");
-		skipStepButton.setFont(FontManager.getRunescapeSmallFont());
-		skipStepButton.setBackground(new Color(80, 80, 80));
-		skipStepButton.setForeground(Color.WHITE);
-		skipStepButton.addActionListener(e ->
-		{
-			if (stepSkipper != null)
+		// Icon-driven controls (#547). The Reset button used to be labelled "Reset",
+		// which during validation read as "stop guidance" when it actually means
+		// "restart this task from step 1". The music-player-style glyphs disambiguate:
+		//   skip-next   → advance/skip (preserves existing Skip semantics)
+		//   stop square → deactivate guidance and clear overlays (NEW)
+		//   restart     → restart the current task from step 1
+		//   sync        → re-evaluate skip-chain against current collection-log state
+		skipStepButton = buildIconButton(
+			StepControlIcons.skipNext(ICON_IDLE_COLOR),
+			StepControlIcons.skipNext(ICON_HOVER_COLOR),
+			"Skip to next step",
+			ICON_BUTTON_BG,
+			e ->
 			{
-				stepSkipper.run();
-			}
-		});
+				if (stepSkipper != null)
+				{
+					stepSkipper.run();
+				}
+			});
 		stepButtonRow.add(skipStepButton);
 
 		stepButtonRow.add(Box.createHorizontalStrut(4));
 
-		resetButton = new JButton("Reset");
-		resetButton.setFont(FontManager.getRunescapeSmallFont());
-		resetButton.setBackground(new Color(70, 50, 50));
-		resetButton.setForeground(new Color(200, 200, 200));
-		resetButton.setToolTipText("Restart from step 1");
-		resetButton.addActionListener(e ->
-		{
-			if (stepResetter != null)
+		// Stop button — visually distinct (red tint) to emphasize that it terminates
+		// guidance and clears all overlays. Resolves the #547 "Reset doesn't stop"
+		// surprise by giving deactivation its own affordance.
+		stopButton = buildIconButton(
+			StepControlIcons.stop(STOP_ICON_IDLE_COLOR),
+			StepControlIcons.stop(STOP_ICON_HOVER_COLOR),
+			"Stop guidance — clear all overlays",
+			STOP_BUTTON_BG,
+			e ->
 			{
-				stepResetter.run();
-			}
-		});
+				if (stepStopper != null)
+				{
+					stepStopper.run();
+				}
+			});
+		stopButton.setBorder(BorderFactory.createCompoundBorder(
+			BorderFactory.createLineBorder(STOP_ICON_IDLE_COLOR, 1),
+			BorderFactory.createEmptyBorder(2, 2, 2, 2)
+		));
+		stepButtonRow.add(stopButton);
+
+		stepButtonRow.add(Box.createHorizontalStrut(4));
+
+		resetButton = buildIconButton(
+			StepControlIcons.restart(ICON_IDLE_COLOR),
+			StepControlIcons.restart(ICON_HOVER_COLOR),
+			"Restart this task from the first step",
+			ICON_BUTTON_BG,
+			e ->
+			{
+				if (stepResetter != null)
+				{
+					stepResetter.run();
+				}
+			});
 		stepButtonRow.add(resetButton);
 
 		stepButtonRow.add(Box.createHorizontalStrut(4));
 
-		syncButton = new JButton("Sync");
-		syncButton.setFont(FontManager.getRunescapeSmallFont());
-		syncButton.setBackground(new Color(50, 60, 80));
-		syncButton.setForeground(new Color(200, 200, 200));
-		syncButton.setToolTipText("Re-evaluate current state");
-		syncButton.addActionListener(e ->
-		{
-			if (stepSyncer != null)
+		syncButton = buildIconButton(
+			StepControlIcons.sync(ICON_IDLE_COLOR),
+			StepControlIcons.sync(ICON_HOVER_COLOR),
+			"Sync collection-log state",
+			ICON_BUTTON_BG,
+			e ->
 			{
-				stepSyncer.run();
-			}
-		});
+				if (stepSyncer != null)
+				{
+					stepSyncer.run();
+				}
+			});
 		stepButtonRow.add(syncButton);
 
 		add(Box.createVerticalStrut(3));
 		add(stepButtonRow);
+	}
+
+	/** Idle-state icon tint for the non-destructive step controls. */
+	private static final Color ICON_IDLE_COLOR = new Color(200, 200, 200);
+	/** Hover-state icon tint for the non-destructive step controls. */
+	private static final Color ICON_HOVER_COLOR = new Color(255, 255, 255);
+	/** Background for the non-destructive step-control buttons. */
+	private static final Color ICON_BUTTON_BG = new Color(45, 55, 75);
+	/** Idle-state icon tint for the stop / deactivate button. */
+	private static final Color STOP_ICON_IDLE_COLOR = new Color(220, 110, 110);
+	/** Hover-state icon tint for the stop / deactivate button. */
+	private static final Color STOP_ICON_HOVER_COLOR = new Color(255, 150, 150);
+	/** Background for the stop / deactivate button. */
+	private static final Color STOP_BUTTON_BG = new Color(70, 40, 40);
+	/** Click-target size for each icon button (≥ 24x24 per the #547 acceptance criteria). */
+	private static final Dimension ICON_BUTTON_SIZE = new Dimension(28, 28);
+
+	/**
+	 * Builds a square icon-only {@link JButton} with hover icon swap, plain Swing
+	 * tooltip, and a 28x28 click target. Used to compose the #547 music-player
+	 * style step-control row.
+	 */
+	private static JButton buildIconButton(BufferedImage idle, BufferedImage hover,
+		String tooltip, Color background, java.awt.event.ActionListener listener)
+	{
+		final ImageIcon idleIcon = new ImageIcon(idle);
+		final ImageIcon hoverIcon = new ImageIcon(hover);
+		JButton button = new JButton(idleIcon);
+		button.setToolTipText(tooltip);
+		button.setBackground(background);
+		button.setForeground(Color.WHITE);
+		button.setFocusPainted(false);
+		button.setContentAreaFilled(true);
+		button.setOpaque(true);
+		button.setBorderPainted(false);
+		button.setMargin(new java.awt.Insets(0, 0, 0, 0));
+		button.setPreferredSize(ICON_BUTTON_SIZE);
+		button.setMinimumSize(ICON_BUTTON_SIZE);
+		button.setMaximumSize(ICON_BUTTON_SIZE);
+		button.setHorizontalAlignment(SwingConstants.CENTER);
+		button.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+		button.addActionListener(listener);
+		button.addMouseListener(new MouseAdapter()
+		{
+			@Override
+			public void mouseEntered(MouseEvent e)
+			{
+				button.setIcon(hoverIcon);
+			}
+
+			@Override
+			public void mouseExited(MouseEvent e)
+			{
+				button.setIcon(idleIcon);
+			}
+		});
+		return button;
 	}
 
 	/**
@@ -282,6 +375,27 @@ public class StepProgressView extends JPanel
 	{
 		this.stepAdvancer = advancer;
 		this.stepSkipper = skipper;
+		this.stepResetter = resetter;
+		this.stepSyncer = syncer;
+	}
+
+	/**
+	 * Sets all five step-control callbacks introduced in #547: advance, skip,
+	 * stop (deactivate guidance), reset, and sync. Any callback may be {@code null}
+	 * (the corresponding button click will be a no-op).
+	 *
+	 * @param advancer  callback for the Next Step button
+	 * @param skipper   callback for the Skip icon button
+	 * @param stopper   callback for the Stop icon button (deactivate guidance, clear overlays)
+	 * @param resetter  callback for the Restart icon button (restart from step 1, no skip-chain)
+	 * @param syncer    callback for the Sync icon button (re-evaluate skip-chain against current state)
+	 */
+	public void setCallbacks(Runnable advancer, Runnable skipper, Runnable stopper,
+		Runnable resetter, Runnable syncer)
+	{
+		this.stepAdvancer = advancer;
+		this.stepSkipper = skipper;
+		this.stepStopper = stopper;
 		this.stepResetter = resetter;
 		this.stepSyncer = syncer;
 	}

--- a/src/test/java/com/collectionloghelper/ui/widget/StepProgressViewTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/StepProgressViewTest.java
@@ -765,56 +765,175 @@ public class StepProgressViewTest
 		return result;
 	}
 
-	// ── Reset / Sync button tests (#369) ────────────────────────────────────
+	// ── Icon-driven step-control button tests (#547) ────────────────────────
+	//
+	// Originally added for #369 to assert the Skip/Reset/Sync text buttons fired
+	// their callbacks. #547 replaced the text buttons with music-player style
+	// icon buttons (skip-next, stop, restart, sync) so these tests now locate
+	// the buttons by tooltip instead of by label text.
 
 	/**
-	 * After construction the Reset and Sync buttons must be present in the
-	 * step-button row (findable via findButtonByText).
+	 * Plain-English tooltip required by the #547 acceptance criteria, one per
+	 * action icon. These strings are the contract — UX validators read them as
+	 * the discoverability story for each control.
+	 */
+	private static final String TOOLTIP_SKIP = "Skip to next step";
+	private static final String TOOLTIP_STOP = "Stop guidance — clear all overlays";
+	private static final String TOOLTIP_RESTART = "Restart this task from the first step";
+	private static final String TOOLTIP_SYNC = "Sync collection-log state";
+
+	/**
+	 * After construction all four icon-driven controls (Skip, Stop, Restart,
+	 * Sync) must be present and resolvable by tooltip.
 	 */
 	@Test
-	public void construction_hasResetAndSyncButtons()
+	public void construction_hasAllFourIconButtons()
 	{
-		assertNotNull("Reset button must exist after construction", findButtonByText(view, "Reset"));
-		assertNotNull("Sync button must exist after construction", findButtonByText(view, "Sync"));
+		assertNotNull("Skip icon button must exist", findButtonByTooltip(view, TOOLTIP_SKIP));
+		assertNotNull("Stop icon button must exist", findButtonByTooltip(view, TOOLTIP_STOP));
+		assertNotNull("Restart icon button must exist", findButtonByTooltip(view, TOOLTIP_RESTART));
+		assertNotNull("Sync icon button must exist", findButtonByTooltip(view, TOOLTIP_SYNC));
 	}
 
 	/**
-	 * The Reset button must invoke the reset callback when clicked.
+	 * Icon buttons must render as icon-only — empty (or null) text so the glyph
+	 * is the sole visual affordance.
 	 */
 	@Test
-	public void resetButton_click_invokesResetCallback() throws Exception
+	public void iconButtons_haveNoText()
 	{
-		AtomicBoolean resetFired = new AtomicBoolean(false);
-		view.setCallbacks(() -> {}, () -> {}, () -> resetFired.set(true), () -> {});
+		for (String tooltip : new String[]{TOOLTIP_SKIP, TOOLTIP_STOP, TOOLTIP_RESTART, TOOLTIP_SYNC})
+		{
+			JButton btn = findButtonByTooltip(view, tooltip);
+			assertNotNull("Icon button for tooltip '" + tooltip + "' must exist", btn);
+			String text = btn.getText();
+			assertTrue("Icon button '" + tooltip + "' must have empty text but had '" + text + "'",
+				text == null || text.isEmpty());
+			assertNotNull("Icon button '" + tooltip + "' must have a graphic icon set",
+				btn.getIcon());
+		}
+	}
+
+	/**
+	 * Each icon button must offer a click target of at least 24x24 to satisfy the
+	 * #547 acceptance criteria.
+	 */
+	@Test
+	public void iconButtons_clickTargetAtLeast24x24()
+	{
+		for (String tooltip : new String[]{TOOLTIP_SKIP, TOOLTIP_STOP, TOOLTIP_RESTART, TOOLTIP_SYNC})
+		{
+			JButton btn = findButtonByTooltip(view, tooltip);
+			assertNotNull(btn);
+			java.awt.Dimension size = btn.getPreferredSize();
+			assertTrue("Icon button '" + tooltip + "' must be ≥24px wide (was " + size.width + ")",
+				size.width >= 24);
+			assertTrue("Icon button '" + tooltip + "' must be ≥24px tall (was " + size.height + ")",
+				size.height >= 24);
+		}
+	}
+
+	/**
+	 * The Skip icon button must invoke the skip callback when clicked.
+	 */
+	@Test
+	public void skipButton_click_invokesSkipCallback() throws Exception
+	{
+		AtomicBoolean fired = new AtomicBoolean(false);
+		view.setCallbacks(() -> {}, () -> fired.set(true), () -> {}, () -> {}, () -> {});
 		flushEdt();
 
-		JButton resetBtn = findButtonByText(view, "Reset");
-		assertNotNull("Reset button must be present", resetBtn);
-		SwingUtilities.invokeAndWait(() -> resetBtn.doClick());
+		JButton btn = findButtonByTooltip(view, TOOLTIP_SKIP);
+		assertNotNull(btn);
+		SwingUtilities.invokeAndWait(btn::doClick);
 
-		assertTrue("Reset callback must fire when Reset button is clicked", resetFired.get());
+		assertTrue("Skip callback must fire when Skip icon clicked", fired.get());
 	}
 
 	/**
-	 * The Sync button must invoke the sync callback when clicked.
+	 * The Stop icon button must invoke the stop callback when clicked.
+	 * This is the new affordance from #547 — replaces the surprise of "Reset
+	 * actually restarts the task" by giving deactivation its own icon.
+	 */
+	@Test
+	public void stopButton_click_invokesStopCallback() throws Exception
+	{
+		AtomicBoolean fired = new AtomicBoolean(false);
+		view.setCallbacks(() -> {}, () -> {}, () -> fired.set(true), () -> {}, () -> {});
+		flushEdt();
+
+		JButton btn = findButtonByTooltip(view, TOOLTIP_STOP);
+		assertNotNull(btn);
+		SwingUtilities.invokeAndWait(btn::doClick);
+
+		assertTrue("Stop callback must fire when Stop icon clicked", fired.get());
+	}
+
+	/**
+	 * The Restart icon button must invoke the reset callback when clicked.
+	 */
+	@Test
+	public void restartButton_click_invokesResetCallback() throws Exception
+	{
+		AtomicBoolean fired = new AtomicBoolean(false);
+		view.setCallbacks(() -> {}, () -> {}, () -> {}, () -> fired.set(true), () -> {});
+		flushEdt();
+
+		JButton btn = findButtonByTooltip(view, TOOLTIP_RESTART);
+		assertNotNull(btn);
+		SwingUtilities.invokeAndWait(btn::doClick);
+
+		assertTrue("Restart callback must fire when Restart icon clicked", fired.get());
+	}
+
+	/**
+	 * The Sync icon button must invoke the sync callback when clicked.
 	 */
 	@Test
 	public void syncButton_click_invokesSyncCallback() throws Exception
 	{
-		AtomicBoolean syncFired = new AtomicBoolean(false);
-		view.setCallbacks(() -> {}, () -> {}, () -> {}, () -> syncFired.set(true));
+		AtomicBoolean fired = new AtomicBoolean(false);
+		view.setCallbacks(() -> {}, () -> {}, () -> {}, () -> {}, () -> fired.set(true));
 		flushEdt();
 
-		JButton syncBtn = findButtonByText(view, "Sync");
-		assertNotNull("Sync button must be present", syncBtn);
-		SwingUtilities.invokeAndWait(() -> syncBtn.doClick());
+		JButton btn = findButtonByTooltip(view, TOOLTIP_SYNC);
+		assertNotNull(btn);
+		SwingUtilities.invokeAndWait(btn::doClick);
 
-		assertTrue("Sync callback must fire when Sync button is clicked", syncFired.get());
+		assertTrue("Sync callback must fire when Sync icon clicked", fired.get());
 	}
 
 	/**
-	 * setCallbacks(advancer, skipper) two-arg overload must remain valid after the
-	 * new four-arg overload is introduced — existing callers are not broken.
+	 * Behavioural compatibility for the legacy 4-arg setCallbacks overload
+	 * (advancer, skipper, resetter, syncer). Clicking restart/sync via the
+	 * icon buttons must still fire the corresponding callbacks after the
+	 * legacy overload is invoked.
+	 */
+	@Test
+	public void legacyFourArgSetCallbacks_stillRoutesRestartAndSync() throws Exception
+	{
+		AtomicBoolean resetFired = new AtomicBoolean(false);
+		AtomicBoolean syncFired = new AtomicBoolean(false);
+		view.setCallbacks(() -> {}, () -> {}, () -> resetFired.set(true), () -> syncFired.set(true));
+		flushEdt();
+
+		JButton restartBtn = findButtonByTooltip(view, TOOLTIP_RESTART);
+		JButton syncBtn = findButtonByTooltip(view, TOOLTIP_SYNC);
+		assertNotNull(restartBtn);
+		assertNotNull(syncBtn);
+		SwingUtilities.invokeAndWait(() ->
+		{
+			restartBtn.doClick();
+			syncBtn.doClick();
+		});
+
+		assertTrue("Legacy 4-arg overload must still route to restart", resetFired.get());
+		assertTrue("Legacy 4-arg overload must still route to sync", syncFired.get());
+	}
+
+	/**
+	 * setCallbacks(advancer, skipper) two-arg overload must remain valid — existing
+	 * callers must not break.
 	 */
 	@Test
 	public void setCallbacks_twoArg_doesNotThrow()
@@ -823,69 +942,88 @@ public class StepProgressViewTest
 	}
 
 	/**
-	 * When setCallbacks is called with null reset/sync callbacks, clicking the buttons
-	 * must not throw a NullPointerException.
+	 * When setCallbacks is called with null stop/reset/sync callbacks, clicking the
+	 * buttons must not throw a NullPointerException.
 	 */
 	@Test
-	public void resetAndSyncButtons_nullCallbacks_doNotThrow() throws Exception
+	public void iconButtons_nullCallbacks_doNotThrow() throws Exception
 	{
-		view.setCallbacks(() -> {}, () -> {}, null, null);
+		view.setCallbacks(() -> {}, () -> {}, null, null, null);
 		flushEdt();
 
-		JButton resetBtn = findButtonByText(view, "Reset");
-		JButton syncBtn = findButtonByText(view, "Sync");
-		assertNotNull(resetBtn);
+		JButton stopBtn = findButtonByTooltip(view, TOOLTIP_STOP);
+		JButton restartBtn = findButtonByTooltip(view, TOOLTIP_RESTART);
+		JButton syncBtn = findButtonByTooltip(view, TOOLTIP_SYNC);
+		assertNotNull(stopBtn);
+		assertNotNull(restartBtn);
 		assertNotNull(syncBtn);
 		SwingUtilities.invokeAndWait(() ->
 		{
-			resetBtn.doClick();
+			stopBtn.doClick();
+			restartBtn.doClick();
 			syncBtn.doClick();
 		});
 	}
 
 	/**
-	 * The Reset button has the tooltip "Restart from step 1".
+	 * Tooltip text contract — the exact plain-English strings the UX checklist
+	 * promises will appear on hover for each control.
 	 */
 	@Test
-	public void resetButton_hasExpectedTooltip()
+	public void iconButtons_haveExpectedTooltips()
 	{
-		JButton resetBtn = findButtonByText(view, "Reset");
-		assertNotNull(resetBtn);
-		assertEquals("Restart from step 1", resetBtn.getToolTipText());
+		assertEquals(TOOLTIP_SKIP, findButtonByTooltip(view, TOOLTIP_SKIP).getToolTipText());
+		assertEquals(TOOLTIP_STOP, findButtonByTooltip(view, TOOLTIP_STOP).getToolTipText());
+		assertEquals(TOOLTIP_RESTART, findButtonByTooltip(view, TOOLTIP_RESTART).getToolTipText());
+		assertEquals(TOOLTIP_SYNC, findButtonByTooltip(view, TOOLTIP_SYNC).getToolTipText());
 	}
 
-	/**
-	 * The Sync button has the tooltip "Re-evaluate current state".
-	 */
-	@Test
-	public void syncButton_hasExpectedTooltip()
-	{
-		JButton syncBtn = findButtonByText(view, "Sync");
-		assertNotNull(syncBtn);
-		assertEquals("Re-evaluate current state", syncBtn.getToolTipText());
-	}
-
-	// ── Helpers (Reset/Sync) ─────────────────────────────────────────────────
+	// ── Helpers (icon button row) ────────────────────────────────────────────
 
 	/**
 	 * Finds the first {@link JButton} anywhere in {@code root}'s component tree
-	 * whose text equals {@code text}. Searches recursively.
+	 * whose tooltip equals {@code tooltip}. Searches recursively. Used for the
+	 * #547 icon-button row where buttons have empty text.
 	 */
-	private static JButton findButtonByText(JPanel root, String text)
+	private static JButton findButtonByTooltip(JPanel root, String tooltip)
 	{
 		for (Component c : root.getComponents())
 		{
 			if (c instanceof JButton)
 			{
 				JButton btn = (JButton) c;
-				if (text.equals(btn.getText()))
+				if (tooltip.equals(btn.getToolTipText()))
 				{
 					return btn;
 				}
 			}
 			else if (c instanceof JPanel)
 			{
-				JButton found = findButtonInPanel((JPanel) c, text);
+				JButton found = findButtonByTooltipInPanel((JPanel) c, tooltip);
+				if (found != null)
+				{
+					return found;
+				}
+			}
+		}
+		return null;
+	}
+
+	private static JButton findButtonByTooltipInPanel(JPanel panel, String tooltip)
+	{
+		for (Component c : panel.getComponents())
+		{
+			if (c instanceof JButton)
+			{
+				JButton btn = (JButton) c;
+				if (tooltip.equals(btn.getToolTipText()))
+				{
+					return btn;
+				}
+			}
+			else if (c instanceof JPanel)
+			{
+				JButton found = findButtonByTooltipInPanel((JPanel) c, tooltip);
 				if (found != null)
 				{
 					return found;

--- a/src/test/java/com/collectionloghelper/ui/widget/StepProgressViewTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/StepProgressViewTest.java
@@ -870,6 +870,35 @@ public class StepProgressViewTest
 	}
 
 	/**
+	 * The Stop icon button must visually render its red border so the destructive
+	 * affordance is distinguishable from the non-destructive controls. The shared
+	 * {@code buildIconButton} helper disables border painting for a clean icon-only
+	 * look on Skip/Restart/Sync; the Stop button must re-enable it after the
+	 * explicit red border is applied, otherwise the border is silently dropped at
+	 * paint time and Stop looks identical to the other icons (#547 regression).
+	 */
+	@Test
+	public void stopButton_paintsRedBorder() throws Exception
+	{
+		JButton stopBtn = findButtonByTooltip(view, TOOLTIP_STOP);
+		assertNotNull("Stop icon button must exist", stopBtn);
+		assertTrue("Stop button must paint its border so the red outline is visible",
+			stopBtn.isBorderPainted());
+		assertNotNull("Stop button must carry an explicit border", stopBtn.getBorder());
+
+		// The other icon buttons must remain borderless for the clean icon-only look.
+		for (String tooltip : new String[]{TOOLTIP_SKIP, TOOLTIP_RESTART, TOOLTIP_SYNC})
+		{
+			JButton btn = findButtonByTooltip(view, tooltip);
+			assertNotNull(btn);
+			assertFalse(
+				"Non-destructive icon button '" + tooltip
+					+ "' must not paint a border (icon-only look)",
+				btn.isBorderPainted());
+		}
+	}
+
+	/**
 	 * The Restart icon button must invoke the reset callback when clicked.
 	 */
 	@Test


### PR DESCRIPTION
## Summary

Replaces the text-labelled `[ Skip ] [ Reset ] [ Sync ]` row in the active guidance panel with a music-player-style icon control row and adds a Stop button so deactivation has its own affordance.

During the 2026-05-19 validation pass users discovered that **Reset** meant "restart this task from step 1" — not "stop guidance" as the label implied. The new icon row both:

1. makes each action more discoverable via familiar media-control metaphors, and
2. splits the surprising overload by giving deactivation its own dedicated Stop button.

Closes #547.

## Controls

Left-to-right, each is a 28x28 icon JButton with a 16x16 glyph, hover colour swap, hand cursor, and plain Swing tooltip:

| Glyph | Action | Tooltip |
| --- | --- | --- |
| `>\|` skip-next | advance to next step | `Skip to next step` |
| `■` stop (red tint + 1px border) | deactivate guidance, clear all overlays | `Stop guidance — clear all overlays` |
| `↻` restart | restart this task from step 1 | `Restart this task from the first step` |
| `⭯` sync | re-evaluate skip-chain against current state | `Sync collection-log state` |

The existing `Next Step` button (visible only on manual steps) is preserved unchanged. **Previous-step navigation is intentionally omitted** — the guidance sequencer has no back-step support, so adding a `<` chevron would require new sequencer behavior beyond the scope of this UX swap.

## Icon source

Icons are drawn programmatically with `Java2D` in `StepControlIcons.java` (new file, ~190 LOC). Two passes per glyph (idle / hover tint) are cached at construction time and swapped via `setIcon` on mouse enter/exit. No PNG assets ship in the jar, so no third-party icon-set license obligations need to ride along with the plugin.

## Behaviour preservation

Each icon button is wired to the exact callback the corresponding text button used:

- Skip → `guidanceSequencer::skipStep`
- Stop → `CollectionLogHelperPlugin::deactivateGuidance` (same entry point used by the Quick Guide header's deactivate affordance)
- Restart → `guidanceSequencer::restartFromStep0`
- Sync → `guidanceSequencer::syncToCurrentState`

A new five-arg `setCallbacks(advancer, skipper, stopper, resetter, syncer)` overload was added on `StepProgressView` and `CollectionLogHelperPanel`. The existing two-arg and four-arg overloads remain valid; a regression test pins that contract.

## Test plan

- [x] `./gradlew compileJava` — clean
- [x] `./gradlew test` — full suite green (StepProgressViewTest expanded from 32 to 41 tests)
- [x] New tests cover: presence of all four icon buttons, empty-text + non-null icon invariant, click-target ≥ 24x24, each callback fires on click, legacy 4-arg overload still routes restart/sync, null-callback no-throw, exact tooltip contract
- [ ] Manual: launch RuneLite, activate guidance, hover each icon, confirm tooltips read correctly and the row reads as a media-control strip
- [ ] Manual: click Stop and confirm overlays clear and guidance deactivates (parity with Quick Guide deactivator)
- [ ] Manual: click Restart and confirm the task restarts from step 1 (no skip-chain)

## Files changed

- `src/main/java/com/collectionloghelper/ui/widget/StepControlIcons.java` *(new)* — Java2D glyph factory
- `src/main/java/com/collectionloghelper/ui/widget/StepProgressView.java` — icon button row + new 5-arg `setCallbacks`
- `src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java` — pass-through 5-arg `setStepCallbacks`
- `src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java` — wire stop callback through `deactivateGuidance`
- `src/test/java/com/collectionloghelper/ui/widget/StepProgressViewTest.java` — tooltip-based lookup, new icon-row tests

LOC delta: +531 / −81 across 5 files.