### PR TITLE
audit(SLAYER): triage 45 sources, auto-fix 2 surface->underground coords, file 2 research issues (part of #495)

### DIFF
--- a/docs/audit/audit-report-SLAYER.json
+++ b/docs/audit/audit-report-SLAYER.json
@@ -1,0 +1,320 @@
+[
+  {
+    "name": "Demonic gorillas",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Lizardman shaman",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Tormented Demons",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Crawling Hand",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Cave Crawler",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Rockslug",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Cockatrice",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Pyrefiend",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Mogre",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Basilisk",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Terror Dog",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Infernal Mage",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Brine Rat",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Frost Nagua",
+    "category": "SLAYER",
+    "bucket": "flagged-research",
+    "findings": [
+      {
+        "source_name": "Frost Nagua",
+        "category": "SLAYER",
+        "check": "coord",
+        "field": "worldX/worldY",
+        "current": "(1693, 3232)",
+        "suggested": "~(1362, 4511) [Ruins of Tapoyauik]",
+        "severity": "high",
+        "bucket": "flagged-research",
+        "note": "coords are 1610 tiles from canonical Ruins of Tapoyauik; tolerance is 50. Could be intentional (e.g. lobby vs. entrance) but verify against the Wiki."
+      }
+    ]
+  },
+  {
+    "name": "Sulphur Nagua",
+    "category": "SLAYER",
+    "bucket": "flagged-research",
+    "findings": [
+      {
+        "source_name": "Sulphur Nagua",
+        "category": "SLAYER",
+        "check": "coord",
+        "field": "worldX/worldY",
+        "current": "(1440, 9602)",
+        "suggested": "~(1435, 3131) [Cam Torum]",
+        "severity": "high",
+        "bucket": "flagged-research",
+        "note": "coords are 6476 tiles from canonical Cam Torum; tolerance is 50. Could be intentional (e.g. lobby vs. entrance) but verify against the Wiki."
+      }
+    ]
+  },
+  {
+    "name": "Earthen Nagua",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Bloodveld",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Gryphon",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Jelly",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Turoth",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Warped Creature",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Cave Horror",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Aberrant Spectre",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Basilisk Knight",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Wyrm",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Lava Strykewyrm",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Dust Devil",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Fossil Island Wyvern",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Kurask",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Skeletal Wyvern",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Gargoyle",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Custodian Stalker",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Aquanite",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Nechryael",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Spiritual Mage",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Spiritual Mage (Zarosian)",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Drake",
+    "category": "SLAYER",
+    "bucket": "flagged-research",
+    "findings": [
+      {
+        "source_name": "Drake",
+        "category": "SLAYER",
+        "check": "coord",
+        "field": "worldX/worldY",
+        "current": "(1310, 10057)",
+        "suggested": "~(1311, 10170) [Karuulm Slayer Dungeon]",
+        "severity": "high",
+        "bucket": "flagged-research",
+        "note": "coords are 114 tiles from canonical Karuulm Slayer Dungeon; tolerance is 50. Could be intentional (e.g. lobby vs. entrance) but verify against the Wiki."
+      }
+    ]
+  },
+  {
+    "name": "Abyssal Demon",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Cave Kraken",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Dark Beast",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Araxyte",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Smoke Devil",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Hydra",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Vyrewatch Sentinel",
+    "category": "SLAYER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Superior Slayer Monster",
+    "category": "SLAYER",
+    "bucket": "flagged-research",
+    "findings": [
+      {
+        "source_name": "Superior Slayer Monster",
+        "category": "SLAYER",
+        "check": "npc-id",
+        "field": "npcId+interactAction",
+        "current": "both missing",
+        "suggested": "set npcId + interactAction OR confirm 'instance lobby' style source",
+        "severity": "low",
+        "bucket": "flagged-research",
+        "note": "combat-style category but no npcId and no interactAction. May be intentional for raid lobbies but worth verifying."
+      }
+    ]
+  }
+]

--- a/docs/audit/audit-report-SLAYER.md
+++ b/docs/audit/audit-report-SLAYER.md
@@ -1,0 +1,63 @@
+# drop_rates.json audit -- SLAYER
+
+Total sources audited: **45**
+
+| Bucket | Count |
+|---|---|
+| verified | 41 |
+| flagged-fixable | 0 |
+| flagged-research | 4 |
+| error | 0 |
+
+## Findings
+
+| Source | Category | Check | Field | Current | Suggested | Severity | Bucket | Note |
+|---|---|---|---|---|---|---|---|---|
+| Frost Nagua | SLAYER | coord | worldX/worldY | (1693, 3232) | ~(1362, 4511) [Ruins of Tapoyauik] | high | flagged-research | coords are 1610 tiles from canonical Ruins of Tapoyauik; tolerance is 50. Could be intentional (e.g. lobby vs. entrance) but verify against the Wiki. |
+| Sulphur Nagua | SLAYER | coord | worldX/worldY | (1440, 9602) | ~(1435, 3131) [Cam Torum] | high | flagged-research | coords are 6476 tiles from canonical Cam Torum; tolerance is 50. Could be intentional (e.g. lobby vs. entrance) but verify against the Wiki. |
+| Drake | SLAYER | coord | worldX/worldY | (1310, 10057) | ~(1311, 10170) [Karuulm Slayer Dungeon] | high | flagged-research | coords are 114 tiles from canonical Karuulm Slayer Dungeon; tolerance is 50. Could be intentional (e.g. lobby vs. entrance) but verify against the Wiki. |
+| Superior Slayer Monster | SLAYER | npc-id | npcId+interactAction | both missing | set npcId + interactAction OR confirm 'instance lobby' style source | low | flagged-research | combat-style category but no npcId and no interactAction. May be intentional for raid lobbies but worth verifying. |
+
+## Verified (41)
+
+- Demonic gorillas
+- Lizardman shaman
+- Tormented Demons
+- Crawling Hand
+- Cave Crawler
+- Rockslug
+- Cockatrice
+- Pyrefiend
+- Mogre
+- Basilisk
+- Terror Dog
+- Infernal Mage
+- Brine Rat
+- Earthen Nagua
+- Bloodveld
+- Gryphon
+- Jelly
+- Turoth
+- Warped Creature
+- Cave Horror
+- Aberrant Spectre
+- Basilisk Knight
+- Wyrm
+- Lava Strykewyrm
+- Dust Devil
+- Fossil Island Wyvern
+- Kurask
+- Skeletal Wyvern
+- Gargoyle
+- Custodian Stalker
+- Aquanite
+- Nechryael
+- Spiritual Mage
+- Spiritual Mage (Zarosian)
+- Abyssal Demon
+- Cave Kraken
+- Dark Beast
+- Araxyte
+- Smoke Devil
+- Hydra
+- Vyrewatch Sentinel

--- a/scripts/canonical_landmarks.json
+++ b/scripts/canonical_landmarks.json
@@ -24,10 +24,16 @@
     "aliases": ["Varrock Grand Exchange", "clue reward hub"]
   },
   "God Wars Dungeon": {
+    "worldX": 2871,
+    "worldY": 5280,
+    "worldPlane": 2,
+    "aliases": ["GWD", "Saradomin Encampment", "Bandos Stronghold", "Armadyl Eyrie", "Zamorak Fortress", "Spiritual Mage area"]
+  },
+  "God Wars Dungeon entrance": {
     "worldX": 2918,
     "worldY": 3745,
     "worldPlane": 0,
-    "aliases": ["GWD", "God Wars Dungeon entrance", "Trollheim GWD"]
+    "aliases": ["GWD entrance", "Trollheim GWD", "Troll Stronghold GWD"]
   },
   "Taverley Dungeon": {
     "worldX": 2883,
@@ -39,7 +45,7 @@
     "worldX": 1308,
     "worldY": 3807,
     "worldPlane": 0,
-    "aliases": ["Karuulm Slayer Dungeon", "Mount Karuulm Slayer Dungeon"]
+    "aliases": ["Mount Karuulm surface", "Karuulm volcano"]
   },
   "Kalphite Lair": {
     "worldX": 3226,
@@ -123,7 +129,7 @@
     "worldX": 2404,
     "worldY": 3060,
     "worldPlane": 0,
-    "aliases": ["Smoke Dungeon", "Thermonuclear smoke devil lair"]
+    "aliases": ["Thermonuclear smoke devil lair", "Castle Wars Smoke Devil Dungeon"]
   },
   "Abyssal Nexus": {
     "worldX": 3039,
@@ -304,5 +310,94 @@
     "worldY": 9867,
     "worldPlane": 0,
     "aliases": ["Varrock Sewers Scurrius"]
+  },
+  "Karuulm Slayer Dungeon": {
+    "worldX": 1311,
+    "worldY": 10170,
+    "worldPlane": 0,
+    "aliases": [
+      "Karuulm Slayer Dungeon lower level",
+      "Karuulm Dungeon",
+      "Wyrm chamber",
+      "Drake chamber",
+      "Hydra chamber"
+    ]
+  },
+  "Smoke Dungeon": {
+    "worldX": 3310,
+    "worldY": 9404,
+    "worldPlane": 0,
+    "aliases": [
+      "Smoke Dungeon Kharidian",
+      "Kharidian Smoke Dungeon",
+      "Pollnivneach Smoke Dungeon"
+    ]
+  },
+  "God Wars Dungeon Ancient Prison": {
+    "worldX": 2904,
+    "worldY": 5203,
+    "worldPlane": 0,
+    "aliases": [
+      "Nex Ancient Prison",
+      "Zaros Encampment",
+      "Frozen Door",
+      "God Wars Dungeon, Ancient Prison"
+    ]
+  },
+  "Stronghold Slayer Cave": {
+    "worldX": 2432,
+    "worldY": 3422,
+    "worldPlane": 0,
+    "aliases": [
+      "Tree Gnome Stronghold Slayer Cave",
+      "Gnome Stronghold Slayer Cave"
+    ]
+  },
+  "Neypotzli": {
+    "worldX": 1440,
+    "worldY": 9602,
+    "worldPlane": 0,
+    "aliases": [
+      "Neypotzli volcanic caves",
+      "Sulphur Nagua cave",
+      "Neypotzli, Cam Torum"
+    ]
+  },
+  "Tonali Cavern": {
+    "worldX": 1309,
+    "worldY": 3104,
+    "worldPlane": 0,
+    "aliases": [
+      "Earthen Nagua cave",
+      "Tonali"
+    ]
+  },
+  "Stalker Den": {
+    "worldX": 1301,
+    "worldY": 9820,
+    "worldPlane": 0,
+    "aliases": [
+      "Custodia Pass Stalker Den",
+      "Custodian Stalker den"
+    ]
+  },
+  "Ynysdail Cavern": {
+    "worldX": 2275,
+    "worldY": 9880,
+    "worldPlane": 0,
+    "aliases": [
+      "Ynysdail Aquanite cave",
+      "Baxtorian Aquanite cave"
+    ]
+  },
+  "Iorwerth Dungeon": {
+    "worldX": 1920,
+    "worldY": 4672,
+    "worldPlane": 0,
+    "aliases": [
+      "Mourner Tunnels",
+      "Prifddinas Iorwerth Dungeon",
+      "Dark Beast lair"
+    ]
   }
 }

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -992,8 +992,8 @@
   {
     "name": "Alchemical Hydra",
     "category": "BOSSES",
-    "worldX": 1308,
-    "worldY": 3807,
+    "worldX": 1364,
+    "worldY": 10265,
     "worldPlane": 0,
     "killTimeSeconds": 120,
     "ironKillTimeSeconds": 124,
@@ -9439,7 +9439,7 @@
     "name": "Dust Devil",
     "category": "SLAYER",
     "worldX": 3310,
-    "worldY": 2962,
+    "worldY": 9404,
     "worldPlane": 0,
     "killTimeSeconds": 6,
     "afkLevel": 2,
@@ -9466,7 +9466,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to Smoke Dungeon, Kharidian Desert.",
+        "description": "Travel to the Pollnivneach well entrance for the Smoke Dungeon, Kharidian Desert.",
         "worldX": 3310,
         "worldY": 2962,
         "worldPlane": 0,
@@ -9476,7 +9476,7 @@
       {
         "description": "Kill Dust Devils in the Smoke Dungeon or Catacombs of Kourend. Requires face protection (slayer helm works). Burst/barrage in Catacombs for fast tasks",
         "worldX": 3310,
-        "worldY": 2962,
+        "worldY": 9404,
         "worldPlane": 0,
         "npcId": 423,
         "interactAction": "Attack",


### PR DESCRIPTION
## Summary

Reuses `scripts/audit_drop_rates.py` (landed in #561, refined in #562/#564) to audit the **45 SLAYER sources** in `drop_rates.json` after the #558 ARRIVE_AT_ZONE migration. Two commits as in #564:

1. **Prep**: extend `scripts/canonical_landmarks.json` with 8 new SLAYER landmarks and refine 3 existing entries (one repointed surface->interior, two with alias collisions removed).
2. **Audit**: run the harness, triage 45 sources, auto-fix two `flagged-fixable` surface->underground coord mismatches, file research issues for the rest.

## Triage results

| Bucket | Count |
|---|---|
| verified | 41 |
| flagged-fixable (auto-fixed in this PR) | 2 |
| flagged-research (issues filed / linked) | 4 |
| error | 0 |

Of the 41 verified, **10 are multi-zone sources** (both zones appearing in the same field, per the pre-cooked rule) and **31 are single-zone**.

## Multi-zone sources verified

These all describe two valid spawn zones in the same field (steps text). Verified per the multi-zone rule:

- Cave Crawler -- Fremennik Slayer Dungeon OR Lumbridge Swamp caves
- Pyrefiend -- Fremennik Slayer Dungeon OR Catacombs of Kourend
- Bloodveld -- Slayer Tower OR Catacombs of Kourend
- Jelly -- Fremennik Slayer Dungeon OR Catacombs of Kourend
- Aberrant Spectre -- Slayer Tower OR Catacombs
- Dust Devil -- Smoke Dungeon OR Catacombs of Kourend (also auto-fixed below)
- Nechryael -- Slayer Tower OR Catacombs of Kourend
- Abyssal Demon -- Slayer Tower OR Catacombs
- Dark Beast -- Iorwerth Dungeon OR Mourner Tunnels OR Catacombs of Kourend
- Terror Dog -- Tarn's Lair (single zone with multi-quest travel options)

## Auto-fixes applied

Surface entrance -> underground encounter coord (decision: underground is canonical, per #558 ARRIVE_AT_ZONE convention):

| Source | Field | Before | After | Reference |
|---|---|---|---|---|
| Dust Devil (SLAYER) | top-level `worldY` | `2962` (Pollnivneach well) | `9404` (Smoke Dungeon interior) | wiki: Dust Devils spawn underground in the Smoke Dungeon; well at `(3310, 2962)` is the surface entry |
| Dust Devil (SLAYER) | guidanceSteps[1] `worldY` | `2962` | `9404` | kill step should be on the underground tile where the NPC actually spawns |
| Dust Devil (SLAYER) | guidanceSteps[0] description | `"Travel to Smoke Dungeon, Kharidian Desert."` | `"Travel to the Pollnivneach well entrance for the Smoke Dungeon, Kharidian Desert."` | clarifies that the surface tile is the well, not the dungeon itself |
| Alchemical Hydra (BOSSES) | top-level `worldX/worldY` | `(1308, 3807)` (Mount Karuulm surface) | `(1364, 10265)` (Karuulm Slayer Dungeon lower level) | wiki: Alchemical Hydra arena is underground; matches the kill step coord that was already at `(1364, 10265)` |

Alchemical Hydra is BOSSES, technically outside the SLAYER batch scope. It is included because adding the new `Karuulm Slayer Dungeon` landmark caused it to flag (the old surface coord was only a false-pass via the `Mount Karuulm` alias), and the fix is the same surface->underground rule. The other BOSSES sources are untouched.

## Cave Kraken (SLAYER) status

**Verified clean.** Coord `(2278, 3611, 0)` matches the existing `Kraken Cove` landmark `(2277, 3611, 0)`. travelTip says Piscatoris, no Fremennik string anywhere in guidance. The kraken-cascade companion pattern from the original lesson holds.

## Issues filed / linked

| Source | Item | Issue |
|---|---|---|
| Frost Nagua | coord `(1693, 3232)` does not match Tapoyauik landmark; loc desc may be stale post-Varlamore release | #565 (new) |
| Lava Strykewyrm | guidance steps still reference Wilderness/PKer risk after the Charred Island move; harness missed it because Charred Island and Varlamore are not in `ZONE_GROUPS` | #566 (new) |
| Drake | within-dungeon coord 114 tiles from landmark; same shape as Catacombs/Scurrius/Inferno tolerance drift | linked to #563 |
| Superior Slayer Monster | meta rollup with intentional null `npcId`/`interactAction`; same pattern as raid lobbies | linked to #560 |
| Sulphur Nagua (harness false positive) | matcher tie-break picks Cam Torum over Neypotzli when both names are length 9. Not a data bug; harness improvement | covered by the matcher-improvement direction in #563 |

## Landmarks added (prep commit)

8 new + 3 refinements:

- `Karuulm Slayer Dungeon` -- covers Wyrm/Hydra cluster (Drake and Alch Hydra remain on the edge due to dungeon sprawl)
- `Smoke Dungeon` -- Kharidian underground (distinct from `Smoke Devil Dungeon` near Castle Wars)
- `God Wars Dungeon Ancient Prison` -- Zarosian/Nex zone (distinct from Phantom Muspah's `Ancient Prison`)
- `Stronghold Slayer Cave` -- referenced in `ZONE_GROUPS` but had no coord seed
- `Neypotzli` -- Sulphur Nagua volcanic caves
- `Tonali Cavern` -- Earthen Nagua cave
- `Stalker Den` -- Custodian Stalker den, Varlamore
- `Ynysdail Cavern` -- Aquanite Sailing cave
- `Iorwerth Dungeon` -- Dark Beast / Mourner Tunnels

Refinements:
- `God Wars Dungeon` repointed from surface `(2918, 3745, 0)` to interior `(2871, 5280, 2)`; surface entry split into new `God Wars Dungeon entrance` landmark so BOSSES coord matches still pass.
- `Mount Karuulm`: removed `Karuulm Slayer Dungeon` alias to avoid surface/underground collision now that the dungeon has its own entry.
- `Smoke Devil Dungeon`: removed `Smoke Dungeon` alias to avoid collision with the new Kharidian Smoke Dungeon landmark.

## Test plan

- [x] `python scripts/audit_drop_rates.py --category SLAYER` runs clean: 41 verified, 2 fixable->fixed, 4 research, 0 error
- [x] `./gradlew lintDropRates` passes
- [x] `./gradlew build` passes (JaCoCo 45% gate held)
- [x] No regressions in BOSSES / RAIDS / CLUES audits (Alchemical Hydra fix accounted for; all other BOSSES sources still match their original landmarks)

## Notes for batch 1e (MINIGAMES, 25 sources)

Observations carried forward from this batch:

- **Multi-zone language is the dominant SLAYER pattern.** 10 of 41 verified sources had `"X or Y"` zone language; the rule worked well. Expect similar density in MINIGAMES (e.g. mini-game tokens often map to multiple chambers).
- **Underground encounter zones need landmarks** even when the surface entrance is well-known. MINIGAMES will likely need Pest Control island, Castle Wars arenas, LMS arena, Soul Wars Isle of Souls, etc.
- **Matcher tie-break is the next harness gap** (after #563). When two landmark names have identical length and both word-boundary-match the loc desc, the matcher picks dict-insertion-order. Adding `(name_length, coord_distance)` as a secondary sort key would resolve Sulphur Nagua style flags automatically.
- **Cross-field check is blind to post-Sailing-update zones.** Charred Island, Varlamore sub-areas, Auburnvale, etc. are not in `ZONE_GROUPS`, so any kraken-cascade involving them will slip through (caught Lava Strykewyrm manually here). Worth extending `ZONE_GROUPS` before MINIGAMES batch if any minigames live in those zones.
- **Word-boundary matcher (#562) is load-bearing.** Verified no false positives like `GE` matching `dungeon` even with the new landmark set.