### PR TITLE
perf: hoist exportEfficiencyIfEnabled to field for literal zero-alloc tick (#541 follow-up)

### DIFF
--- a/src/main/java/com/collectionloghelper/lifecycle/GameTickOrchestrator.java
+++ b/src/main/java/com/collectionloghelper/lifecycle/GameTickOrchestrator.java
@@ -70,9 +70,12 @@ import net.runelite.api.coords.WorldPoint;
  * {@link BooleanSupplier} ("poll-and-clear") and {@link Runnable} ("set
  * dirty") callbacks, plus a {@link Supplier} for the nullable panel.
  *
- * <p>All callbacks are stored as fields in {@link #setCallbacks}, called
- * exactly once from {@code startUp()}. The tick body therefore invokes
- * pre-allocated lambdas -- no per-tick {@code new} sites. The only
+ * <p>All plugin-owned callbacks are stored as fields in {@link #setCallbacks},
+ * called exactly once from {@code startUp()}. The bound method-ref for
+ * {@code collectionStateChangeHandler::exportEfficiencyIfEnabled} is hoisted
+ * to a final field in the constructor for the same reason. The tick body
+ * therefore invokes pre-allocated lambdas/method-refs -- no per-tick
+ * {@code new} sites and no inline {@code ::} expressions. The only
  * non-primitive return values produced inside the hot path are:
  * <ul>
  *   <li>{@link SyncStateCoordinator.SyncTickResult} -- an enum, singleton.</li>
@@ -104,6 +107,11 @@ public class GameTickOrchestrator
 	private final PlayerLocationResolver playerLocationResolver;
 	private final AuthoringLogger authoringLogger;
 	private final CollectionStateChangeHandler collectionStateChangeHandler;
+
+	// Method-ref hoisted to a field so the tick body never allocates this
+	// bound reference per call. Wired once in the constructor since
+	// collectionStateChangeHandler is available at injection time.
+	private final Runnable exportEfficiencyCallback;
 
 	// All callbacks are wired once in startUp() and stored as fields so the
 	// tick body never allocates lambdas per call.
@@ -138,6 +146,7 @@ public class GameTickOrchestrator
 		this.playerLocationResolver = playerLocationResolver;
 		this.authoringLogger = authoringLogger;
 		this.collectionStateChangeHandler = collectionStateChangeHandler;
+		this.exportEfficiencyCallback = collectionStateChangeHandler::exportEfficiencyIfEnabled;
 	}
 
 	/**
@@ -255,7 +264,7 @@ public class GameTickOrchestrator
 			sync.getSyncStateCoordinator().tickSync(
 				panel,
 				markPanelRebuildAndRankedDirty,
-				collectionStateChangeHandler::exportEfficiencyIfEnabled);
+				exportEfficiencyCallback);
 		if (syncResult == SyncStateCoordinator.SyncTickResult.RANKED_DIRTY)
 		{
 			markRankedDirty.run();

--- a/src/test/java/com/collectionloghelper/lifecycle/GameTickOrchestratorTest.java
+++ b/src/test/java/com/collectionloghelper/lifecycle/GameTickOrchestratorTest.java
@@ -31,6 +31,10 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
@@ -478,5 +482,44 @@ public class GameTickOrchestratorTest
 		verify(guidanceCoordinator, times(1)).tick();
 		verify(syncStateCoordinator, times(1))
 			.tickSync(eq(panel), any(), any());
+	}
+
+	// ── exportEfficiency callback hoisted to a field (#541 follow-up) ────────
+
+	/**
+	 * The {@code exportEfficiencyIfEnabled} method-ref used to be created
+	 * inline per-tick in the call to {@code tickSync(...)}. It is now hoisted
+	 * to a final field initialized once in the constructor. This test asserts
+	 * the field is wired, is the same instance across ticks (i.e. not
+	 * reallocated per tick), and that invoking it dispatches to the underlying
+	 * handler.
+	 */
+	@Test
+	public void exportEfficiencyCallback_isHoistedAndInvokesHandler()
+	{
+		stubQuietSyncTick();
+		when(pluginDataManager.getCharacterDir()).thenReturn(new File("."));
+
+		ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+
+		// Tick twice and capture the export callback both times.
+		orchestrator.tick();
+		orchestrator.tick();
+
+		verify(syncStateCoordinator, times(2))
+			.tickSync(any(), any(), captor.capture());
+
+		List<Runnable> captured = captor.getAllValues();
+		assertNotNull("export callback must be non-null on first tick", captured.get(0));
+		assertNotNull("export callback must be non-null on second tick", captured.get(1));
+		assertSame(
+			"export callback must be the same hoisted instance across ticks "
+				+ "(not reallocated per tick)",
+			captured.get(0), captured.get(1));
+
+		// Invoking the captured callback must dispatch to the underlying
+		// handler exactly as the inline method-ref did before the hoist.
+		captured.get(0).run();
+		verify(collectionStateChangeHandler).exportEfficiencyIfEnabled();
 	}
 }


### PR DESCRIPTION
## Summary

Polish follow-up to PR #541 (`GameTickOrchestrator` extraction). The reviewer note on #541 flagged one remaining per-tick method-ref creation site:

> The only per-tick method-ref creation site inside the tick body is `collectionStateChangeHandler::exportEfficiencyIfEnabled` passed to `tickSync(...)` at orchestrator line 523 ... If you ever want a literally zero-allocation tick, field-store that one in `setCallbacks`.

This PR does exactly that. The bound method-ref is now a `private final Runnable exportEfficiencyCallback` initialized once in the constructor (since `collectionStateChangeHandler` is available at injection time, no need to defer to `setCallbacks`). The `tick()` body now contains zero `::` expressions and zero `->` lambdas.

## Changes

- `GameTickOrchestrator.java` — add `private final Runnable exportEfficiencyCallback` field, initialize in constructor, pass field to `tickSync(...)` instead of inline method-ref. Javadoc updated to reflect the hoist.
- `GameTickOrchestratorTest.java` — new test `exportEfficiencyCallback_isHoistedAndInvokesHandler` that ticks twice, captures the `Runnable` passed to `tickSync` on each tick, asserts both captures are the **same instance** (proves the field is initialized once, not re-allocated per tick), and asserts that running the captured callback dispatches to `collectionStateChangeHandler.exportEfficiencyIfEnabled()`.

## LOC delta

- `GameTickOrchestrator.java`: +13 / -4
- `GameTickOrchestratorTest.java`: +43 / -0
- Total: +56 / -4 across 2 files

## Test plan

- [x] `./gradlew test --tests GameTickOrchestratorTest` — all tests green (16 tests)
- [x] `./gradlew compileJava compileTestJava` — clean
- [x] Re-read `tick()` body end-to-end: zero `::` expressions, zero `->` lambdas inside the method body
- [x] Behavior parity: existing tests (`requirementsChanged_*`, `syncTickReturnsRankedDirty_*`, `noOpTick_*`, etc.) continue to pass unchanged — the export callback is wired into `tickSync` identically to the previous inline method-ref