### PR TITLE
audit(raids): strip npcId/interactAction from ToB-HM to match lobby convention (#560)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -5496,8 +5496,6 @@
     "mutuallyExclusiveSources": [
       "Theatre of Blood"
     ],
-    "npcId": 10852,
-    "interactAction": "Attack",
     "guidanceSteps": [
       {
         "description": "Use Drakan's medallion to teleport to Ver Sinhaza",


### PR DESCRIPTION
## Summary

Resolves the RAIDS lobby `npcId` / `interactAction` inconsistency surfaced by the Pass 1 audit harness (#560). Theatre of Blood (Hard Mode) was the only one of 7 RAIDS sources carrying these two fields; the other 6 raids (CoX, CoX-CM, ToB, ToA, ToA-300, ToA-500) leave them unset. Picked **Option A** from the issue: remove the ToB-HM fields so all 7 raids follow the same lobby convention.

## Why Option A

- **Caller behaviour is uneven for raids.** `DropRateDatabase` only registers a source in `sourcesByNpcId` when `npcId > 0`. `GuidanceEventRouter` then uses that map to attach a right-click "Collection Log Guide" menu entry to that one NPC.
- **Raid bosses have many phase IDs.** Verzik Vitur exposes 23 NPC IDs (8250, 8369-75, 10830-36, 10847-53, 11178). The original ToB-HM entry pinned ID 10852, one HM-phase variant. Backfilling the other 6 raids would require picking arbitrary phase IDs across Olm (CoX), Verzik (ToB), and the Wardens (ToA) and would still under-cover the multi-phase fights.
- **Lobby trigger semantics already work for the other 6 raids** via chat / `completionChatPattern` triggers in `guidanceSteps`. ToB-HM has the same `completionChatPattern: "Your completed Theatre of Blood: Hard Mode count is:"` step, so completion detection is unchanged.
- The fields are documented as optional in `docs/contributor-guide/schema-reference.md`, so no schema or code changes are needed.

## Changes

- `src/main/resources/com/collectionloghelper/drop_rates.json` — remove top-level `npcId: 10852` and `interactAction: "Attack"` from the `Theatre of Blood (Hard Mode)` source (2 lines deleted).

## Build

- `./gradlew lintDropRates` -> BUILD SUCCESSFUL
- `./gradlew build` -> BUILD SUCCESSFUL
- Non-ASCII byte check on `drop_rates.json` -> 0 hits

## Test plan

- [x] `./gradlew build` passes locally
- [x] `./gradlew lintDropRates` passes locally
- [ ] Confirm in-game that right-clicking Verzik Vitur in HM no longer offers a "Collection Log Guide" entry (matches behaviour of normal ToB / CoX / ToA)
- [ ] Confirm ToB-HM completion still registers via `completionChatPattern` (unchanged path)

Closes #560