### PR TITLE
fix(ui): sync step-control STOP icon with source-level Stop Guidance button (#576)

### DIFF
--- a/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
@@ -524,6 +524,11 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 			guidanceBannerView.hideGuidance();
 		}
 		quickGuidePanelView.syncGuidanceState(active, source);
+		// #576 — sync the source-level Guide Me / Stop Guidance button on the
+		// active item-detail card. Without this fan-out, deactivating guidance
+		// from the step-control STOP icon would update the Quick Guide button
+		// but leave the detail-view button stuck in "Stop Guidance" mode.
+		detailViewBuilder.syncGuidanceState(active, source);
 	}
 
 	public void showClueGuidance(CollectionLogSource source)

--- a/src/main/java/com/collectionloghelper/ui/DetailViewBuilder.java
+++ b/src/main/java/com/collectionloghelper/ui/DetailViewBuilder.java
@@ -57,6 +57,17 @@ public class DetailViewBuilder
 	private final BiConsumer<CollectionLogSource, Integer> guidanceActivator;
 	private final Runnable guidanceDeactivator;
 
+	/**
+	 * Most-recently-rendered detail panel. Held so that
+	 * {@link #syncGuidanceState(boolean, CollectionLogSource)} can reach the
+	 * currently-visible Guide Me / Stop Guidance button when guidance is
+	 * deactivated from a different surface (e.g., the step-control STOP icon
+	 * in {@code StepProgressView}). Mirrors the {@code lastGuideButton} held by
+	 * {@link com.collectionloghelper.ui.widget.QuickGuidePanelView}. See
+	 * cha-ndler/collection-log-helper#576.
+	 */
+	private ItemDetailPanel lastDetail;
+
 	public DetailViewBuilder(
 		PlayerCollectionState collectionState,
 		RequirementsChecker requirementsChecker,
@@ -119,6 +130,32 @@ public class DetailViewBuilder
 			isGuidingThis
 		);
 		target.add(detail, BorderLayout.NORTH);
+		lastDetail = detail;
+	}
+
+	/**
+	 * Syncs the most-recently-rendered detail panel's Guide Me / Stop Guidance
+	 * button to the canonical guidance-active state. Called from
+	 * {@link CollectionLogHelperPanel#setGuidanceState} so that deactivating
+	 * guidance from any surface — including the step-control STOP icon — flips
+	 * the source-level button back to "Guide Me" instead of leaving it stuck on
+	 * "Stop Guidance". Resolves cha-ndler/collection-log-helper#576.
+	 *
+	 * <p>Safe to call from any thread; the underlying button update is queued onto
+	 * the EDT by {@link ItemDetailPanel#syncGuidanceState}. A no-op when no detail
+	 * panel has been populated yet (e.g., the user has never entered detail view).
+	 *
+	 * @param active       whether guidance is now active
+	 * @param guidedSource the currently guided source (may be {@code null})
+	 */
+	public void syncGuidanceState(boolean active, CollectionLogSource guidedSource)
+	{
+		ItemDetailPanel detail = lastDetail;
+		if (detail == null)
+		{
+			return;
+		}
+		detail.syncGuidanceState(active, guidedSource);
 	}
 
 	private int countObtainedItems(CollectionLogSource source)

--- a/src/main/java/com/collectionloghelper/ui/ItemDetailPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/ItemDetailPanel.java
@@ -40,6 +40,7 @@ import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
@@ -55,6 +56,7 @@ class ItemDetailPanel extends JPanel
 	private static final Color LOCKED_COLOR = new Color(200, 80, 80);
 
 	private final JButton guideMeButton;
+	private final CollectionLogSource source;
 
 	ItemDetailPanel(CollectionLogItem item, CollectionLogSource source, boolean obtained,
 		boolean locked, List<String> unmetRequirements,
@@ -64,6 +66,8 @@ class ItemDetailPanel extends JPanel
 		Runnable onBack, Runnable onGuideMe, Runnable onStopGuidance,
 		boolean guidanceActive)
 	{
+		this.source = source;
+
 		setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
 		setBorder(BorderFactory.createEmptyBorder(8, 8, 8, 8));
 		setBackground(ColorScheme.DARK_GRAY_COLOR);
@@ -256,6 +260,34 @@ class ItemDetailPanel extends JPanel
 			guideMeButton.setForeground(Color.WHITE);
 			guideMeButton.setToolTipText("Show overlays to guide you");
 		}
+	}
+
+	/**
+	 * Syncs this detail panel's Guide Me / Stop Guidance button to the canonical
+	 * guidance-active state held by {@link CollectionLogHelperPanel}.
+	 *
+	 * <p>Resolves cha-ndler/collection-log-helper#576: when the step-control row's
+	 * STOP icon deactivates guidance via
+	 * {@link com.collectionloghelper.guidance.GuidanceOverlayCoordinator#deactivateGuidance},
+	 * the panel's {@code setGuidanceState(false, null, null)} fan-out updates the
+	 * Quick Guide button but used to leave the source-level detail-view button stuck
+	 * in "Stop Guidance" mode. Routing both surfaces through the same sync entry
+	 * point keeps them in lockstep regardless of which control initiated the stop.
+	 *
+	 * <p>Safe to call from any thread; mirrors
+	 * {@link com.collectionloghelper.ui.widget.QuickGuidePanelView#syncGuidanceState}.
+	 *
+	 * @param active       whether guidance is now active
+	 * @param guidedSource the currently guided source (may be {@code null})
+	 */
+	void syncGuidanceState(boolean active, CollectionLogSource guidedSource)
+	{
+		SwingUtilities.invokeLater(() ->
+		{
+			boolean isGuidingThis = active && guidedSource != null
+				&& guidedSource.getName().equals(source.getName());
+			updateGuideButtonState(isGuidingThis);
+		});
 	}
 
 	private void appendInfoRow(StringBuilder sb, String label, String value)

--- a/src/test/java/com/collectionloghelper/ui/DetailViewBuilderTest.java
+++ b/src/test/java/com/collectionloghelper/ui/DetailViewBuilderTest.java
@@ -245,6 +245,76 @@ public class DetailViewBuilderTest
 		assertEquals("Activator must NOT fire when stopping guidance", -1, activatorItemId.get());
 	}
 
+	/**
+	 * Regression coverage for #576 — the step-control STOP icon used to stop
+	 * guidance without flipping the source-level Guide Me / Stop Guidance button
+	 * back to "Guide Me", leaving the two buttons desynced. After the fix, the
+	 * builder's {@code syncGuidanceState(false, null)} fan-out reaches the
+	 * currently-rendered detail panel and reverts its button.
+	 */
+	@Test
+	public void syncGuidanceStateFlipsStopGuidanceButtonBackToGuideMe() throws Exception
+	{
+		when(collectionState.isItemObtained(anyInt())).thenReturn(false);
+		when(requirementsChecker.isAccessible(anyString())).thenReturn(true);
+
+		// Render the detail view in the "currently guiding this source" state so the
+		// source-level button reads "Stop Guidance".
+		builder.populate(target, item, source, true, source, () -> { });
+		ItemDetailPanel detail = (ItemDetailPanel) target.getComponent(0);
+		assertNotNull("Detail view should expose a Stop Guidance button before sync",
+			findFirstButton(detail, "Stop Guidance"));
+
+		// Simulate the step-control STOP icon path: GuidanceOverlayCoordinator
+		// .deactivateGuidance -> OverlayDeactivator -> panel.setGuidanceState(false, null, null)
+		// -> detailViewBuilder.syncGuidanceState(false, null).
+		builder.syncGuidanceState(false, null);
+		javax.swing.SwingUtilities.invokeAndWait(() -> { /* flush EDT */ });
+
+		assertNotNull("After sync the detail button must read 'Guide Me'",
+			findFirstButton(detail, "Guide Me"));
+		assertEquals("Stop Guidance button must no longer be present after sync",
+			null, findFirstButton(detail, "Stop Guidance"));
+	}
+
+	/**
+	 * Guards the inverse direction: when guidance is re-activated for the same
+	 * source from another surface (e.g. the Top Pick "Guide Me" button), the
+	 * detail-view button should flip into "Stop Guidance" mode without needing a
+	 * detail-view rebuild.
+	 */
+	@Test
+	public void syncGuidanceStateFlipsGuideMeButtonToStopGuidanceWhenActivatedElsewhere() throws Exception
+	{
+		when(collectionState.isItemObtained(anyInt())).thenReturn(false);
+		when(requirementsChecker.isAccessible(anyString())).thenReturn(true);
+
+		builder.populate(target, item, source, false, null, () -> { });
+		ItemDetailPanel detail = (ItemDetailPanel) target.getComponent(0);
+		assertNotNull("Initial detail view should show 'Guide Me'",
+			findFirstButton(detail, "Guide Me"));
+
+		builder.syncGuidanceState(true, source);
+		javax.swing.SwingUtilities.invokeAndWait(() -> { /* flush EDT */ });
+
+		assertNotNull("After sync the detail button must read 'Stop Guidance'",
+			findFirstButton(detail, "Stop Guidance"));
+	}
+
+	/**
+	 * Sync calls before any detail view has been populated must be a safe no-op
+	 * (the user may toggle guidance from the Quick Guide panel before ever
+	 * entering detail view).
+	 */
+	@Test
+	public void syncGuidanceStateBeforePopulateIsNoOp()
+	{
+		// No populate() call — lastDetail is still null.
+		builder.syncGuidanceState(false, null);
+		builder.syncGuidanceState(true, source);
+		// Reaching this line without an NPE is the assertion.
+	}
+
 	private static javax.swing.JButton findFirstButton(java.awt.Container root, String labelSubstring)
 	{
 		for (Component c : root.getComponents())


### PR DESCRIPTION
## Summary

Fixes #576. The step-control STOP icon (the red square in the
step-instruction control bar introduced in #547) used to deactivate
guidance without flipping the source-level Guide Me / Stop Guidance
button on the active item-detail card. Both controls drive the same
underlying guidance-active state, so they need to render in lockstep.

## Root cause

The deactivate fan-out chain is:

`StepProgressView` stop callback -> `CollectionLogHelperPlugin.deactivateGuidance` ->
`GuidanceOverlayCoordinator.deactivateGuidance` -> `OverlayDeactivator.deactivate` ->
`panel.setGuidanceState(false, null, null)`

`setGuidanceState` updated the panel's own `guidanceActive` field and
called `quickGuidePanelView.syncGuidanceState(false, null)`, but never
reached the `ItemDetailPanel` currently rendered in the detail card.
`ItemDetailPanel` only updated its button text/background from inside its
own action listener (lines 213-228), so the only path that kept it in
sync was a click on its own Stop Guidance button.

## Fix

- Added `ItemDetailPanel.syncGuidanceState(active, guidedSource)` —
  the same shape as the existing `QuickGuidePanelView.syncGuidanceState`.
- Added `DetailViewBuilder.syncGuidanceState(active, guidedSource)` that
  forwards to the most-recently-rendered detail panel (no-op when none).
- `CollectionLogHelperPanel.setGuidanceState` now fans out to both
  `quickGuidePanelView.syncGuidanceState` and
  `detailViewBuilder.syncGuidanceState`, so every surface stays in sync
  no matter which control initiated the activate/deactivate.

## Test plan

- [x] `./gradlew build` green (Checkstyle, all tests, JaCoCo 80% gate).
- [x] New unit tests in `DetailViewBuilderTest`:
  - `syncGuidanceStateFlipsStopGuidanceButtonBackToGuideMe` — STOP icon path.
  - `syncGuidanceStateFlipsGuideMeButtonToStopGuidanceWhenActivatedElsewhere` — inverse direction (activate from elsewhere).
  - `syncGuidanceStateBeforePopulateIsNoOp` — guards the never-entered-detail-view path.
- [ ] Manual: click the source-level Guide Me button -> step-control row appears with active state; click the red STOP icon -> source-level button reverts to Guide Me without leaving detail view.
- [ ] Manual: with detail view open and guidance active, click the Quick Guide Stop Guidance button -> detail-view button reverts too.