### PR TITLE
audit(OTHER): triage 58 sources, auto-fix 2 mismatches; Pass 1 complete (part of #495)

### DIFF
--- a/docs/audit/audit-report-OTHER.json
+++ b/docs/audit/audit-report-OTHER.json
@@ -1,0 +1,350 @@
+[
+  {
+    "name": "Revenants",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Brimstone Chest",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Larran's Big Chest",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Zombie Pirate Locker",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Boat Paints",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Champion's Challenge",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Chompy Bird Hunting",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Forestry",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Fossil Island Notes",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Glough's Experiments",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Hunter Guild",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Lost Schematics",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Monkey Backpacks",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "My Notes",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Ocean Encounters",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Sailing Misc",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Sea Treasures",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Pyramid Plunder",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Stronghold of Security",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Catacombs of Kourend",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Wilderness God Wars Dungeon",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Elven Crystal Chest",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Miscellaneous",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Random Events",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Camdozaal",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "TzHaar",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Cyclopes",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Elder Chaos Druids",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Shayzien Armour",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Creature Creation (Newtroost)",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Creature Creation (Unicow)",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Creature Creation (Spidine)",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Creature Creation (Swordchick)",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Creature Creation (Jubster)",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Creature Creation (Frogeel)",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Stingray (Boat Combat)",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Albatross (Boat Combat)",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Narwhal (Boat Combat)",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Orcas (Boat Combat)",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Great White Shark (Boat Combat)",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Vampyre Kraken (Boat Combat)",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Small Salvage",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Fishy Salvage",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Barracuda Salvage",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Large Salvage",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Plundered Salvage",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Martial Salvage",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Fremennik Salvage",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Opulent Salvage",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Mithril Dragon",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Adamant Dragon",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Rune Dragon",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Ogress Shaman",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Armoured Zombie",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Prifddinas Elf",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Fountain of Rune",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Waterfiend",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  },
+  {
+    "name": "Port Tasks",
+    "category": "OTHER",
+    "bucket": "verified",
+    "findings": []
+  }
+]

--- a/docs/audit/audit-report-OTHER.md
+++ b/docs/audit/audit-report-OTHER.md
@@ -1,0 +1,75 @@
+# drop_rates.json audit -- OTHER
+
+Total sources audited: **58**
+
+| Bucket | Count |
+|---|---|
+| verified | 58 |
+| flagged-fixable | 0 |
+| flagged-research | 0 |
+| error | 0 |
+
+## Findings
+
+_No findings; all sources verified clean._
+
+## Verified (58)
+
+- Revenants
+- Brimstone Chest
+- Larran's Big Chest
+- Zombie Pirate Locker
+- Boat Paints
+- Champion's Challenge
+- Chompy Bird Hunting
+- Forestry
+- Fossil Island Notes
+- Glough's Experiments
+- Hunter Guild
+- Lost Schematics
+- Monkey Backpacks
+- My Notes
+- Ocean Encounters
+- Sailing Misc
+- Sea Treasures
+- Pyramid Plunder
+- Stronghold of Security
+- Catacombs of Kourend
+- Wilderness God Wars Dungeon
+- Elven Crystal Chest
+- Miscellaneous
+- Random Events
+- Camdozaal
+- TzHaar
+- Cyclopes
+- Elder Chaos Druids
+- Shayzien Armour
+- Creature Creation (Newtroost)
+- Creature Creation (Unicow)
+- Creature Creation (Spidine)
+- Creature Creation (Swordchick)
+- Creature Creation (Jubster)
+- Creature Creation (Frogeel)
+- Stingray (Boat Combat)
+- Albatross (Boat Combat)
+- Narwhal (Boat Combat)
+- Orcas (Boat Combat)
+- Great White Shark (Boat Combat)
+- Vampyre Kraken (Boat Combat)
+- Small Salvage
+- Fishy Salvage
+- Barracuda Salvage
+- Large Salvage
+- Plundered Salvage
+- Martial Salvage
+- Fremennik Salvage
+- Opulent Salvage
+- Mithril Dragon
+- Adamant Dragon
+- Rune Dragon
+- Ogress Shaman
+- Armoured Zombie
+- Prifddinas Elf
+- Fountain of Rune
+- Waterfiend
+- Port Tasks

--- a/scripts/audit_drop_rates.py
+++ b/scripts/audit_drop_rates.py
@@ -104,11 +104,134 @@ ZONE_GROUPS: dict[str, list[str]] = {
     "karuulm": ["Mount Karuulm", "Karuulm", "Kebos Lowlands", "Kebos"],
     "slayer_tower": ["Slayer Tower"],
     "slayer_cave": ["Stronghold Slayer Cave"],
-    "zeah": ["Zeah"],
-    "asgarnia": ["Asgarnia"],
-    "misthalin": ["Misthalin"],
-    "karamja": ["Karamja"],
-    "tirannwn": ["Tirannwn"],
+    "zeah": [
+        "Zeah",
+        "Great Kourend",
+        "Hosidius",
+        "Shayzien",
+        "Lovakengj",
+        "Piscarilius",
+        "Arceuus",
+        "Kourend Castle",
+    ],
+    "asgarnia": [
+        "Asgarnia",
+        "Falador",
+        "Falador Park",
+        "Burthorpe",
+        "Taverley",
+        "Ice Mountain",
+        "Barbarian Village",
+        "Edgeville",
+        "Warriors' Guild",
+        "Warriors Guild",
+    ],
+    "misthalin": [
+        "Misthalin",
+        "Varrock",
+        "Lumbridge",
+        "Draynor Village",
+        "Champions' Guild",
+        "Champions Guild",
+        "Al Kharid",
+    ],
+    "karamja": [
+        "Karamja",
+        "Brimhaven",
+        "Shilo Village",
+        "Tai Bwo Wannai",
+        "Musa Point",
+        "Crandor",
+    ],
+    "tirannwn": [
+        "Tirannwn",
+        "Prifddinas",
+        "Lletya",
+        "Iorwerth",
+        "Isafdar",
+        "Tyras Camp",
+    ],
+    # Wilderness sub-locations -- same broad region as Wilderness, share zone
+    # group to avoid kraken-cascade false positives.
+    "wilderness_sub": [
+        "Revenant Caves",
+        "Pirates' Hideout",
+        "Pirates Hideout",
+        "Bandit Camp",
+        "Chaos Temple",
+        "Elder Chaos Temple",
+        "Lava Maze",
+        "Rogues' Castle",
+        "Rogues Castle",
+        "Fountain of Rune",
+    ],
+    # Kandarin / Seers' / Catherby / Camelot / Tree Gnome Stronghold cluster
+    "kandarin": [
+        "Kandarin",
+        "Seers' Village",
+        "Seers Village",
+        "Camelot",
+        "Catherby",
+        "Ardougne",
+        "Yanille",
+        "Tree Gnome Stronghold",
+        "Tree Gnome Village",
+        "Gnome Stronghold",
+        "Grand Tree",
+        "Baxtorian Falls",
+        "Ancient Cavern",
+    ],
+    # Feldip Hills and southern Kandarin / Yanille hunting areas
+    "feldip": [
+        "Feldip Hills",
+        "Feldip",
+        "Rantz",
+        "Oo'glog",
+        "Jiggig",
+    ],
+    # Kharidian Desert -- Pyramid Plunder / Sophanem / Jalsavrah / Smoke Dungeon
+    "kharidian": [
+        "Kharidian Desert",
+        "Sophanem",
+        "Jalsavrah",
+        "Pollnivneach",
+        "Nardah",
+        "Bedabin Camp",
+    ],
+    # Crash Site Cavern -- beneath Gnome Stronghold / Ape Atoll surface
+    "crash_site": [
+        "Crash Site Cavern",
+        "Crash Site",
+        "Ape Atoll",
+    ],
+    # Stronghold of Security -- beneath Barbarian Village in Asgarnia
+    "stronghold_security": [
+        "Stronghold of Security",
+        "Vault of War",
+        "Catacomb of Famine",
+        "Pit of Pestilence",
+        "Sepulchre of Death",
+    ],
+    # Fossil Island family
+    "fossil_island_family": [
+        "Fossil Island",
+        "House on the Hill",
+        "Museum Camp",
+    ],
+    # Lithkren -- isolated dragon vault zone
+    "lithkren": ["Lithkren", "Lithkren Vault"],
+    # Corsair Cove dungeon
+    "corsair": ["Corsair Cove", "Corsair Cove Dungeon"],
+    # Ardougne basement / Tower of Life
+    "tower_of_life": ["Tower of Life"],
+    # Zemouregal's Fort -- isolated zone so harness flags any cross-mention
+    # like "Shayzien Crypts" alongside "Zemouregal's Fort"
+    "zemouregal": ["Zemouregal's Fort", "Zemouregal Fort"],
+    # Camdozaal -- beneath Ice Mountain (shares asgarnia surface)
+    "camdozaal": [
+        "Ruins of Camdozaal",
+        "Camdozaal",
+    ],
     # Varlamore / post-Sailing zones (extension to close the gap surfaced in
     # #566/#567 -- harness was previously blind to kraken-cascade mismatches
     # across Civitas illa Fortis, Auburnvale, Quetzacalli Gorge, etc.).
@@ -253,6 +376,7 @@ RELATIVE_PREPOSITIONS = (
     "near ",
     "outside ",
     "below ",
+    "beneath ",
     "above ",
     "next to ",
 )

--- a/scripts/audit_drop_rates.py
+++ b/scripts/audit_drop_rates.py
@@ -97,7 +97,20 @@ ZONE_GROUPS: dict[str, list[str]] = {
     ],
     "raid_toa": ["Necropolis", "Tombs of Amascut", "Kharidian Desert"],
     "catacombs": ["Catacombs of Kourend", "Catacombs"],
-    "wilderness": ["Wilderness"],
+    "wilderness": [
+        "Wilderness",
+        "Revenant Caves",
+        "Pirates' Hideout",
+        "Pirates Hideout",
+        "Bandit Camp",
+        "Chaos Temple",
+        "Elder Chaos Temple",
+        "Lava Maze",
+        "Rogues' Castle",
+        "Rogues Castle",
+        "Fountain of Rune",
+        "Wilderness God Wars Dungeon",
+    ],
     "gwd": ["God Wars Dungeon"],
     "fremennik": ["Fremennik Slayer Dungeon", "Fremennik"],
     "piscatoris": ["Piscatoris"],
@@ -125,6 +138,8 @@ ZONE_GROUPS: dict[str, list[str]] = {
         "Edgeville",
         "Warriors' Guild",
         "Warriors Guild",
+        "Ruins of Camdozaal",
+        "Camdozaal",
     ],
     "misthalin": [
         "Misthalin",
@@ -150,20 +165,6 @@ ZONE_GROUPS: dict[str, list[str]] = {
         "Iorwerth",
         "Isafdar",
         "Tyras Camp",
-    ],
-    # Wilderness sub-locations -- same broad region as Wilderness, share zone
-    # group to avoid kraken-cascade false positives.
-    "wilderness_sub": [
-        "Revenant Caves",
-        "Pirates' Hideout",
-        "Pirates Hideout",
-        "Bandit Camp",
-        "Chaos Temple",
-        "Elder Chaos Temple",
-        "Lava Maze",
-        "Rogues' Castle",
-        "Rogues Castle",
-        "Fountain of Rune",
     ],
     # Kandarin / Seers' / Catherby / Camelot / Tree Gnome Stronghold cluster
     "kandarin": [
@@ -227,11 +228,6 @@ ZONE_GROUPS: dict[str, list[str]] = {
     # Zemouregal's Fort -- isolated zone so harness flags any cross-mention
     # like "Shayzien Crypts" alongside "Zemouregal's Fort"
     "zemouregal": ["Zemouregal's Fort", "Zemouregal Fort"],
-    # Camdozaal -- beneath Ice Mountain (shares asgarnia surface)
-    "camdozaal": [
-        "Ruins of Camdozaal",
-        "Camdozaal",
-    ],
     # Varlamore / post-Sailing zones (extension to close the gap surfaced in
     # #566/#567 -- harness was previously blind to kraken-cascade mismatches
     # across Civitas illa Fortis, Auburnvale, Quetzacalli Gorge, etc.).

--- a/scripts/canonical_landmarks.json
+++ b/scripts/canonical_landmarks.json
@@ -275,11 +275,11 @@
     "worldPlane": 0,
     "aliases": ["TzHaar city", "Karamja Volcano", "Fight Caves", "Inferno arena"]
   },
-  "Tar Swamp": {
+  "Tar Swamp, Fossil Island": {
     "worldX": 3683,
     "worldY": 3706,
     "worldPlane": 0,
-    "aliases": ["Deranged Archaeologist lair", "Fossil Island Tar Swamp"]
+    "aliases": ["Tar Swamp", "Deranged Archaeologist lair", "Fossil Island Tar Swamp"]
   },
   "Zul-Andra": {
     "worldX": 2268,
@@ -950,10 +950,10 @@
     "aliases": ["Lletya elf town", "Lletya village"]
   },
   "Tree Gnome Stronghold": {
-    "worldX": 2461,
-    "worldY": 3445,
+    "worldX": 2436,
+    "worldY": 3500,
     "worldPlane": 0,
-    "aliases": ["Gnome Stronghold", "Spirit tree Stronghold", "Grand Tree", "Tree Gnome Village"]
+    "aliases": ["Gnome Stronghold", "Spirit tree Stronghold", "Grand Tree", "Tree Gnome Village", "Tree Gnome Stronghold restaurant"]
   },
   "Lumbridge Swamp": {
     "worldX": 3204,
@@ -966,5 +966,11 @@
     "worldY": 3805,
     "worldPlane": 0,
     "aliases": ["Fossil Island surface", "Museum Camp", "Mushroom forest", "Fossil Island northern"]
+  },
+  "Wyvern Cave, Fossil Island": {
+    "worldX": 3602,
+    "worldY": 10290,
+    "worldPlane": 0,
+    "aliases": ["Wyvern Cave", "Fossil Island Wyvern Cave", "Wyvern Cave Fossil Island", "Ancient Wyvern lair"]
   }
 }

--- a/scripts/canonical_landmarks.json
+++ b/scripts/canonical_landmarks.json
@@ -551,10 +551,16 @@
     "aliases": ["Deep sea fishing shoals", "Deep Sea Fishing hub", "Deep sea fishing", "Tempoross hub"]
   },
   "Hunter Guild": {
+    "worldX": 1565,
+    "worldY": 3047,
+    "worldPlane": 0,
+    "aliases": ["Hunter Guild Varlamore", "Avium Savannah Hunter Guild", "Hunter Guild building"]
+  },
+  "Colossal Wyrm Agility Course": {
     "worldX": 1651,
     "worldY": 2931,
     "worldPlane": 0,
-    "aliases": ["Colossal Wyrm Agility Course", "Colossal Wyrm Course", "Hunter Guild Varlamore", "Avium Savannah Hunter Guild"]
+    "aliases": ["Colossal Wyrm Course", "Avium Savannah Agility Course"]
   },
   "Varrock rooftop course": {
     "worldX": 3214,
@@ -627,5 +633,338 @@
     "worldY": 3325,
     "worldPlane": 0,
     "aliases": ["Darkmeyer city", "Vyrewatch Sentinel area", "Drakan's medallion destination"]
+  },
+  "Revenant Caves": {
+    "worldX": 3073,
+    "worldY": 3654,
+    "worldPlane": 0,
+    "aliases": ["Revenant Caves Wilderness", "Rev Caves", "Revenants lair", "Revenant Caves entrance"]
+  },
+  "Pirates' Hideout": {
+    "worldX": 3041,
+    "worldY": 3950,
+    "worldPlane": 0,
+    "aliases": ["Pirates Hideout", "Wilderness Pirates' Hideout", "Larran's big chest hideout"]
+  },
+  "Bandit Camp Wilderness": {
+    "worldX": 3038,
+    "worldY": 3700,
+    "worldPlane": 0,
+    "aliases": ["Bandit Camp", "Wilderness Bandit Camp", "Burning amulet Bandit Camp"]
+  },
+  "Chaos Temple Wilderness": {
+    "worldX": 3236,
+    "worldY": 3608,
+    "worldPlane": 0,
+    "aliases": ["Chaos Temple", "Wilderness Chaos Temple"]
+  },
+  "Champions' Guild": {
+    "worldX": 3191,
+    "worldY": 3361,
+    "worldPlane": 0,
+    "aliases": ["Champions Guild", "Champion's Challenge", "Varrock Champions' Guild"]
+  },
+  "Feldip Hills": {
+    "worldX": 2387,
+    "worldY": 3040,
+    "worldPlane": 0,
+    "aliases": ["Feldip", "Rantz", "Chompy hunting grounds", "Feldip Hills south of Rantz"]
+  },
+  "Seers' Village": {
+    "worldX": 2725,
+    "worldY": 3490,
+    "worldPlane": 0,
+    "aliases": ["Seers Village", "Seers' Village oak", "Camelot Seers'"]
+  },
+  "House on the Hill": {
+    "worldX": 3774,
+    "worldY": 3819,
+    "worldPlane": 0,
+    "aliases": ["House on the Hill Fossil Island", "Fossil Island house"]
+  },
+  "Crash Site Cavern": {
+    "worldX": 2130,
+    "worldY": 5647,
+    "worldPlane": 0,
+    "aliases": [
+      "Glough's Experiments lair",
+      "Crash Site Cavern beneath Ape Atoll",
+      "Crash Site Cavern beneath Gnome Stronghold",
+      "Crash Site"
+    ]
+  },
+  "Jalsavrah": {
+    "worldX": 3288,
+    "worldY": 2801,
+    "worldPlane": 0,
+    "aliases": ["Jalsavrah Pyramid", "Pyramid Plunder", "Sophanem Pyramid", "Sophanem"]
+  },
+  "Stronghold of Security": {
+    "worldX": 1859,
+    "worldY": 5243,
+    "worldPlane": 0,
+    "aliases": [
+      "Stronghold of Security beneath Barbarian Village",
+      "Vault of War",
+      "Catacomb of Famine",
+      "Pit of Pestilence",
+      "Sepulchre of Death"
+    ]
+  },
+  "Barbarian Village": {
+    "worldX": 3082,
+    "worldY": 3420,
+    "worldPlane": 0,
+    "aliases": ["Barbarian Village surface", "Stronghold of Security entrance"]
+  },
+  "Catacombs of Kourend underground": {
+    "worldX": 1664,
+    "worldY": 10050,
+    "worldPlane": 0,
+    "aliases": [
+      "Catacombs of Kourend beneath Kourend Castle",
+      "Catacombs interior",
+      "Skotizo arena"
+    ]
+  },
+  "Wilderness God Wars Dungeon entrance": {
+    "worldX": 3015,
+    "worldY": 3739,
+    "worldPlane": 0,
+    "aliases": [
+      "Wilderness GWD entrance",
+      "Wilderness God Wars Dungeon",
+      "Wildy GWD",
+      "God Wars Dungeon entrance in the Wilderness"
+    ]
+  },
+  "Prifddinas": {
+    "worldX": 3265,
+    "worldY": 6062,
+    "worldPlane": 0,
+    "aliases": [
+      "Prifddinas city",
+      "Elven Crystal Chest",
+      "Song of the Elves city",
+      "Iorwerth Camp Prifddinas"
+    ]
+  },
+  "Ice Mountain": {
+    "worldX": 3007,
+    "worldY": 3479,
+    "worldPlane": 0,
+    "aliases": ["Ice Mountain surface", "Edgeville Ice Mountain"]
+  },
+  "Ruins of Camdozaal": {
+    "worldX": 2957,
+    "worldY": 5774,
+    "worldPlane": 0,
+    "aliases": [
+      "Camdozaal",
+      "Below Ice Mountain",
+      "Camdozaal Ruins",
+      "Ruins of Camdozaal beneath Ice Mountain"
+    ]
+  },
+  "TzHaar City": {
+    "worldX": 2444,
+    "worldY": 5175,
+    "worldPlane": 0,
+    "aliases": [
+      "TzHaar City beneath the Karamja Volcano",
+      "TzHaar",
+      "Mor Ul Rek city",
+      "Karamja Volcano interior"
+    ]
+  },
+  "Warriors' Guild": {
+    "worldX": 2855,
+    "worldY": 3543,
+    "worldPlane": 0,
+    "aliases": [
+      "Warriors Guild",
+      "Burthorpe Warriors' Guild",
+      "Cyclopes room",
+      "Warrior guild defender"
+    ]
+  },
+  "Burthorpe": {
+    "worldX": 2898,
+    "worldY": 3535,
+    "worldPlane": 0,
+    "aliases": ["Burthorpe town", "Burthorpe Games Room"]
+  },
+  "Elder Chaos Temple": {
+    "worldX": 3232,
+    "worldY": 3621,
+    "worldPlane": 0,
+    "aliases": [
+      "Elder Chaos Temple Wilderness",
+      "Elder Chaos Druids",
+      "Wilderness Elder Chaos"
+    ]
+  },
+  "Shayzien Combat Ring": {
+    "worldX": 1516,
+    "worldY": 3617,
+    "worldPlane": 0,
+    "aliases": [
+      "Shayzien Combat Ring Great Kourend",
+      "Shayzien Soldiers",
+      "Shayzien Armour ring"
+    ]
+  },
+  "Tower of Life": {
+    "worldX": 2639,
+    "worldY": 3218,
+    "worldPlane": 0,
+    "aliases": [
+      "Tower of Life basement",
+      "Tower of Life south of Ardougne",
+      "Creature Creation altar"
+    ]
+  },
+  "Ancient Cavern": {
+    "worldX": 1745,
+    "worldY": 5323,
+    "worldPlane": 0,
+    "aliases": [
+      "Ancient Cavern beneath the Baxtorian Falls",
+      "Ancient Cavern Baxtorian",
+      "Mithril Dragon lair",
+      "Waterfiend lair",
+      "Otto's Grotto whirlpool"
+    ]
+  },
+  "Baxtorian Falls": {
+    "worldX": 2519,
+    "worldY": 3503,
+    "worldPlane": 0,
+    "aliases": ["Baxtorian Falls surface", "Otto's Grotto", "Otto Godblessed grotto"]
+  },
+  "Lithkren Vault": {
+    "worldX": 1568,
+    "worldY": 5062,
+    "worldPlane": 0,
+    "aliases": [
+      "Lithkren",
+      "Lithkren Vault Digsite pendant",
+      "Lithkren adamant dragon vault",
+      "Lithkren rune dragon vault"
+    ]
+  },
+  "Corsair Cove Dungeon": {
+    "worldX": 2459,
+    "worldY": 9488,
+    "worldPlane": 2,
+    "aliases": [
+      "Corsair Cove",
+      "Ogress Shaman lair",
+      "Corsair Cove dungeon"
+    ]
+  },
+  "Zemouregal's Fort": {
+    "worldX": 3566,
+    "worldY": 3390,
+    "worldPlane": 0,
+    "aliases": [
+      "Zemouregal Fort",
+      "Zemouregal's Fort north of Varrock",
+      "Armoured Zombie fort"
+    ]
+  },
+  "Fountain of Rune": {
+    "worldX": 3380,
+    "worldY": 3893,
+    "worldPlane": 0,
+    "aliases": [
+      "Fountain of Rune deep Wilderness",
+      "Wilderness Fountain of Rune",
+      "Wilderness sword 4 teleport"
+    ]
+  },
+  "Varrock": {
+    "worldX": 3210,
+    "worldY": 3424,
+    "worldPlane": 0,
+    "aliases": ["Varrock city", "Varrock central", "Varrock square"]
+  },
+  "Varrock west bank": {
+    "worldX": 3186,
+    "worldY": 3437,
+    "worldPlane": 0,
+    "aliases": ["Varrock west", "Varrock west bank stalls"]
+  },
+  "Lumbridge": {
+    "worldX": 3222,
+    "worldY": 3218,
+    "worldPlane": 0,
+    "aliases": ["Lumbridge castle", "Lumbridge town", "Lumbridge centre", "Lumbridge market"]
+  },
+  "Edgeville": {
+    "worldX": 3087,
+    "worldY": 3493,
+    "worldPlane": 0,
+    "aliases": ["Edgeville bank", "Edgeville town"]
+  },
+  "Camelot": {
+    "worldX": 2757,
+    "worldY": 3478,
+    "worldPlane": 0,
+    "aliases": ["Camelot castle", "Camelot teleport landing"]
+  },
+  "Catherby": {
+    "worldX": 2807,
+    "worldY": 3434,
+    "worldPlane": 0,
+    "aliases": ["Catherby beach", "Catherby fishing", "Catherby surface"]
+  },
+  "Ardougne": {
+    "worldX": 2662,
+    "worldY": 3305,
+    "worldPlane": 0,
+    "aliases": ["East Ardougne", "Ardougne market", "Ardougne city"]
+  },
+  "Yanille": {
+    "worldX": 2607,
+    "worldY": 3092,
+    "worldPlane": 0,
+    "aliases": ["Yanille town", "Yanille bank"]
+  },
+  "Falador town centre": {
+    "worldX": 2965,
+    "worldY": 3380,
+    "worldPlane": 0,
+    "aliases": ["Falador centre", "Falador town", "Falador square"]
+  },
+  "Al Kharid": {
+    "worldX": 3293,
+    "worldY": 3184,
+    "worldPlane": 0,
+    "aliases": ["Al Kharid bank", "Al Kharid town"]
+  },
+  "Lletya": {
+    "worldX": 2351,
+    "worldY": 3163,
+    "worldPlane": 0,
+    "aliases": ["Lletya elf town", "Lletya village"]
+  },
+  "Tree Gnome Stronghold": {
+    "worldX": 2461,
+    "worldY": 3445,
+    "worldPlane": 0,
+    "aliases": ["Gnome Stronghold", "Spirit tree Stronghold", "Grand Tree", "Tree Gnome Village"]
+  },
+  "Lumbridge Swamp": {
+    "worldX": 3204,
+    "worldY": 3175,
+    "worldPlane": 0,
+    "aliases": ["Lumbridge swamp caves", "Swamp boys hut", "Lumbridge swamp surface"]
+  },
+  "Fossil Island": {
+    "worldX": 3736,
+    "worldY": 3805,
+    "worldPlane": 0,
+    "aliases": ["Fossil Island surface", "Museum Camp", "Mushroom forest", "Fossil Island northern"]
   }
 }

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -15993,8 +15993,8 @@
   {
     "name": "My Notes",
     "category": "OTHER",
-    "worldX": 2520,
-    "worldY": 3571,
+    "worldX": 1745,
+    "worldY": 5323,
     "worldPlane": 0,
     "killTimeSeconds": 10,
     "afkLevel": 2,
@@ -16207,8 +16207,8 @@
       },
       {
         "description": "Kill mithril dragons in the Ancient Cavern for ancient page drops.",
-        "worldX": 2520,
-        "worldY": 3571,
+        "worldX": 1745,
+        "worldY": 5323,
         "worldPlane": 0,
         "completionCondition": "MANUAL"
       }
@@ -26668,7 +26668,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Kill Armoured Zombies in the Shayzien Crypts",
+        "description": "Kill Armoured Zombies at Zemouregal's Fort",
         "worldX": 3566,
         "worldY": 3390,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Final batch of Pass 1 for #495. Runs the audit harness over all 58 OTHER sources (Wilderness chests, Sailing/Boat Combat/Salvage cluster, Creature Creation, Tower of Life, dragon vaults, underground dungeons, Random Events catch-all, etc.).

After the landmark/ZONE_GROUPS extension in two prep commits, OTHER reports 58/58 verified. Two unambiguous mismatches auto-fixed during triage.

## Pass 1 (data audit) -- COMPLETE per #495

| Batch     | Sources | Auto-fixes | Issues filed     | PR        |
|-----------|--------:|-----------:|------------------|-----------|
| RAIDS     |       7 |          0 | 1 (#560)         | #561      |
| CLUES     |      12 |          0 | 0                | #562      |
| BOSSES    |      61 |          0 | 1 (#563)         | #564      |
| SLAYER    |      45 |          2 | 2 (#565, #566)   | #567      |
| MINIGAMES |      25 |          4 | 0                | #568      |
| SKILLING  |      17 |          1 | 0                | #570      |
| OTHER     |      58 |          2 | 0 (comments on #563, #565, #566) | this |
| **Total** | **225** |      **9** | **4**            |           |

Pass 2 (in-game Phase 2/5 validation) is the remaining work for #495.

## Triage results (OTHER)

| Bucket           | Count |
|------------------|------:|
| verified         |    58 |
| flagged-fixable  |     0 |
| flagged-research |     0 |
| error            |     0 |

## Pattern groups

- Sailing/Boat Combat/Salvage placeholder coord (1824, 3691) -- 17 sources share the Aldarin harbor placeholder convention introduced in SKILLING #570 (Cutting Squid). All verified as intentional placeholders for the Sailing reward system: Boat Paints, Lost Schematics, Ocean Encounters, Sailing Misc, Sea Treasures, Port Tasks, 6 Boat Combat sources, 8 Salvage sources.
- Creature Creation cluster (2639, 3218) -- 6 sources at the Tower of Life basement: Newtroost, Unicow, Spidine, Swordchick, Jubster, Frogeel. All verified.
- Random Events / Miscellaneous (3222, 3218) -- 2 catch-all entries using Lumbridge centre as a generic anchor. Verified.
- Underground arenas Y>5000 -- TzHaar City, Stronghold of Security, Camdozaal, Catacombs of Kourend, Ancient Cavern (Mithril Dragon + Waterfiend + My Notes after fix), Lithkren Vault (Adamant + Rune Dragon), Crash Site Cavern (Gloughs Experiments), Corsair Cove Dungeon (Ogress Shaman, only plane-2 source in the dataset). All verified after seeding underground landmarks.
- Two real mismatches auto-fixed (My Notes, Armoured Zombie) -- see below.

## Auto-fixes applied (OTHER)

| Source | Field | Before | After | Reason |
|---|---|---|---|---|
| My Notes | worldX / worldY (root) | 2520, 3571 | 1745, 5323 | locationDescription says "Ancient Cavern beneath the Baxtorian Falls" but coord was the surface entrance. Aligned with Mithril Dragon (same arena, same NPC, identical wording) which already uses 1745, 5323. |
| My Notes | guidanceSteps[2] worldX / worldY | 2520, 3571 | 1745, 5323 | Step description is "Kill mithril dragons in the Ancient Cavern" but coord was on the surface. Patched to match root. |
| Armoured Zombie | guidanceSteps[1] description | (referenced the wrong dungeon) | "Kill Armoured Zombies at Zemouregals Fort" | NPC 14113 with the Defender of Varrock quest gate spawns at Zemouregals Fort north-east of Varrock. Prior wording was leftover from a different planned source. |

## Harness changes (prep commits)

Prep 1 -- landmarks + ZONE_GROUPS extension:

- ~40 new landmarks added: town anchors, Wilderness sub-locations, Varlamore Hunter Guild proper (renamed prior "Hunter Guild" landmark to "Colossal Wyrm Agility Course" since those coords were the agility course), dungeon entrances + interiors, plus brand-new zone groups for Kandarin / Kharidian / Feldip / Fossil Island family / Crash Site / Stronghold of Security / Lithkren / Corsair / Tower of Life / Zemouregals Fort.
- ZONE_GROUPS extended with sub-region tokens for asgarnia, misthalin, karamja, tirannwn, zeah.
- "beneath " added to RELATIVE_PREPOSITIONS so phrases like "Ancient Cavern beneath the Baxtorian Falls" anchor to Ancient Cavern instead of the surface Baxtorian Falls -- this is what surfaced the My Notes drift that prior runs missed.

Prep 2 -- consolidate sub-zone groups:

The initial split of wilderness_sub and camdozaal as separate zone groups caused kraken-cascade false positives for KBD / Scorpia / Venenatis / Vetion / Callisto / Crazy archaeologist / Whisperer. Consolidated wilderness_sub tokens into "wilderness" and camdozaal tokens into "asgarnia" (shared Ice Mountain surface). Also reordered Tar Swamp + Wyvern Cave landmark keys so the multi-word string anchors take priority over the broader Fossil Island landmark, and dropped the "East of Chaos Temple" alias from Chaos Temple Wilderness (it bypassed the relative-preposition skip).

Optional surface->underground sniffer (skipped):

Smoke-tested a check that flags locationDescription containing dungeon/cavern/cave/etc. keywords with worldY less than 5000. Produced 26 hits across the dataset of which 25 are intentional surface-entrance coords (e.g. General Graardor at GWD entrance, Cerberus at Taverley Dungeon entrance, Sarachnis at Forthos Dungeon entrance). Signal-to-noise was too low so the sniffer was not shipped. The "beneath " preposition addition catches the highest-value variant of this fingerprint via the landmark distance check instead, and is what found My Notes.

## Issues filed / comments

No new issues filed for OTHER. Pre-existing findings surfaced by the harness extension are tracked under existing umbrellas:

- #563 (BOSSES sub-zone coord drift) -- comments added for The Inferno, Deranged Archaeologist, Alchemical Hydra, Scurrius surface vs underground deltas
- #565 (Frost Nagua) -- comment added confirming the harness extension keeps the same finding
- #566 (Lava Strykewyrm) -- comment added confirming the harness extension keeps the same finding

## Test plan

- [x] `python scripts/audit_drop_rates.py --category OTHER` -> 58 verified / 0 flagged
- [x] `python scripts/audit_drop_rates.py --category ALL` -> 207 verified / 18 flagged (all 18 pre-existing or already tracked under #560 / #563 / #565 / #566)
- [x] `./gradlew lintDropRates` -> BUILD SUCCESSFUL
- [x] `./gradlew test jacocoTestReport jacocoTestCoverageVerification check` -> BUILD SUCCESSFUL
- [x] Diff drop_rates.json against master shows exactly the 3 auto-fix edits (My Notes root coord, My Notes step 3 coord, Armoured Zombie step 2 description)
- [ ] In-game Pass 2 verification of My Notes and Armoured Zombie navigation hints -- deferred to #495 Phase 2/5

## Notes for Pass 2 (in-game validation)

Observations from Pass 1 that should shape Pass 2 testing priority:

1. Sailing/Boat Combat/Salvage shared placeholder (1824, 3691) -- 17 OTHER sources route to the same coord. In-game UX testing should confirm players reach a sensible Sailing hub from that anchor and that the per-source travelTip / guidanceSteps wording differentiates the activities once they arrive.
2. My Notes underground coord change -- the navigation hint now teleports / walks the player into the Ancient Cavern (Y=5323) directly. Pass 2 should confirm the path-finder copes with the surface->dive transition or that the first guidance step (Ottos Grotto surface, Y=3509) still gets visited before the underground tile.
3. Armoured Zombie wording fix -- now reads as "at Zemouregals Fort". Confirm visually in-game that the overlay description matches the players surroundings.
4. Underground sources with plane greater than 0 -- Ogress Shaman is the only plane-2 source in the dataset; verify the arrival overlay actually points to the second floor of Corsair Cove Dungeon and not the dungeon entrance plane.
5. Demonic gorillas, Fossil Island Wyvern, Scurrius (BOSSES / SLAYER) -- these now surface in the harness as potential surface->underground drift but are out of OTHERs scope. Should be on the in-game shortlist.
