### PR TITLE
fix(f3): KillTimeTracker — off-thread persistence + local-player attribution (#480, #481)

### DIFF
--- a/src/main/java/com/collectionloghelper/learning/KillTimeTracker.java
+++ b/src/main/java/com/collectionloghelper/learning/KillTimeTracker.java
@@ -35,15 +35,24 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.ArrayDeque;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.OptionalInt;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Hitsplat;
 import net.runelite.api.NPC;
 import net.runelite.api.events.ActorDeath;
+import net.runelite.api.events.HitsplatApplied;
 import net.runelite.client.eventbus.Subscribe;
 
 /**
@@ -58,8 +67,20 @@ import net.runelite.client.eventbus.Subscribe;
  * Kill time is measured as the elapsed time between two successive kills of any NPC
  * that maps to the same {@link com.collectionloghelper.data.CollectionLogSource}.
  *
- * <p>Data is persisted to {@code kill_times.json} in the per-character directory and
- * survives across sessions. The file is written after each kill to ensure consistency.
+ * <h2>Attribution (issue #481)</h2>
+ * Only deaths of NPCs the local player has personally damaged are recorded.
+ * {@link HitsplatApplied} events with {@link Hitsplat#isMine()} mark the NPC's
+ * scene index as "tagged by me"; on {@link ActorDeath} the kill is only recorded
+ * if the NPC's index is in the tagged set. This prevents group content
+ * (CoX/ToB/ToA, Wintertodt, Tempoross, GWD masses) from poisoning the personal
+ * rolling average with other players' kills.
+ *
+ * <h2>Persistence (issue #480)</h2>
+ * Disk I/O is moved off the client thread. {@code recordKill} marks the in-memory
+ * state dirty and the actual file write happens on a background single-thread
+ * executor, debounced by {@value #SAVE_DEBOUNCE_MS} ms so high-throughput sources
+ * (Wintertodt, Tempoross, Barbarian Assault) coalesce into one write per debounce
+ * window instead of one per kill.
  */
 @Slf4j
 @Singleton
@@ -73,6 +94,13 @@ public class KillTimeTracker
 
 	/** Maximum plausible kill time in seconds — 30 min cap prevents stale data poisoning. */
 	static final int MAX_KILL_SECONDS = 1800;
+
+	/**
+	 * Debounce window for persisting kill-time data to disk.
+	 * High-throughput sources (Wintertodt) generate many kills per minute; coalescing
+	 * those into a single write per window prevents the disk I/O storm that motivated #480.
+	 */
+	static final long SAVE_DEBOUNCE_MS = 2_000L;
 
 	static final String DATA_FILE_NAME = "kill_times.json";
 
@@ -89,8 +117,29 @@ public class KillTimeTracker
 	/** Timestamp (ms) of the most recent kill event, keyed by source name. */
 	private final Map<String, Long> lastKillTime = new HashMap<>();
 
+	/**
+	 * NPC scene indices the local player has personally damaged.
+	 * Populated by {@link #onHitsplatApplied(HitsplatApplied)} and consumed
+	 * (removed) by {@link #onActorDeath(ActorDeath)} to gate kill recording.
+	 * Thread-safety: only mutated from the client thread.
+	 */
+	private final Set<Integer> playerDamagedNpcIndices = new HashSet<>();
+
 	/** File where rolling data is persisted; set on {@link #init(File)}. */
 	private File dataFile;
+
+	/**
+	 * Single-thread executor for off-client-thread persistence.
+	 * Created lazily on first {@link #init(File)} so tests that drive
+	 * {@link #recordKill(int, long)} without persistence don't spin up a thread.
+	 */
+	private ExecutorService saveExecutor;
+
+	/** Set when state has been mutated since the last persisted snapshot. */
+	private final AtomicBoolean dirty = new AtomicBoolean(false);
+
+	/** Set while a debounced save is in-flight so we coalesce instead of queueing N writes. */
+	private final AtomicBoolean saveScheduled = new AtomicBoolean(false);
 
 	@Inject
 	KillTimeTracker(CollectionLogHelperConfig config, DropRateDatabase database, Gson gson)
@@ -113,17 +162,23 @@ public class KillTimeTracker
 			return;
 		}
 		dataFile = new File(characterDir, DATA_FILE_NAME);
+		ensureExecutor();
 		loadFromDisk();
 	}
 
 	/**
 	 * Resets tracker state on logout / plugin shutdown.
-	 * Does NOT delete the persisted file — data survives across sessions.
+	 *
+	 * <p>Flushes any pending writes synchronously before clearing in-memory state
+	 * so we don't lose the tail end of a kill session, then shuts the background
+	 * executor down. Does NOT delete the persisted file — data survives across sessions.
 	 */
 	public void reset()
 	{
+		flushAndShutdownExecutor();
 		windows.clear();
 		lastKillTime.clear();
+		playerDamagedNpcIndices.clear();
 		dataFile = null;
 	}
 
@@ -164,7 +219,8 @@ public class KillTimeTracker
 	 * Finds the source the NPC belongs to, computes elapsed seconds since the last kill
 	 * of that source, and pushes the sample into the rolling window.
 	 *
-	 * <p>Called from {@link #onActorDeath(ActorDeath)} when the feature is enabled.
+	 * <p>Called from {@link #onActorDeath(ActorDeath)} when the feature is enabled
+	 * and the NPC was attributed to the local player.
 	 * Package-visible for testing.
 	 *
 	 * @param npcId the RuneLite NPC id of the dying actor
@@ -204,7 +260,49 @@ public class KillTimeTracker
 			window.stream().mapToInt(Integer::intValue).average().orElse(0),
 			window.size());
 
-		saveToDisk();
+		scheduleSave();
+	}
+
+	/**
+	 * Marks the local player as having damaged the NPC at the given scene index.
+	 *
+	 * <p>Package-visible for testing — production callers go through
+	 * {@link #onHitsplatApplied(HitsplatApplied)}.
+	 */
+	void markPlayerDamaged(int npcIndex)
+	{
+		playerDamagedNpcIndices.add(npcIndex);
+	}
+
+	/**
+	 * Returns {@code true} if the NPC at the given scene index has at least one
+	 * hitsplat attributed to the local player. Package-visible for testing.
+	 */
+	boolean isPlayerDamaged(int npcIndex)
+	{
+		return playerDamagedNpcIndices.contains(npcIndex);
+	}
+
+	@Subscribe
+	public void onHitsplatApplied(HitsplatApplied event)
+	{
+		if (!config.learnKillTimes())
+		{
+			return;
+		}
+		if (!(event.getActor() instanceof NPC))
+		{
+			return;
+		}
+		Hitsplat hitsplat = event.getHitsplat();
+		// Only "mine" hitsplats count toward attribution. Hitsplat.isMine() returns
+		// true for damage the local player dealt (DAMAGE_ME, BLOCK_ME, POISON, etc.).
+		if (hitsplat == null || !hitsplat.isMine())
+		{
+			return;
+		}
+		NPC npc = (NPC) event.getActor();
+		playerDamagedNpcIndices.add(npc.getIndex());
 	}
 
 	@Subscribe
@@ -219,6 +317,18 @@ public class KillTimeTracker
 			return;
 		}
 		NPC npc = (NPC) event.getActor();
+
+		// Attribution gate (#481): only record kills where the local player landed
+		// at least one hitsplat. Group content (CoX/ToB/ToA, Wintertodt, GWD masses,
+		// BA) otherwise poisons the personal rolling average with other players' kills.
+		boolean attributed = playerDamagedNpcIndices.remove(npc.getIndex());
+		if (!attributed)
+		{
+			log.debug("KillTimeTracker: skipping unattributed death of npcId={} (no local-player hitsplat)",
+				npc.getId());
+			return;
+		}
+
 		recordKill(npc.getId(), System.currentTimeMillis());
 	}
 
@@ -262,17 +372,94 @@ public class KillTimeTracker
 		}
 	}
 
-	private void saveToDisk()
+	/**
+	 * Marks state dirty and schedules a debounced background save (#480).
+	 *
+	 * <p>If a save is already scheduled within the current {@link #SAVE_DEBOUNCE_MS}
+	 * window, this is a no-op — the in-flight write will pick up the latest snapshot
+	 * because it reads {@link #windows} at flush time. This coalesces N kills inside
+	 * one window into a single disk write, eliminating the per-kill stutter that
+	 * motivated #480.
+	 *
+	 * <p>Falls back to a synchronous write when no executor is available — that path
+	 * is only hit by unit tests that exercise {@link #recordKill(int, long)} without
+	 * calling {@link #init(File)}.
+	 */
+	private void scheduleSave()
 	{
+		dirty.set(true);
 		if (dataFile == null)
 		{
 			return;
 		}
-		Map<String, int[]> serializable = new HashMap<>();
-		for (Map.Entry<String, Deque<Integer>> entry : windows.entrySet())
+		if (saveExecutor == null || saveExecutor.isShutdown())
 		{
-			int[] arr = entry.getValue().stream().mapToInt(Integer::intValue).toArray();
-			serializable.put(entry.getKey(), arr);
+			// No background thread available (e.g. tests). Flush inline so persistence
+			// round-trip tests still pass; the production wiring always sets up the executor.
+			flushIfDirty();
+			return;
+		}
+		if (!saveScheduled.compareAndSet(false, true))
+		{
+			return;
+		}
+		try
+		{
+			saveExecutor.submit(() ->
+			{
+				try
+				{
+					// Debounce: wait SAVE_DEBOUNCE_MS so subsequent kills within the window
+					// coalesce into one write. Reads the live windows map under no lock —
+					// only mutated on the client thread, and the writer is a single thread,
+					// so a momentarily-stale snapshot just means the next dirty flag flips
+					// back on and we run again.
+					Thread.sleep(SAVE_DEBOUNCE_MS);
+				}
+				catch (InterruptedException e)
+				{
+					Thread.currentThread().interrupt();
+					// Fall through: still attempt to flush so we don't lose data on shutdown.
+				}
+				finally
+				{
+					saveScheduled.set(false);
+				}
+				flushIfDirty();
+			});
+		}
+		catch (java.util.concurrent.RejectedExecutionException e)
+		{
+			// Executor was shut down between the check and submit; fall back to inline write.
+			saveScheduled.set(false);
+			flushIfDirty();
+		}
+	}
+
+	/**
+	 * Writes the current state to disk if dirty. Safe to call from any thread.
+	 * Package-visible for testing.
+	 */
+	void flushIfDirty()
+	{
+		if (!dirty.getAndSet(false))
+		{
+			return;
+		}
+		if (dataFile == null)
+		{
+			return;
+		}
+		// Snapshot under a brief lock on windows — the producer (client thread) may
+		// be mutating concurrently with the background writer.
+		Map<String, int[]> serializable = new HashMap<>();
+		synchronized (windows)
+		{
+			for (Map.Entry<String, Deque<Integer>> entry : windows.entrySet())
+			{
+				int[] arr = entry.getValue().stream().mapToInt(Integer::intValue).toArray();
+				serializable.put(entry.getKey(), arr);
+			}
 		}
 		try (FileWriter writer = new FileWriter(dataFile))
 		{
@@ -281,6 +468,59 @@ public class KillTimeTracker
 		catch (IOException e)
 		{
 			log.warn("KillTimeTracker: failed to save {}", dataFile, e);
+			// Re-mark dirty so the next scheduleSave retries.
+			dirty.set(true);
 		}
+	}
+
+	private void ensureExecutor()
+	{
+		if (saveExecutor != null && !saveExecutor.isShutdown())
+		{
+			return;
+		}
+		saveExecutor = Executors.newSingleThreadExecutor(r ->
+		{
+			Thread t = new Thread(r, "clh-kill-time-save");
+			t.setDaemon(true);
+			return t;
+		});
+	}
+
+	/**
+	 * Synchronously drains any pending save and shuts down the background executor.
+	 * Called from {@link #reset()}; safe to call when no executor is running.
+	 */
+	private void flushAndShutdownExecutor()
+	{
+		ExecutorService toShutdown = saveExecutor;
+		saveExecutor = null;
+		if (toShutdown == null)
+		{
+			// Still flush any dirty state inline so persistence-only tests work.
+			flushIfDirty();
+			return;
+		}
+		// Stop accepting new tasks; interrupt the in-flight debounce sleep so we flush now.
+		toShutdown.shutdownNow();
+		try
+		{
+			toShutdown.awaitTermination(5, TimeUnit.SECONDS);
+		}
+		catch (InterruptedException e)
+		{
+			Thread.currentThread().interrupt();
+		}
+		// Final synchronous flush on the calling thread — guarantees no data loss.
+		saveScheduled.set(false);
+		flushIfDirty();
+	}
+
+	/**
+	 * Returns an immutable snapshot of the player-damaged NPC index set for testing.
+	 */
+	Set<Integer> snapshotPlayerDamagedNpcIndices()
+	{
+		return Collections.unmodifiableSet(new HashSet<>(playerDamagedNpcIndices));
 	}
 }

--- a/src/test/java/com/collectionloghelper/learning/KillTimeTrackerTest.java
+++ b/src/test/java/com/collectionloghelper/learning/KillTimeTrackerTest.java
@@ -29,6 +29,11 @@ import com.collectionloghelper.data.DropRateDatabase;
 import com.google.gson.GsonBuilder;
 import java.io.File;
 import java.util.OptionalInt;
+import net.runelite.api.Actor;
+import net.runelite.api.Hitsplat;
+import net.runelite.api.NPC;
+import net.runelite.api.events.ActorDeath;
+import net.runelite.api.events.HitsplatApplied;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -38,6 +43,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
@@ -45,12 +51,14 @@ import static org.mockito.Mockito.when;
  *
  * <p>Uses a temporary directory to exercise persistence without touching the
  * real filesystem. The {@code recordKill} package-visible method is called
- * directly so tests do not depend on the RuneLite event bus.
+ * directly so most tests do not depend on the RuneLite event bus.
+ * Event-driven tests for attribution (#481) use real event objects with mocked actors.
  */
 @RunWith(MockitoJUnitRunner.class)
 public class KillTimeTrackerTest
 {
 	private static final int NPC_ID = 42;
+	private static final int NPC_INDEX = 7;
 	private static final String SOURCE_NAME = "Giant Mole";
 	private static final long T0 = 1_000_000L;
 
@@ -218,6 +226,9 @@ public class KillTimeTrackerTest
 		tracker.recordKill(NPC_ID, T0);
 		tracker.recordKill(NPC_ID, T0 + 60_000L);
 
+		// Drain debounced background writer so the file is on disk for the assertion.
+		tracker.reset();
+
 		File expected = new File(characterDir, KillTimeTracker.DATA_FILE_NAME);
 		assertTrue("kill_times.json should exist under characterDir", expected.exists());
 	}
@@ -232,7 +243,7 @@ public class KillTimeTrackerTest
 		tracker.recordKill(NPC_ID, T0 + 60_000L);
 		assertEquals(1, tracker.getObservationCount(SOURCE_NAME));
 
-		// Logout / switch account — state is cleared
+		// Logout / switch account — state is cleared (reset() flushes pending writes too)
 		tracker.reset();
 		assertEquals(0, tracker.getObservationCount(SOURCE_NAME));
 
@@ -255,6 +266,10 @@ public class KillTimeTrackerTest
 		tracker.recordKill(NPC_ID, T0);
 		tracker.recordKill(NPC_ID, T0 + 45_000L); // 45 s written to disk
 
+		// reset() drains the debounced background writer synchronously, so the data
+		// is guaranteed on disk before tracker2 loads it.
+		tracker.reset();
+
 		// New tracker instance reads from the same file
 		KillTimeTracker tracker2 = new KillTimeTracker(config, database, new GsonBuilder().create());
 		tracker2.init(characterDir);
@@ -275,5 +290,217 @@ public class KillTimeTrackerTest
 
 		assertEquals(0, tracker.getObservationCount(SOURCE_NAME));
 		assertFalse(tracker.getLearnedKillTime(SOURCE_NAME).isPresent());
+	}
+
+	// ── Issue #480: disk I/O off client thread ──────────────────────────────────
+
+	/**
+	 * Regression for #480: a kill-record loop at Wintertodt-style throughput must
+	 * not block on disk I/O. After {@code init()} the tracker installs a background
+	 * single-thread executor and {@code recordKill} only marks state dirty; it does
+	 * NOT perform a synchronous write per call.
+	 *
+	 * <p>We assert this by verifying that immediately after recording a kill, the
+	 * persisted file does NOT yet exist — it would exist if write were synchronous.
+	 * Then {@code reset()} drains the executor and the file appears.
+	 */
+	@Test
+	public void recordKill_doesNotWriteSynchronously_afterInit() throws Exception
+	{
+		File characterDir = tmp.newFolder("perfPlayer");
+		tracker.init(characterDir);
+		File dataFile = new File(characterDir, KillTimeTracker.DATA_FILE_NAME);
+		assertFalse("data file should not exist before any kill", dataFile.exists());
+
+		// Two kills => one sample recorded. The save is debounced for SAVE_DEBOUNCE_MS,
+		// so the file should NOT exist immediately after recordKill returns.
+		tracker.recordKill(NPC_ID, T0);
+		tracker.recordKill(NPC_ID, T0 + 60_000L);
+		assertFalse("data file must not be written synchronously inside recordKill (#480)",
+			dataFile.exists());
+
+		// reset() drains the executor and flushes, so now the file must exist.
+		tracker.reset();
+		assertTrue("data file should be flushed by reset()", dataFile.exists());
+	}
+
+	/**
+	 * Regression for #480: many rapid kills inside the debounce window coalesce
+	 * into a single disk write — the producer thread returns immediately.
+	 *
+	 * <p>This is a wall-clock budget check: 100 kills should complete in well under
+	 * the debounce window because they only mark state dirty.
+	 */
+	@Test
+	public void recordKill_manyRapidKills_returnImmediately() throws Exception
+	{
+		File characterDir = tmp.newFolder("turboPlayer");
+		tracker.init(characterDir);
+
+		long startNanos = System.nanoTime();
+		long t = T0;
+		tracker.recordKill(NPC_ID, t);
+		for (int i = 0; i < 100; i++)
+		{
+			t += 30_000L;
+			tracker.recordKill(NPC_ID, t);
+		}
+		long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000L;
+
+		// 100 calls should be sub-second even on slow CI. Generous budget = 500ms.
+		// The bug (#480) had each kill blocking on FileWriter, which on a slow disk
+		// can be 10-50ms per kill — 100 kills would push past the budget.
+		assertTrue("100 recordKill calls should be fast (<500ms), was " + elapsedMs + "ms",
+			elapsedMs < 500);
+
+		tracker.reset();
+	}
+
+	// ── Issue #481: local-player attribution ────────────────────────────────────
+
+	/**
+	 * Regression for #481: deaths of NPCs the local player did NOT damage are
+	 * NOT recorded. This is the core fix — group content (CoX/ToB/ToA, Wintertodt,
+	 * Tempoross, GWD masses) used to poison the average with other players' kills.
+	 */
+	@Test
+	public void onActorDeath_unattributedNpc_doesNotRecord()
+	{
+		NPC npc = mock(NPC.class);
+		when(npc.getId()).thenReturn(NPC_ID);
+		when(npc.getIndex()).thenReturn(NPC_INDEX);
+
+		// First death starts no timer because the NPC was not tagged by the player.
+		tracker.onActorDeath(deathOf(npc));
+		// Even a "second" death is silently dropped because no attribution.
+		tracker.onActorDeath(deathOf(npc));
+
+		assertEquals(0, tracker.getObservationCount(SOURCE_NAME));
+		assertFalse(tracker.getLearnedKillTime(SOURCE_NAME).isPresent());
+	}
+
+	/**
+	 * Regression for #481: when the player tags and kills two NPCs spaced apart,
+	 * the elapsed time between attributed deaths is recorded in the rolling window.
+	 *
+	 * <p>Drives both event handlers end-to-end through the event bus methods (not the
+	 * package-visible {@code recordKill}), so this exercises the attribution gate
+	 * AND the time-between-deaths math together. Because {@code onActorDeath} reads
+	 * {@link System#currentTimeMillis()} we can't dictate the exact elapsed value;
+	 * we only assert that an observation was recorded and the value is plausible.
+	 */
+	@Test
+	public void onActorDeath_twoAttributedKills_recordsObservation() throws Exception
+	{
+		NPC npc = mock(NPC.class);
+		when(npc.getId()).thenReturn(NPC_ID);
+		when(npc.getIndex()).thenReturn(NPC_INDEX);
+
+		// First kill: tag + die. Seeds the timer, no sample yet.
+		tracker.onHitsplatApplied(mineHitsplatOn(npc));
+		tracker.onActorDeath(deathOf(npc));
+		assertEquals("first attributed death seeds the timer, no sample",
+			0, tracker.getObservationCount(SOURCE_NAME));
+
+		// Sleep long enough to be above MIN_KILL_SECONDS = 3s (use 3.1s to be safe).
+		Thread.sleep(3_100L);
+
+		// Second kill: tag + die. Now the elapsed time is recorded as a sample.
+		tracker.onHitsplatApplied(mineHitsplatOn(npc));
+		tracker.onActorDeath(deathOf(npc));
+
+		assertEquals("second attributed death records one sample",
+			1, tracker.getObservationCount(SOURCE_NAME));
+		OptionalInt result = tracker.getLearnedKillTime(SOURCE_NAME);
+		assertTrue(result.isPresent());
+		int learned = result.getAsInt();
+		assertTrue("learned kill time should be in plausible range, was " + learned,
+			learned >= KillTimeTracker.MIN_KILL_SECONDS
+				&& learned <= KillTimeTracker.MAX_KILL_SECONDS);
+	}
+
+	/**
+	 * Regression for #481: the "isMine" attribution mark is cleared after the
+	 * matching death event, so a respawned NPC reusing the same scene index
+	 * cannot inherit attribution from a previous kill.
+	 */
+	@Test
+	public void onActorDeath_clearsAttributionMark()
+	{
+		NPC npc = mock(NPC.class);
+		when(npc.getId()).thenReturn(NPC_ID);
+		when(npc.getIndex()).thenReturn(NPC_INDEX);
+
+		tracker.onHitsplatApplied(mineHitsplatOn(npc));
+		assertTrue(tracker.isPlayerDamaged(NPC_INDEX));
+
+		tracker.onActorDeath(deathOf(npc));
+		assertFalse("death should consume the player-damaged mark",
+			tracker.isPlayerDamaged(NPC_INDEX));
+	}
+
+	/**
+	 * Regression for #481: hitsplats from OTHER players ({@link Hitsplat#isMine()}
+	 * == false) do not mark an NPC as player-damaged.
+	 */
+	@Test
+	public void onHitsplatApplied_otherPlayersHitsplats_doNotMarkAttribution()
+	{
+		// No getIndex() stub — the production code returns before calling getIndex()
+		// when isMine() is false, so stubbing it would be flagged as unnecessary.
+		NPC npc = mock(NPC.class);
+
+		tracker.onHitsplatApplied(otherHitsplatOn(npc));
+		assertFalse("non-mine hitsplats must not mark attribution",
+			tracker.isPlayerDamaged(NPC_INDEX));
+	}
+
+	/**
+	 * Regression for #481: the feature flag gates both event handlers — when
+	 * disabled, no attribution marks are recorded.
+	 */
+	@Test
+	public void featureDisabled_attributionAndDeathEvents_areNoOps()
+	{
+		when(config.learnKillTimes()).thenReturn(false);
+
+		// No stubs on the NPC mock — both handlers must short-circuit at the feature
+		// flag check before touching the npc, so even an un-stubbed mock is safe.
+		NPC npc = mock(NPC.class);
+
+		tracker.onHitsplatApplied(mineHitsplatOn(npc));
+		assertFalse(tracker.isPlayerDamaged(NPC_INDEX));
+
+		tracker.onActorDeath(deathOf(npc));
+		assertEquals(0, tracker.getObservationCount(SOURCE_NAME));
+	}
+
+	// ── Test helpers ────────────────────────────────────────────────────────────
+
+	private static ActorDeath deathOf(Actor actor)
+	{
+		return new ActorDeath(actor);
+	}
+
+	private static HitsplatApplied mineHitsplatOn(Actor actor)
+	{
+		Hitsplat hitsplat = mock(Hitsplat.class);
+		when(hitsplat.isMine()).thenReturn(true);
+		HitsplatApplied event = new HitsplatApplied();
+		event.setActor(actor);
+		event.setHitsplat(hitsplat);
+		return event;
+	}
+
+	private static HitsplatApplied otherHitsplatOn(Actor actor)
+	{
+		// Mockito's default for boolean is false → isMine() returns false without stubbing,
+		// which is exactly what we want for an "other player" hitsplat. Stubbing to the
+		// default trips MockitoJUnitRunner.STRICT_STUBS as an unnecessary stubbing.
+		Hitsplat hitsplat = mock(Hitsplat.class);
+		HitsplatApplied event = new HitsplatApplied();
+		event.setActor(actor);
+		event.setHitsplat(hitsplat);
+		return event;
 	}
 }


### PR DESCRIPTION
## Summary

Bundles two F3 KillTimeTracker fixes that share the same file and risk surface.

- **#480 (P1):** `saveToDisk()` was running synchronously inside `@Subscribe onActorDeath` — a `FileWriter` open + full-map serialize on the client thread per kill. Visible frame stutter at Wintertodt / Tempoross / BA.
- **#481 (P2):** Every NPC death in scene was recorded, regardless of attribution. Group content (CoX/ToB/ToA, Wintertodt, GWD masses) poisoned the personal rolling average with other players' kills.

## Fix details

### #480 — off-thread persistence
- Added a single-thread `ExecutorService` (`clh-kill-time-save`, daemon) — same pattern as `TempleOsrsKcSyncer`.
- `recordKill` now flips a `dirty` flag and calls `scheduleSave()`, which submits one debounced flush per `SAVE_DEBOUNCE_MS` (2s) window. Subsequent kills inside the window coalesce — no per-kill writes.
- `reset()` (already called from `PluginShutdownRoutine` and `GameStateRouter` on logout) drains the executor synchronously via `shutdownNow()` + `awaitTermination(5s)` + final inline flush. No data loss at session boundary.
- Fallback: when no executor is wired (unit tests that drive `recordKill` directly without `init()`), the save path is inline so persistence round-trip tests still pass.

### #481 — local-player attribution gate
- New `@Subscribe onHitsplatApplied` records the NPC scene index whenever `Hitsplat.isMine()` is true.
- `onActorDeath` only records the kill if the NPC's index is in the player-damaged set; the mark is consumed (removed) on death so a respawn at the same index can't inherit attribution.
- `Hitsplat.isMine()` matches RuneLite's own attribution heuristic (used by Loot Tracker and damage-counter overlays).

### Heuristic limits (intentional)

- Pure tagging where you switch off mid-kill and a teammate finishes will still register as attributed (one hitsplat is enough). This is the conservative direction — better to occasionally over-record than to silently drop legitimate solo kills.
- Damage-tank scenarios where you take agro but never deal damage will NOT register. That matches the spirit of "personal kill time" learning.
- Reflection/Recoil hitsplats: per RuneLite's `Hitsplat.isMine()`, only directly-dealt damage counts.

## Test plan

- [x] `./gradlew build` green
- [x] 22 KillTimeTracker unit tests pass, including 7 new tests:
  - `recordKill_doesNotWriteSynchronously_afterInit` — asserts the file is NOT on disk immediately after `recordKill` returns, then IS after `reset()` drains the executor.
  - `recordKill_manyRapidKills_returnImmediately` — wall-clock budget: 100 rapid kills complete in <500ms (was previously dominated by per-kill FileWriter).
  - `onActorDeath_unattributedNpc_doesNotRecord` — group-content regression: NPC death without a prior `mine` hitsplat is dropped.
  - `onActorDeath_twoAttributedKills_recordsObservation` — end-to-end through both event handlers.
  - `onActorDeath_clearsAttributionMark` — respawn cannot inherit attribution.
  - `onHitsplatApplied_otherPlayersHitsplats_doNotMarkAttribution`
  - `featureDisabled_attributionAndDeathEvents_areNoOps`
- [x] Existing 15 KillTimeTracker tests still pass (persistence round-trip test updated to call `reset()` to drain the debounce window before reading).

Fixes #480
Fixes #481