### PR TITLE
fix(data): restructure GWD boss guidance steps to fix order + dedupe kill (#574)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -116,16 +116,6 @@
         "section": "Travel"
       },
       {
-        "description": "Kill General Graardor. Use Protect from Melee, pray Piety, and tank the minions. Kill Sergeant Steelwill first if you want to reduce damage taken",
-        "worldX": 2882,
-        "worldY": 5310,
-        "worldPlane": 2,
-        "objectId": 26415,
-        "objectInteractAction": "Move",
-        "completionCondition": "PLAYER_ON_PLANE",
-        "section": "Combat"
-      },
-      {
         "description": "Get 40 Bandos killcount by killing goblins, hobgoblins, or jogres in the main chamber",
         "worldX": 2862,
         "worldY": 5357,
@@ -136,7 +126,7 @@
         "section": "Combat"
       },
       {
-        "description": "Enter the Bandos boss room and kill General Graardor",
+        "description": "Enter the Bandos boss room and kill General Graardor. Use Protect from Melee, pray Piety, and tank the minions. Kill Sergeant Steelwill first if you want to reduce damage taken",
         "worldX": 2864,
         "worldY": 5360,
         "worldPlane": 2,
@@ -273,16 +263,6 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Commander Zilyana. Use Protect from Ranged and a crossbow. Kite her in a large loop around the room to avoid melee damage",
-        "worldX": 2882,
-        "worldY": 5310,
-        "worldPlane": 2,
-        "objectId": 26415,
-        "objectInteractAction": "Move",
-        "completionCondition": "PLAYER_ON_PLANE",
-        "section": "Combat"
-      },
-      {
         "description": "Get 40 Saradomin killcount by killing knights and spiritual warriors in the main chamber",
         "worldX": 2907,
         "worldY": 5265,
@@ -293,7 +273,7 @@
         "section": "Combat"
       },
       {
-        "description": "Enter the Saradomin boss room and kill Commander Zilyana",
+        "description": "Enter the Saradomin boss room and kill Commander Zilyana. Use Protect from Ranged and a crossbow. Kite her in a large loop around the room to avoid melee damage",
         "worldX": 2925,
         "worldY": 5265,
         "worldPlane": 2,
@@ -430,16 +410,6 @@
         "section": "Travel"
       },
       {
-        "description": "Kill K'ril Tsutsaroth. Use Protect from Melee and high-healing food. His special attack can hit through prayer. Shadow of Tumeken or arclight effective",
-        "worldX": 2882,
-        "worldY": 5310,
-        "worldPlane": 2,
-        "objectId": 26415,
-        "objectInteractAction": "Move",
-        "completionCondition": "PLAYER_ON_PLANE",
-        "section": "Combat"
-      },
-      {
         "description": "Get 40 Zamorak killcount by killing imps, werewolves, or vampyres in the main chamber",
         "worldX": 2914,
         "worldY": 5350,
@@ -450,7 +420,7 @@
         "section": "Combat"
       },
       {
-        "description": "Enter the Zamorak boss room and kill K'ril Tsutsaroth",
+        "description": "Enter the Zamorak boss room and kill K'ril Tsutsaroth. Use Protect from Melee and high-healing food. His special attack can hit through prayer. Shadow of Tumeken or arclight effective",
         "worldX": 2914,
         "worldY": 5350,
         "worldPlane": 2,
@@ -587,16 +557,6 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Kree'arra. Use Protect from Ranged and chinchompas or crossbow. Kite in a loop. All GWD bosses require 40 KC of the corresponding faction",
-        "worldX": 2882,
-        "worldY": 5310,
-        "worldPlane": 2,
-        "objectId": 26415,
-        "objectInteractAction": "Move",
-        "completionCondition": "PLAYER_ON_PLANE",
-        "section": "Combat"
-      },
-      {
         "description": "Get 40 Armadyl killcount by killing aviansie in the main chamber",
         "worldX": 2844,
         "worldY": 5280,
@@ -607,7 +567,7 @@
         "section": "Combat"
       },
       {
-        "description": "Use a mithril grapple to enter the Armadyl boss room and kill Kree'arra",
+        "description": "Use a mithril grapple to enter the Armadyl boss room and kill Kree'arra. Use Protect from Ranged and chinchompas or a crossbow. Kite in a loop to avoid the minions",
         "worldX": 2844,
         "worldY": 5280,
         "worldPlane": 2,


### PR DESCRIPTION
@
## Summary

Restructures the guidance steps for all four God Wars Dungeon bosses to match the canonical 3-step pattern already used by Nex. The previous structure had a duplicate kill step that preceded the KC gate, which was logically impossible (you cannot kill the boss without first earning 40 KC). The in-game step pointer was landing on the wrong step as a result.

Fixes #574.

## Pattern applied (matches Nex)

| Step | Section | Description |
|---|---|---|
| 1 | Travel | Teleport to Trollheim and run north to the GWD entrance |
| 2 | Combat | Get 40 <faction> killcount in the main chamber |
| 3 | Combat | Enter the <faction> boss room and kill <boss>. [strategy advice merged in] |

## Per-boss before/after

### General Graardor (4 -> 3 steps)
- Before: Travel -> Kill Graardor (orphan, with strategy) -> Get 40 Bandos KC -> Enter Bandos room and kill Graardor
- After: Travel -> Get 40 Bandos KC -> Enter Bandos room and kill Graardor (strategy merged)

### Commander Zilyana (4 -> 3 steps)
- Before: Travel -> Kill Zilyana (orphan, with strategy) -> Get 40 Saradomin KC -> Enter Saradomin room and kill Zilyana
- After: Travel -> Get 40 Saradomin KC -> Enter Saradomin room and kill Zilyana (strategy merged)

### K`ril Tsutsaroth (4 -> 3 steps)
- Before: Travel -> Kill K`ril (orphan, with strategy) -> Get 40 Zamorak KC -> Enter Zamorak room and kill K`ril
- After: Travel -> Get 40 Zamorak KC -> Enter Zamorak room and kill K`ril (strategy merged)

### Kree`arra (4 -> 3 steps)
- Before: Travel -> Kill Kree`arra (orphan, with strategy) -> Get 40 Armadyl KC -> Use mithril grapple to enter and kill Kree`arra
- After: Travel -> Get 40 Armadyl KC -> Use mithril grapple to enter Armadyl room and kill Kree`arra (strategy merged)

The orphan kill step (which had `completionCondition: PLAYER_ON_PLANE` against the GWD entrance plane and pointed at the dungeon entry rope, not the actual boss room) is dropped in all four cases. Strategy advice from that step is preserved by being merged into the final enter-and-kill step. The Kree`arra step also drops the trailing "All GWD bosses require 40 KC of the corresponding faction" sentence because that requirement is now its own explicit step 2.

## Test plan

- [x] `./gradlew lintDropRates` passes
- [x] `./gradlew build` passes (tests + JaCoCo coverage gate)
- [x] `drop_rates.json` is ASCII-clean (no non-ASCII bytes introduced)
- [x] All four GWD boss entries deserialize and load via `DropRateDatabase`
- [x] Each boss now has exactly 3 `guidanceSteps` entries
- [x] KC gate step precedes the enter-and-kill step in every case
- [ ] In-game smoke test on at least one GWD boss to confirm the step pointer advances correctly through Travel -> KC gate -> Kill (deferred to the live-validation pass for #495)
@