### PR TITLE
fix(overlay): render C1-C5 detected state in C7 debug overlay + add accurate quest count

### DIFF
--- a/src/main/java/com/collectionloghelper/overlay/PlayerCapabilityDebugOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/PlayerCapabilityDebugOverlay.java
@@ -47,6 +47,7 @@ import net.runelite.api.Player;
 import net.runelite.api.Quest;
 import net.runelite.api.QuestState;
 import net.runelite.api.Skill;
+import net.runelite.api.VarPlayer;
 import net.runelite.client.ui.overlay.OverlayPanel;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.LineComponent;
@@ -59,7 +60,8 @@ import net.runelite.client.ui.overlay.components.TitleComponent;
  * <p>Renders three blocks:
  * <ol>
  *   <li><b>Account summary</b> — combat, key skills, spellbook, prayer book, slayer
- *       task, quest enum count, POH built.</li>
+ *       task, quest count (enum-derived ratio plus the in-game Quest Points
+ *       varplayer for cross-checking against the Quest List header), POH built.</li>
  *   <li><b>Tier C detection</b> — one section per detection layer:
  *       C1 POH teleport inventory, C2 equipped items, C3 diary tiers per region,
  *       C4 skill cape perks, C5 partial-quest sub-milestones.</li>
@@ -141,17 +143,17 @@ public class PlayerCapabilityDebugOverlay extends OverlayPanel
 			.color(TITLE_COLOR)
 			.build());
 
-		renderAccountSummary();
+		safeRender("Account", this::renderAccountSummary);
 		renderSection("POH Teleports (C1)");
-		renderPohTeleports();
+		safeRender("POH Teleports", this::renderPohTeleports);
 		renderSection("Equipped (C2)");
-		renderEquipped();
+		safeRender("Equipped", this::renderEquipped);
 		renderSection("Diary tiers (C3)");
-		renderDiary();
+		safeRender("Diary tiers", this::renderDiary);
 		renderSection("Cape perks (C4)");
-		renderCapePerks();
+		safeRender("Cape perks", this::renderCapePerks);
 		renderSection("Quest sub-milestones (C5)");
-		renderQuestSubMilestones();
+		safeRender("Quest sub-milestones", this::renderQuestSubMilestones);
 
 		return super.render(graphics);
 	}
@@ -189,12 +191,23 @@ public class PlayerCapabilityDebugOverlay extends OverlayPanel
 			addRow("Task", "none");
 		}
 
-		// "Quest entries" rather than "Quests done" — the RuneLite Quest enum
-		// counts miniquests and some sub-entries separately from the in-game
-		// Quest List, so this number can exceed the player's main-quest count
-		// (see #487 for the longer-term reclassification).
+		// Quest counts (#487):
+		//
+		// The RuneLite {@link Quest} enum mixes main quests, miniquests, and other
+		// quest-list sub-entries, so a naive `Quest.values()` walk produces a number
+		// (e.g. 207) that is larger than the in-game Quest List "Completed: X/Y"
+		// figure (e.g. 179/179 on a maxed account). We expose two complementary
+		// values so authors can cross-check against the live client:
+		//
+		//   - "Quests" — finished / total over the Quest enum surface. This is
+		//     the value our partial-quest detection (C5) actually operates on.
+		//   - "Quest points" — the in-game QP varplayer. Matches the number shown
+		//     under the Quest List header verbatim, giving an unambiguous sanity
+		//     check that doesn't depend on enum membership.
 		int finishedCount = countFinishedQuests();
-		addRow("Quest entries", String.valueOf(finishedCount));
+		int totalQuestEntries = Quest.values().length;
+		addRow("Quests", finishedCount + "/" + totalQuestEntries);
+		addRow("Quest points", String.valueOf(safeVarp(VarPlayer.QUEST_POINTS)));
 
 		int pohLocation = safeVarbit(VARBIT_POH_LOCATION);
 		addRow("POH built", pohLocation > 0 ? "yes" : "no");
@@ -316,6 +329,23 @@ public class PlayerCapabilityDebugOverlay extends OverlayPanel
 			.build());
 	}
 
+	/**
+	 * Run a section renderer and, if it throws or trips an NPE because a data
+	 * source is wired up incorrectly, emit a dim {@code (error)} row instead of
+	 * letting the exception bubble up and kill the overlay paint thread.
+	 */
+	private void safeRender(String sectionLabel, Runnable body)
+	{
+		try
+		{
+			body.run();
+		}
+		catch (Exception e)
+		{
+			addDimRow(sectionLabel + ": (error)");
+		}
+	}
+
 	private void renderSection(String label)
 	{
 		panelComponent.getChildren().add(LineComponent.builder()
@@ -344,6 +374,18 @@ public class PlayerCapabilityDebugOverlay extends OverlayPanel
 		try
 		{
 			return client.getVarbitValue(varbitId);
+		}
+		catch (Exception e)
+		{
+			return -1;
+		}
+	}
+
+	private int safeVarp(int varpId)
+	{
+		try
+		{
+			return client.getVarpValue(varpId);
 		}
 		catch (Exception e)
 		{

--- a/src/test/java/com/collectionloghelper/overlay/PlayerCapabilityDebugOverlayTest.java
+++ b/src/test/java/com/collectionloghelper/overlay/PlayerCapabilityDebugOverlayTest.java
@@ -26,39 +26,67 @@ package com.collectionloghelper.overlay;
 
 import com.collectionloghelper.CollectionLogHelperConfig;
 import com.collectionloghelper.data.SlayerTaskState;
+import com.collectionloghelper.player.DiaryRegion;
+import com.collectionloghelper.player.DiaryTier;
 import com.collectionloghelper.player.DiaryTierState;
 import com.collectionloghelper.player.EquippedItemState;
 import com.collectionloghelper.player.PlayerQuestProgressState;
+import com.collectionloghelper.player.PohTeleport;
 import com.collectionloghelper.player.PohTeleportInventory;
+import com.collectionloghelper.player.QuestSubMilestone;
+import com.collectionloghelper.player.SkillCapePerk;
 import com.collectionloghelper.player.SkillCapePerkState;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import net.runelite.api.Client;
 import net.runelite.api.Player;
+import net.runelite.api.Quest;
+import net.runelite.api.QuestState;
 import net.runelite.api.Skill;
+import net.runelite.api.VarPlayer;
+import net.runelite.client.ui.overlay.components.LayoutableRenderableEntity;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.PanelComponent;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
  * Tests for {@link PlayerCapabilityDebugOverlay} covering:
- * - Returns null when config flag is disabled (default)
- * - Renders panel when enabled with mocked client values (uses a real Graphics2D
- *   from a BufferedImage because OverlayPanel.render requires FontMetrics)
- * - Handles null localPlayer gracefully (no NPE)
- * - Slayer task row shows "none" when no task is active
- * - Slayer task row shows creature name and count when task is active
+ *
+ * <ul>
+ *   <li>Guard clause when config flag is disabled.</li>
+ *   <li>Account summary fields (combat, skills, slayer task, quest counts, POH).</li>
+ *   <li>Tier C1–C5 sections render labelled rows for detected state, and
+ *       {@code (none ...)} placeholders when state is empty.</li>
+ *   <li>{@code (error)} fallback when a section's data source throws.</li>
+ *   <li>Null {@code localPlayer} does not throw.</li>
+ *   <li>Quest count line uses the enum-derived ratio (finished/total) plus the
+ *       in-game quest-points varplayer — guard against the #487 regression.</li>
+ * </ul>
  */
 @RunWith(MockitoJUnitRunner.class)
 public class PlayerCapabilityDebugOverlayTest
@@ -114,6 +142,11 @@ public class PlayerCapabilityDebugOverlayTest
 			pohTeleportInventory, equippedItemState,
 			diaryTierState, skillCapePerkState, questProgressState);
 
+		// OverlayPanel.render() clears panel children at the end of each frame
+		// by default. Disable that here so tests can inspect the rendered rows
+		// after calling overlay.render(...).
+		overlay.setClearChildren(false);
+
 		// Default mock behaviour: empty / false for all Tier-C state. Individual
 		// tests override as needed.
 		when(pohTeleportInventory.getAvailableTeleports()).thenReturn(Collections.emptySet());
@@ -147,15 +180,7 @@ public class PlayerCapabilityDebugOverlayTest
 	@Test
 	public void render_returnsNonNull_whenEnabled()
 	{
-		when(config.enableCapabilityDebugOverlay()).thenReturn(true);
-
-		Player player = mock(Player.class);
-		when(player.getCombatLevel()).thenReturn(126);
-		when(client.getLocalPlayer()).thenReturn(player);
-
-		stubSkillLevels();
-		when(client.getVarbitValue(anyInt())).thenReturn(0);
-		when(slayerTaskState.isTaskActive()).thenReturn(false);
+		enableWithBaseStubs();
 
 		Dimension result = overlay.render(realGraphics);
 
@@ -174,6 +199,7 @@ public class PlayerCapabilityDebugOverlayTest
 
 		stubSkillLevels();
 		when(client.getVarbitValue(anyInt())).thenReturn(0);
+		when(client.getVarpValue(anyInt())).thenReturn(0);
 		when(slayerTaskState.isTaskActive()).thenReturn(false);
 
 		// Must complete without NullPointerException; combat level shown as "?"
@@ -188,25 +214,211 @@ public class PlayerCapabilityDebugOverlayTest
 	@Test
 	public void render_includesTaskRow_whenTaskActive()
 	{
-		when(config.enableCapabilityDebugOverlay()).thenReturn(true);
-
-		Player player = mock(Player.class);
-		when(player.getCombatLevel()).thenReturn(126);
-		when(client.getLocalPlayer()).thenReturn(player);
-
-		stubSkillLevels();
-		when(client.getVarbitValue(anyInt())).thenReturn(0);
-
+		enableWithBaseStubs();
 		when(slayerTaskState.isTaskActive()).thenReturn(true);
 		when(slayerTaskState.getCreatureName()).thenReturn("Abyssal demons");
 		when(slayerTaskState.getRemaining()).thenReturn(150);
 
-		Dimension result = overlay.render(realGraphics);
-		assertNotNull(result);
+		overlay.render(realGraphics);
+
+		assertEquals("expected Task row to include creature name and remaining",
+			"Abyssal demons x150", rightForLeft(panelRows(), "Task"));
 	}
 
 	@Test
 	public void render_showsNoneTask_whenNoTaskActive()
+	{
+		enableWithBaseStubs();
+		when(slayerTaskState.isTaskActive()).thenReturn(false);
+
+		overlay.render(realGraphics);
+
+		assertTrue("expected Task row to say 'none' when no slayer task is active",
+			rightForLeft(panelRows(), "Task").contains("none"));
+	}
+
+	// -------------------------------------------------------------------------
+	// #487 — Quest count rendering
+	// -------------------------------------------------------------------------
+
+	@Test
+	public void render_includesQuestRatio_andQuestPointsLine()
+	{
+		enableWithBaseStubs();
+		when(client.getVarpValue(VarPlayer.QUEST_POINTS)).thenReturn(333);
+
+		overlay.render(realGraphics);
+
+		List<Row> rows = panelRows();
+		String questsValue = rightForLeft(rows, "Quests");
+		assertTrue("expected Quests row to render as <finished>/<total>, got: " + questsValue,
+			questsValue.matches("\\d+/\\d+"));
+		assertEquals("expected Quests denominator to equal Quest.values().length",
+			Quest.values().length, parseDenominator(questsValue));
+
+		assertEquals("expected Quest points to match VarPlayer.QUEST_POINTS",
+			"333", rightForLeft(rows, "Quest points"));
+
+		// #487 guard: ensure the old "Quest entries" label no longer ships.
+		for (Row r : rows)
+		{
+			assertFalse("did not expect legacy 'Quest entries' label after #487 fix",
+				"Quest entries".equals(r.left));
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// #486 — Tier C sections each render a header + content
+	// -------------------------------------------------------------------------
+
+	@Test
+	public void render_pohTeleportSection_emptyState_showsNoneDetected()
+	{
+		enableWithBaseStubs();
+		when(pohTeleportInventory.getAvailableTeleports()).thenReturn(Collections.emptySet());
+
+		overlay.render(realGraphics);
+
+		List<String> lefts = panelLeftStrings();
+		assertTrue("expected POH Teleports section header",
+			lefts.stream().anyMatch(s -> s.startsWith("POH Teleports")));
+		assertTrue("expected '(none detected)' placeholder when teleport set is empty",
+			lefts.contains("(none detected)"));
+	}
+
+	@Test
+	public void render_pohTeleportSection_populated_listsTeleports()
+	{
+		enableWithBaseStubs();
+		PohTeleport sample = PohTeleport.values()[0];
+		when(pohTeleportInventory.getAvailableTeleports())
+			.thenReturn(EnumSet.of(sample));
+
+		overlay.render(realGraphics);
+
+		List<Row> rows = panelRows();
+		assertTrue("expected a row for the detected POH teleport",
+			rows.stream().anyMatch(r -> "yes".equals(r.right)
+				&& r.left != null
+				&& !r.left.equals("POH built")));
+	}
+
+	@Test
+	public void render_equippedSection_rendersCount()
+	{
+		enableWithBaseStubs();
+		Set<Integer> equipped = new HashSet<>(Arrays.asList(4151, 11832, 11834, 11840, 9185));
+		when(equippedItemState.getEquippedItems()).thenReturn(equipped);
+
+		overlay.render(realGraphics);
+
+		List<Row> rows = panelRows();
+		assertEquals("expected items-equipped count to reflect snapshot size",
+			"5", rightForLeft(rows, "Items equipped"));
+	}
+
+	@Test
+	public void render_diarySection_rendersHighestCompletedTier()
+	{
+		enableWithBaseStubs();
+		// Stub: Ardougne ELITE is the highest completed; everything else false.
+		when(diaryTierState.hasDiary(eq(DiaryRegion.ARDOUGNE), eq(DiaryTier.EASY))).thenReturn(true);
+		when(diaryTierState.hasDiary(eq(DiaryRegion.ARDOUGNE), eq(DiaryTier.MEDIUM))).thenReturn(true);
+		when(diaryTierState.hasDiary(eq(DiaryRegion.ARDOUGNE), eq(DiaryTier.HARD))).thenReturn(true);
+		when(diaryTierState.hasDiary(eq(DiaryRegion.ARDOUGNE), eq(DiaryTier.ELITE))).thenReturn(true);
+
+		overlay.render(realGraphics);
+
+		List<Row> rows = panelRows();
+		assertEquals("expected Ardougne to render as ELITE",
+			"ELITE", rightForLeft(rows, humanise("ARDOUGNE")));
+		// Other regions still appear with "-"
+		assertEquals("expected Desert region (no diary stubbed) to render as '-'",
+			"-", rightForLeft(rows, humanise("DESERT")));
+	}
+
+	@Test
+	public void render_capePerkSection_listsAvailablePerks()
+	{
+		enableWithBaseStubs();
+		SkillCapePerk sample = SkillCapePerk.values()[0];
+		when(skillCapePerkState.hasPerkAvailable(sample)).thenReturn(true);
+
+		overlay.render(realGraphics);
+
+		List<Row> rows = panelRows();
+		assertTrue("expected at least one cape-perk row marked 'yes'",
+			rows.stream().anyMatch(r -> "yes".equals(r.right)
+				&& humanise(sample.name()).equals(r.left)));
+	}
+
+	@Test
+	public void render_capePerkSection_empty_showsNoneAvailable()
+	{
+		enableWithBaseStubs();
+		// All perks return false by default in setUp.
+
+		overlay.render(realGraphics);
+
+		assertTrue("expected '(none available)' placeholder when no cape perks detected",
+			panelLeftStrings().contains("(none available)"));
+	}
+
+	@Test
+	public void render_questSubMilestoneSection_listsCompletedMilestones()
+	{
+		enableWithBaseStubs();
+		QuestSubMilestone sample = QuestSubMilestone.values()[0];
+		when(questProgressState.hasSubProgress(sample)).thenReturn(true);
+
+		overlay.render(realGraphics);
+
+		List<Row> rows = panelRows();
+		assertTrue("expected at least one quest sub-milestone row marked 'yes'",
+			rows.stream().anyMatch(r -> "yes".equals(r.right)
+				&& humanise(sample.name()).equals(r.left)));
+	}
+
+	@Test
+	public void render_questSubMilestoneSection_empty_showsNoneCompleted()
+	{
+		enableWithBaseStubs();
+		// All sub-milestones return false by default.
+
+		overlay.render(realGraphics);
+
+		assertTrue("expected '(none completed)' placeholder when no sub-milestones complete",
+			panelLeftStrings().contains("(none completed)"));
+	}
+
+	// -------------------------------------------------------------------------
+	// Error fallback — data source throwing must not kill the overlay
+	// -------------------------------------------------------------------------
+
+	@Test
+	public void render_dataSourceThrows_emitsErrorRowAndContinues()
+	{
+		enableWithBaseStubs();
+		when(pohTeleportInventory.getAvailableTeleports())
+			.thenThrow(new RuntimeException("simulated failure"));
+
+		// Must not throw out of render().
+		Dimension result = overlay.render(realGraphics);
+		assertNotNull(result);
+
+		List<String> lefts = panelLeftStrings();
+		assertTrue("expected an '(error)' placeholder for the failing section",
+			lefts.stream().anyMatch(s -> s.contains("(error)")));
+		// Subsequent sections still render.
+		assertTrue("expected Diary section to still render after upstream section failure",
+			lefts.stream().anyMatch(s -> s.startsWith("Diary tiers")));
+	}
+
+	// -------------------------------------------------------------------------
+	// Test helpers
+	// -------------------------------------------------------------------------
+
+	private void enableWithBaseStubs()
 	{
 		when(config.enableCapabilityDebugOverlay()).thenReturn(true);
 
@@ -216,15 +428,14 @@ public class PlayerCapabilityDebugOverlayTest
 
 		stubSkillLevels();
 		when(client.getVarbitValue(anyInt())).thenReturn(0);
+		when(client.getVarpValue(anyInt())).thenReturn(0);
 		when(slayerTaskState.isTaskActive()).thenReturn(false);
 
-		Dimension result = overlay.render(realGraphics);
-		assertNotNull(result);
+		// Default quest state for Quest enum: each quest returns NOT_STARTED.
+		// Actual countFinishedQuests() walks Quest.values() and calls
+		// quest.getState(client) — that's a static enum call we cannot mock,
+		// but it tolerates the client mock returning 0 and yields NOT_STARTED.
 	}
-
-	// -------------------------------------------------------------------------
-	// Helpers
-	// -------------------------------------------------------------------------
 
 	private void stubSkillLevels()
 	{
@@ -232,5 +443,100 @@ public class PlayerCapabilityDebugOverlayTest
 		when(client.getRealSkillLevel(Skill.CONSTRUCTION)).thenReturn(83);
 		when(client.getRealSkillLevel(Skill.FARMING)).thenReturn(99);
 		when(client.getRealSkillLevel(Skill.MAGIC)).thenReturn(99);
+	}
+
+	/**
+	 * Inspect the {@link PanelComponent} the overlay built up via reflection so we
+	 * can assert on individual {@link LineComponent} rows without needing a full
+	 * graphics pipeline.
+	 */
+	private List<Row> panelRows()
+	{
+		try
+		{
+			PanelComponent panel = overlay.getPanelComponent();
+			List<Row> rows = new ArrayList<>();
+			for (LayoutableRenderableEntity child : panel.getChildren())
+			{
+				if (child instanceof LineComponent)
+				{
+					LineComponent lc = (LineComponent) child;
+					rows.add(new Row(readField(lc, "left"), readField(lc, "right")));
+				}
+			}
+			return rows;
+		}
+		catch (ReflectiveOperationException e)
+		{
+			throw new AssertionError("Unable to reflectively inspect overlay panel rows", e);
+		}
+	}
+
+	private List<String> panelLeftStrings()
+	{
+		List<String> lefts = new ArrayList<>();
+		for (Row r : panelRows())
+		{
+			if (r.left != null)
+			{
+				lefts.add(r.left);
+			}
+		}
+		return lefts;
+	}
+
+	private static String readField(Object target, String fieldName) throws ReflectiveOperationException
+	{
+		Field f = target.getClass().getDeclaredField(fieldName);
+		f.setAccessible(true);
+		Object v = f.get(target);
+		return v == null ? null : v.toString();
+	}
+
+	private static String rightForLeft(List<Row> rows, String leftLabel)
+	{
+		for (Row r : rows)
+		{
+			if (leftLabel.equals(r.left))
+			{
+				return r.right == null ? "" : r.right;
+			}
+		}
+		throw new AssertionError("no row found with left=" + leftLabel
+			+ "; available lefts=" + rows);
+	}
+
+	private static int parseDenominator(String ratio)
+	{
+		int slash = ratio.indexOf('/');
+		return Integer.parseInt(ratio.substring(slash + 1));
+	}
+
+	/**
+	 * Mirror the overlay's private {@code humanise} helper so test expectations
+	 * read in the same form as rendered rows.
+	 */
+	private static String humanise(String upperSnake)
+	{
+		String lower = upperSnake.toLowerCase().replace('_', ' ');
+		return Character.toUpperCase(lower.charAt(0)) + lower.substring(1);
+	}
+
+	private static final class Row
+	{
+		final String left;
+		final String right;
+
+		Row(String left, String right)
+		{
+			this.left = left;
+			this.right = right;
+		}
+
+		@Override
+		public String toString()
+		{
+			return "Row{" + left + " -> " + right + "}";
+		}
 	}
 }


### PR DESCRIPTION
Fixes #486
Fixes #487

## Summary

The C7 `PlayerCapabilityDebugOverlay` already enumerated C1–C5 detection state per the #486 follow-up. This PR hardens that block and replaces the misleading `Quest entries: 207` line that #487 flagged.

## Changes

### #486 — fault-isolation around C1–C5 sections

Each Tier C section render is now wrapped in a `safeRender(label, ...)` guard. A throwing data source (NPE, RuntimeException, etc.) now emits a dim `<section>: (error)` row instead of bubbling out of `render(Graphics2D)` and killing the entire overlay paint thread. Subsequent sections still render — one broken source can no longer mask the others.

The rendered ordering is unchanged:

1. Account summary (combat / skills / spellbook / prayers / slayer task / quest counts / POH)
2. POH Teleports (C1) — per-teleport `yes` rows, `(none detected)` when empty
3. Equipped (C2) — count + sample item ID
4. Diary tiers (C3) — highest completed tier per region, `-` when none
5. Cape perks (C4) — per-perk `yes` rows, `(none available)` when empty
6. Quest sub-milestones (C5) — per-milestone `yes` rows (capped at 8 with `+N more` overflow), `(none completed)` when empty

### #487 — quest count semantic

`Quest entries: 207` was a re-derivation that walks the RuneLite `Quest` enum and counts `FINISHED` entries. The enum mixes main quests, miniquests, and Quest-List sub-entries, so the figure was always going to disagree with the in-game `Completed: X/Y` line (e.g. 179/179 on a maxed account).

The single ambiguous line is replaced with two explicit fields:

- **`Quests: <finished>/<total>`** — the same enum walk reframed as an explicit ratio over `Quest.values().length`, so the divergence from in-game is self-explanatory. This is also the surface that C5 partial-quest detection operates on, so the figure is still useful for verifying C5.
- **`Quest points: <n>`** — reads `VarPlayer.QUEST_POINTS` (varplayer 101), which is exactly the number the game shows under the Quest List header. Authors get an unambiguous in-game cross-check that does not depend on RuneLite enum membership.

The legacy `Quest entries` label is removed; a regression test asserts it never reappears.

### Other touches

- New `safeVarp(int)` helper mirrors the existing `safeVarbit(int)` pattern.
- Class javadoc updated to describe the new quest count fields.

## Test plan

- [x] `./gradlew build` green (compile + test + JaCoCo verification + drop-rate lint).
- [x] `PlayerCapabilityDebugOverlayTest` expanded from 5 to 15 cases. New coverage:
  - Per-section populated state (POH teleport, equipped count, diary tier, cape perk, quest sub-milestone).
  - Per-section empty state placeholders (`(none detected)`, `(none available)`, `(none completed)`, diary `-`).
  - `safeRender` error-fallback path: a throwing data source emits an `(error)` row and subsequent sections still render.
  - `#487` regression guard: `Quests` row matches `\d+/\d+`, denominator equals `Quest.values().length`, `Quest points` row equals the stubbed VarPlayer value, and no `Quest entries` label appears.
  - Slayer task active vs inactive row content.
  - Null `localPlayer` still does not throw.
- [ ] In-game smoke: enable the debug overlay on a maxed account and confirm `Quests: 207/<total>` and `Quest points: 333` (or whatever the live varplayer reports) line up with the Quest List header.

## Files

- `src/main/java/com/collectionloghelper/overlay/PlayerCapabilityDebugOverlay.java`
- `src/test/java/com/collectionloghelper/overlay/PlayerCapabilityDebugOverlayTest.java`