### PR TITLE
fix(guidance): migrate 23 travel-then-descend sources to ARRIVE_AT_ZONE (closes #555)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -1116,8 +1116,8 @@
         "worldX": 1311,
         "worldY": 3807,
         "worldPlane": 0,
-        "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15,
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionZone": [1300, 3795, 1380, 10280, 0],
         "section": "Travel"
       },
       {
@@ -1329,8 +1329,8 @@
         "worldX": 3227,
         "worldY": 3108,
         "worldPlane": 0,
-        "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15,
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionZone": [3215, 3095, 3520, 9520, 0],
         "travelTip": "Fairy ring BIQ, or desert amulet to Kalphite Cave (with Hard Desert Diary)"
       },
       {
@@ -3163,8 +3163,8 @@
         "worldPlane": 0,
         "objectId": 34862,
         "objectInteractAction": "Climb-down",
-        "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 8
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionZone": [1690, 3560, 1860, 9920, 0]
       },
       {
         "description": "Enter Forthos Dungeon and navigate to the spider area in the south. Enter Sarachnis' lair",
@@ -3665,8 +3665,8 @@
         "worldX": 2278,
         "worldY": 3611,
         "worldPlane": 0,
-        "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15,
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionZone": [2260, 3600, 2290, 10030, 0],
         "travelTip": "Fairy ring AKQ then run west to Kraken Cove"
       },
       {
@@ -3754,8 +3754,8 @@
         "worldX": 2412,
         "worldY": 3061,
         "worldPlane": 0,
-        "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15,
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionZone": [2370, 3050, 2420, 9460, 0],
         "travelTip": "Fairy ring BKP, or ring of dueling to Castle Wars + run south-west"
       },
       {
@@ -3951,8 +3951,8 @@
         "worldX": 3028,
         "worldY": 3842,
         "worldPlane": 0,
-        "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20,
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionZone": [3015, 3830, 3080, 10265, 0],
         "travelTip": "Burning amulet to Lava Maze (level 41 Wilderness)"
       },
       {
@@ -4098,8 +4098,8 @@
         "worldX": 3231,
         "worldY": 3936,
         "worldPlane": 0,
-        "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionZone": [3215, 3920, 3250, 10355, 0]
       },
       {
         "description": "Enter the Cavern to access Scorpia's underground lair",
@@ -7652,8 +7652,8 @@
         "worldX": 1435,
         "worldY": 3131,
         "worldPlane": 0,
-        "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 100
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionZone": [1420, 3115, 1450, 9720, 0]
       },
       {
         "description": "Enter Cam Torum and make your way north through the city to the Neypotzli dungeon entrance",
@@ -8155,8 +8155,8 @@
         "worldX": 2797,
         "worldY": 3614,
         "worldPlane": 0,
-        "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionZone": [2690, 3600, 2810, 10050, 0]
       },
       {
         "description": "Enter the Fremennik Slayer Dungeon (fairy ring AJR) or Lumbridge Swamp caves",
@@ -8214,8 +8214,8 @@
         "worldX": 2797,
         "worldY": 3614,
         "worldPlane": 0,
-        "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionZone": [2690, 3600, 2810, 10050, 0]
       },
       {
         "description": "Enter the Fremennik Slayer Dungeon (fairy ring AJR). Bring a bag of salt to finish them",
@@ -8287,8 +8287,8 @@
         "worldX": 2797,
         "worldY": 3614,
         "worldPlane": 0,
-        "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionZone": [2690, 3600, 2810, 10050, 0]
       },
       {
         "description": "Enter the Fremennik Slayer Dungeon (fairy ring AJR). Mirror shield required",
@@ -8346,8 +8346,8 @@
         "worldX": 2797,
         "worldY": 3614,
         "worldPlane": 0,
-        "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionZone": [2690, 3600, 2810, 10050, 0]
       },
       {
         "description": "Enter the Fremennik Slayer Dungeon (fairy ring AJR) or use Catacombs of Kourend",
@@ -8462,8 +8462,8 @@
         "worldX": 2797,
         "worldY": 3614,
         "worldPlane": 0,
-        "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionZone": [2690, 3600, 2810, 10050, 0]
       },
       {
         "description": "Enter the Fremennik Slayer Dungeon (fairy ring AJR). Mirror shield required",
@@ -8977,8 +8977,8 @@
         "worldX": 2797,
         "worldY": 3614,
         "worldPlane": 0,
-        "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionZone": [2690, 3600, 2810, 10050, 0]
       },
       {
         "description": "Enter the Fremennik Slayer Dungeon (fairy ring AJR) or Catacombs of Kourend for burst tasks",
@@ -9043,8 +9043,8 @@
         "worldX": 2797,
         "worldY": 3614,
         "worldPlane": 0,
-        "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionZone": [2690, 3600, 2810, 10050, 0]
       },
       {
         "description": "Enter the Fremennik Slayer Dungeon (fairy ring AJR). Leaf-bladed weapons required",
@@ -9357,8 +9357,8 @@
         "worldX": 1311,
         "worldY": 3807,
         "worldPlane": 0,
-        "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionZone": [1300, 3795, 1330, 10220, 0]
       },
       {
         "description": "Take the elevator down into the Karuulm Slayer Dungeon.",
@@ -9537,8 +9537,8 @@
         "worldX": 3745,
         "worldY": 3777,
         "worldPlane": 0,
-        "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionZone": [3590, 3765, 3760, 10305, 0]
       },
       {
         "description": "Enter the Wyvern Cave. Elemental/mind/dragonfire shield required",
@@ -9617,8 +9617,8 @@
         "worldX": 2797,
         "worldY": 3614,
         "worldPlane": 0,
-        "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionZone": [2690, 3600, 2810, 10050, 0]
       },
       {
         "description": "Enter the Fremennik Slayer Dungeon (fairy ring AJR). Leaf-bladed weapons required",
@@ -9886,8 +9886,8 @@
         "worldX": 2218,
         "worldY": 3477,
         "worldPlane": 0,
-        "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionZone": [2210, 3465, 2290, 9895, 0]
       },
       {
         "description": "Kill Aquanites in Ynysdail Cavern (requires 73 Sailing). Use crush weapons for best accuracy",
@@ -10137,8 +10137,8 @@
         "worldX": 1311,
         "worldY": 3807,
         "worldPlane": 0,
-        "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionZone": [1300, 3795, 1330, 10075, 0]
       },
       {
         "description": "Take the elevator down into the Karuulm Slayer Dungeon.",
@@ -10520,8 +10520,8 @@
         "worldX": 1311,
         "worldY": 3807,
         "worldPlane": 0,
-        "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionZone": [1300, 3795, 1330, 10205, 0]
       },
       {
         "description": "Take the elevator down into the Karuulm Slayer Dungeon.",
@@ -11425,8 +11425,8 @@
         "worldX": 3360,
         "worldY": 3151,
         "worldPlane": 0,
-        "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionZone": [3345, 3140, 3380, 11500, 0]
       },
       {
         "description": "Talk to Kovac to select a commission. Bring metal bars (mithril+ recommended) from the bank",
@@ -16877,8 +16877,8 @@
         "worldX": 1636,
         "worldY": 3673,
         "worldPlane": 0,
-        "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionZone": [1620, 3660, 1690, 10070, 0]
       },
       {
         "description": "Investigate the Statue of King Rada I to enter the Catacombs.",

--- a/src/test/java/com/collectionloghelper/data/DropRateDatabaseTest.java
+++ b/src/test/java/com/collectionloghelper/data/DropRateDatabaseTest.java
@@ -27,8 +27,10 @@ package com.collectionloghelper.data;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import java.lang.reflect.Field;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import net.runelite.api.coords.WorldPoint;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -661,5 +663,98 @@ public class DropRateDatabaseTest
 		// Wrong plane must not match.
 		assertFalse("Zone must not match plane 1",
 			zone.contains(new net.runelite.api.coords.WorldPoint(1324, 3364, 1)));
+	}
+
+	/**
+	 * Regression test for #555: the 23 sources migrated from ARRIVE_AT_TILE to
+	 * ARRIVE_AT_ZONE in the batch follow-up to #553 must all have a step 0 that:
+	 *   1. Uses ARRIVE_AT_ZONE (not ARRIVE_AT_TILE).
+	 *   2. Declares a zone on plane 0 covering both a representative surface coord
+	 *      AND a representative underground coord for that source.
+	 *   3. Rejects plane 1+ (so the auto-advance doesn't fire on the floor above).
+	 *
+	 * <p>Modelled on the #548 Custodian Stalker regression test above. Each case
+	 * carries the source name, expected zone array, one surface coord that must be
+	 * inside the zone, and one underground coord that must also be inside. Coords
+	 * are sourced from the issue #555 audit table.
+	 */
+	@Test
+	public void regression_555_batchMigratedSources_useArriveAtZone()
+	{
+		Object[][] cases = new Object[][]
+		{
+			// { name, expectedZone, surfaceCoord, undergroundCoord }
+			{"Sarachnis",                  new int[]{1690, 3560, 1860, 9920, 0},  new WorldPoint(1701, 3574, 0),  new WorldPoint(1847, 9910, 0)},
+			{"Kraken",                     new int[]{2260, 3600, 2290, 10030, 0}, new WorldPoint(2278, 3611, 0),  new WorldPoint(2272, 10016, 0)},
+			{"Thermonuclear smoke devil",  new int[]{2370, 3050, 2420, 9460, 0},  new WorldPoint(2412, 3061, 0),  new WorldPoint(2379, 9452, 0)},
+			{"Alchemical Hydra",           new int[]{1300, 3795, 1380, 10280, 0}, new WorldPoint(1311, 3807, 0),  new WorldPoint(1364, 10265, 0)},
+			{"Wyrm",                       new int[]{1300, 3795, 1330, 10220, 0}, new WorldPoint(1311, 3807, 0),  new WorldPoint(1311, 10205, 0)},
+			{"Drake",                      new int[]{1300, 3795, 1330, 10075, 0}, new WorldPoint(1311, 3807, 0),  new WorldPoint(1310, 10057, 0)},
+			{"Hydra",                      new int[]{1300, 3795, 1330, 10205, 0}, new WorldPoint(1311, 3807, 0),  new WorldPoint(1310, 10190, 0)},
+			{"Cave Crawler",               new int[]{2690, 3600, 2810, 10050, 0}, new WorldPoint(2797, 3614, 0),  new WorldPoint(2788, 10000, 0)},
+			{"Rockslug",                   new int[]{2690, 3600, 2810, 10050, 0}, new WorldPoint(2797, 3614, 0),  new WorldPoint(2794, 10018, 0)},
+			{"Cockatrice",                 new int[]{2690, 3600, 2810, 10050, 0}, new WorldPoint(2797, 3614, 0),  new WorldPoint(2792, 10035, 0)},
+			{"Pyrefiend",                  new int[]{2690, 3600, 2810, 10050, 0}, new WorldPoint(2797, 3614, 0),  new WorldPoint(2761, 10008, 0)},
+			{"Basilisk",                   new int[]{2690, 3600, 2810, 10050, 0}, new WorldPoint(2797, 3614, 0),  new WorldPoint(2744, 10008, 0)},
+			{"Jelly",                      new int[]{2690, 3600, 2810, 10050, 0}, new WorldPoint(2797, 3614, 0),  new WorldPoint(2704, 10028, 0)},
+			{"Turoth",                     new int[]{2690, 3600, 2810, 10050, 0}, new WorldPoint(2797, 3614, 0),  new WorldPoint(2722, 10002, 0)},
+			{"Kurask",                     new int[]{2690, 3600, 2810, 10050, 0}, new WorldPoint(2797, 3614, 0),  new WorldPoint(2701, 9992, 0)},
+			{"Aquanite",                   new int[]{2210, 3465, 2290, 9895, 0},  new WorldPoint(2218, 3477, 0),  new WorldPoint(2275, 9880, 0)},
+			{"Fossil Island Wyvern",       new int[]{3590, 3765, 3760, 10305, 0}, new WorldPoint(3745, 3777, 0),  new WorldPoint(3602, 10290, 0)},
+			{"Catacombs of Kourend",       new int[]{1620, 3660, 1690, 10070, 0}, new WorldPoint(1636, 3673, 0),  new WorldPoint(1664, 10050, 0)},
+			{"Kalphite Queen",             new int[]{3215, 3095, 3520, 9520, 0},  new WorldPoint(3227, 3108, 0),  new WorldPoint(3471, 9506, 0)},
+			{"Scorpia",                    new int[]{3215, 3920, 3250, 10355, 0}, new WorldPoint(3231, 3936, 0),  new WorldPoint(3233, 10341, 0)},
+			{"Perilous Moons",             new int[]{1420, 3115, 1450, 9720, 0},  new WorldPoint(1435, 3131, 0),  new WorldPoint(1435, 9700, 0)},
+			{"Giants' Foundry",            new int[]{3345, 3140, 3380, 11500, 0}, new WorldPoint(3360, 3151, 0),  new WorldPoint(3365, 11489, 0)},
+			{"King Black Dragon",          new int[]{3015, 3830, 3080, 10265, 0}, new WorldPoint(3028, 3842, 0),  new WorldPoint(3067, 10253, 0)},
+		};
+
+		for (Object[] tc : cases)
+		{
+			String name = (String) tc[0];
+			int[] expectedZone = (int[]) tc[1];
+			WorldPoint surface = (WorldPoint) tc[2];
+			WorldPoint underground = (WorldPoint) tc[3];
+
+			CollectionLogSource source = null;
+			for (CollectionLogSource s : database.getAllSources())
+			{
+				if (name.equals(s.getName()))
+				{
+					source = s;
+					break;
+				}
+			}
+			assertNotNull("Source must exist in drop_rates.json: " + name, source);
+
+			List<GuidanceStep> steps = source.getGuidanceSteps();
+			assertNotNull("Source must have guidance steps: " + name, steps);
+			assertTrue("Source must have at least one guidance step: " + name, !steps.isEmpty());
+
+			GuidanceStep travelStep = steps.get(0);
+			assertEquals(
+				"Step 0 must use ARRIVE_AT_ZONE (issue #555): " + name,
+				CompletionCondition.ARRIVE_AT_ZONE, travelStep.getCompletionCondition());
+
+			Zone zone = travelStep.getZone();
+			assertNotNull("Step 0 must declare a completionZone: " + name, zone);
+			assertEquals("Zone must be on plane 0: " + name, 0, zone.getPlane());
+
+			// Surface entrance must be inside the zone (auto-advance must fire on arrival
+			// at the surface entrance, matching the prior ARRIVE_AT_TILE behaviour).
+			assertTrue("Zone must contain surface coord " + surface + " for " + name,
+				zone.contains(surface));
+
+			// Underground destination must also be inside the zone (auto-advance must fire
+			// even when the player descends without crossing the surface radius).
+			assertTrue("Zone must contain underground coord " + underground + " for " + name,
+				zone.contains(underground));
+
+			// Plane 1+ must never match — prevents false-positives on the floor above.
+			assertFalse("Zone must not match plane 1 at surface for " + name,
+				zone.contains(new WorldPoint(surface.getX(), surface.getY(), 1)));
+			assertFalse("Zone must not match plane 2 at surface for " + name,
+				zone.contains(new WorldPoint(surface.getX(), surface.getY(), 2)));
+		}
 	}
 }

--- a/src/test/java/com/collectionloghelper/data/SailingSourceTriageTest.java
+++ b/src/test/java/com/collectionloghelper/data/SailingSourceTriageTest.java
@@ -234,7 +234,13 @@ public class SailingSourceTriageTest
 	 * a static overworld island north of Gwenith, reachable by rowboat or Sailing ship.
 	 * The underground cave coords (2275, 9880) = 3480 + 6400 are geographically plausible,
 	 * but the surface entrance step at (2218, 3477) cannot be verified against the static
-	 * NPC cache. Requires in-game capture to confirm ARRIVE_AT_TILE fires correctly.
+	 * NPC cache.
+	 *
+	 * <p>As of #555, the travel step uses ARRIVE_AT_ZONE covering both the surface
+	 * entrance band and the underground cavern interior on plane 0, so the
+	 * auto-advance no longer depends on satisfying the surface radius first.
+	 * In-game capture is still desirable to confirm the surface entrance coord, but
+	 * the predicate shape is now resilient either way.
 	 *
 	 * Wiki: https://oldschool.runescape.wiki/w/Aquanite
 	 */
@@ -249,10 +255,10 @@ public class SailingSourceTriageTest
 		assertNotNull("Aquanite guidance steps must not be null", steps);
 		assertEquals("Aquanite must have exactly 2 guidance steps", 2, steps.size());
 
-		// Step 0: ARRIVE_AT_TILE for the surface entrance area
+		// Step 0: ARRIVE_AT_ZONE covering surface entrance + underground cavern (#555).
 		GuidanceStep entranceStep = steps.get(0);
-		assertEquals("Aquanite step 0 must be ARRIVE_AT_TILE",
-			CompletionCondition.ARRIVE_AT_TILE, entranceStep.getCompletionCondition());
+		assertEquals("Aquanite step 0 must be ARRIVE_AT_ZONE after #555 batch migration",
+			CompletionCondition.ARRIVE_AT_ZONE, entranceStep.getCompletionCondition());
 		// Entrance near Tirannwn/Gwenith coast (unverified placeholder).
 		// TODO(#314): verify via in-game authoring log that this fires on Ynysdail surface.
 		assertEquals("Aquanite entrance step worldX placeholder", 2218, entranceStep.getWorldX());

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
@@ -751,6 +751,74 @@ public class GuidanceSequencerTest
 		assertEquals(1, sequencer.getCurrentIndex());
 	}
 
+	/**
+	 * Regression test for #555: the batch ARRIVE_AT_ZONE migration applied to 23
+	 * travel-then-descend sources must produce zones that auto-advance the step
+	 * when the player arrives at the underground destination, not just the surface
+	 * entrance.
+	 *
+	 * <p>Loops over a representative subset of the migrated zones from
+	 * drop_rates.json and asserts that:
+	 *   - Starting outside the zone keeps the sequencer on step 0.
+	 *   - Arriving at the underground coord (the case the old ARRIVE_AT_TILE
+	 *     predicate could not satisfy) advances to step 1.
+	 *   - Plane 1 inside the X/Y rectangle does not advance.
+	 *
+	 * <p>The subset covers each distinct zone shape (single-source, multi-source
+	 * Karuulm cluster, shared Fremennik Slayer Dungeon zone, multi-region
+	 * wilderness, and the wide Kalphite Queen chamber span).
+	 */
+	@Test
+	public void testArriveAtZoneCompletesStepFromUnderground_batchMigratedZones()
+	{
+		// { minX, minY, maxX, maxY, plane, surfaceX, surfaceY, undergroundX, undergroundY, label }
+		Object[][] cases = new Object[][]
+		{
+			{1690, 3560, 1860, 9920, 0,  1701, 3574,  1847, 9910,  "Sarachnis (Forthos Dungeon)"},
+			{2260, 3600, 2290, 10030, 0, 2278, 3611,  2272, 10016, "Kraken Cove"},
+			{1300, 3795, 1380, 10280, 0, 1311, 3807,  1364, 10265, "Alchemical Hydra (Karuulm)"},
+			{2690, 3600, 2810, 10050, 0, 2797, 3614,  2701, 9992,  "Fremennik Slayer Dungeon shared"},
+			{3590, 3765, 3760, 10305, 0, 3745, 3777,  3602, 10290, "Fossil Island Wyvern Cave"},
+			{3215, 3095, 3520, 9520, 0,  3227, 3108,  3471, 9506,  "Kalphite Queen chamber (wide X)"},
+			{3215, 3920, 3250, 10355, 0, 3231, 3936,  3233, 10341, "Scorpia lair (Wilderness)"},
+		};
+
+		for (Object[] tc : cases)
+		{
+			int minX = (int) tc[0];
+			int minY = (int) tc[1];
+			int maxX = (int) tc[2];
+			int maxY = (int) tc[3];
+			int plane = (int) tc[4];
+			int sx = (int) tc[5];
+			int sy = (int) tc[6];
+			int ux = (int) tc[7];
+			int uy = (int) tc[8];
+			String label = (String) tc[9];
+
+			// Fresh sequence per case so onPlayerMoved state isn't carried over.
+			List<GuidanceStep> steps = Arrays.asList(
+				makeArriveAtZoneStep(minX, minY, maxX, maxY, plane),
+				makeManualStep("Arrived")
+			);
+			startSequence(steps);
+			assertEquals("initial index for " + label, 0, sequencer.getCurrentIndex());
+
+			// Far outside the zone — must not advance.
+			sequencer.onPlayerMoved(new WorldPoint(minX - 100, minY - 100, plane));
+			assertEquals("outside zone must not advance: " + label, 0, sequencer.getCurrentIndex());
+
+			// Wrong plane at the surface entrance — must not advance.
+			sequencer.onPlayerMoved(new WorldPoint(sx, sy, 1));
+			assertEquals("plane 1 must not advance: " + label, 0, sequencer.getCurrentIndex());
+
+			// Underground destination on correct plane — must advance. This is the
+			// case the old ARRIVE_AT_TILE predicate could not satisfy.
+			sequencer.onPlayerMoved(new WorldPoint(ux, uy, plane));
+			assertEquals("underground arrival must advance: " + label, 1, sequencer.getCurrentIndex());
+		}
+	}
+
 	@Test
 	public void testPlayerOnPlaneCompletesStep()
 	{


### PR DESCRIPTION
## Summary

Follows the #553 template for #548 to fix the same broken travel-then-descend predicate across 23 other sources. Each step 0 previously used ARRIVE_AT_TILE around a surface entrance; once the player descended (typically Y +6400), the surface tile became unreachable and the step stayed at 1/N until manual Skip. Step 0 is now ARRIVE_AT_ZONE with a plane-0 rectangle covering both the surface band and the underground band for each source.

Closes #555. Builds on #548 / #553.

## Sources migrated (23 sources, 16 distinct zones)

**Definitely-broken (#548 exact pattern, 20):**

| Source | Zone (minX, minY_surface, maxX, maxY_underground, plane) |
|---|---|
| Sarachnis | `[1690, 3560, 1860, 9920, 0]` |
| Kraken | `[2260, 3600, 2290, 10030, 0]` |
| Thermonuclear smoke devil | `[2370, 3050, 2420, 9460, 0]` |
| Alchemical Hydra | `[1300, 3795, 1380, 10280, 0]` |
| Wyrm | `[1300, 3795, 1330, 10220, 0]` |
| Drake | `[1300, 3795, 1330, 10075, 0]` |
| Hydra | `[1300, 3795, 1330, 10205, 0]` |
| Cave Crawler / Rockslug / Cockatrice / Pyrefiend / Basilisk / Jelly / Turoth / Kurask | `[2690, 3600, 2810, 10050, 0]` (shared Fremennik Slayer Dungeon zone) |
| Aquanite | `[2210, 3465, 2290, 9895, 0]` |
| Fossil Island Wyvern | `[3590, 3765, 3760, 10305, 0]` |
| Catacombs of Kourend | `[1620, 3660, 1690, 10070, 0]` |
| Kalphite Queen | `[3215, 3095, 3520, 9520, 0]` |
| Scorpia | `[3215, 3920, 3250, 10355, 0]` |

**Likely-broken (migrated for consistency, 3):**

| Source | Zone |
|---|---|
| Perilous Moons | `[1420, 3115, 1450, 9720, 0]` |
| Giants' Foundry | `[3345, 3140, 3380, 11500, 0]` |
| King Black Dragon | `[3015, 3830, 3080, 10265, 0]` |

The 8 Fremennik Slayer Dungeon sources share one zone — they all live in the same dungeon, all reached through the same entrance at (2797, 3614, 0).

## Test plan

- [x] `DropRateDatabaseTest.regression_555_batchMigratedSources_useArriveAtZone` asserts every migrated source has step 0 = ARRIVE_AT_ZONE on plane 0, zone contains the audit-documented surface coord AND underground coord, and the zone rejects plane 1+.
- [x] `GuidanceSequencerTest.testArriveAtZoneCompletesStepFromUnderground_batchMigratedZones` runs a representative subset (Sarachnis, Kraken, Karuulm, Fremennik SD shared, Fossil Island Wyvern, KQ wide span, Scorpia) end-to-end through the sequencer, asserting underground arrival auto-advances.
- [x] `SailingSourceTriageTest.aquanite_needsCapture` updated to match the new ARRIVE_AT_ZONE shape (#314 coord-capture follow-up is unchanged).
- [x] `./gradlew test` passes (1351 tests, all green).
- [x] `./gradlew build` passes (JaCoCo + lint).
- [x] `./gradlew lintDropRates` passes.

## Excluded (per issue audit)

- Skeletal Wyvern — coord-data bug, not the #548 predicate-too-strict bug.
- Cerberus — instance coords, different completion semantics.
- Brutal Black Dragons — covered by Catacombs of Kourend.
- Barrows — not at risk (different predicate, listed for transparency).

## References

- #548 — original bug report (Custodian Stalker).
- #553 — single-source fix that established the zone-shape template.
- #555 — audit issue this PR closes.