### PR TITLE
audit(BOSSES): triage 61 sources, 0 auto-fixes, 1 research issue filed (part of #495)

### DIFF
--- a/docs/audit/audit-report-BOSSES.json
+++ b/docs/audit/audit-report-BOSSES.json
@@ -1,0 +1,392 @@
+[
+  {
+    "name": "General Graardor",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Commander Zilyana",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "K'ril Tsutsaroth",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Kree'arra",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Zulrah",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Vorkath",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Cerberus",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Alchemical Hydra",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Corporeal Beast",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Kalphite Queen",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Phantom Muspah",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Duke Sucellus",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "The Leviathan",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "The Whisperer",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Vardorvis",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Duke Sucellus (Awakened)",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "The Leviathan (Awakened)",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "The Whisperer (Awakened)",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Vardorvis (Awakened)",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Grotesque Guardians",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "The Nightmare",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Phosani's Nightmare",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Nex",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Sarachnis",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Giant Mole",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Bryophyta",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Obor",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Dagannoth Rex",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Dagannoth Prime",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Dagannoth Supreme",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Kraken",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Thermonuclear smoke devil",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Abyssal Sire",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "King Black Dragon",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Chaos Elemental",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Scorpia",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Chaos Fanatic",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Venenatis",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Vet'ion",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Callisto",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Skotizo",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Hespori",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Corrupted Gauntlet",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "The Gauntlet",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Barrows",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Zalcano",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Sol Heredit",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Crazy archaeologist",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Araxxor",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Perilous Moons",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "The Hueycoatl",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Yama",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Doom of Mokhaiotl",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Royal Titans",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Amoxliatl",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Brutus",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Shellbane Gryphon",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Scurrius",
+    "category": "BOSSES",
+    "bucket": "flagged-research",
+    "findings": [
+      {
+        "source_name": "Scurrius",
+        "category": "BOSSES",
+        "check": "coord",
+        "field": "worldX/worldY",
+        "current": "(3299, 9867)",
+        "suggested": "~(3174, 3435) [Varrock Sewers]",
+        "severity": "high",
+        "bucket": "flagged-research",
+        "note": "coords are 6557 tiles from canonical Varrock Sewers; tolerance is 50. Could be intentional (e.g. lobby vs. entrance) but verify against the Wiki."
+      }
+    ]
+  },
+  {
+    "name": "The Fight Caves",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "The Inferno",
+    "category": "BOSSES",
+    "bucket": "flagged-research",
+    "findings": [
+      {
+        "source_name": "The Inferno",
+        "category": "BOSSES",
+        "check": "coord",
+        "field": "worldX/worldY",
+        "current": "(2496, 5122)",
+        "suggested": "~(2439, 5172) [Mor Ul Rek]",
+        "severity": "high",
+        "bucket": "flagged-research",
+        "note": "coords are 107 tiles from canonical Mor Ul Rek; tolerance is 50. Could be intentional (e.g. lobby vs. entrance) but verify against the Wiki."
+      }
+    ]
+  },
+  {
+    "name": "Deranged Archaeologist",
+    "category": "BOSSES",
+    "bucket": "verified",
+    "findings": []
+  }
+]

--- a/docs/audit/audit-report-BOSSES.md
+++ b/docs/audit/audit-report-BOSSES.md
@@ -1,0 +1,79 @@
+# drop_rates.json audit -- BOSSES
+
+Total sources audited: **61**
+
+| Bucket | Count |
+|---|---|
+| verified | 59 |
+| flagged-fixable | 0 |
+| flagged-research | 2 |
+| error | 0 |
+
+## Findings
+
+| Source | Category | Check | Field | Current | Suggested | Severity | Bucket | Note |
+|---|---|---|---|---|---|---|---|---|
+| Scurrius | BOSSES | coord | worldX/worldY | (3299, 9867) | ~(3174, 3435) [Varrock Sewers] | high | flagged-research | coords are 6557 tiles from canonical Varrock Sewers; tolerance is 50. Could be intentional (e.g. lobby vs. entrance) but verify against the Wiki. |
+| The Inferno | BOSSES | coord | worldX/worldY | (2496, 5122) | ~(2439, 5172) [Mor Ul Rek] | high | flagged-research | coords are 107 tiles from canonical Mor Ul Rek; tolerance is 50. Could be intentional (e.g. lobby vs. entrance) but verify against the Wiki. |
+
+## Verified (59)
+
+- General Graardor
+- Commander Zilyana
+- K'ril Tsutsaroth
+- Kree'arra
+- Zulrah
+- Vorkath
+- Cerberus
+- Alchemical Hydra
+- Corporeal Beast
+- Kalphite Queen
+- Phantom Muspah
+- Duke Sucellus
+- The Leviathan
+- The Whisperer
+- Vardorvis
+- Duke Sucellus (Awakened)
+- The Leviathan (Awakened)
+- The Whisperer (Awakened)
+- Vardorvis (Awakened)
+- Grotesque Guardians
+- The Nightmare
+- Phosani's Nightmare
+- Nex
+- Sarachnis
+- Giant Mole
+- Bryophyta
+- Obor
+- Dagannoth Rex
+- Dagannoth Prime
+- Dagannoth Supreme
+- Kraken
+- Thermonuclear smoke devil
+- Abyssal Sire
+- King Black Dragon
+- Chaos Elemental
+- Scorpia
+- Chaos Fanatic
+- Venenatis
+- Vet'ion
+- Callisto
+- Skotizo
+- Hespori
+- Corrupted Gauntlet
+- The Gauntlet
+- Barrows
+- Zalcano
+- Sol Heredit
+- Crazy archaeologist
+- Araxxor
+- Perilous Moons
+- The Hueycoatl
+- Yama
+- Doom of Mokhaiotl
+- Royal Titans
+- Amoxliatl
+- Brutus
+- Shellbane Gryphon
+- The Fight Caves
+- Deranged Archaeologist

--- a/scripts/audit_drop_rates.py
+++ b/scripts/audit_drop_rates.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from dataclasses import dataclass, field, asdict
 from pathlib import Path
@@ -169,13 +170,25 @@ def load_landmarks(path: Path) -> dict[str, dict[str, Any]]:
 # ---------------------------------------------------------------------------
 
 
+def _word_boundary_search(needle: str, haystack_lower: str) -> int:
+    """Return the start index of needle in haystack_lower with word boundaries
+    on both sides, or -1 if not found.
+
+    A "word" character is [a-z0-9_]. The boundary check uses regex \\b so e.g.
+    `GE` does NOT match `dungeon` but `GWD` matches `Trollheim GWD`.
+    """
+    pattern = r"\b" + re.escape(needle.lower()) + r"\b"
+    m = re.search(pattern, haystack_lower)
+    return m.start() if m else -1
+
+
 def extract_region_tokens(text: str) -> set[str]:
     if not text:
         return set()
     found: set[str] = set()
     lower = text.lower()
     for token in REGION_TOKENS:
-        if token.lower() in lower:
+        if _word_boundary_search(token, lower) >= 0:
             found.add(token)
     return found
 
@@ -228,8 +241,7 @@ def match_landmark(
     for name, data in landmarks.items():
         names_to_check = [name] + list(data.get("aliases", []))
         for n in names_to_check:
-            n_lower = n.lower()
-            idx = lower.find(n_lower)
+            idx = _word_boundary_search(n, lower)
             if idx < 0:
                 continue
             # Check the text immediately preceding the landmark name.

--- a/scripts/canonical_landmarks.json
+++ b/scripts/canonical_landmarks.json
@@ -21,6 +21,288 @@
     "worldX": 3165,
     "worldY": 3487,
     "worldPlane": 0,
-    "aliases": ["Varrock Grand Exchange", "GE", "clue reward hub"]
+    "aliases": ["Varrock Grand Exchange", "clue reward hub"]
+  },
+  "God Wars Dungeon": {
+    "worldX": 2918,
+    "worldY": 3745,
+    "worldPlane": 0,
+    "aliases": ["GWD", "God Wars Dungeon entrance", "Trollheim GWD"]
+  },
+  "Taverley Dungeon": {
+    "worldX": 2883,
+    "worldY": 3397,
+    "worldPlane": 0,
+    "aliases": ["Taverley Dungeon entrance", "Cerberus lair"]
+  },
+  "Mount Karuulm": {
+    "worldX": 1308,
+    "worldY": 3807,
+    "worldPlane": 0,
+    "aliases": ["Karuulm Slayer Dungeon", "Mount Karuulm Slayer Dungeon"]
+  },
+  "Kalphite Lair": {
+    "worldX": 3226,
+    "worldY": 3108,
+    "worldPlane": 0,
+    "aliases": ["Kalphite Lair entrance", "Kalphite Queen lair"]
+  },
+  "Ancient Prison": {
+    "worldX": 2846,
+    "worldY": 3938,
+    "worldPlane": 0,
+    "aliases": ["Ancient Prison entrance", "Phantom Muspah lair", "Ghorrock Prison"]
+  },
+  "The Scar": {
+    "worldX": 3104,
+    "worldY": 3162,
+    "worldPlane": 0,
+    "aliases": ["Temple of the Eye Scar", "Leviathan lair"]
+  },
+  "Lassar Undercity": {
+    "worldX": 3007,
+    "worldY": 3477,
+    "worldPlane": 0,
+    "aliases": ["Lassar Undercity entrance", "Whisperer lair"]
+  },
+  "The Stranglewood": {
+    "worldX": 1175,
+    "worldY": 3424,
+    "worldPlane": 0,
+    "aliases": ["Stranglewood", "Vardorvis lair"]
+  },
+  "Slayer Tower": {
+    "worldX": 3427,
+    "worldY": 3543,
+    "worldPlane": 0,
+    "aliases": ["Slayer Tower rooftop", "Canifis Slayer Tower"]
+  },
+  "Slepe": {
+    "worldX": 3728,
+    "worldY": 3302,
+    "worldPlane": 0,
+    "aliases": ["Nightmare lair", "Slepe Sisterhood Sanctuary"]
+  },
+  "Forthos Dungeon": {
+    "worldX": 1701,
+    "worldY": 3574,
+    "worldPlane": 0,
+    "aliases": ["Sarachnis lair", "Forthos"]
+  },
+  "Falador Park": {
+    "worldX": 2987,
+    "worldY": 3376,
+    "worldPlane": 0,
+    "aliases": ["Giant Mole lair", "Falador centre park"]
+  },
+  "Varrock Sewers": {
+    "worldX": 3174,
+    "worldY": 3435,
+    "worldPlane": 0,
+    "aliases": ["Varrock sewer", "Bryophyta lair"]
+  },
+  "Edgeville Dungeon": {
+    "worldX": 3097,
+    "worldY": 3468,
+    "worldPlane": 0,
+    "aliases": ["Hill Giant Dungeon", "Obor lair"]
+  },
+  "Waterbirth Island": {
+    "worldX": 2521,
+    "worldY": 3740,
+    "worldPlane": 0,
+    "aliases": ["Dagannoth lair", "Waterbirth Dungeon"]
+  },
+  "Kraken Cove": {
+    "worldX": 2277,
+    "worldY": 3611,
+    "worldPlane": 0,
+    "aliases": ["Piscatoris Kraken Cove", "Kraken lair"]
+  },
+  "Smoke Devil Dungeon": {
+    "worldX": 2404,
+    "worldY": 3060,
+    "worldPlane": 0,
+    "aliases": ["Smoke Dungeon", "Thermonuclear smoke devil lair"]
+  },
+  "Abyssal Nexus": {
+    "worldX": 3039,
+    "worldY": 4763,
+    "worldPlane": 0,
+    "aliases": ["Abyssal Sire lair", "Abyss Nexus"]
+  },
+  "King Black Dragon Lair": {
+    "worldX": 3005,
+    "worldY": 3849,
+    "worldPlane": 0,
+    "aliases": ["KBD lair", "KBD"]
+  },
+  "Rogues' Castle": {
+    "worldX": 3261,
+    "worldY": 3927,
+    "worldPlane": 0,
+    "aliases": ["Chaos Elemental lair", "Rogues Castle"]
+  },
+  "Scorpia's Cave": {
+    "worldX": 3231,
+    "worldY": 3936,
+    "worldPlane": 0,
+    "aliases": ["Scorpia lair"]
+  },
+  "Lava Maze": {
+    "worldX": 2979,
+    "worldY": 3846,
+    "worldPlane": 0,
+    "aliases": ["Chaos Fanatic lair", "Lava Maze ruins"]
+  },
+  "Silk Chasm": {
+    "worldX": 3321,
+    "worldY": 3794,
+    "worldPlane": 0,
+    "aliases": ["Venenatis lair", "Venenatis den"]
+  },
+  "Vet'ion's Rest": {
+    "worldX": 3220,
+    "worldY": 3783,
+    "worldPlane": 0,
+    "aliases": ["Vet'ion lair", "Vetion lair"]
+  },
+  "Callisto's Den": {
+    "worldX": 3291,
+    "worldY": 3849,
+    "worldPlane": 0,
+    "aliases": ["Callisto lair"]
+  },
+  "Catacombs of Kourend": {
+    "worldX": 1636,
+    "worldY": 3673,
+    "worldPlane": 0,
+    "aliases": ["Skotizo lair", "Kourend catacombs"]
+  },
+  "Farming Guild": {
+    "worldX": 1233,
+    "worldY": 3731,
+    "worldPlane": 0,
+    "aliases": ["Hespori lair", "Farming Guild Hosidius"]
+  },
+  "The Gauntlet": {
+    "worldX": 3230,
+    "worldY": 6073,
+    "worldPlane": 0,
+    "aliases": ["Gauntlet Prifddinas", "Corrupted Gauntlet"]
+  },
+  "Barrows": {
+    "worldX": 3565,
+    "worldY": 3298,
+    "worldPlane": 0,
+    "aliases": ["Barrows tombs", "Mort'ton Barrows"]
+  },
+  "Zalcano's Prison": {
+    "worldX": 3031,
+    "worldY": 6048,
+    "worldPlane": 0,
+    "aliases": ["Zalcano lair", "Zalcano Prifddinas"]
+  },
+  "Fortis Colosseum": {
+    "worldX": 1794,
+    "worldY": 3107,
+    "worldPlane": 0,
+    "aliases": ["Colosseum", "Sol Heredit arena"]
+  },
+  "Morytania Spider Cave": {
+    "worldX": 3686,
+    "worldY": 3426,
+    "worldPlane": 0,
+    "aliases": ["Araxxor lair", "Araxyte lair"]
+  },
+  "Cam Torum": {
+    "worldX": 1435,
+    "worldY": 3131,
+    "worldPlane": 0,
+    "aliases": ["Cam Torum entrance", "Perilous Moons", "Ralos Rise"]
+  },
+  "The Darkfrost": {
+    "worldX": 1509,
+    "worldY": 3290,
+    "worldPlane": 0,
+    "aliases": ["Hueycoatl lair", "Darkfrost", "Hailstorm Mountains"]
+  },
+  "Yama's Domain": {
+    "worldX": 1503,
+    "worldY": 10091,
+    "worldPlane": 0,
+    "aliases": ["Yama lair", "Chasm of Fire", "Shayzien Chasm of Fire"]
+  },
+  "Ruins of Mokhaiotl": {
+    "worldX": 1311,
+    "worldY": 9520,
+    "worldPlane": 0,
+    "aliases": ["Mokhaiotl ruins", "Tlati Rainforest ruins"]
+  },
+  "Asgarnian Ice Dungeon": {
+    "worldX": 3008,
+    "worldY": 3150,
+    "worldPlane": 0,
+    "aliases": ["Royal Titans lair", "Ice Dungeon Asgarnia"]
+  },
+  "Ruins of Tapoyauik": {
+    "worldX": 1362,
+    "worldY": 4511,
+    "worldPlane": 0,
+    "aliases": ["Tapoyauik", "Amoxliatl lair"]
+  },
+  "Lumbridge cow field": {
+    "worldX": 3263,
+    "worldY": 3297,
+    "worldPlane": 0,
+    "aliases": ["Brutus lair", "Lumbridge cows"]
+  },
+  "Shellbane Gryphon Cave": {
+    "worldX": 13993,
+    "worldY": 9901,
+    "worldPlane": 0,
+    "aliases": ["The Great Conch", "Shellbane lair"]
+  },
+  "Mor Ul Rek": {
+    "worldX": 2439,
+    "worldY": 5172,
+    "worldPlane": 0,
+    "aliases": ["TzHaar city", "Karamja Volcano", "Fight Caves", "Inferno arena"]
+  },
+  "Tar Swamp": {
+    "worldX": 3683,
+    "worldY": 3706,
+    "worldPlane": 0,
+    "aliases": ["Deranged Archaeologist lair", "Fossil Island Tar Swamp"]
+  },
+  "Zul-Andra": {
+    "worldX": 2268,
+    "worldY": 3069,
+    "worldPlane": 0,
+    "aliases": ["Zulrah lair", "Tirannwn Zul-Andra"]
+  },
+  "Ungael": {
+    "worldX": 2272,
+    "worldY": 4054,
+    "worldPlane": 0,
+    "aliases": ["Vorkath lair", "Ungael Island"]
+  },
+  "Corporeal Beast Cave": {
+    "worldX": 2966,
+    "worldY": 4382,
+    "worldPlane": 0,
+    "aliases": ["Corp cave", "Corporeal Beast lair"]
+  },
+  "Crazy archaeologist ruins": {
+    "worldX": 2975,
+    "worldY": 3696,
+    "worldPlane": 0,
+    "aliases": ["Crazy archaeologist lair"]
+  },
+  "Scurrius lair": {
+    "worldX": 3299,
+    "worldY": 9867,
+    "worldPlane": 0,
+    "aliases": ["Varrock Sewers Scurrius"]
   }
 }


### PR DESCRIPTION
## Summary

Reuses the audit harness from #561 (refined #562) against the BOSSES category (61 sources). All 61 either verify clean or flag as harness-tolerance research items. **Zero kraken-cascade pattern hits** — the original #09 motivator is confirmed resolved.

Two commits:
1. **Prep** — extend `scripts/canonical_landmarks.json` with ~46 PvM landmark entries and harden the harness substring matcher with word boundaries (the prior `GE` alias was matching `dunGEon` and triggering 12 false-positive coord findings).
2. **Audit** — write triage reports to `docs/audit/audit-report-BOSSES.{md,json}`, no data edits.

## Triage results

| Bucket | Count |
|---|---|
| verified | 59 |
| flagged-fixable | 0 |
| flagged-research | 2 |
| error | 0 |

## Auto-fixes applied

None. Both research findings are coord-precision edge cases against broader-zone landmarks; the underlying data appears correct.

## Issues filed

- #563 — harness tolerance vs underground/sub-zone coord drift (Scurrius, The Inferno). Single umbrella issue; both findings share the same root cause (landmark granularity).

## Kraken cascade status

**RESOLVED — already clean.** Manually re-verified the two Kraken entries called out in #495 item #09:

- BOSSES Kraken (line ~3592): locationDescription "Kraken Cove, Piscatoris"; travelTip "Fairy ring AKQ -> Piscatoris"; all three guidanceSteps describe Piscatoris / Kraken Cove. No Fremennik reference anywhere.
- SLAYER Cave Kraken (line ~10238): locationDescription "Kraken Cove"; travelTip "Fairy ring AKQ -> Piscatoris"; guidanceSteps describe Piscatoris / Kraken Cove. No Fremennik reference.

The cascade was repaired in earlier work; this batch confirms it stays clean and that the harness's cross-field check finds zero remaining kraken-cascade-pattern hits across the entire BOSSES slice.

## Harness hardening

The prep commit also adds word-boundary matching (`\b`) to `extract_region_tokens` and `match_landmark`. Without this, the existing `GE` alias on Grand Exchange matched the substring `dungeon` and produced 12 false positives in the initial run. The `GE` alias is removed (too short to disambiguate reliably) and remaining short aliases like `GWD` and `KBD` are safe under word-boundary matching.

## Test plan

- [x] `python scripts/audit_drop_rates.py --category BOSSES` re-runs and produces the same triage counts (59 / 0 / 2 / 0).
- [x] `./gradlew lintDropRates` passes.
- [x] `./gradlew build` passes (JaCoCo gate green).
- [x] Manual re-verification of both Kraken entries against the original #09 cascade pattern.
- [ ] Reviewer spot-checks one verified source per major zone (GWD, Wilderness, Karuulm, Mor Ul Rek, Prifddinas) against the Wiki.

## Notes for batch 1d (SLAYER)

- The new word-boundary matcher is now load-bearing; SLAYER will exercise the `Slayer Tower` / `Catacombs of Kourend` / `Mount Karuulm` / `Stronghold Slayer Cave` landmarks heavily — most are already seeded by this batch.
- Add Stronghold Slayer Cave landmark seed before the SLAYER run (only the cross-field token list references it today).
- The Bryophyta vs Scurrius coord-convention inconsistency surfaced in #563 may indicate a broader sewer/underground convention question worth verifying against SLAYER sources too.
- Cave Kraken (SLAYER) is the canonical companion to BOSSES Kraken — it should also verify clean. If it doesn't, harness or data needs another look.