### PR TITLE
fix(guidance): convert Custodian Stalker travel step to ARRIVE_AT_ZONE (#548)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -9823,8 +9823,8 @@
         "worldX": 1324,
         "worldY": 3364,
         "worldPlane": 0,
-        "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionZone": [1260, 3340, 1370, 9870, 0]
       },
       {
         "description": "Enter the Stalker Den through the cave entrance",

--- a/src/test/java/com/collectionloghelper/data/DropRateDatabaseTest.java
+++ b/src/test/java/com/collectionloghelper/data/DropRateDatabaseTest.java
@@ -608,4 +608,58 @@ public class DropRateDatabaseTest
 			}
 		}
 	}
+
+	/**
+	 * Regression test for #548: the Custodian Stalker source's first guidance step
+	 * (Travel to the Stalker Den entrance) must use ARRIVE_AT_ZONE with a zone that
+	 * covers both the surface entrance area and the underground den interior.
+	 *
+	 * <p>The prior ARRIVE_AT_TILE with a 15-tile radius around (1324, 3364, 0) could
+	 * be bypassed when the player's pathfinding-to-squeeze-through skipped the
+	 * proximity window, leaving step 1/3 stuck and requiring manual Skip. Switching
+	 * to a zone that includes both the surface approach (Y ~3360) and the
+	 * underground den (Y ~9820) on plane 0 guarantees the step auto-advances once
+	 * the player is anywhere meaningful inside the den region.
+	 */
+	@Test
+	public void regression_548_custodianStalker_step1_usesArriveAtZone()
+	{
+		CollectionLogSource custodianStalker = null;
+		for (CollectionLogSource source : database.getAllSources())
+		{
+			if ("Custodian Stalker".equals(source.getName()))
+			{
+				custodianStalker = source;
+				break;
+			}
+		}
+		assertNotNull("Custodian Stalker source must exist in drop_rates.json", custodianStalker);
+
+		List<GuidanceStep> steps = custodianStalker.getGuidanceSteps();
+		assertNotNull("Custodian Stalker must have guidance steps", steps);
+		assertTrue("Custodian Stalker must have at least one guidance step", !steps.isEmpty());
+
+		GuidanceStep travelStep = steps.get(0);
+		assertEquals(
+			"Step 1 must use ARRIVE_AT_ZONE so arrival auto-advances via either surface "
+				+ "or underground (issue #548)",
+			CompletionCondition.ARRIVE_AT_ZONE, travelStep.getCompletionCondition());
+
+		Zone zone = travelStep.getZone();
+		assertNotNull("Step 1 must declare a completionZone for ARRIVE_AT_ZONE", zone);
+		assertEquals("Zone must be on plane 0", 0, zone.getPlane());
+
+		// Zone must contain the documented surface entrance object location.
+		assertTrue("Zone must contain the surface entrance at (1324, 3364, 0)",
+			zone.contains(new net.runelite.api.coords.WorldPoint(1324, 3364, 0)));
+
+		// Zone must also contain the underground den interior so a player who
+		// descends without crossing the surface radius still auto-advances.
+		assertTrue("Zone must contain the underground den interior at (1301, 9820, 0)",
+			zone.contains(new net.runelite.api.coords.WorldPoint(1301, 9820, 0)));
+
+		// Wrong plane must not match.
+		assertFalse("Zone must not match plane 1",
+			zone.contains(new net.runelite.api.coords.WorldPoint(1324, 3364, 1)));
+	}
 }

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
@@ -224,6 +224,40 @@ public class GuidanceSequencerTest
 		);
 	}
 
+	private GuidanceStep makeArriveAtZoneStep(int minX, int minY, int maxX, int maxY, int plane)
+	{
+		return new GuidanceStep(
+			"Walk into zone",
+			null,  // perItemStepDescription
+			0, 0, 0,
+			0, null, null, null,
+			null, null,
+			null,  // perItemRequiredItemIds
+			null,  // recommendedItemIds
+			null,           // perItemRecommendedItemIds
+			CompletionCondition.ARRIVE_AT_ZONE,
+			0, 0, 0, 0,
+			null,  // completionNpcIds
+			null,
+			0, null, null,
+			null, null,
+			null,
+			0, 0,
+			false,
+			0,     // objectMaxDistance
+			null,  // objectFilterTiles
+			null,  // highlightWidgetIds
+			0, 0,  // loopBackToStep, loopCount
+			null,  // skipIfHasAnyItemIds
+			null,  // dynamicItemObjectTiers
+			new int[] {minX, minY, maxX, maxY, plane},  // completionZone
+			null,  // conditionalAlternatives
+			null, // section
+			null, // waypoints
+			null  // dynamicTargetEvaluator
+		);
+	}
+
 	private GuidanceStep makeNpcTalkedToStep(int npcId)
 	{
 		return new GuidanceStep(
@@ -668,6 +702,52 @@ public class GuidanceSequencerTest
 
 		// Within distance on correct plane
 		sequencer.onPlayerMoved(new WorldPoint(3003, 3002, 0));
+		assertEquals(1, sequencer.getCurrentIndex());
+	}
+
+	/**
+	 * Regression test for #548: a travel step that uses ARRIVE_AT_ZONE must auto-advance
+	 * when the player arrives anywhere inside the zone, including both the surface
+	 * approach and the underground destination (same plane, large Y range).
+	 *
+	 * <p>Matches the Custodian Stalker Step 1 shape: zone [1260, 3340, 1370, 9870, 0]
+	 * which spans both the surface entrance at (1324, 3364, 0) and the underground
+	 * Stalker Den interior at (~1301, 9820, 0). Before the fix, this step used a
+	 * 15-tile ARRIVE_AT_TILE radius that the player's pathfinding-to-squeeze-through
+	 * could bypass, leaving the step stuck at 1/3 until manual Skip.
+	 */
+	@Test
+	public void testArriveAtZoneCompletesStepFromSurfaceAndUnderground()
+	{
+		// Zone covers Custodia Pass surface (Y ~3360) + underground den (Y ~9820), plane 0.
+		List<GuidanceStep> surfaceArrival = Arrays.asList(
+			makeArriveAtZoneStep(1260, 3340, 1370, 9870, 0),
+			makeManualStep("Arrived")
+		);
+		startSequence(surfaceArrival);
+		assertEquals(0, sequencer.getCurrentIndex());
+
+		// Outside zone — must not advance.
+		sequencer.onPlayerMoved(new WorldPoint(1200, 3300, 0));
+		assertEquals(0, sequencer.getCurrentIndex());
+
+		// Wrong plane — must not advance even when X/Y are inside.
+		sequencer.onPlayerMoved(new WorldPoint(1324, 3364, 1));
+		assertEquals(0, sequencer.getCurrentIndex());
+
+		// Player arrives at the surface entrance — must advance.
+		sequencer.onPlayerMoved(new WorldPoint(1324, 3364, 0));
+		assertEquals(1, sequencer.getCurrentIndex());
+
+		// Independent run: same zone, player descends and arrives in the underground den.
+		List<GuidanceStep> undergroundArrival = Arrays.asList(
+			makeArriveAtZoneStep(1260, 3340, 1370, 9870, 0),
+			makeManualStep("Arrived")
+		);
+		startSequence(undergroundArrival);
+		assertEquals(0, sequencer.getCurrentIndex());
+
+		sequencer.onPlayerMoved(new WorldPoint(1301, 9820, 0));
 		assertEquals(1, sequencer.getCurrentIndex());
 	}
 


### PR DESCRIPTION
## Summary

Fixes #548. The Custodian Stalker source's Step 1 (Travel to the Stalker Den entrance) used `ARRIVE_AT_TILE` with a 15-tile radius around the surface entrance object at `(1324, 3364, 0)`. That predicate is fragile for travel-then-squeeze-through patterns — clicking the cave object from further away lets the engine pathfind straight into the squeeze-through interaction, potentially skipping the proximity window entirely. Once the player has descended underground to `Y ~9820`, the surface tile is unreachable on `distanceTo2D` and no future tick can satisfy the check, leaving the step stuck at `1/3` until manual Skip.

## Root cause

Single-tile + narrow-radius `ARRIVE_AT_TILE` on a step whose semantic intent is reach the den region, combined with an engine-driven object interaction that teleports the player into an underground region with a Y offset of ~6400 from the entrance tile.

## Fix approach

Convert Step 1 to `ARRIVE_AT_ZONE` with `completionZone: [1260, 3340, 1370, 9870, 0]`. The zone covers:
- the surface approach band around the southern den entrance (`X 1260-1370, Y 3340-3390`)
- the underground den interior on plane 0 (`X 1260-1370, Y 9740-9870`)

Plane 0 spans both surface and underground in OSRS coords; the intermediate Y range `(3391-9739)` is empty for this X band, so no false positives are possible. Whether the player approaches from the south, takes the northern entrance, or descends without crossing the surface radius, arrival auto-advance fires.

`ARRIVE_AT_ZONE` was already wired through `GuidanceStep` → `Zone` → `CompletionChecker.isArriveAtZoneSatisfying` → `GuidanceSequencer.onPlayerMoved`, but had zero production-data users until this fix. The new sequencer test is the first integration-level coverage.

## Tests added

- `GuidanceSequencerTest.testArriveAtZoneCompletesStepFromSurfaceAndUnderground` — stubs an ARRIVE_AT_ZONE step with the same bounds and asserts auto-advance fires for `(1324, 3364, 0)` (surface entrance), `(1301, 9820, 0)` (underground den), and does NOT fire outside the zone or on the wrong plane.
- `DropRateDatabaseTest.regression_548_custodianStalker_step1_usesArriveAtZone` — loads the real `drop_rates.json`, looks up the Custodian Stalker source, and verifies Step 1's condition, zone contents (both surface and underground), and plane.

Full test suite green: `./gradlew test` passes.

## Evidence

Issue body cites:
- `roast/phaseD-step1-no-autoadvance-at-den.png` — Step 1 InfoBox text still showing at the den interior.
- `roast/phaseD-step3-npc-highlights-working.png` — kill step rendering correctly after manual Skip cycles.
- `roast/phaseD-step3-panel.png` — panel state on step 3/3.

The southern entrance object location was cross-verified via `object_lookup(57279)` which returns the single spawn at `(1324, 3364, 0)` — matching the original step coordinates. The bug is therefore not a coord typo; it is a predicate-too-strict problem solved by widening to a zone.

## Test plan

- [x] `./gradlew test` passes locally
- [x] `regression_548_custodianStalker_step1_usesArriveAtZone` asserts the JSON schema matches the fix
- [x] `testArriveAtZoneCompletesStepFromSurfaceAndUnderground` exercises the sequencer end-to-end with the same zone shape
- [ ] In-game validation: start guidance on Alchemist's signet → Custodian Stalker, travel via Fairy ring AIS → Auburnvale, walk to the southern den entrance, confirm step auto-advances to 2/3 before squeezing through; alternatively descend without crossing the surface and confirm step still auto-advances once inside the den.

Closes #548.