### PR TITLE
feat(config): standardize F1/F2 sync labels + add explanatory tooltips (#577)

### DIFF
--- a/src/main/java/com/collectionloghelper/CollectionLogHelperConfig.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperConfig.java
@@ -51,8 +51,10 @@ public interface CollectionLogHelperConfig extends Config
 
 	@ConfigItem(
 		keyName = "enableCollectionLogNetImport",
-		name = "collectionlog.net import",
-		description = "Show a 'Sync from collectionlog.net' button in the panel to import your obtained items from collectionlog.net",
+		name = "collectionlog.net Sync",
+		description = "Imports your collection log progress from collectionlog.net using your RSN. "
+			+ "Marks obtained items in the panel without needing to open the in-game collection log first. "
+			+ "Optional — without this, items are detected automatically once you open the collection log in-game.",
 		section = syncSection,
 		position = 0
 	)
@@ -289,9 +291,9 @@ public interface CollectionLogHelperConfig extends Config
 	@ConfigItem(
 		keyName = "enableTempleOsrsSync",
 		name = "TempleOSRS KC Sync",
-		description = "Enable the 'Sync KC from TempleOSRS' button in the panel. "
-			+ "When clicked the plugin fetches your boss/activity kill counts from "
-			+ "templeosrs.com and stores them locally for use in efficiency scoring.",
+		description = "Pulls your kill counts for tracked activities from TempleOSRS. "
+			+ "Powers the Dry Streak panel and tightens kill-time estimates per source. "
+			+ "Optional — without this, kill counts are learned per session via the Learn Kill Times option below.",
 		section = syncSection,
 		position = 1
 	)


### PR DESCRIPTION
## Summary

Three small polish items on the F1 (collectionlog.net) and F2 (TempleOSRS) sync config entries — config interface only, no panel/overlay/data changes.

- **Label normalization** — renamed `collectionlog.net import` → `collectionlog.net Sync` to match the existing `TempleOSRS KC Sync` label (consistent "Sync" verb, consistent capitalization). Site-brand lowercase `c` in `collectionlog.net` preserved.
- **Tooltip descriptions** — rewrote both `@ConfigItem` `description` fields so the RuneLite config panel mouseover explains what each sync does, what it powers, and that it is optional.
- **Defaults verified opt-in** — both items remain `defaultValue = false` (unchanged; already correct).

## Test plan

- [x] `./gradlew build` green locally (compile + tests + jacoco + lintDropRates)
- [ ] Spot-check in-client: hover both checkboxes in the Sync section, confirm new tooltip text renders
- [ ] Spot-check in-client: confirm both labels render as `collectionlog.net Sync` and `TempleOSRS KC Sync`

Closes #577