### PR TITLE
feat(panel): add source-level Recommended gear strip + wiki strategy link (#573)

### DIFF
--- a/docs/contributor-guide/schema-reference.md
+++ b/docs/contributor-guide/schema-reference.md
@@ -61,6 +61,9 @@ Each source represents a single collection log category (e.g., "General Graardor
 | `requirements` | object | No | Quest and skill requirements. See [Requirements](#requirements) |
 | `guidanceSteps` | array | No | Ordered list of `GuidanceStep` objects. See [`GuidanceStep`](#guidancestep) |
 | `items` | array | Yes | List of `CollectionLogItem` objects |
+| `metaAuthoredDate` | string | No | ISO 8601 date (e.g. `"2024-01-01"`) indicating when meta-sensitive recommendations were last verified. Rendered as a color-coded age badge in the source header |
+| `wikiStrategyUrl` | string | No | Optional override for the wiki Strategies page URL surfaced by the "Wiki Strategy" button. Defaults to a URL derived from the source name with spaces replaced by underscores: `https://oldschool.runescape.wiki/w/<name>/Strategies` |
+| `recommendedItemIds` | int array | No | Optional source-level recommended-gear list rendered in the source detail header. When absent, the strip rolls up the union of per-step `recommendedItemIds` across all guidance steps |
 
 ## `CollectionLogItem`
 

--- a/src/main/java/com/collectionloghelper/data/CollectionLogSource.java
+++ b/src/main/java/com/collectionloghelper/data/CollectionLogSource.java
@@ -79,6 +79,31 @@ public class CollectionLogSource
 	@Nullable
 	String metaAuthoredDate;
 
+	/**
+	 * Optional override for the wiki Strategies page URL surfaced in the source
+	 * header (#573). When null, {@link #getEffectiveWikiStrategyUrl()} derives a
+	 * URL from the source name (e.g. {@code General Graardor} →
+	 * {@code https://oldschool.runescape.wiki/w/General_Graardor/Strategies}).
+	 * Sources whose wiki strategy page does not match the derived URL can override
+	 * with the full URL.
+	 *
+	 * <p>Backward compatible: existing JSON without this field deserialises to null.
+	 */
+	@Nullable
+	String wikiStrategyUrl;
+
+	/**
+	 * Optional source-level recommended gear item IDs (#573). When set, the
+	 * source-header recommended chip strip uses this list verbatim. When null,
+	 * {@link #getEffectiveRecommendedItemIds()} rolls up the union of per-step
+	 * {@code recommendedItemIds} from {@link #guidanceSteps} so authors don't
+	 * have to maintain two parallel lists.
+	 *
+	 * <p>Backward compatible: existing JSON without this field deserialises to null.
+	 */
+	@Nullable
+	List<Integer> recommendedItemIds;
+
 	public RewardType getRewardType()
 	{
 		return rewardType != null ? rewardType : RewardType.DROP;
@@ -146,5 +171,68 @@ public class CollectionLogSource
 			return locationDescription;
 		}
 		return name;
+	}
+
+	/**
+	 * Returns the effective wiki Strategies page URL for this source (#573).
+	 *
+	 * <p>If {@link #wikiStrategyUrl} is non-blank, returns it verbatim. Otherwise
+	 * derives a URL from {@link #name} using the OSRS Wiki convention of
+	 * replacing spaces with underscores and appending {@code /Strategies}:
+	 * <pre>https://oldschool.runescape.wiki/w/&lt;urlEncodedName&gt;/Strategies</pre>
+	 *
+	 * <p>The derived URL is a best-effort guess. Sources whose wiki page name
+	 * differs from the source name should set {@link #wikiStrategyUrl} explicitly.
+	 *
+	 * @return a non-null wiki Strategies URL
+	 */
+	public String getEffectiveWikiStrategyUrl()
+	{
+		if (wikiStrategyUrl != null && !wikiStrategyUrl.isEmpty())
+		{
+			return wikiStrategyUrl;
+		}
+		String slug = name == null ? "" : name.replace(' ', '_');
+		return "https://oldschool.runescape.wiki/w/" + slug + "/Strategies";
+	}
+
+	/**
+	 * Returns the effective source-level recommended-item IDs for the source
+	 * header chip strip (#573).
+	 *
+	 * <p>If {@link #recommendedItemIds} is non-empty, returns it. Otherwise rolls
+	 * up the union of per-step {@code recommendedItemIds} across
+	 * {@link #guidanceSteps}, preserving insertion order and deduplicating.
+	 * Returns an empty list when neither field has data.
+	 *
+	 * @return a non-null, possibly empty list of item IDs
+	 */
+	public List<Integer> getEffectiveRecommendedItemIds()
+	{
+		if (recommendedItemIds != null && !recommendedItemIds.isEmpty())
+		{
+			return recommendedItemIds;
+		}
+		if (guidanceSteps == null || guidanceSteps.isEmpty())
+		{
+			return java.util.Collections.emptyList();
+		}
+		java.util.LinkedHashSet<Integer> rollup = new java.util.LinkedHashSet<>();
+		for (GuidanceStep step : guidanceSteps)
+		{
+			List<Integer> stepIds = step.getRecommendedItemIds();
+			if (stepIds == null)
+			{
+				continue;
+			}
+			for (Integer id : stepIds)
+			{
+				if (id != null && id > 0)
+				{
+					rollup.add(id);
+				}
+			}
+		}
+		return new java.util.ArrayList<>(rollup);
 	}
 }

--- a/src/main/java/com/collectionloghelper/ui/ItemDetailPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/ItemDetailPanel.java
@@ -28,6 +28,7 @@ import com.collectionloghelper.data.CollectionLogCategory;
 import com.collectionloghelper.data.CollectionLogItem;
 import com.collectionloghelper.data.CollectionLogSource;
 import com.collectionloghelper.efficiency.ClueCompletionEstimator;
+import com.collectionloghelper.ui.widget.SourceRecommendedItemsChipPanel;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
@@ -203,8 +204,18 @@ class ItemDetailPanel extends JPanel
 		infoLabel.setBorder(BorderFactory.createEmptyBorder(0, 0, 8, 0));
 		add(infoLabel);
 
-		// Action buttons
-		JPanel buttonPanel = new JPanel(new GridLayout(1, 2, 8, 0));
+		// Source-level Recommended Gear chip strip (#573). Rendered above the
+		// action-button row so players can scan recommended kit before
+		// activating guidance. Hidden when the source has no recommended items
+		// (neither a source-level override nor any per-step recommendations).
+		SourceRecommendedItemsChipPanel sourceRecChips = new SourceRecommendedItemsChipPanel(itemManager);
+		sourceRecChips.setAlignmentX(LEFT_ALIGNMENT);
+		sourceRecChips.setBorder(BorderFactory.createEmptyBorder(0, 0, 8, 0));
+		sourceRecChips.update(source.getEffectiveRecommendedItemIds());
+		add(sourceRecChips);
+
+		// Action buttons — three columns: Guide Me / Open Wiki / Wiki Strategy (#573).
+		JPanel buttonPanel = new JPanel(new GridLayout(1, 3, 6, 0));
 		buttonPanel.setOpaque(false);
 		buttonPanel.setAlignmentX(LEFT_ALIGNMENT);
 		buttonPanel.setMaximumSize(new Dimension(Integer.MAX_VALUE, 32));
@@ -237,6 +248,11 @@ class ItemDetailPanel extends JPanel
 		wikiButton.setToolTipText("Open wiki page for " + item.getName());
 		wikiButton.addActionListener(e -> openWiki(item));
 		buttonPanel.add(wikiButton);
+
+		JButton wikiStrategyButton = new JButton("Wiki Strategy");
+		wikiStrategyButton.setToolTipText("Open wiki strategies page for " + source.getName());
+		wikiStrategyButton.addActionListener(e -> openWikiStrategy(source));
+		buttonPanel.add(wikiStrategyButton);
 
 		add(buttonPanel);
 
@@ -320,6 +336,21 @@ class ItemDetailPanel extends JPanel
 			.build()
 			.toString();
 
+		LinkBrowser.browse(url);
+	}
+
+	/**
+	 * Opens the wiki Strategies page for the given source (#573). Resolves the
+	 * URL via {@link CollectionLogSource#getEffectiveWikiStrategyUrl()} which
+	 * prefers the per-source override and otherwise derives the URL from the
+	 * source name. The default browser is launched via
+	 * {@link LinkBrowser#browse(String)}.
+	 *
+	 * <p>Package-visible for tests to bypass the action-listener path.
+	 */
+	static void openWikiStrategy(CollectionLogSource source)
+	{
+		String url = source.getEffectiveWikiStrategyUrl();
 		LinkBrowser.browse(url);
 	}
 }

--- a/src/main/java/com/collectionloghelper/ui/widget/SourceRecommendedItemsChipPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/widget/SourceRecommendedItemsChipPanel.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.ui.widget;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
+import java.util.Collections;
+import java.util.List;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.ImageIcon;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingConstants;
+import javax.swing.SwingUtilities;
+import net.runelite.api.ItemComposition;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.ui.FontManager;
+import net.runelite.client.util.AsyncBufferedImage;
+
+/**
+ * A horizontal strip of item-icon chips rendered in the source-detail header
+ * for the source-level "Recommended Gear" list (#573).
+ *
+ * <p>This differs from {@link RecommendedItemsChipPanel} in three ways:
+ * <ul>
+ *   <li>Renders in the source header (above the step list) so players see the
+ *       source's recommended kit <em>before</em> activating guidance, not just
+ *       during an active step.</li>
+ *   <li>No availability colouring — guidance is not yet active, so live
+ *       inventory/bank status is irrelevant at this point. The chip border uses
+ *       a single muted neutral colour.</li>
+ *   <li>The data source is {@link com.collectionloghelper.data.CollectionLogSource#getEffectiveRecommendedItemIds()}
+ *       which rolls up the per-step recommended items by default and accepts an
+ *       optional source-level override.</li>
+ * </ul>
+ *
+ * <p>The panel hides itself when the supplied item list is null or empty,
+ * preserving the blank-space contract for sources with no recommended items
+ * authored on any step.
+ *
+ * <p>All mutations to Swing state are dispatched on the EDT via
+ * {@link SwingUtilities#invokeLater}.
+ */
+public class SourceRecommendedItemsChipPanel extends JPanel
+{
+	/** Border width in pixels — matches the muted advisory feel of the per-step strip. */
+	static final int CHIP_BORDER = 1;
+
+	/** Icon size within each chip. */
+	static final int ICON_SIZE = 28;
+
+	/** Total chip dimension: icon + borders on each side. */
+	static final int CHIP_SIZE = ICON_SIZE + CHIP_BORDER * 2;
+
+	/** Background of the source-header strip. Matches the requirements/banner section tone. */
+	private static final Color BG = new Color(25, 35, 55);
+
+	/** Muted neutral border — chip strip is informational only at this surface. */
+	static final Color BORDER_COLOR = new Color(180, 180, 180, 160);
+
+	/** Heading text shown to the left of the chip row. */
+	static final String HEADING_TEXT = "Recommended:";
+
+	private final ItemManager itemManager;
+
+	/** The horizontal row that holds the heading label and chip labels. */
+	private final JPanel chipRow;
+
+	public SourceRecommendedItemsChipPanel(ItemManager itemManager)
+	{
+		this.itemManager = itemManager;
+
+		setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+		setBackground(BG);
+		setAlignmentX(LEFT_ALIGNMENT);
+		setVisible(false);
+
+		chipRow = new JPanel();
+		chipRow.setLayout(new BoxLayout(chipRow, BoxLayout.X_AXIS));
+		chipRow.setBackground(BG);
+		chipRow.setAlignmentX(LEFT_ALIGNMENT);
+		add(chipRow);
+	}
+
+	/**
+	 * Rebuilds the chip strip from the given item IDs and sets visibility.
+	 * Safe to call from any thread; dispatches to the EDT internally.
+	 *
+	 * @param itemIds the source-level recommended item IDs (typically the result
+	 *                of {@link com.collectionloghelper.data.CollectionLogSource#getEffectiveRecommendedItemIds()});
+	 *                {@code null} or empty hides the panel
+	 */
+	public void update(List<Integer> itemIds)
+	{
+		final List<Integer> safeIds =
+			(itemIds != null) ? itemIds : Collections.<Integer>emptyList();
+
+		SwingUtilities.invokeLater(() ->
+		{
+			chipRow.removeAll();
+
+			if (safeIds.isEmpty())
+			{
+				setVisible(false);
+				return;
+			}
+
+			JLabel heading = new JLabel(HEADING_TEXT);
+			heading.setFont(FontManager.getRunescapeSmallFont());
+			heading.setForeground(new Color(150, 150, 150));
+			heading.setAlignmentX(LEFT_ALIGNMENT);
+			chipRow.add(heading);
+			chipRow.add(Box.createHorizontalStrut(6));
+
+			for (Integer itemId : safeIds)
+			{
+				if (itemId == null || itemId <= 0)
+				{
+					continue;
+				}
+				JLabel chip = buildChip(itemId);
+				chipRow.add(chip);
+				chipRow.add(Box.createHorizontalStrut(3));
+			}
+
+			setVisible(true);
+			chipRow.revalidate();
+			chipRow.repaint();
+			revalidate();
+			if (getParent() != null)
+			{
+				getParent().revalidate();
+			}
+		});
+	}
+
+	/**
+	 * Builds a single chip label: a fixed-size icon placeholder surrounded by a
+	 * 1-pixel muted neutral border. The icon and tooltip are loaded
+	 * asynchronously when {@code itemManager} can resolve them.
+	 *
+	 * <p>Package-visible for test reflection.
+	 */
+	JLabel buildChip(int itemId)
+	{
+		JLabel chip = new JLabel();
+		chip.setPreferredSize(new Dimension(CHIP_SIZE, CHIP_SIZE));
+		chip.setMinimumSize(new Dimension(CHIP_SIZE, CHIP_SIZE));
+		chip.setMaximumSize(new Dimension(CHIP_SIZE, CHIP_SIZE));
+		chip.setHorizontalAlignment(SwingConstants.CENTER);
+		chip.setVerticalAlignment(SwingConstants.CENTER);
+		chip.setBorder(BorderFactory.createLineBorder(BORDER_COLOR, CHIP_BORDER));
+		chip.setBackground(BG);
+		chip.setOpaque(true);
+
+		// Tooltip — item name when resolvable; fall back to the raw ID so
+		// players can spot-check missing names in dev builds.
+		String tooltip = lookupName(itemId);
+		chip.setToolTipText(tooltip);
+
+		loadChipIcon(itemId, chip);
+
+		return chip;
+	}
+
+	/**
+	 * Loads the item sprite for {@code itemId} into {@code chip} asynchronously.
+	 * No-op when the item manager has no image (e.g. in unit tests).
+	 *
+	 * <p>Package-visible so tests can stub behavior without touching the EDT.
+	 */
+	void loadChipIcon(int itemId, JLabel chip)
+	{
+		if (itemManager == null)
+		{
+			return;
+		}
+		AsyncBufferedImage asyncImage = itemManager.getImage(itemId);
+		if (asyncImage == null)
+		{
+			return;
+		}
+
+		Runnable applyIcon = () ->
+		{
+			if (asyncImage.getWidth() > 0)
+			{
+				BufferedImage scaled = scaleImage(asyncImage, ICON_SIZE, ICON_SIZE);
+				chip.setIcon(new ImageIcon(scaled));
+				chip.revalidate();
+				chip.repaint();
+			}
+		};
+
+		asyncImage.onLoaded(applyIcon);
+
+		if (asyncImage.getWidth() > 0)
+		{
+			applyIcon.run();
+		}
+	}
+
+	/**
+	 * Returns the item name for {@code itemId} via {@link ItemManager#getItemComposition},
+	 * falling back to {@code "Item " + itemId} if the lookup fails or returns null.
+	 */
+	private String lookupName(int itemId)
+	{
+		if (itemManager == null)
+		{
+			return "Item " + itemId;
+		}
+		try
+		{
+			ItemComposition comp = itemManager.getItemComposition(itemId);
+			if (comp != null && comp.getName() != null)
+			{
+				return comp.getName();
+			}
+		}
+		catch (RuntimeException ignored)
+		{
+			// Some test contexts don't wire up ItemManager fully.
+		}
+		return "Item " + itemId;
+	}
+
+	private static BufferedImage scaleImage(BufferedImage source, int width, int height)
+	{
+		BufferedImage scaled = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+		Graphics2D g = scaled.createGraphics();
+		g.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+			RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+		g.drawImage(source, 0, 0, width, height, null);
+		g.dispose();
+		return scaled;
+	}
+}

--- a/src/test/java/com/collectionloghelper/ActivateGuidanceClientThreadTest.java
+++ b/src/test/java/com/collectionloghelper/ActivateGuidanceClientThreadTest.java
@@ -141,6 +141,6 @@ public class ActivateGuidanceClientThreadTest
 			0,         // cumulativeTrackThreshold
 			null,      // items
 			null       // metaAuthoredDate
-		);
+		, null, null);
 	}
 }

--- a/src/test/java/com/collectionloghelper/OnSequenceCompletePerItemTest.java
+++ b/src/test/java/com/collectionloghelper/OnSequenceCompletePerItemTest.java
@@ -158,6 +158,6 @@ public class OnSequenceCompletePerItemTest
 			null,
 			null, null, 0, null, 0,
 			Collections.emptyList()
-		, null);
+		, null, null, null);
 	}
 }

--- a/src/test/java/com/collectionloghelper/data/CollectionLogSourceTest.java
+++ b/src/test/java/com/collectionloghelper/data/CollectionLogSourceTest.java
@@ -49,7 +49,7 @@ public class CollectionLogSourceTest
 		return new CollectionLogSource(name, CollectionLogCategory.BOSSES, x, y, plane,
 			60, 0, locationDesc, waypoints,
 			null, 0, null, 0, false, 0, null, 0, null, null, null, null, null, 0, null, 0,
-			Collections.emptyList(), null);
+			Collections.emptyList(), null, null, null);
 
 	}
 
@@ -234,5 +234,154 @@ public class CollectionLogSourceTest
 		CollectionLogSource source = makeSource("Test", 3000, 3100, 0, "Default",
 			Arrays.asList(wp1, wp2));
 		assertEquals("Last", source.getDisplayLocation(checker));
+	}
+
+	// ========================================================================
+	// #573 — wiki Strategies URL derivation + per-source override
+	// ========================================================================
+
+	private CollectionLogSource makeSourceWith573(String name, String wikiOverride,
+		List<Integer> recommendedItemIds, List<GuidanceStep> guidanceSteps)
+	{
+		return new CollectionLogSource(name, CollectionLogCategory.BOSSES, 3000, 3000, 0,
+			60, 0, null, Collections.emptyList(),
+			null, 0, null, 0, false, 0, null, 0, null, null,
+			guidanceSteps != null ? guidanceSteps : Collections.<GuidanceStep>emptyList(),
+			null, null, 0, null, 0,
+			Collections.<CollectionLogItem>emptyList(), null,
+			wikiOverride, recommendedItemIds);
+	}
+
+	@Test
+	public void getEffectiveWikiStrategyUrl_derivesFromSourceNameWithUnderscores()
+	{
+		CollectionLogSource graardor = makeSourceWith573("General Graardor", null, null, null);
+		assertEquals(
+			"https://oldschool.runescape.wiki/w/General_Graardor/Strategies",
+			graardor.getEffectiveWikiStrategyUrl());
+	}
+
+	@Test
+	public void getEffectiveWikiStrategyUrl_returnsOverrideVerbatimWhenSet()
+	{
+		String url = "https://oldschool.runescape.wiki/w/Theatre_of_Blood/Strategies";
+		CollectionLogSource tob = makeSourceWith573("Theatre of Blood", url, null, null);
+		assertEquals(url, tob.getEffectiveWikiStrategyUrl());
+	}
+
+	@Test
+	public void getEffectiveWikiStrategyUrl_emptyOverrideFallsBackToDerivedUrl()
+	{
+		CollectionLogSource s = makeSourceWith573("Cerberus", "", null, null);
+		assertEquals("https://oldschool.runescape.wiki/w/Cerberus/Strategies",
+			s.getEffectiveWikiStrategyUrl());
+	}
+
+	@Test
+	public void getEffectiveWikiStrategyUrl_singleWordSourceName()
+	{
+		CollectionLogSource s = makeSourceWith573("Cerberus", null, null, null);
+		assertEquals("https://oldschool.runescape.wiki/w/Cerberus/Strategies",
+			s.getEffectiveWikiStrategyUrl());
+	}
+
+	// ========================================================================
+	// #573 — source-level recommended item rollup with optional override
+	// ========================================================================
+
+	@Test
+	public void getEffectiveRecommendedItemIds_returnsOverrideWhenSet()
+	{
+		List<Integer> override = Arrays.asList(11802, 12817, 4151);
+		CollectionLogSource s = makeSourceWith573("Test", null, override, null);
+		assertEquals(override, s.getEffectiveRecommendedItemIds());
+	}
+
+	@Test
+	public void getEffectiveRecommendedItemIds_emptyOverrideRollsUpFromSteps()
+	{
+		GuidanceStep step = stepWithRecommendedIds(Arrays.asList(100, 200));
+		CollectionLogSource s = makeSourceWith573("Test", null,
+			Collections.<Integer>emptyList(), Collections.singletonList(step));
+
+		assertEquals(Arrays.asList(100, 200), s.getEffectiveRecommendedItemIds());
+	}
+
+	@Test
+	public void getEffectiveRecommendedItemIds_nullOverrideRollsUpUnionAcrossSteps()
+	{
+		GuidanceStep s1 = stepWithRecommendedIds(Arrays.asList(100, 200));
+		GuidanceStep s2 = stepWithRecommendedIds(Arrays.asList(200, 300)); // dedupe 200
+		GuidanceStep s3 = stepWithRecommendedIds(Arrays.asList(400));
+		CollectionLogSource s = makeSourceWith573("Test", null, null, Arrays.asList(s1, s2, s3));
+
+		assertEquals("Rollup must dedupe and preserve insertion order",
+			Arrays.asList(100, 200, 300, 400), s.getEffectiveRecommendedItemIds());
+	}
+
+	@Test
+	public void getEffectiveRecommendedItemIds_skipsNullAndNonPositiveIds()
+	{
+		GuidanceStep s1 = stepWithRecommendedIds(Arrays.asList(0, -1, 100, null));
+		CollectionLogSource s = makeSourceWith573("Test", null, null, Collections.singletonList(s1));
+
+		assertEquals(Collections.singletonList(100), s.getEffectiveRecommendedItemIds());
+	}
+
+	@Test
+	public void getEffectiveRecommendedItemIds_emptyEverythingReturnsEmpty()
+	{
+		CollectionLogSource s = makeSourceWith573("Test", null, null, Collections.<GuidanceStep>emptyList());
+		assertTrue(s.getEffectiveRecommendedItemIds().isEmpty());
+	}
+
+	@Test
+	public void getEffectiveRecommendedItemIds_skipsStepsWithNullRecommendedList()
+	{
+		GuidanceStep withRec = stepWithRecommendedIds(Arrays.asList(100));
+		GuidanceStep withoutRec = stepWithRecommendedIds(null);
+		CollectionLogSource s = makeSourceWith573("Test", null, null,
+			Arrays.asList(withoutRec, withRec, withoutRec));
+
+		assertEquals(Collections.singletonList(100), s.getEffectiveRecommendedItemIds());
+	}
+
+	/**
+	 * Builds a minimal {@link GuidanceStep} carrying only the
+	 * {@code recommendedItemIds} field — every other slot is zero/empty/null.
+	 * Mirrors the pattern used in {@code GuidanceStepTest#stepWithOverrides}.
+	 */
+	private static GuidanceStep stepWithRecommendedIds(List<Integer> recommendedItemIds)
+	{
+		return new GuidanceStep(
+			"desc",
+			null,           // perItemStepDescription
+			0, 0, 0,        // worldX, worldY, worldPlane
+			0, null, null, null,  // npcId, perItemNpcId, interactAction, dialogOptions
+			null, null,     // travelTip, requiredItemIds
+			null,           // perItemRequiredItemIds
+			recommendedItemIds,
+			null,           // perItemRecommendedItemIds
+			CompletionCondition.MANUAL,
+			0, 0, 0, 0,    // completionItemId, completionItemCount, completionDistance, completionNpcId
+			null,           // completionNpcIds
+			null,           // worldMessage
+			0, null, null,  // objectId, objectIds, objectInteractAction
+			null, null,     // highlightItemIds, groundItemIds
+			null,           // completionChatPattern
+			0, 0,           // completionVarbitId, completionVarbitValue
+			false,          // useItemOnObject
+			0,              // objectMaxDistance
+			null,           // objectFilterTiles
+			null,           // highlightWidgetIds
+			0, 0,           // loopBackToStep, loopCount
+			null,           // skipIfHasAnyItemIds
+			null,           // dynamicItemObjectTiers
+			null,           // completionZone
+			null,           // conditionalAlternatives
+			null,           // section
+			null,           // waypoints
+			null            // dynamicTargetEvaluator
+		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/efficiency/CrossSourceRankerTest.java
+++ b/src/test/java/com/collectionloghelper/efficiency/CrossSourceRankerTest.java
@@ -120,7 +120,7 @@ public class CrossSourceRankerTest
 		return new CollectionLogSource(name, CollectionLogCategory.BOSSES, 3000, 3000, 0,
 			killTimeSeconds, 0, name, Collections.emptyList(),
 			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null,
-			null /* guidanceHelperKey */, null, 0, null, 0, items, null /* metaAuthoredDate */);
+			null /* guidanceHelperKey */, null, 0, null, 0, items, null /* metaAuthoredDate */, null, null);
 	}
 
 	private CollectionLogItem makeItem(int id, String name, double dropRate)

--- a/src/test/java/com/collectionloghelper/efficiency/EfficiencyCalculatorTest.java
+++ b/src/test/java/com/collectionloghelper/efficiency/EfficiencyCalculatorTest.java
@@ -99,7 +99,7 @@ public class EfficiencyCalculatorTest
 	{
 		return new CollectionLogSource(name, category, 3000, 3000, 0,
 			killTimeSeconds, 0, name, Collections.emptyList(),
-			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0, items, null);
+			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0, items, null, null, null);
 	}
 
 	private CollectionLogSource makeShopSource(String name, int killTimeSeconds,
@@ -107,7 +107,7 @@ public class EfficiencyCalculatorTest
 	{
 		return new CollectionLogSource(name, CollectionLogCategory.OTHER, 3000, 3000, 0,
 			killTimeSeconds, 0, name, Collections.emptyList(),
-			RewardType.SHOP, pointsPerHour, null, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0, items, null);
+			RewardType.SHOP, pointsPerHour, null, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0, items, null, null, null);
 	}
 
 	private CollectionLogSource makeMilestoneSource(String name, int killTimeSeconds,
@@ -115,7 +115,7 @@ public class EfficiencyCalculatorTest
 	{
 		return new CollectionLogSource(name, CollectionLogCategory.OTHER, 3000, 3000, 0,
 			killTimeSeconds, 0, name, Collections.emptyList(),
-			RewardType.MILESTONE, 0, null, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0, items, null);
+			RewardType.MILESTONE, 0, null, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0, items, null, null, null);
 	}
 
 	private CollectionLogSource makeMixedSource(String name, int killTimeSeconds,
@@ -123,7 +123,7 @@ public class EfficiencyCalculatorTest
 	{
 		return new CollectionLogSource(name, CollectionLogCategory.OTHER, 3000, 3000, 0,
 			killTimeSeconds, 0, name, Collections.emptyList(),
-			RewardType.MIXED, pointsPerHour, null, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0, items, null);
+			RewardType.MIXED, pointsPerHour, null, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0, items, null, null, null);
 	}
 
 	private CollectionLogSource makeAggregatedSource(String name, int killTimeSeconds,
@@ -131,7 +131,7 @@ public class EfficiencyCalculatorTest
 	{
 		return new CollectionLogSource(name, CollectionLogCategory.OTHER, 3000, 3000, 0,
 			killTimeSeconds, 0, name, Collections.emptyList(),
-			RewardType.DROP, 0, null, 1, true, 0, null, 0, null, null, null, null, null, 0, null, 0, items, null);
+			RewardType.DROP, 0, null, 1, true, 0, null, 0, null, null, null, null, null, 0, null, 0, items, null, null, null);
 	}
 
 	private CollectionLogItem makeItem(int id, String name, double dropRate)
@@ -164,7 +164,7 @@ public class EfficiencyCalculatorTest
 	{
 		return new CollectionLogSource(name, category, 3000, 3000, 0,
 			killTimeSeconds, 0, name, Collections.emptyList(),
-			RewardType.DROP, 0, variants, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0, items, null);
+			RewardType.DROP, 0, variants, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0, items, null, null, null);
 	}
 
 	// --- Per-item scoring: score = best individual item's score ---
@@ -389,7 +389,7 @@ public class EfficiencyCalculatorTest
 		List<CollectionLogItem> items = Collections.singletonList(makeItem(1, "Drop", 1.0 / 512));
 		CollectionLogSource source = new CollectionLogSource("Test", CollectionLogCategory.BOSSES,
 			3000, 3000, 0, 120, 0, "Test", Collections.emptyList(),
-			RewardType.DROP, 0, null, 2, false, 0, null, 0, null, null, null, null, null, 0, null, 0, items, null);
+			RewardType.DROP, 0, null, 2, false, 0, null, 0, null, null, null, null, null, 0, null, 0, items, null, null, null);
 		when(collectionState.isItemObtained(anyInt())).thenReturn(false);
 
 		ScoredItem result = calculator.scoreSource(source, false);
@@ -544,7 +544,7 @@ public class EfficiencyCalculatorTest
 			CollectionLogCategory.CLUES, 3000, 3000, 0, 600, 0,
 			"Easy Treasure Trails", Collections.emptyList(),
 			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0,
-			Collections.singletonList(makeItem(1, "Drop", 0.01)), null);
+			Collections.singletonList(makeItem(1, "Drop", 0.01)), null, null, null);
 		when(clueEstimator.estimateCompletionSeconds("Easy Treasure Trails")).thenReturn(900);
 
 		int effective = calculator.getEffectiveKillTime(source);
@@ -558,7 +558,7 @@ public class EfficiencyCalculatorTest
 			CollectionLogCategory.CLUES, 3000, 3000, 0, 600, 0,
 			"Easy Treasure Trails", Collections.emptyList(),
 			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0,
-			Collections.singletonList(makeItem(1, "Drop", 0.01)), null);
+			Collections.singletonList(makeItem(1, "Drop", 0.01)), null, null, null);
 		when(clueEstimator.estimateCompletionSeconds("Easy Treasure Trails")).thenReturn(0);
 
 		int effective = calculator.getEffectiveKillTime(source);
@@ -650,7 +650,7 @@ public class EfficiencyCalculatorTest
 		CollectionLogSource source = new CollectionLogSource("Test Boss", CollectionLogCategory.BOSSES,
 			3000, 3000, 0, 60, 0, "Test Boss", Collections.emptyList(),
 			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0,
-			Collections.singletonList(makeItem(1, "Drop", 0.01)), null);
+			Collections.singletonList(makeItem(1, "Drop", 0.01)), null, null, null);
 		lenient().when(collectionState.isItemObtained(1)).thenReturn(false);
 		when(database.getAllSources()).thenReturn(Collections.singletonList(source));
 		when(config.afkFilter()).thenReturn(AfkFilter.AFK);
@@ -666,7 +666,7 @@ public class EfficiencyCalculatorTest
 		CollectionLogSource source = new CollectionLogSource("AFK Source", CollectionLogCategory.BOSSES,
 			3000, 3000, 0, 60, 0, "AFK Source", Collections.emptyList(),
 			RewardType.DROP, 0, null, 1, false, 2, null, 0, null, null, null, null, null, 0, null, 0,
-			Collections.singletonList(makeItem(1, "Drop", 0.01)), null);
+			Collections.singletonList(makeItem(1, "Drop", 0.01)), null, null, null);
 		when(collectionState.isItemObtained(1)).thenReturn(false);
 		when(database.getAllSources()).thenReturn(Collections.singletonList(source));
 		when(config.afkFilter()).thenReturn(AfkFilter.AFK);
@@ -682,7 +682,7 @@ public class EfficiencyCalculatorTest
 		CollectionLogSource source = new CollectionLogSource("Test Boss", CollectionLogCategory.BOSSES,
 			3000, 3000, 0, 60, 0, "Test Boss", Collections.emptyList(),
 			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0,
-			Collections.singletonList(makeItem(1, "Drop", 0.01)), null);
+			Collections.singletonList(makeItem(1, "Drop", 0.01)), null, null, null);
 		when(collectionState.isItemObtained(1)).thenReturn(false);
 		when(database.getAllSources()).thenReturn(Collections.singletonList(source));
 		when(config.afkFilter()).thenReturn(AfkFilter.OFF);
@@ -701,7 +701,7 @@ public class EfficiencyCalculatorTest
 		CollectionLogSource source = new CollectionLogSource("Abyssal Demon", CollectionLogCategory.OTHER,
 			3000, 3000, 0, 20, 0, "Abyssal Demon", Collections.emptyList(),
 			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0,
-			Collections.singletonList(makeItem(1, "Whip", 0.001953)), null);
+			Collections.singletonList(makeItem(1, "Whip", 0.001953)), null, null, null);
 		when(slayerMasterDatabase.getMasterNames()).thenReturn(Collections.singletonList("Duradel"));
 		when(slayerMasterDatabase.getTaskProbability("Duradel", "abyssal demons")).thenReturn(0.05);
 
@@ -716,7 +716,7 @@ public class EfficiencyCalculatorTest
 		CollectionLogSource source = new CollectionLogSource("Abyssal Demon", CollectionLogCategory.OTHER,
 			3000, 3000, 0, 20, 0, "Abyssal Demon", Collections.emptyList(),
 			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0,
-			Collections.singletonList(makeItem(1, "Whip", 0.001953)), null);
+			Collections.singletonList(makeItem(1, "Whip", 0.001953)), null, null, null);
 		when(slayerTaskState.isTaskActive()).thenReturn(true);
 		when(slayerTaskState.getCreatureName()).thenReturn("Abyssal demons");
 
@@ -731,7 +731,7 @@ public class EfficiencyCalculatorTest
 		CollectionLogSource source = new CollectionLogSource("Abyssal Sire", CollectionLogCategory.BOSSES,
 			3000, 3000, 0, 180, 0, "Abyssal Sire", Collections.emptyList(),
 			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0,
-			Collections.singletonList(makeItem(1, "Unsired", 0.0078)), null);
+			Collections.singletonList(makeItem(1, "Unsired", 0.0078)), null, null, null);
 
 		int effectiveTime = calculator.getEffectiveKillTime(source);
 		assertEquals(180, effectiveTime);
@@ -744,7 +744,7 @@ public class EfficiencyCalculatorTest
 		CollectionLogSource source = new CollectionLogSource("Abyssal Demon", CollectionLogCategory.OTHER,
 			3000, 3000, 0, 12, 0, "Abyssal Demon", Collections.emptyList(),
 			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0,
-			Collections.singletonList(makeItem(1, "Whip", 0.001953)), null);
+			Collections.singletonList(makeItem(1, "Whip", 0.001953)), null, null, null);
 		when(slayerMasterDatabase.getMasterNames()).thenReturn(Arrays.asList("Duradel", "Nieve"));
 		when(slayerMasterDatabase.getTaskProbability("Duradel", "abyssal demons")).thenReturn(0.06);
 		when(slayerMasterDatabase.getTaskProbability("Nieve", "abyssal demons")).thenReturn(0.04);
@@ -948,7 +948,7 @@ public class EfficiencyCalculatorTest
 		CollectionLogSource source = new CollectionLogSource("Test Boss", CollectionLogCategory.BOSSES,
 			3000, 3000, 0, 60, 120, "Test Boss", Collections.emptyList(),
 			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0,
-			Collections.singletonList(makeItem(1, "Drop", 0.01)), null);
+			Collections.singletonList(makeItem(1, "Drop", 0.01)), null, null, null);
 		when(config.accountType()).thenReturn(AccountType.IRONMAN);
 
 		int effectiveTime = calculator.getEffectiveKillTime(source);
@@ -962,7 +962,7 @@ public class EfficiencyCalculatorTest
 		CollectionLogSource source = new CollectionLogSource("Test Boss", CollectionLogCategory.BOSSES,
 			3000, 3000, 0, 60, 0, "Test Boss", Collections.emptyList(),
 			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0,
-			Collections.singletonList(makeItem(1, "Drop", 0.01)), null);
+			Collections.singletonList(makeItem(1, "Drop", 0.01)), null, null, null);
 		when(config.accountType()).thenReturn(AccountType.IRONMAN);
 
 		int effectiveTime = calculator.getEffectiveKillTime(source);
@@ -976,7 +976,7 @@ public class EfficiencyCalculatorTest
 		CollectionLogSource source = new CollectionLogSource("Test Boss", CollectionLogCategory.BOSSES,
 			3000, 3000, 0, 60, 120, "Test Boss", Collections.emptyList(),
 			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0,
-			Collections.singletonList(makeItem(1, "Drop", 0.01)), null);
+			Collections.singletonList(makeItem(1, "Drop", 0.01)), null, null, null);
 		when(config.accountType()).thenReturn(AccountType.MAIN);
 
 		int effectiveTime = calculator.getEffectiveKillTime(source);
@@ -1197,7 +1197,7 @@ public class EfficiencyCalculatorTest
 		CollectionLogSource source = new CollectionLogSource("Test Raid", CollectionLogCategory.RAIDS,
 			3000, 3000, 0, 1800, 2400, "Test Raid", Collections.emptyList(),
 			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0,
-			Collections.singletonList(makeItem(1, "Unique", 0.01)), null);
+			Collections.singletonList(makeItem(1, "Unique", 0.01)), null, null, null);
 		when(config.accountType()).thenReturn(AccountType.IRONMAN);
 		when(config.raidTeamSize()).thenReturn(RaidTeamSize.SOLO);
 

--- a/src/test/java/com/collectionloghelper/efficiency/SlayerStrategyCalculatorTest.java
+++ b/src/test/java/com/collectionloghelper/efficiency/SlayerStrategyCalculatorTest.java
@@ -76,7 +76,7 @@ public class SlayerStrategyCalculatorTest
 	{
 		return new CollectionLogSource(name, CollectionLogCategory.OTHER, 3000, 3000, 0,
 			60, 0, name, Collections.emptyList(),
-			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0, items, null);
+			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0, items, null, null, null);
 	}
 
 	private CollectionLogItem makeItem(int id, String name)

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorDescriptionTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorDescriptionTest.java
@@ -415,6 +415,6 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 			Arrays.asList(steps),
 			null, null, 0, null, 0,
 			Collections.emptyList()
-		, null);
+		, null, null, null);
 	}
 }

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorMapPointTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorMapPointTest.java
@@ -388,7 +388,7 @@ public class GuidanceOverlayCoordinatorMapPointTest
 			null,  // cumulativeTrackObjectIds
 			0,     // cumulativeTrackThreshold
 			Collections.emptyList()  // items
-		, null);
+		, null, null, null);
 	}
 
 	/** Builds a BOSSES source with coordinates and an explicitly empty guidanceSteps list. */
@@ -419,6 +419,6 @@ public class GuidanceOverlayCoordinatorMapPointTest
 			null,
 			0,
 			Collections.emptyList()
-		, null);
+		, null, null, null);
 	}
 }

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorNpcIdTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorNpcIdTest.java
@@ -423,6 +423,6 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 			null,
 			null, 0, null, 0,
 			Collections.emptyList()
-		, null);
+		, null, null, null);
 	}
 }

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerNestedConditionalTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerNestedConditionalTest.java
@@ -535,7 +535,7 @@ public class GuidanceSequencerNestedConditionalTest
 			"Test Source", CollectionLogCategory.BOSSES, 3000, 3000, 0,
 			60, 0, "Test Source", Collections.emptyList(),
 			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null,
-			steps, null, null, 0, null, 0, Collections.emptyList(), null);
+			steps, null, null, 0, null, 0, Collections.emptyList(), null, null, null);
 		sequencer.startSequence(source, step -> {}, () -> {});
 	}
 }

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
@@ -507,7 +507,7 @@ public class GuidanceSequencerTest
 		return new CollectionLogSource(name, CollectionLogCategory.BOSSES, 3000, 3000, 0,
 			60, 0, name, Collections.emptyList(),
 			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null,
-			steps, null, null, 0, null, cumulativeTrackThreshold, Collections.emptyList(), null);
+			steps, null, null, 0, null, cumulativeTrackThreshold, Collections.emptyList(), null, null, null);
 	}
 
 	private void startSequence(List<GuidanceStep> steps)

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerWaypointTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerWaypointTest.java
@@ -177,7 +177,7 @@ public class GuidanceSequencerWaypointTest
 			60, 0, "Test Source", Collections.emptyList(),
 			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null,
 			Arrays.asList(steps),
-			null /* guidanceHelperKey */, null, 0, null, 0, Collections.emptyList(), null /* metaAuthoredDate */);
+			null /* guidanceHelperKey */, null, 0, null, 0, Collections.emptyList(), null /* metaAuthoredDate */, null, null);
 	}
 
 	// ── Test cases ────────────────────────────────────────────────────────────

--- a/src/test/java/com/collectionloghelper/guidance/bosses/BossGuidanceDispatchTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/bosses/BossGuidanceDispatchTest.java
@@ -118,7 +118,7 @@ public class BossGuidanceDispatchTest
 			jsonSteps,
 			helperKey,
 			null, 0, null, 0, items, null /* metaAuthoredDate */
-		);
+		, null, null);
 	}
 
 	@Test

--- a/src/test/java/com/collectionloghelper/learning/DryStreakAnalyzerTest.java
+++ b/src/test/java/com/collectionloghelper/learning/DryStreakAnalyzerTest.java
@@ -385,6 +385,6 @@ public class DryStreakAnalyzerTest
 			0,          // cumulativeTrackThreshold
 			items,
 			null        // metaAuthoredDate
-		);
+		, null, null);
 	}
 }

--- a/src/test/java/com/collectionloghelper/learning/PersonalizedKillTimeTest.java
+++ b/src/test/java/com/collectionloghelper/learning/PersonalizedKillTimeTest.java
@@ -80,7 +80,7 @@ public class PersonalizedKillTimeTest
 			/* guidanceSteps */ null, /* guidanceHelperKey */ null, /* requirements */ null,
 			/* cumulativeTrackItemId */ 0, /* cumulativeTrackObjectIds */ null,
 			/* cumulativeTrackThreshold */ 0,
-			Collections.emptyList(), null /* metaAuthoredDate */);
+			Collections.emptyList(), null /* metaAuthoredDate */, null, null);
 	}
 
 	// ── No learned data ──────────────────────────────────────────────────────────

--- a/src/test/java/com/collectionloghelper/lifecycle/CollectionStateChangeHandlerTest.java
+++ b/src/test/java/com/collectionloghelper/lifecycle/CollectionStateChangeHandlerTest.java
@@ -249,6 +249,6 @@ public class CollectionStateChangeHandlerTest
 			null,
 			null, null, 0, null, 0,
 			Collections.emptyList()
-		, null);
+		, null, null, null);
 	}
 }

--- a/src/test/java/com/collectionloghelper/lifecycle/GuidanceEventRouterTest.java
+++ b/src/test/java/com/collectionloghelper/lifecycle/GuidanceEventRouterTest.java
@@ -175,7 +175,7 @@ public class GuidanceEventRouterTest
 			0,         // cumulativeTrackThreshold
 			null,      // items
 			null       // metaAuthoredDate
-		);
+		, null, null);
 	}
 
 	/**
@@ -207,7 +207,7 @@ public class GuidanceEventRouterTest
 			objectIds,
 			0,
 			null
-		, null);
+		, null, null, null);
 	}
 
 	@Before

--- a/src/test/java/com/collectionloghelper/sync/TempleSyncOrchestratorTest.java
+++ b/src/test/java/com/collectionloghelper/sync/TempleSyncOrchestratorTest.java
@@ -211,6 +211,6 @@ public class TempleSyncOrchestratorTest
 		return new CollectionLogSource(name, CollectionLogCategory.BOSSES, 0, 0, 0,
 			60, 0, null, Collections.emptyList(),
 			null, 0.0, null, 0, false, 0, null, 0, null, null, null, null, null, 0, null, 0,
-			Collections.emptyList(), null);
+			Collections.emptyList(), null, null, null);
 	}
 }

--- a/src/test/java/com/collectionloghelper/ui/DetailViewBuilderTest.java
+++ b/src/test/java/com/collectionloghelper/ui/DetailViewBuilderTest.java
@@ -30,6 +30,7 @@ import com.collectionloghelper.data.CollectionLogSource;
 import com.collectionloghelper.data.PlayerCollectionState;
 import com.collectionloghelper.data.RequirementsChecker;
 import com.collectionloghelper.efficiency.ClueCompletionEstimator;
+import com.collectionloghelper.ui.widget.SourceRecommendedItemsChipPanel;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.util.Arrays;
@@ -38,6 +39,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
+import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import net.runelite.client.game.ItemManager;
@@ -120,6 +122,15 @@ public class DetailViewBuilderTest
 
 	private static CollectionLogSource newSource(String name, List<CollectionLogItem> items)
 	{
+		return newSource(name, items, null, null);
+	}
+
+	private static CollectionLogSource newSource(
+		String name,
+		List<CollectionLogItem> items,
+		String wikiStrategyUrl,
+		List<Integer> recommendedItemIds)
+	{
 		return new CollectionLogSource(
 			name,                          // name
 			CollectionLogCategory.BOSSES,  // category
@@ -145,7 +156,9 @@ public class DetailViewBuilderTest
 			Collections.emptyList(),       // cumulativeTrackObjectIds
 			0,                             // cumulativeTrackThreshold
 			items,                         // items
-			null);                         // metaAuthoredDate
+			null,                          // metaAuthoredDate
+			wikiStrategyUrl,               // wikiStrategyUrl (#573)
+			recommendedItemIds);           // recommendedItemIds (#573)
 	}
 
 	@Test
@@ -313,6 +326,147 @@ public class DetailViewBuilderTest
 		builder.syncGuidanceState(false, null);
 		builder.syncGuidanceState(true, source);
 		// Reaching this line without an NPE is the assertion.
+	}
+
+	/**
+	 * #573 — the detail panel must expose a "Wiki Strategy" button on the action
+	 * row so players can open the source's wiki Strategies page in their default
+	 * browser before activating guidance.
+	 */
+	@Test
+	public void populateRendersWikiStrategyButton()
+	{
+		when(collectionState.isItemObtained(anyInt())).thenReturn(false);
+		when(requirementsChecker.isAccessible(anyString())).thenReturn(true);
+
+		builder.populate(target, item, source, false, null, () -> { });
+
+		ItemDetailPanel detail = (ItemDetailPanel) target.getComponent(0);
+		JButton wikiStrategy = findFirstButton(detail, "Wiki Strategy");
+		assertNotNull("ItemDetailPanel should expose a Wiki Strategy button", wikiStrategy);
+		assertEquals("Wiki Strategy", wikiStrategy.getText());
+	}
+
+	/**
+	 * #573 — when {@code wikiStrategyUrl} is null the source should derive a
+	 * default Strategies URL from the source name with spaces converted to
+	 * underscores. Verifies the resolver on {@link CollectionLogSource} rather
+	 * than the side-effecting browser launch (which would open a real window).
+	 */
+	@Test
+	public void wikiStrategyUrlDerivesFromSourceNameWhenOverrideIsNull()
+	{
+		CollectionLogSource graardor =
+			newSource("General Graardor", Arrays.asList(item), null, null);
+		assertEquals(
+			"https://oldschool.runescape.wiki/w/General_Graardor/Strategies",
+			graardor.getEffectiveWikiStrategyUrl());
+	}
+
+	/**
+	 * #573 — when {@code wikiStrategyUrl} is set the override is returned
+	 * verbatim, allowing sources whose wiki page name does not match the
+	 * source name to point at the correct URL.
+	 */
+	@Test
+	public void wikiStrategyUrlUsesOverrideWhenSet()
+	{
+		String override = "https://oldschool.runescape.wiki/w/Theatre_of_Blood/Strategies/Verzik_Vitur";
+		CollectionLogSource tob = newSource("Theatre of Blood", Arrays.asList(item), override, null);
+		assertEquals(override, tob.getEffectiveWikiStrategyUrl());
+	}
+
+	/**
+	 * #573 — when the source carries an explicit source-level
+	 * {@code recommendedItemIds} list, the source-header chip strip is rendered
+	 * (visible) with the same order. The strip is a
+	 * {@link SourceRecommendedItemsChipPanel} added as a child of the
+	 * {@link ItemDetailPanel}.
+	 */
+	@Test
+	public void populateRendersSourceLevelRecommendedStripWhenOverrideIsSet() throws Exception
+	{
+		when(collectionState.isItemObtained(anyInt())).thenReturn(false);
+		when(requirementsChecker.isAccessible(anyString())).thenReturn(true);
+
+		List<Integer> recOverride = Arrays.asList(11802, 12817, 4151); // Bandos chest, helm, whip
+		CollectionLogSource overrideSrc =
+			newSource("Test Boss", Arrays.asList(item, otherItem), null, recOverride);
+
+		builder.populate(target, item, overrideSrc, false, null, () -> { });
+
+		// Chip-strip update is dispatched via SwingUtilities.invokeLater inside
+		// the widget; flush the EDT before asserting visibility.
+		javax.swing.SwingUtilities.invokeAndWait(() -> { /* flush */ });
+
+		SourceRecommendedItemsChipPanel strip = findFirstChipPanel(target);
+		assertNotNull("Source-level recommended chip panel must be present", strip);
+		assertTrue("Source-level recommended chip panel must be visible when override is non-empty",
+			strip.isVisible());
+	}
+
+	/**
+	 * #573 — sources with neither a source-level recommended override nor any
+	 * per-step recommended items should hide the chip strip entirely (the
+	 * blank-space contract). The base test {@link #source} has empty guidance
+	 * steps and no override, so the strip should be hidden.
+	 */
+	@Test
+	public void populateHidesSourceLevelRecommendedStripWhenNoData() throws Exception
+	{
+		when(collectionState.isItemObtained(anyInt())).thenReturn(false);
+		when(requirementsChecker.isAccessible(anyString())).thenReturn(true);
+
+		builder.populate(target, item, source, false, null, () -> { });
+		javax.swing.SwingUtilities.invokeAndWait(() -> { /* flush */ });
+
+		SourceRecommendedItemsChipPanel strip = findFirstChipPanel(target);
+		assertNotNull("Source-level recommended chip panel must be present in the tree", strip);
+		assertEquals("Strip must be hidden when no recommended items exist",
+			false, strip.isVisible());
+	}
+
+	/**
+	 * #573 — when the source has no source-level override but per-step
+	 * recommended items exist, {@link CollectionLogSource#getEffectiveRecommendedItemIds()}
+	 * rolls up the union (preserving insertion order, deduplicated). Verified
+	 * directly on the source rather than via the chip strip to avoid the
+	 * heavyweight {@link com.collectionloghelper.data.GuidanceStep} constructor.
+	 */
+	@Test
+	public void effectiveRecommendedItemIdsReturnsOverrideWhenSet()
+	{
+		List<Integer> recOverride = Arrays.asList(11802, 12817);
+		CollectionLogSource src =
+			newSource("Test Boss", Arrays.asList(item), null, recOverride);
+
+		assertEquals(recOverride, src.getEffectiveRecommendedItemIds());
+	}
+
+	/**
+	 * Walks the panel tree to locate the first
+	 * {@link SourceRecommendedItemsChipPanel}. Returns {@code null} if none
+	 * exists in the subtree.
+	 */
+	private static SourceRecommendedItemsChipPanel findFirstChipPanel(java.awt.Container root)
+	{
+		for (Component c : root.getComponents())
+		{
+			if (c instanceof SourceRecommendedItemsChipPanel)
+			{
+				return (SourceRecommendedItemsChipPanel) c;
+			}
+			if (c instanceof java.awt.Container)
+			{
+				SourceRecommendedItemsChipPanel nested =
+					findFirstChipPanel((java.awt.Container) c);
+				if (nested != null)
+				{
+					return nested;
+				}
+			}
+		}
+		return null;
 	}
 
 	private static javax.swing.JButton findFirstButton(java.awt.Container root, String labelSubstring)

--- a/src/test/java/com/collectionloghelper/ui/ItemRowPanelHoverTest.java
+++ b/src/test/java/com/collectionloghelper/ui/ItemRowPanelHoverTest.java
@@ -80,7 +80,7 @@ public class ItemRowPanelHoverTest
 			"Shayzien Armour", CollectionLogCategory.OTHER,
 			1516, 3617, 0, 36, 0, null, null, null, 0, null, 0, false, 2,
 			null, 0, null, null, null, null, null, 0, null, 0,
-			Collections.singletonList(item), null);
+			Collections.singletonList(item), null, null, null);
 
 		row = new ItemRowPanel(item, source, false, 0, false,
 			Collections.emptyList(), itemManager, () -> {});

--- a/src/test/java/com/collectionloghelper/ui/mode/DryStreakFeedModeControllerTest.java
+++ b/src/test/java/com/collectionloghelper/ui/mode/DryStreakFeedModeControllerTest.java
@@ -250,6 +250,6 @@ public class DryStreakFeedModeControllerTest
 			0,
 			Collections.emptyList(),
 			null /* metaAuthoredDate */
-		);
+		, null, null);
 	}
 }

--- a/src/test/java/com/collectionloghelper/ui/mode/StatisticsModeControllerTest.java
+++ b/src/test/java/com/collectionloghelper/ui/mode/StatisticsModeControllerTest.java
@@ -113,7 +113,7 @@ public class StatisticsModeControllerTest
 			null, null, null, 0.0, null,
 			0, false, 0, null,
 			0, null, null, null, null,
-			null, 0, null, 0, Collections.emptyList(), null);
+			null, 0, null, 0, Collections.emptyList(), null, null, null);
 		List<CollectionLogSource> bossList = Collections.singletonList(source);
 		when(database.getSourcesByCategory(CollectionLogCategory.BOSSES)).thenReturn(bossList);
 		when(collectionState.getCategoryCount(CollectionLogCategory.BOSSES)).thenReturn(5);

--- a/src/test/java/com/collectionloghelper/ui/widget/GuidanceBannerViewTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/GuidanceBannerViewTest.java
@@ -51,7 +51,7 @@ public class GuidanceBannerViewTest
 		return new CollectionLogSource(name, CollectionLogCategory.BOSSES, 0, 0, 0,
 			60, 0, null, null,
 			null, 0, null, 0, false, 0, null, 0, null, null, null, null, null, 0, null, 0,
-			Collections.emptyList(), null);
+			Collections.emptyList(), null, null, null);
 	}
 
 	@Before

--- a/src/test/java/com/collectionloghelper/ui/widget/QuickGuidePanelViewTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/QuickGuidePanelViewTest.java
@@ -59,7 +59,7 @@ public class QuickGuidePanelViewTest
 	{
 		return new CollectionLogSource(name, CollectionLogCategory.BOSSES, 0, 0, 0,
 			60, 0, null, null, null, 0, null, 0, false, 0, null, 0, null, null, null, null, null, 0, null, 0,
-			Collections.emptyList(), null);
+			Collections.emptyList(), null, null, null);
 	}
 
 	@Test

--- a/src/test/java/com/collectionloghelper/ui/widget/SourceRequirementsHeaderTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/SourceRequirementsHeaderTest.java
@@ -522,6 +522,6 @@ public class SourceRequirementsHeaderTest
 			/* cumulativeTrackItemId */ 0,
 			/* cumulativeTrackObjectIds */ null,
 			/* cumulativeTrackThreshold */ 0,
-			Collections.emptyList(), null /* metaAuthoredDate */);
+			Collections.emptyList(), null /* metaAuthoredDate */, null, null);
 	}
 }


### PR DESCRIPTION
## Summary

Closes #573. Surfaces two new affordances in the source detail header so players can triage a source before activating guidance.

### Sub-deliverable A — Wiki Strategy button

New "Wiki Strategy" button on the detail-panel action row. Click opens the source's wiki Strategies page in the player's default browser via `LinkBrowser.browse()`.

URL resolution lives on `CollectionLogSource.getEffectiveWikiStrategyUrl()`:
1. If the new optional `wikiStrategyUrl` source field is set, returns it verbatim.
2. Otherwise derives `https://oldschool.runescape.wiki/w/<name>/Strategies` from the source name with spaces replaced by underscores (OSRS Wiki convention).

The derived URL is a best-effort default. Sources whose wiki page name differs from the source name (e.g. raid sub-pages, encounter variants) can override with the full URL.

### Sub-deliverable B — Source-level Recommended Gear strip

New `SourceRecommendedItemsChipPanel` widget rendered between the info table and the action-button row. Renders item icons with neutral muted borders (no live availability colouring — guidance hasn't started yet, so inventory state isn't meaningful at this surface).

Item IDs resolve from `CollectionLogSource.getEffectiveRecommendedItemIds()`:
1. If the new optional source-level `recommendedItemIds` field is set, uses it verbatim.
2. Otherwise rolls up the union of per-step `recommendedItemIds` across `guidanceSteps`, preserving insertion order and deduplicating.

The strip hides itself when neither field has data (blank-space contract).

## Backward compatibility

- Both `wikiStrategyUrl` and `recommendedItemIds` are nullable trailing additions on `CollectionLogSource`. Gson deserialisation of existing `drop_rates.json` entries is unchanged — no data backfill required in this PR.
- The existing per-step `RecommendedItemsChipPanel` (B.5.2 / PR #472) is untouched and continues to surface step-specific kit during active guidance. The two surfaces coexist by design: source header = source-wide kit (NEW); active-step body = step-specific additions (existing).
- All 25 `new CollectionLogSource(...)` test-constructor call sites updated to pass trailing `null, null` for the two new optional fields, matching the pattern established when `metaAuthoredDate` was added (#467).

## Tests

New coverage in `DetailViewBuilderTest` and `CollectionLogSourceTest`:
- Wiki Strategy button renders on the detail panel.
- `getEffectiveWikiStrategyUrl()` derives correct URL from multi-word and single-word source names.
- `getEffectiveWikiStrategyUrl()` returns the override verbatim when set; empty override falls back to derived URL.
- Source-level recommended strip is visible when `recommendedItemIds` override is non-empty.
- Strip hidden when neither override nor any per-step recommended items exist.
- `getEffectiveRecommendedItemIds()` returns the override verbatim when set.
- Rollup unions per-step lists across steps, dedupes repeated IDs, preserves insertion order.
- Rollup skips null and non-positive IDs.
- Rollup tolerates steps with null `recommendedItemIds` lists.

## Follow-ups

Data-backfill follow-ups recommended (separate PRs, no blocker for this one):
- Surface sources where the derived `https://oldschool.runescape.wiki/w/<name>/Strategies` 404s and add `wikiStrategyUrl` overrides. Likely candidates: raid encounters (CoX/ToB/ToA bosses live under sub-pages), Slayer monsters (some redirect), DT2 awakened variants.
- Add source-level `recommendedItemIds` overrides where the per-step rollup misses or mis-prioritises kit (e.g. GWD bosses where the meta gear shifts per role).

## Test plan

- [x] `./gradlew build` passes (compile + 25 patched test files + 11 new tests)
- [ ] Open the side panel, navigate to a source's detail view, verify "Wiki Strategy" button is present and tooltips correctly
- [ ] Click "Wiki Strategy" on General Graardor; confirm it opens https://oldschool.runescape.wiki/w/General_Graardor/Strategies in the default browser
- [ ] Confirm source-level Recommended strip appears for sources with per-step recommendations (e.g. Cerberus, which has `recommendedItemIds` on multiple steps)
- [ ] Confirm strip is hidden for sources with no recommended items anywhere
- [ ] Confirm the per-step Recommended strip inside `StepProgressView` still works during active guidance (unchanged)