### PR TITLE
docs: refresh CHANGELOG Unreleased + ROADMAP pre-resubmission table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,88 @@
 
 ## Unreleased
 
+### Added
+
+- **Source-level Recommended gear strip + wiki strategy link** — the
+  guidance panel header now renders a chip strip for any source carrying
+  a `recommendedGearItemIds` field, advisory-only (no bank-scan colors),
+  and a "Strategy guide" link that opens the canonical wiki article in
+  the system browser. The strip and link both render below the existing
+  general requirements / required-items section so the established
+  hierarchy (mandatory → recommended → strategy) stays visually
+  consistent. Pilot data populates the field on a handful of high-impact
+  bossing sources; broader backfill is a separate data pass. Closes
+  [#573](../../issues/573) (PR [#584](../../pull/584)).
+- **`drop_rates.json` audit harness** — new `scripts/audit_drop_rates.py`
+  cross-checks every source's `worldX/worldY` / `npcId` / step
+  descriptions / fairy-ring codes against the in-repo wiki snapshot and
+  flags drift. Runs as part of the pre-hub data sweep tracked in
+  [#495](../../issues/495); harness landed alongside the RAIDS pass
+  ([#561](../../pull/561)) and was widened twice — once for large arenas
+  ([#586](../../pull/586), [#563](../../issues/563)) and once to fix a
+  longest-token bias that mismatched multi-city sources like "Edgeville
+  / Lumbridge" ([#594](../../issues/594), [#595](../../pull/595)).
+
+### Changed
+
+- **`F1`/`F2` sync components now receive a shared `ScheduledExecutorService` via DI** —
+  `CollectionLogNetSyncWorker` and `TempleOsrsSyncWorker` used to
+  `Executors.newSingleThreadScheduledExecutor()` in their own
+  constructors, which (a) leaked threads on plugin shutdown if a sync
+  was in flight and (b) made the workers untestable without spawning
+  real OS threads. They now receive the executor via `@Inject` from a
+  shared sync module that owns shutdown ordering. End-users will notice
+  cleaner client shutdown timing during a sync; the public sync UX is
+  unchanged. Closes [#478](../../issues/478) /
+  [#479](../../issues/479) (PR [#592](../../pull/592)).
+- **`F1`/`F2` config labels standardized + tooltips added** — the two
+  external-sync entries in the plugin config panel were inconsistently
+  named ("Enable collectionlog.net" vs "TempleOSRS sync"); both now
+  follow a `"Sync from <service>"` pattern and carry explanatory
+  tooltips that name the data each sync pulls and the rate limit the
+  client honors. Pure UX clean-up — no behavior change. Closes
+  [#577](../../issues/577) (PR [#582](../../pull/582)).
+- **Step-control buttons replaced with icon controls + tooltips** — the
+  per-step Skip / Reset / Sync text buttons inside the guidance side
+  panel were wide enough to push the panel wider than the standard
+  RuneLite sidebar on some skins. Replaced with three icon buttons
+  carrying tooltips that match the previous label text. The source-level
+  Stop Guidance button now uses the same STOP icon as the step-control
+  pause so the panel's two stop affordances no longer drift visually
+  ([#576](../../issues/576) / PR [#581](../../pull/581)). Closes
+  [#547](../../issues/547) (PR [#552](../../pull/552)).
+- **`CONTRIBUTING.md` trimmed to a focused quickstart** — the deep
+  guidance authoring bar, schema reference, audit playbook, and
+  per-source category taxonomy moved into a new
+  `docs/contributor-guide/` directory. `CONTRIBUTING.md` itself is now a
+  one-screen quickstart that links into the deeper docs. Closes
+  [#549](../../issues/549) (PR [#556](../../pull/556)).
+- **23 travel-then-descend sources migrated to `ARRIVE_AT_ZONE`** —
+  sources with a "travel to surface tile, then descend a ladder/stairs"
+  pattern (Custodian Stalker [#548](../../issues/548) /
+  [#553](../../pull/553) was the pilot;
+  [#558](../../pull/558) batched the remaining 23) used to depend on
+  `ARRIVE_AT_TILE` on the surface coordinate, which silently failed when
+  the player teleported directly underground. They now use
+  `ARRIVE_AT_ZONE` against the broader surface region, so the
+  travel-step auto-advance fires reliably regardless of how the player
+  reached the area. Closes [#555](../../issues/555).
+- **Plugin Hub self-review doc refreshed against current master** —
+  `docs/plugin-hub-review.md` re-audited; all previously-yellow items
+  closed and the table is now 0 Red. Cited in the upcoming hub
+  resubmission PR (PR [#593](../../pull/593)).
+
 ### Fixed
 
+- **GWD boss guidance step order corrected + duplicate kill step
+  dropped** — Armadyl, Bandos, Saradomin, and Zamorak GWD sources had
+  inverted step ordering (kill step listed before the boss-room entry
+  step) and a duplicate kill step at the end of each sequence. Both
+  artefacts dated back to the original GWD data pass and were missed by
+  the Pass 1 audit harness, which only checked coord / npcId drift and
+  not step-order coherence. Closes [#574](../../issues/574)
+  (PR [#579](../../pull/579)); harness gap captured for a follow-up
+  audit class.
 - **Plugin no longer fails to instantiate in a live RuneLite client** —
   Guice could not resolve four C-tier player-state interfaces
   (`DiaryTierState`, `EquippedItemState`, `PohTeleportInventory`,
@@ -49,6 +129,132 @@
   `worldX/worldY` in `drop_rates.json`, so step auto-advance silently failed for
   every guidance sequence that crossed into an instance. Closes
   [#485](../../issues/485).
+
+- **Fairy-ring code corrected to `AIQ` for the Asgarnian Ice Dungeon
+  travel step** — the Cave Krakens / Krakens travel step was emitting
+  `AKQ`, which lands at the Piscatoris Fishing Colony, not the
+  Asgarnian Ice Dungeon. Player-facing step text and the underlying
+  `travelTip` now both reference `AIQ`. Closes
+  [#484](../../issues/484) (PR [#493](../../pull/493)).
+
+- **Step descriptions wrap to the panel width** — long single-string
+  descriptions used to render mid-word truncated on narrow side panels
+  because the rendering path skipped the `<html>` wrapper added in
+  [#483](../../issues/483). The wrap now applies uniformly to every
+  step-rendering surface. Closes [#575](../../issues/575) (PR
+  [#580](../../pull/580)).
+
+- **`KillTimeTracker` disk I/O moved off the client thread + attribution
+  filtered to the local player** — the per-account kill-time learning
+  feature (`F3`) wrote to disk synchronously on every `ACTOR_DEATH`
+  observed in the scene, which (a) blocked the client tick under slow
+  disk and (b) attributed kills from nearby other players to the local
+  account. I/O now hops to the shared sync executor and attribution is
+  gated to `client.getLocalPlayer()`. Closes [#480](../../issues/480) /
+  [#481](../../issues/481) (PR [#589](../../pull/589)).
+
+- **`C7` debug overlay surfaces Tier C detection state + accurate quest
+  count** — the player-capability debug overlay shipped in
+  [#459](../../pull/459) showed each tier's bound impl but never
+  reflected whether that impl had detected current player state (e.g.
+  diary tier, equipped slot, POH teleport availability). The overlay
+  now renders detected state per tier and includes a corrected
+  partial-quest count (the previous string reflected total quests, not
+  partial-progress entries). Closes [#486](../../issues/486) /
+  [#487](../../issues/487) (PR [#583](../../pull/583)).
+
+- **Side-panel sync button visibility refreshes on config toggle** —
+  toggling `F1` / `F2` sync from the plugin config used to require a
+  panel rebuild for the sync button row to appear or disappear. The
+  panel now subscribes to the relevant config keys and refreshes the
+  sync button strip on the next tick. PR
+  [#492](../../pull/492).
+
+- **`SLAYER` and `SKILLING` category counts aggregate from the source
+  database** — both categories rendered "0/N" in the panel header
+  because the count aggregator only read the top-level category keys
+  and missed sub-categorized sources. Counts now sum from a
+  source-database walk so the header reflects actual completion.
+  Closes [#545](../../issues/545) (PR [#546](../../pull/546)).
+
+- **23 data corrections from the Pass 1 audit sweep** — the audit
+  harness from [#561](../../pull/561) was applied across CLUES
+  (PR [#562](../../pull/562), 12 sources clean), BOSSES
+  (PR [#564](../../pull/564), 61 sources triaged, 1 research issue
+  filed), SLAYER (PR [#567](../../pull/567), 45 sources, 2 surface→
+  underground coord fixes + 2 research issues), MINIGAMES
+  (PR [#568](../../pull/568), 25 sources, 4 wording fixes), SKILLING
+  (PR [#570](../../pull/570), 17 sources, 1 surface→underground fix),
+  OTHER (PR [#571](../../pull/571), 58 sources, 2 mismatches fixed),
+  RAIDS (PR [#561](../../pull/561), npc/coord fixes + ToB-HM cleanup in
+  PR [#585](../../pull/585)), and a follow-up Slayer pass for Frost
+  Nagua coord-vs-description drift + Lava Strykewyrm Charred Island
+  move (PRs [#587](../../pull/587), closes
+  [#565](../../issues/565) / [#566](../../issues/566)). Pass 1 closed
+  as part of [#495](../../issues/495).
+
+### Changed (refactors)
+
+- **`CollectionLogHelperPlugin` decomposed into routers, orchestrators,
+  and modules (#503)** — the plugin class dropped from 904 LOC to 555
+  LOC through a 25+ PR campaign. Event handling now flows through
+  dedicated routers (`GameStateRouter`,
+  `VarbitChangeRouter`, `SequencerEventAdapter`,
+  `ChatEventHandler`); per-tick work runs in `GameTickOrchestrator`;
+  shutdown sequencing lives in `PluginShutdownRoutine`; and Guice
+  bindings are split across `DataModule`, `EfficiencyModule`,
+  `GuidanceModule`, `SyncModule`
+  (PRs [#509](../../pull/509), [#514](../../pull/514),
+  [#518](../../pull/518), [#521](../../pull/521)). The panel was
+  similarly split — `PanelRebuildOrchestrator`,
+  `PanelHeaderBuilder`, `SelectorControlsPanel`,
+  `SyncButtonController`, `ListContainerScrollPane`, and
+  `DetailViewBuilder` are now stand-alone collaborators
+  (PRs [#513](../../pull/513), [#515](../../pull/515),
+  [#519](../../pull/519), [#522](../../pull/522),
+  [#531](../../pull/531), [#534](../../pull/534)). The guidance
+  coordinator and sequencer shed `WorldMapController`,
+  `NpcTrackerHelper`, `DynamicTargetManager`,
+  `DynamicItemObjectTierResolver`, `StepChangeHandler`,
+  `OverlayStepApplier`, `OverlayDeactivator`, `OverlaySourceApplier`,
+  `StepAdvancer`, and `CompletionChecker`
+  (PRs [#510](../../pull/510), [#512](../../pull/512),
+  [#516](../../pull/516), [#520](../../pull/520),
+  [#523](../../pull/523), [#526](../../pull/526),
+  [#529](../../pull/529), [#532](../../pull/532),
+  [#535](../../pull/535), [#537](../../pull/537)). Closes
+  [#503](../../issues/503) (umbrella PR [#542](../../pull/542)).
+  No user-visible behavior change; the result is a substantially
+  smaller core class and far better test isolation.
+
+- **`guidance.helper` package renamed to `guidance.bosses`** to match
+  the actual contents (boss-specific `GuidanceHelper` implementations,
+  e.g. `CerberusHelper`). Closes [#502](../../issues/502) (PR
+  [#508](../../pull/508)).
+
+### Changed (build hygiene)
+
+- **Allocation-free guard-fail paths in `DynamicTargetManager` +
+  hoisted `exportEfficiencyIfEnabled` field** — the per-tick guard-fail
+  path in `DynamicTargetManager` allocated a fresh `Optional` even when
+  no dynamic target was active (PR [#539](../../pull/539),
+  [#527](../../issues/527)), and `Plugin.exportEfficiencyIfEnabled`
+  resolved its config flag on every tick instead of caching it as a
+  field (PR [#554](../../pull/554), follow-up to
+  [#541](../../issues/541)). Both paths now run literal-zero
+  allocations on the steady-state tick.
+
+- **Non-ASCII guard on `drop_rates.json`** — the build now fails on
+  non-ASCII characters in `drop_rates.json` (em-dashes were the
+  recurring offender, sourced from Wiki copy-paste). Existing
+  em-dashes were replaced with ASCII equivalents in the same PR.
+  Closes [#501](../../issues/501) (PR [#507](../../pull/507)).
+
+- **Plugin metadata polish for hub resubmission** — `icon.png`
+  re-exported at the 48x72 convention the hub expects
+  (PR [#505](../../pull/505) / [#499](../../issues/499)) and plugin
+  description + tags refined to align with the hub's manifest schema
+  (PR [#506](../../pull/506) / [#500](../../issues/500)).
 
 ## 1.0.0-hub — 2026-05-15
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -68,7 +68,7 @@ None of this is a reason to throw out the JSON model. It is a reason to decide e
 - Data correctness. 2,109 items ID-verified, drop rates audited twice.
 - Feature breadth. The `README.md` "Features" list is accurate and most of it has been used end-to-end.
 - Test coverage — 503 tests passing, critical services covered.
-- Build hygiene. `./gradlew build` clean. shadowJar 293 KB, runeLiteVersion pinned to 1.12.24, verification-metadata.xml committed.
+- Build hygiene. `./gradlew build` clean. shadowJar 293 KB, runeLiteVersion pinned to 1.12.26.3, verification-metadata.xml committed.
 - License, CREDITS.md, CONTRIBUTING.md, privacy — all present and correct.
 - Screenshots — exist in `docs/screenshots/`.
 
@@ -76,14 +76,14 @@ None of this is a reason to throw out the JSON model. It is a reason to decide e
 
 These are the items that would have made the previous PR cycle smoother.
 
-| Item | Why it matters for review | Effort |
-|------|---------------------------|--------|
-| **Panel decomposition** (1,661-LOC `CollectionLogHelperPanel`) | Reviewers look at LOC per file. This is the largest untouched god-object. Split into view controllers per mode (Efficient / Category / Search / Pet / Statistics) behind a shared panel shell. | 2-3 agent-days |
-| **Close/verify all merge-blocking open issues** (#319, #323 — already verified; #314, #306 need in-game capture or triage; #134 is P3) | A clean issue tracker signals maintenance discipline. | 0.5 day of triage + scheduling in-game capture |
-| **Stable tag + changelog cutover** | Tag a `v1.0.0-hub` commit with frozen CHANGELOG.md entry. Don't update it while the PR queues. | 0.5 day |
-| **Plugin Hub self-review checklist** | Run the Plugin Hub checklist (no premium-plugin-like features, no external-service calls without user opt-in, no PII, correct manifest icon/description/tags). Write the results into a `docs/plugin-hub-review.md` we can cite in the PR. | 1 day |
-| **Final LOC pass on `CollectionLogHelperPlugin`** | Aim for under 1,000 LOC on the plugin class. Extract the remaining event dispatch and any residual overlay wiring. | 1-2 days |
-| **Smoke-test onboarding flow** | Record a fresh-install walk-through video (or screenshot series) covering: install → open panel → sync log → Guide Me on a source → step auto-advance. Attach to PR. | 0.5 day |
+| Item | Status | Why it matters for review | Effort |
+|------|--------|---------------------------|--------|
+| **Panel decomposition** (1,661-LOC `CollectionLogHelperPanel`) | done — Panel now 677 LOC; #503 umbrella closed via #542 + 25+ extraction PRs | Reviewers look at LOC per file. This is the largest untouched god-object. Split into view controllers per mode (Efficient / Category / Search / Pet / Statistics) behind a shared panel shell. | 2-3 agent-days |
+| **Close/verify all merge-blocking open issues** (#319, #323 — already verified; #314, #306 need in-game capture or triage; #134 is P3) | mostly done — #319, #323, #306, #314 closed or labeled; remaining open hub-blockers tracked under #495 (Pass 2 in-game validation, partial), #134 (P3), #588 (Pass 2 follow-ups), #569 (audit harness research) | A clean issue tracker signals maintenance discipline. | 0.5 day of triage + scheduling in-game capture |
+| **Stable tag + changelog cutover** | pending — intentionally deferred until resubmission day (CHANGELOG `Unreleased` section refreshed in this PR; v1.0.0-hub-2 will be cut + frozen at resubmission, not before) | Tag a `v1.0.0-hub` commit with frozen CHANGELOG.md entry. Don't update it while the PR queues. | 0.5 day |
+| **Plugin Hub self-review checklist** | done — `docs/plugin-hub-review.md` refreshed against current master via [#593](../../pull/593); 0 Red entries | Run the Plugin Hub checklist (no premium-plugin-like features, no external-service calls without user opt-in, no PII, correct manifest icon/description/tags). Write the results into a `docs/plugin-hub-review.md` we can cite in the PR. | 1 day |
+| **Final LOC pass on `CollectionLogHelperPlugin`** | done — Plugin class now 555 LOC (target was <1,000) after #503 decomposition campaign | Aim for under 1,000 LOC on the plugin class. Extract the remaining event dispatch and any residual overlay wiring. | 1-2 days |
+| **Smoke-test onboarding flow** | blocked — requires an in-game capture session; queued behind #495 Pass 2 in-game validation work | Record a fresh-install walk-through video (or screenshot series) covering: install → open panel → sync log → Guide Me on a source → step auto-advance. Attach to PR. | 0.5 day |
 
 ### Recommendation: hold resubmission ~2 weeks
 
@@ -527,8 +527,8 @@ Focus: god-object decomposition, build hardening, test expansion. Resulted in th
 **Tier A — Production polish for Plugin Hub resubmission**
 
 - [x] A1 — Panel decomposition                          status: done          owner: cha-ndler  updated: 2026-04-17  pr: #349  note: 5 mode controllers extracted (94–297 LOC each) behind PanelModeDispatcher; 468/468 tests green. Shell still 1,288 LOC (shared widgets) — follow-up A1b.
-- [x] A1b — Shell widget decomposition                   status: done          owner: cha-ndler  updated: 2026-04-17  pr: #351  note: 6 widgets extracted (SyncStatusView, ClueSummaryView, GuidanceBannerView, StepProgressView, SlayerStrategyView, QuickGuidePanelView); shell 1,288 → 698 LOC (−46%); 511 tests green. Shell didn't hit <600 target (final-field constructor overhead ~175 LOC) but is under the 800-LOC Plugin Hub flag threshold.
-- [x] A2 — Plugin class <1,000 LOC                       status: done          owner: cha-ndler  updated: 2026-04-17  pr: #347  note: 1,281 → 904 LOC via GuidanceEventRouter extraction
+- [x] A1b — Shell widget decomposition                   status: done          owner: cha-ndler  updated: 2026-05-20  pr: #351 + #503 follow-up  note: 6 widgets extracted in #351 (SyncStatusView, ClueSummaryView, GuidanceBannerView, StepProgressView, SlayerStrategyView, QuickGuidePanelView); shell 1,288 → 698 LOC (−46%) at #351. Subsequent #503 panel-decomposition campaign (PanelRebuildOrchestrator/PanelHeaderBuilder/SelectorControlsPanel/SyncButtonController/ListContainerScrollPane/DetailViewBuilder) drove the shell to 677 LOC.
+- [x] A2 — Plugin class <1,000 LOC                       status: done          owner: cha-ndler  updated: 2026-05-20  pr: #347 + #503 follow-up  note: 1,281 → 904 LOC at #347 via GuidanceEventRouter extraction; further reduced to 555 LOC across the #503 router/orchestrator extractions (GameStateRouter, VarbitChangeRouter, GameTickOrchestrator, ChatEventHandler, PluginShutdownRoutine, etc.) closed by #542.
 - [x] A3 — Issue triage & labels                         status: done          owner: cha-ndler  updated: 2026-04-17  note: GitHub-only — summary in #345; 10 labels created, #319 closed, #323/#314/#306/#134 labeled
 - [x] A4 — Plugin Hub self-review doc                    status: done          owner: cha-ndler  updated: 2026-04-17  pr: #346  note: 27 green / 3 yellow / 2 red — docs/plugin-hub-review.md
 - [x] A5 — Screenshots refresh                           status: done          owner: cha-ndler  updated: 2026-04-16  note: docs/screenshots/ populated


### PR DESCRIPTION
## Summary

Rolls up the ~60 PRs that have landed since `v1.0.0-hub` into the `CHANGELOG.md` `Unreleased` section and refreshes the `docs/ROADMAP.md` pre-resubmission readiness table against current state. No code changes, no behavior changes — pure docs hygiene ahead of the hub resubmission.

**Why now**: the `Unreleased` section was four entries deep (covering #543, #483, #494, #485) but ~25+ PRs of refactor / audit / sync-DI / panel UX work had merged since without CHANGELOG coverage, and the pre-resubmission table still listed items (panel decomposition, plugin-class LOC) that have since shipped.

## CHANGELOG

New `Unreleased` entries, grouped by section:

- **Added** (2): source-level Recommended gear strip + wiki strategy link (#584); `drop_rates.json` audit harness (#561 + widening PRs #586 / #594 / #595).
- **Changed — features/UX** (5): `F1`/`F2` sync executor injection (#592), `F1`/`F2` config-label standardization (#582), step-control icon controls + STOP-icon sync (#552 / #581), `CONTRIBUTING.md` quickstart trim (#556), 23-source migration from `ARRIVE_AT_TILE` → `ARRIVE_AT_ZONE` for travel-then-descend pattern (#558), plus a pointer to the plugin-hub-review.md refresh (#593).
- **Fixed** (10): the 4 pre-existing entries (#543 / #483 / #494 / #485) plus GWD boss step-order + dedupe-kill (#579), Asgarnian Ice Dungeon fairy ring `AKQ`→`AIQ` (#493), step description wrap (#580), `KillTimeTracker` off-thread + local-player attribution (#589), `C7` debug overlay detection state + accurate quest count (#583), sync-button visibility on config toggle (#492), `SLAYER`/`SKILLING` category aggregation (#546), and the rolled-up 23-source Pass 1 data correction sweep (#562 / #564 / #567 / #568 / #570 / #571 / #585 / #587 under umbrella #495).
- **Changed (refactors)** (2): `#503` Plugin/Panel/Coordinator/Sequencer decomposition campaign (25+ PRs collapsed into one entry that names each extracted collaborator) closed by umbrella PR #542; `guidance.helper` → `guidance.bosses` package rename (#508).
- **Changed (build hygiene)** (3): allocation-free guard-fail path + hoisted field (#539 / #554), non-ASCII guard on `drop_rates.json` (#507), and the hub metadata polish (icon 48x72 / description / tags) (#505 / #506).

Test-infra-only chores (JUnit 5 migration #590, Mockito 5 bump #591, headless test skips #557 / #572, validation log PR #578) intentionally omitted — they don't affect end-users.

## ROADMAP

Pre-resubmission readiness table got a new **Status** column with per-row state:

| Row | Status |
|-----|--------|
| Panel decomposition | done (#503 closed via #542; Panel now 677 LOC) |
| Close/verify hub-blocker issues | mostly done; remaining open: #495 (Pass 2 partial) / #134 (P3) / #588 / #569 |
| Stable tag + changelog cutover | pending — intentionally deferred to resubmission day |
| Plugin Hub self-review checklist | done (#593, 0 Red) |
| Final LOC pass on `CollectionLogHelperPlugin` | done (555 LOC; target was <1,000) |
| Smoke-test onboarding flow | blocked on in-game session |

Also bumped the stale `runeLiteVersion` line under "What is genuinely ready today" from `1.12.24` to `1.12.26.3` (the actual pinned version since #379), and appended `#503` follow-up notes to the A1b / A2 status-log entries so their LOC snapshots reflect current state instead of the original #347 / #351 numbers.

## Notes

- Rolls up changes since `v1.0.0-hub` for resubmission prep — no specific issue to close.
- Leaves the `## Unreleased` header in place. Cutting `v1.0.0-hub-2` and freezing the section is a resubmission-day step, not this PR's job.

## Test plan

- [x] `./gradlew build` clean locally
- [x] Doc-only diff (CHANGELOG.md + docs/ROADMAP.md) — no source changes
- [x] PR refs cross-checked against `git log v1.0.0-hub..origin/master --oneline`