### PR TITLE
fix(f1, f2): inject ScheduledExecutorService into sync components (#478, #479)

### DIFF
--- a/src/main/java/com/collectionloghelper/lifecycle/PluginShutdownRoutine.java
+++ b/src/main/java/com/collectionloghelper/lifecycle/PluginShutdownRoutine.java
@@ -52,18 +52,21 @@ import net.runelite.client.ui.NavigationButton;
  * <ol>
  *   <li>Unregister the {@code !clh} chat command.</li>
  *   <li>Close the authoring logger file handle.</li>
- *   <li>Shut down the collectionlog.net importer.</li>
  *   <li>Tear down the panel (if it was constructed).</li>
  *   <li>Remove the nav button from the client toolbar.</li>
  *   <li>Unregister overlays.</li>
  *   <li>Unregister event-bus listeners (scene router, guidance routers,
  *       movement tracker, kill-time tracker).</li>
  *   <li>Reset state on each collaborator
- *       (kill-time tracker, guidance, sync coordinator, kc store, TempleOSRS
- *       syncer, player location resolver, overlays, data sync state, bank
+ *       (kill-time tracker, guidance, sync coordinator, kc store,
+ *       player location resolver, overlays, data sync state, bank
  *       state, inventory state, slayer state, travel caps, collection state,
  *       plugin data manager).</li>
- *   <li>Shut down the shared HTTP result executor (if present).</li>
+ *   <li>Shut down the shared HTTP result executor (if present).  The
+ *       collectionlog.net importer and TempleOSRS syncer no longer manage
+ *       their own executors (#478, #479) -- the runtime-provided
+ *       {@code ScheduledExecutorService} they use is shut down by the
+ *       RuneLite runtime, not by this routine.</li>
  *   <li>Clear plugin-private state via the {@code clearPluginState}
  *       callback -- the plugin owns {@code sourcesWithMissingItems},
  *       {@code pendingPanelRebuild}, {@code rankedSourcesDirty}, and
@@ -143,7 +146,9 @@ public class PluginShutdownRoutine
 	{
 		chatCommandManager.unregisterCommand("clh");
 		authoringLogger.close();
-		sync.getCollectionLogNetImporter().shutdown();
+		// CollectionLogNetImporter no longer owns its executor (#478) -- the
+		// shared ScheduledExecutorService is now lifecycle-managed by the
+		// RuneLite runtime, so no per-class shutdown call is needed.
 		if (panel != null)
 		{
 			panel.shutDown();
@@ -158,7 +163,9 @@ public class PluginShutdownRoutine
 		guidance.getGuidanceCoordinator().deactivateGuidance();
 		sync.getSyncStateCoordinator().reset();
 		sync.getSourceKcStore().clear();
-		sync.getTempleOsrsKcSyncer().shutdown();
+		// TempleOsrsKcSyncer no longer owns its executor (#479) -- the shared
+		// ScheduledExecutorService is now lifecycle-managed by the RuneLite
+		// runtime, so no per-class shutdown call is needed.
 		if (httpResultExecutor != null)
 		{
 			httpResultExecutor.shutdownNow();

--- a/src/main/java/com/collectionloghelper/sync/CollectionLogNetImporter.java
+++ b/src/main/java/com/collectionloghelper/sync/CollectionLogNetImporter.java
@@ -31,9 +31,8 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import java.io.IOException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
@@ -67,28 +66,27 @@ public class CollectionLogNetImporter
 	private final OkHttpClient httpClient;
 	private final Gson gson;
 	private final PlayerCollectionState collectionState;
-	private final ExecutorService executor;
-
-	@Inject
-	CollectionLogNetImporter(OkHttpClient httpClient, Gson gson, PlayerCollectionState collectionState)
-	{
-		this.httpClient = httpClient;
-		this.gson = gson;
-		this.collectionState = collectionState;
-		this.executor = Executors.newSingleThreadExecutor(r ->
-		{
-			Thread t = new Thread(r, "clh-collectionlog-net-import");
-			t.setDaemon(true);
-			return t;
-		});
-	}
+	private final ScheduledExecutorService executor;
 
 	/**
-	 * Package-private constructor for testing — accepts an injected executor so
-	 * unit tests can use a same-thread executor without spawning real threads.
+	 * Constructs the importer with all dependencies supplied by Guice.
+	 *
+	 * <p>The {@link ScheduledExecutorService} is provided by the RuneLite runtime
+	 * (see {@code RuneLite.scheduledExecutorService}) — a shared, singleton pool
+	 * whose lifecycle is owned by the client rather than by this plugin.  Plugin
+	 * Hub convention favours this pattern over per-class
+	 * {@code Executors.newSingleThreadExecutor()} construction because it avoids
+	 * leaked threads on plugin restart and lets the runtime cap total worker
+	 * count across all plugins.
+	 *
+	 * @param httpClient HTTP client used for the collectionlog.net request
+	 * @param gson JSON parser
+	 * @param collectionState target store for obtained-item marks
+	 * @param executor shared scheduled executor provided by the runtime
 	 */
-	CollectionLogNetImporter(OkHttpClient httpClient, Gson gson,
-		PlayerCollectionState collectionState, ExecutorService executor)
+	@Inject
+	CollectionLogNetImporter(OkHttpClient httpClient, Gson gson, PlayerCollectionState collectionState,
+		ScheduledExecutorService executor)
 	{
 		this.httpClient = httpClient;
 		this.gson = gson;
@@ -305,11 +303,4 @@ public class CollectionLogNetImporter
 		return el.getAsJsonObject();
 	}
 
-	/**
-	 * Shuts down the background executor.  Safe to call multiple times.
-	 */
-	public void shutdown()
-	{
-		executor.shutdown();
-	}
 }

--- a/src/main/java/com/collectionloghelper/sync/TempleOsrsKcSyncer.java
+++ b/src/main/java/com/collectionloghelper/sync/TempleOsrsKcSyncer.java
@@ -32,9 +32,8 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
@@ -98,19 +97,29 @@ public class TempleOsrsKcSyncer
 
 	private final OkHttpClient okHttpClient;
 	private final Gson gson;
-	private final ExecutorService executor;
+	private final ScheduledExecutorService executor;
 
+	/**
+	 * Constructs the syncer with all dependencies supplied by Guice.
+	 *
+	 * <p>The {@link ScheduledExecutorService} is provided by the RuneLite runtime
+	 * (see {@code RuneLite.scheduledExecutorService}) — a shared, singleton pool
+	 * whose lifecycle is owned by the client rather than by this plugin.  Plugin
+	 * Hub convention favours this pattern over per-class
+	 * {@code Executors.newSingleThreadExecutor()} construction because it avoids
+	 * leaked threads on plugin restart and lets the runtime cap total worker
+	 * count across all plugins.
+	 *
+	 * @param okHttpClient HTTP client used for the TempleOSRS request
+	 * @param gson JSON parser
+	 * @param executor shared scheduled executor provided by the runtime
+	 */
 	@Inject
-	TempleOsrsKcSyncer(OkHttpClient okHttpClient, Gson gson)
+	TempleOsrsKcSyncer(OkHttpClient okHttpClient, Gson gson, ScheduledExecutorService executor)
 	{
 		this.okHttpClient = okHttpClient;
 		this.gson = gson;
-		this.executor = Executors.newSingleThreadExecutor(r ->
-		{
-			Thread t = new Thread(r, "clh-temple-sync");
-			t.setDaemon(true);
-			return t;
-		});
+		this.executor = executor;
 	}
 
 	/**
@@ -125,14 +134,6 @@ public class TempleOsrsKcSyncer
 	public Future<SyncResult> syncKc(String username)
 	{
 		return executor.submit(() -> doSync(username));
-	}
-
-	/**
-	 * Shuts down the internal executor. Call during plugin shutdown.
-	 */
-	public void shutdown()
-	{
-		executor.shutdownNow();
 	}
 
 	// ---- package-private for testing ----

--- a/src/test/java/com/collectionloghelper/lifecycle/PluginShutdownRoutineTest.java
+++ b/src/test/java/com/collectionloghelper/lifecycle/PluginShutdownRoutineTest.java
@@ -135,10 +135,14 @@ public class PluginShutdownRoutineTest
 	}
 
 	@Test
-	public void tearDown_shutsDownCollectionLogNetImporter()
+	public void tearDown_doesNotInteractWithCollectionLogNetImporter()
 	{
+		// #478: CollectionLogNetImporter no longer owns its executor; the
+		// runtime-provided ScheduledExecutorService is shut down by the
+		// RuneLite runtime, not by this routine.  The teardown must not
+		// invoke any method on the importer.
 		routine.tearDown(panel, navButton, executor, () -> { });
-		verify(collectionLogNetImporter).shutdown();
+		org.mockito.Mockito.verifyNoInteractions(collectionLogNetImporter);
 	}
 
 	@Test
@@ -187,7 +191,11 @@ public class PluginShutdownRoutineTest
 		verify(guidanceCoordinator).deactivateGuidance();
 		verify(syncStateCoordinator).reset();
 		verify(sourceKcStore).clear();
-		verify(templeOsrsKcSyncer).shutdown();
+		// #479: TempleOsrsKcSyncer no longer owns its executor; the
+		// runtime-provided ScheduledExecutorService is shut down by the
+		// RuneLite runtime, not by this routine.  The teardown must not
+		// invoke any method on the syncer.
+		org.mockito.Mockito.verifyNoInteractions(templeOsrsKcSyncer);
 		verify(playerLocationResolver).reset();
 		verify(guidanceOverlay).setShowCollectionLogReminder(false);
 		verify(guidanceOverlay).setShowBankReminder(false);

--- a/src/test/java/com/collectionloghelper/sync/CollectionLogNetImporterTest.java
+++ b/src/test/java/com/collectionloghelper/sync/CollectionLogNetImporterTest.java
@@ -28,15 +28,16 @@ import com.collectionloghelper.data.PlayerCollectionState;
 import com.google.gson.Gson;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -109,15 +110,24 @@ public class CollectionLogNetImporterTest
 	private PlayerCollectionState mockCollectionState;
 
 	private final Gson gson = new Gson();
-	private final ExecutorService sameThread = Executors.newSingleThreadExecutor();
+	private ScheduledExecutorService sameThread;
 
 	private CollectionLogNetImporter importer;
 
 	@BeforeEach
 	public void setUp()
 	{
+		// Single-thread scheduled executor — deterministic enough for these tests
+		// and a reasonable stand-in for the runtime-supplied scheduler.
+		sameThread = Executors.newSingleThreadScheduledExecutor();
 		importer = new CollectionLogNetImporter(mockHttpClient, gson, mockCollectionState, sameThread);
 		when(mockHttpClient.newCall(any(Request.class))).thenReturn(mockCall);
+	}
+
+	@AfterEach
+	public void tearDown()
+	{
+		sameThread.shutdownNow();
 	}
 
 	// ── Happy path ────────────────────────────────────────────────────────────

--- a/src/test/java/com/collectionloghelper/sync/TempleOsrsKcSyncerTest.java
+++ b/src/test/java/com/collectionloghelper/sync/TempleOsrsKcSyncerTest.java
@@ -29,6 +29,8 @@ import com.google.gson.JsonObject;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import okhttp3.Call;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
@@ -36,6 +38,7 @@ import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -54,13 +57,22 @@ public class TempleOsrsKcSyncerTest
 	private OkHttpClient mockClient;
 	private TempleOsrsKcSyncer syncer;
 	private Gson gson;
+	private ScheduledExecutorService executor;
 
 	@BeforeEach
 	public void setUp()
 	{
 		mockClient = mock(OkHttpClient.class);
 		gson = new Gson();
-		syncer = new TempleOsrsKcSyncer(mockClient, gson);
+		// Single-thread scheduled executor stands in for the runtime-supplied scheduler.
+		executor = Executors.newSingleThreadScheduledExecutor();
+		syncer = new TempleOsrsKcSyncer(mockClient, gson, executor);
+	}
+
+	@AfterEach
+	public void tearDown()
+	{
+		executor.shutdownNow();
 	}
 
 	// ========================================================================


### PR DESCRIPTION
## Summary

Replaces the per-class `Executors.newSingleThreadExecutor()` construction in `CollectionLogNetImporter` and `TempleOsrsKcSyncer` with `@Inject ScheduledExecutorService`, matching the convention used by Plugin Hub reference plugins (Ground Items, Quest Helper, et al). The RuneLite runtime owns the worker-pool lifecycle, so neither class needs a `shutdown()` method anymore and `PluginShutdownRoutine` no longer calls them.

- F1: `CollectionLogNetImporter` -- drop private executor + shutdown(), inject `ScheduledExecutorService` instead. Test-only 2-arg constructor removed (the 4-arg constructor now takes the scheduled executor, which tests supply via `Executors.newSingleThreadScheduledExecutor()`).
- F2: `TempleOsrsKcSyncer` -- same refactor. Public `shutdown()` removed.
- `PluginShutdownRoutine` -- drop the two stale `shutdown()` calls and update the teardown-order javadoc. The plugin's own `httpResultExecutor` (for awaiting async sync futures off the EDT) is unchanged.
- Tests -- swap the same-thread executor for a single-thread `ScheduledExecutorService`, add `@AfterEach` teardown, and invert the two `PluginShutdownRoutineTest` expectations so the new contract (runtime owns the executor lifecycle) is locked in via `verifyNoInteractions`.

## Adjacent note

`KillTimeTracker` (recently touched by #480/#481/#589) does not own an `ExecutorService` of its own -- the disk-I/O work it offloads runs on the plugin's shared `httpResultExecutor`. No parallel fix is needed there. If the long-term goal is to also retire `httpResultExecutor` in favour of injecting `ScheduledExecutorService` directly into `CollectionLogHelperPlugin`, that's worth a separate ticket -- the lifecycle there is slightly different (it's used as a generic future-waiter rather than the per-class executor pattern these two issues target).

## Test plan

- [x] `./gradlew build` green (compileJava + compileTestJava + test + JaCoCo 45% gate + lintDropRates + check)
- [x] `CollectionLogNetImporterTest` -- all paths still pass with the new constructor and `ScheduledExecutorService` test fixture; `@AfterEach` shuts down the test executor so no thread leaks
- [x] `TempleOsrsKcSyncerTest` -- same as above
- [x] `PluginShutdownRoutineTest` -- two inverted expectations confirm the routine no longer touches the importer or syncer mocks
- [x] Constructor injection only -- no field-injection regression; both classes still `@Singleton`
- [ ] Manual sanity: load the plugin in RuneLite, trigger a TempleOSRS KC sync and a collectionlog.net import, verify both still complete and that no `clh-temple-sync` / `clh-collectionlog-net-import` daemon thread appears in `jstack` (the work should now run on the runtime's shared scheduler thread)

Fixes #478
Fixes #479