### PR TITLE
audit(slayer): fix Frost Nagua coord drift + Lava Strykewyrm Charred Island move (#565, #566)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -8621,8 +8621,8 @@
   {
     "name": "Frost Nagua",
     "category": "SLAYER",
-    "worldX": 1693,
-    "worldY": 3232,
+    "worldX": 1362,
+    "worldY": 4511,
     "worldPlane": 0,
     "killTimeSeconds": 20,
     "afkLevel": 2,
@@ -8657,23 +8657,23 @@
         "wikiPage": "Pendant_of_ates_(inert)"
       }
     ],
-    "locationDescription": "Ruins of Tapoyauik, Cam Torum",
-    "travelTip": "Quetzal whistle -> Cam Torum",
+    "locationDescription": "Ruins of Tapoyauik, Twilight Temple (Varlamore)",
+    "travelTip": "Pendant of ates -> Twilight Temple, or quetzal whistle -> Varlamore",
     "npcId": 13728,
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to the Ruins of Tapoyauik in Cam Torum, Varlamore (quetzal whistle)",
-        "worldX": 1693,
-        "worldY": 3232,
+        "description": "Travel to the Ruins of Tapoyauik beneath the Twilight Temple in Varlamore (pendant of ates teleports directly; requires The Heart of Darkness)",
+        "worldX": 1362,
+        "worldY": 4511,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20
       },
       {
-        "description": "Kill Frost Nagua in the icy caves of Varlamore. Use fire spells or crush weapons for weakness",
-        "worldX": 1693,
-        "worldY": 3232,
+        "description": "Kill Frost Nagua in the Ruins of Tapoyauik. Use fire spells or crush weapons for weakness",
+        "worldX": 1362,
+        "worldY": 4511,
         "worldPlane": 0,
         "npcId": 13728,
         "interactAction": "Attack",
@@ -9370,13 +9370,13 @@
         "wikiPage": "Dragon_metal_sheet"
       }
     ],
-    "locationDescription": "Charred Island",
-    "travelTip": "Quetzal whistle -> Varlamore",
+    "locationDescription": "Charred Dungeon, Charred Island",
+    "travelTip": "Sail from Void Knights' Outpost to Charred Island (requires 60 Sailing)",
     "npcId": 15500,
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to the Wilderness Lava Strykewyrm area (level 34+). Use burning amulet to Bandit Camp",
+        "description": "Travel to Charred Island in the Unquiet Ocean (sail from Void Knights' Outpost; requires 60 Sailing). Descend into the Charred Dungeon via the dark hole in the northwest of the island",
         "worldX": 2150,
         "worldY": 2968,
         "worldPlane": 0,
@@ -9384,7 +9384,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Kill Lava Strykewyrms in the Wilderness (level 34+). Use ice spells to freeze them, then attack with melee. Bring cheap gear for PKer risk",
+        "description": "Kill Lava Strykewyrms in the Charred Dungeon beneath Charred Island. Standard combat mechanics; no PKer risk",
         "worldX": 2150,
         "worldY": 2968,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Bundles two SLAYER data-audit fixes from #495 Pass 1 — same file, same section, both small.

### #565 — Frost Nagua coord/description drift
Wiki confirms Frost Nagua spawn in the **Ruins of Tapoyauik** beneath the Twilight Temple in Varlamore (not on the Varlamore surface). The old coord `(1693, 3232, 0)` was on the surface near Cam Torum. Moved to `(1362, 4511, 0)`, which `coordinate_helper identify` confirms is the same Tapoyauik chamber Amoxliatl uses. Updated locationDescription, travelTip, and both guidance steps to reference Twilight Temple / pendant of ates / The Heart of Darkness gating.

### #566 — Lava Strykewyrm Wilderness -> Charred Island
Wiki confirms current spawn is the **Charred Dungeon beneath Charred Island** (Sailing-locked, 60 Sailing). The existing coord `(2150, 2968, 0)` is already on Charred Island (verified via `coordinate_helper identify`), so coord stays. Rewrote both guidance steps to drop the stale Wilderness language (burning amulet -> Bandit Camp, "cheap gear for PKer risk") and describe the Sailing route from Void Knights' Outpost. Updated locationDescription + travelTip to match.

## Wiki citations
- https://oldschool.runescape.wiki/w/Frost_Nagua — "found in the Ruins of Tapoyauik, accessed from the Twilight Temple"
- https://oldschool.runescape.wiki/w/Lava_Strykewyrm — "Charred Dungeon beneath Charred Island … requiring 60 Sailing"
- https://oldschool.runescape.wiki/w/Charred_Island — "sail from the Void Knights' Outpost"

## Verification
- `LC_ALL=C grep -P '[^\x00-\x7f]'` -> zero non-ASCII bytes
- `./gradlew lintDropRates` -> BUILD SUCCESSFUL
- `./gradlew build` -> BUILD SUCCESSFUL (test, jacoco, lint all green)
- `python scripts/audit_drop_rates.py --category SLAYER` -> Frost Nagua and Lava Strykewyrm both in the verified bucket post-fix (45/45 audited, 0 fixable findings, 3 pre-existing unrelated research items: Demonic gorillas, Drake, Superior Slayer Monster)

## Test plan
- [ ] In-game spot check: Frost Nagua guidance routes to Twilight Temple lift, not Cam Torum surface
- [ ] In-game spot check: Lava Strykewyrm guidance describes Sailing route, no Wilderness wording reaches the panel
- [ ] CI green on master after merge

Closes #565
Closes #566