### PR TITLE
fix(config): trim F1/F2 Sync tooltips to single sentence (#600)

### DIFF
--- a/src/main/java/com/collectionloghelper/CollectionLogHelperConfig.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperConfig.java
@@ -52,9 +52,7 @@ public interface CollectionLogHelperConfig extends Config
 	@ConfigItem(
 		keyName = "enableCollectionLogNetImport",
 		name = "collectionlog.net Sync",
-		description = "Imports your collection log progress from collectionlog.net using your RSN. "
-			+ "Marks obtained items in the panel without needing to open the in-game collection log first. "
-			+ "Optional — without this, items are detected automatically once you open the collection log in-game.",
+		description = "Pulls collection-log progress from collectionlog.net by RSN.",
 		section = syncSection,
 		position = 0
 	)
@@ -291,9 +289,7 @@ public interface CollectionLogHelperConfig extends Config
 	@ConfigItem(
 		keyName = "enableTempleOsrsSync",
 		name = "TempleOSRS KC Sync",
-		description = "Pulls your kill counts for tracked activities from TempleOSRS. "
-			+ "Powers the Dry Streak panel and tightens kill-time estimates per source. "
-			+ "Optional — without this, kill counts are learned per session via the Learn Kill Times option below.",
+		description = "Pulls per-source kill counts from TempleOSRS by RSN.",
 		section = syncSection,
 		position = 1
 	)


### PR DESCRIPTION
## Summary

Trims the hover tooltips for the F1 (\`collectionlog.net Sync\`) and F2 (\`TempleOSRS KC Sync\`) config rows from multi-sentence paragraphs to a single short sentence each. Matches the suggested copy in #600.

**Before** — both tooltips spanned the full screen width at typical RuneLite client widths:
- F1: \`"Imports your collection log progress from collectionlog.net using your RSN. Marks obtained items in the panel without needing to open the in-game collection log first. Optional — without this, items are detected automatically once you open the collection log in-game."\`
- F2: \`"Pulls your kill counts for tracked activities from TempleOSRS. Powers the Dry Streak panel and tightens kill-time estimates per source. Optional — without this, kill counts are learned per session via the Learn Kill Times option below."\`

**After** — single-line, scannable hint:
- F1: \`"Pulls collection-log progress from collectionlog.net by RSN."\`
- F2: \`"Pulls per-source kill counts from TempleOSRS by RSN."\`

Fallback-behavior copy still lives in the README; the tooltip now only states what enabling the row does.

Fixes #600.

## Test plan

- [ ] \`./gradlew compileJava\` succeeds (verified locally)
- [ ] In a maximized RuneLite client, hover F1 in the plugin config — tooltip fits on one line
- [ ] Hover F2 — tooltip fits on one line
- [ ] No other functional change; sync rows still toggle as before