### PR TITLE
test: skip captureRecordsScrollPositionFromEnclosingScrollPane on headless (#517/#536/#551 follow-up)

### DIFF
--- a/src/test/java/com/collectionloghelper/ui/PanelRebuildOrchestratorTest.java
+++ b/src/test/java/com/collectionloghelper/ui/PanelRebuildOrchestratorTest.java
@@ -31,6 +31,7 @@ import com.collectionloghelper.data.RequirementsChecker;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.EventQueue;
+import java.awt.GraphicsEnvironment;
 import java.util.Collections;
 import java.util.Set;
 import javax.swing.BoxLayout;
@@ -42,6 +43,7 @@ import javax.swing.JScrollPane;
 import javax.swing.SwingUtilities;
 import net.runelite.client.game.ItemManager;
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
@@ -288,9 +290,36 @@ public class PanelRebuildOrchestratorTest
 		assertTrue(snapshot.getExpandedCategories().isEmpty());
 	}
 
+	/**
+	 * Skipped on headless environments (e.g. headless-Linux CI on JDK 17). The
+	 * test relies on {@link JScrollBar#setValue(int)} preserving the written
+	 * value across a subsequent synchronous read, but a synchronous Swing
+	 * layout pass that runs between {@code setValue} and {@code capture()} can
+	 * re-clamp the bounded range model on headless platforms. Three prior
+	 * hardening attempts have failed to stabilise this on headless CI:
+	 * <ul>
+	 *   <li>#517 - class-wide pinScrollBounds() helper using setValues(...)</li>
+	 *   <li>#536 - PinnedRangeModel rejecting range-narrowing setters</li>
+	 *   <li>#551 - pre-attach pin in setUp + EDT drain + deterministic order</li>
+	 * </ul>
+	 * The Swing behaviour itself is what this test wants to verify, but
+	 * headless-Linux does not reproduce non-headless Swing semantics reliably
+	 * enough to gate CI on. The same code path is still exercised end-to-end
+	 * on non-headless developer machines (Windows, macOS) and indirectly by
+	 * {@code deferScrollRestoreSchedulesValueOnVerticalScrollBar}, which
+	 * flushes the EDT before asserting and is therefore not subject to the
+	 * same race.
+	 */
 	@Test
 	public void captureRecordsScrollPositionFromEnclosingScrollPane()
 	{
+		Assume.assumeFalse(
+			"Headless environments (notably headless-Linux JDK 17 CI) do not "
+				+ "preserve JScrollBar.setValue across synchronous layout "
+				+ "passes reliably; see PRs #517, #536, #551 for prior "
+				+ "hardening attempts.",
+			GraphicsEnvironment.isHeadless());
+
 		pinScrollBounds(vBar());
 		vBar().setValue(250);
 


### PR DESCRIPTION
## Summary

Fourth attempt at stabilising `PanelRebuildOrchestratorTest > captureRecordsScrollPositionFromEnclosingScrollPane` on headless-Linux JDK 17 CI. Three prior hardening attempts failed to keep this test reliable:

- **#517** - class-wide `pinScrollBounds()` helper using `bar.setValues(...)`. Worked in-class, recurred across test methods.
- **#536** - introduced `PinnedRangeModel` rejecting range-narrowing setters. Worked in-class, recurred in full-suite cross-test runs.
- **#551** - pre-attached the pin in `setUp`, drained the EDT in `@After`, and pinned method order via `@FixMethodOrder(NAME_ASCENDING)`. Passed locally and on the PR's own CI, then re-flaked on docs-only PR #556's JDK 17 CI run.

The underlying behaviour the test wants to verify - `JScrollBar.setValue` surviving an immediate synchronous read - is not reproduced reliably on headless platforms. A synchronous Swing layout pass between `setValue` and `capture()` can re-clamp the bounded range model, and we have not found a path to suppress that fully on headless-Linux without contorting the test surface further.

## Why this is more durable than #517/#536/#551

This PR stops fighting the platform and acknowledges the constraint directly: `Assume.assumeFalse(GraphicsEnvironment.isHeadless())`. On non-headless machines (Windows, macOS, non-headless Linux) the assertion still runs unchanged, so the meaningful coverage of `PanelRebuildOrchestrator.capture()` reading the scrollbar value is preserved. Only the CI environment that cannot reproduce the Swing semantic skips it.

The remaining tests in the class - notably `deferScrollRestoreSchedulesValueOnVerticalScrollBar` - flush the EDT via `invokeAndWait` before asserting and are not subject to the same race, so they continue to run unconditionally on every platform. The whole `PinnedRangeModel` / `pinScrollBounds()` machinery introduced by #536 and #551 stays in place to support those tests; only the one chronically flaky method is gated.

## Why Option 1 (skip) over Option 4 (Ignore)

`@Ignore` would drop the assertion on every platform, including the developer machines where it has always passed. `Assume.assumeFalse` lets the test keep providing value where it works while removing the CI flake source. Per the existing module comments and prior PR retrospectives, the flake has only ever reproduced on headless-Linux; Windows + macOS runs of the same test have been green continuously, including in this PR's local verification (5/5 reruns of `./gradlew test --rerun-tasks --tests com.collectionloghelper.ui.PanelRebuildOrchestratorTest`).

## Test plan

- [x] `./gradlew build` passes locally
- [x] `./gradlew test --rerun-tasks --tests com.collectionloghelper.ui.PanelRebuildOrchestratorTest` 5x consecutive passes locally on Windows
- [ ] CI confirms green on headless-Linux JDK 17 (the test reports as skipped, not failed)
- [ ] No other test in `PanelRebuildOrchestratorTest` regresses

## Future investigation (optional)

If we ever want full-platform coverage of this code path, the durable route is probably either (a) move this test to a non-headless integration target (`./gradlew swingTests` with `-Djava.awt.headless=false`), or (b) reflect on the snapshot construction to verify `capture()` reads from `bar.getValue()` directly rather than asserting through observed Swing state. Both are larger changes than this PR warrants given the test's narrow scope.