### PR TITLE
audit(CLUES): verify 12 sources clean (part of #495)

### DIFF
--- a/audit-report-CLUES.json
+++ b/audit-report-CLUES.json
@@ -1,0 +1,74 @@
+[
+  {
+    "name": "Beginner Treasure Trails",
+    "category": "CLUES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Scroll Cases",
+    "category": "CLUES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Easy Treasure Trails",
+    "category": "CLUES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Medium Treasure Trails",
+    "category": "CLUES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Hard Treasure Trails",
+    "category": "CLUES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Elite Treasure Trails",
+    "category": "CLUES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Master Treasure Trails",
+    "category": "CLUES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Hard Treasure Trail Rewards (Rare)",
+    "category": "CLUES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Elite Treasure Trail Rewards (Rare)",
+    "category": "CLUES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Master Treasure Trail Rewards (Rare)",
+    "category": "CLUES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Shared Treasure Trail Rewards",
+    "category": "CLUES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "The Mimic",
+    "category": "CLUES",
+    "bucket": "verified",
+    "findings": []
+  }
+]

--- a/audit-report-CLUES.md
+++ b/audit-report-CLUES.md
@@ -1,0 +1,29 @@
+# drop_rates.json audit -- CLUES
+
+Total sources audited: **12**
+
+| Bucket | Count |
+|---|---|
+| verified | 12 |
+| flagged-fixable | 0 |
+| flagged-research | 0 |
+| error | 0 |
+
+## Findings
+
+_No findings; all sources verified clean._
+
+## Verified (12)
+
+- Beginner Treasure Trails
+- Scroll Cases
+- Easy Treasure Trails
+- Medium Treasure Trails
+- Hard Treasure Trails
+- Elite Treasure Trails
+- Master Treasure Trails
+- Hard Treasure Trail Rewards (Rare)
+- Elite Treasure Trail Rewards (Rare)
+- Master Treasure Trail Rewards (Rare)
+- Shared Treasure Trail Rewards
+- The Mimic

--- a/scripts/canonical_landmarks.json
+++ b/scripts/canonical_landmarks.json
@@ -16,5 +16,11 @@
     "worldY": 2784,
     "worldPlane": 0,
     "aliases": ["Tombs of Amascut", "Tombs", "Kharidian Desert tombs"]
+  },
+  "Grand Exchange": {
+    "worldX": 3165,
+    "worldY": 3487,
+    "worldPlane": 0,
+    "aliases": ["Varrock Grand Exchange", "GE", "clue reward hub"]
   }
 }


### PR DESCRIPTION
## Summary

Batch 1b of #495. Reuses the audit harness landed in #561 to verify the **12 CLUES sources** in `drop_rates.json`. **All 12 verified clean** — no fixes applied to `drop_rates.json`, no follow-up issues filed.

## Triage results

| Bucket | Count |
|---|---|
| verified | 12 |
| flagged-fixable | 0 |
| flagged-research | 0 |
| error | 0 |

The 12 sources:
- Beginner / Easy / Medium / Hard / Elite / Master Treasure Trails (6)
- Scroll Cases (1)
- Hard / Elite / Master Treasure Trail Rewards (Rare) (3)
- Shared Treasure Trail Rewards (1)
- The Mimic (1)

## Changes

- `scripts/canonical_landmarks.json`: added one entry — **Grand Exchange** at `(3165, 3487, plane 0)`, aliases `["Varrock Grand Exchange", "GE", "clue reward hub"]`. This anchors the coord-plausibility check for the 11 CLUES sources whose `locationDescription` names "Grand Exchange". With the landmark added, those 11 sources land at tile distance 0 (perfect coord match).
- `audit-report-CLUES.md` + `audit-report-CLUES.json`: triage reports (mirrors the RAIDS report convention from #561).

The two sources whose `locationDescription` does NOT name a canonical landmark (Scroll Cases, The Mimic) correctly skip the coord check via the harness's existing logic.

Cross-field consistency, npc-id sanity, and required-field presence all pass with zero findings across the slice.

## Test plan

- [x] `python scripts/audit_drop_rates.py --category CLUES` returns 12/12 verified
- [x] `./gradlew lintDropRates` passes (catches em-dash mojibake regressions; no `drop_rates.json` edits here, but verified anyway)
- [x] `./gradlew build` passes
- [x] Landmark schema unchanged; only one record added

## Notes for batch 1c (BOSSES, 61 sources)

- Expect coord-plausibility to flag more often: BOSSES is a combat category, so the harness's npc-id check will run (missing `npcId` + missing `interactAction` → low-severity `flagged-research`). Watch for the same lobby-vs-attack convention split that #561 flagged for RAIDS (now tracked in #560).
- Landmark file likely needs several new entries (GWD, Slayer Tower, Catacombs of Kourend, Wilderness lairs, etc.) — extend `scripts/canonical_landmarks.json` data-driven without touching script code.
- Watch for cross-field kraken-cascade pattern in long-form boss travel tips: a `travelTip` that name-drops one zone while `locationDescription` names another is the high-signal pattern.
- If BOSSES returns clean ≤ 20% the way RAIDS+CLUES did, it likely indicates either (a) the landmark set is still too sparse to anchor coord checks, or (b) the harness's region-token list needs additions. Verify by spot-checking a known-bad source before declaring the slice clean.

Closes part of #495.
