### PR TITLE
feat(panel): hoist Recommended chip strip to source-level Requirements area (#599)

### DIFF
--- a/src/main/java/com/collectionloghelper/ui/PanelHeaderBuilder.java
+++ b/src/main/java/com/collectionloghelper/ui/PanelHeaderBuilder.java
@@ -133,7 +133,7 @@ final class PanelHeaderBuilder
 		slayerStrategyView.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
 		controlsPanel.add(slayerStrategyView);
 
-		GuidanceBannerView guidanceBannerView = new GuidanceBannerView(requirementsChecker);
+		GuidanceBannerView guidanceBannerView = new GuidanceBannerView(requirementsChecker, itemManager);
 		guidanceBannerView.setAlignmentX(JComponent.CENTER_ALIGNMENT);
 		guidanceBannerView.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
 		controlsPanel.add(guidanceBannerView);

--- a/src/main/java/com/collectionloghelper/ui/widget/GuidanceBannerView.java
+++ b/src/main/java/com/collectionloghelper/ui/widget/GuidanceBannerView.java
@@ -38,6 +38,7 @@ import javax.swing.BoxLayout;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
+import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.FontManager;
 
 /**
@@ -66,11 +67,30 @@ public class GuidanceBannerView extends JPanel
 	// Per-source requirements section (quest / skill / diary rows)
 	private final RequirementsView requirementsView;
 
+	/**
+	 * Source-level Recommended Gear chip strip (#599). Rendered directly below
+	 * the per-source requirements section so recommended kit is visible from
+	 * step 1, not buried below the active step body. Null when constructed via
+	 * the legacy 1-arg constructor (no {@link ItemManager} available — strip is
+	 * silently omitted in that path).
+	 */
+	private final SourceRecommendedItemsChipPanel recommendedChipPanel;
+
 	// Clue-guidance banner (purple/blue)
 	private final JPanel clueGuidanceBanner;
 	private final JLabel clueGuidanceLabel;
 
+	/**
+	 * Legacy 1-arg constructor retained for tests that do not exercise the
+	 * source-level Recommended chip strip. New production callers should use
+	 * {@link #GuidanceBannerView(RequirementsChecker, ItemManager)}.
+	 */
 	public GuidanceBannerView(RequirementsChecker requirementsChecker)
+	{
+		this(requirementsChecker, null);
+	}
+
+	public GuidanceBannerView(RequirementsChecker requirementsChecker, ItemManager itemManager)
 	{
 		this.requirementsChecker = requirementsChecker;
 
@@ -116,6 +136,22 @@ public class GuidanceBannerView extends JPanel
 		requirementsView.setAlignmentX(CENTER_ALIGNMENT);
 		requirementsView.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
 		add(requirementsView);
+
+		// Source-level Recommended chip strip (#599) — rendered directly below
+		// the requirements section so it is visible from step 1 of guidance.
+		// Hidden by default; populated in showGuidance from
+		// CollectionLogSource.getEffectiveRecommendedItemIds().
+		if (itemManager != null)
+		{
+			recommendedChipPanel = new SourceRecommendedItemsChipPanel(itemManager);
+			recommendedChipPanel.setAlignmentX(LEFT_ALIGNMENT);
+			recommendedChipPanel.setBorder(BorderFactory.createEmptyBorder(2, 0, 4, 0));
+			add(recommendedChipPanel);
+		}
+		else
+		{
+			recommendedChipPanel = null;
+		}
 
 		// Clue guidance banner (hidden by default)
 		clueGuidanceBanner = new JPanel(new BorderLayout());
@@ -197,6 +233,13 @@ public class GuidanceBannerView extends JPanel
 
 		// Delegate to RequirementsView \u2014 hides itself when rows is empty
 		requirementsView.showRequirements(rows);
+
+		// #599 \u2014 populate source-level Recommended chip strip. Hides itself when
+		// the source has no effective recommended items.
+		if (recommendedChipPanel != null)
+		{
+			recommendedChipPanel.update(source.getEffectiveRecommendedItemIds());
+		}
 	}
 
 	/**
@@ -217,6 +260,10 @@ public class GuidanceBannerView extends JPanel
 			}
 		});
 		requirementsView.hideRequirements();
+		if (recommendedChipPanel != null)
+		{
+			recommendedChipPanel.update(Collections.<Integer>emptyList());
+		}
 	}
 
 	/**

--- a/src/main/java/com/collectionloghelper/ui/widget/StepProgressView.java
+++ b/src/main/java/com/collectionloghelper/ui/widget/StepProgressView.java
@@ -184,9 +184,15 @@ public class StepProgressView extends JPanel
 		chipPanel.setAlignmentX(LEFT_ALIGNMENT);
 		add(chipPanel);
 
-		// B.5.2 chip strip — directly below the required-items chips
+		// B.5.2 chip strip — kept in the layout for backwards compatibility with
+		// test helpers that locate components by ordinal position, but permanently
+		// hidden. The source-level Recommended chip strip rendered by
+		// GuidanceBannerView (#599) replaces this per-step strip so recommended
+		// kit is visible from step 1 instead of only when the active step itself
+		// carries recommended items.
 		recChipPanel = new RecommendedItemsChipPanel(itemManager);
 		recChipPanel.setAlignmentX(LEFT_ALIGNMENT);
+		recChipPanel.setVisible(false);
 		add(recChipPanel);
 		add(Box.createVerticalStrut(2));
 
@@ -509,18 +515,19 @@ public class StepProgressView extends JPanel
 
 			if (groups.isEmpty())
 			{
-				// Flat layout — hide sections, show chip strip + required/recommended items inline
+				// Flat layout — hide sections, show chip strip + required/recommended items inline.
+				// recChipPanel is intentionally not updated; it was hoisted to source-level
+				// (#599) and is permanently hidden in this widget.
 				sectionsPanel.setVisible(false);
 				chipPanel.update(rows);
-				recChipPanel.update(recRows);
 				updateRequiredItemDisplay(rows);
 				updateRecommendedItemDisplay(recRows);
 			}
 			else
 			{
-				// Sectioned layout — hide inline panels (including chip strip), render section blocks
+				// Sectioned layout — hide inline panels (including chip strip), render section blocks.
+				// recChipPanel is intentionally not updated; see #599.
 				chipPanel.update(Collections.<RequiredItemDisplay>emptyList());
-				recChipPanel.update(Collections.<RequiredItemDisplay>emptyList());
 				requiredItemsPanel.removeAll();
 				requiredItemsPanel.setVisible(false);
 				recommendedItemsPanel.removeAll();


### PR DESCRIPTION
## Summary

Hoists the Recommended-kit chip strip from per-step (inside \`StepProgressView\`) to source-level (inside \`GuidanceBannerView\`, rendered directly below the per-source Requirements section). Recommended kit is now visible from step 1 of guidance instead of only when the active step happens to carry recommended items.

Fixes the placement regression noted in #599 against PR #584: the strip previously sat below the step body AND below the section list (position 7 of the panel order), now sits between Requirements (position 3) and the step body (position 4).

## Changes

- \`GuidanceBannerView\`: new 2-arg constructor accepting \`ItemManager\`. A \`SourceRecommendedItemsChipPanel\` is added to the layout directly after the \`RequirementsView\`. \`showGuidance\` populates it from \`source.getEffectiveRecommendedItemIds()\`; \`hideGuidance\` clears it. The legacy 1-arg constructor still works for tests that don't exercise the chip strip (passes null \`ItemManager\`; chip strip is omitted from the layout).
- \`PanelHeaderBuilder\`: passes the existing \`itemManager\` to the new \`GuidanceBannerView\` constructor.
- \`StepProgressView\`: the per-step Recommended chip strip (\`recChipPanel\`) is kept in the layout for backwards compatibility with test helpers that find components by ordinal position, but is now permanently hidden and no longer populated.

## Acceptance criteria coverage

| AC | Status |
|---|---|
| 1. Strip renders directly under Requirements | ✅ |
| 2. Visible on every guidance step (incl. step 1) | ✅ |
| 3. Color rules carry over (green/yellow/red availability) | ⚠️ Deferred — source-level strip currently renders neutral chips. Placement fix lands first; live colouring at the new location is a focused follow-up. |
| 4. Hover-tooltip behavior | ✅ \`SourceRecommendedItemsChipPanel\` already shows item-name tooltips |
| 5. Wiki strategy link from #584 stays | ✅ Untouched |

## Test plan

- [x] \`./gradlew compileJava compileTestJava\` succeeds
- [x] Widget tests pass: \`GuidanceBannerViewTest\`, \`StepProgressViewTest\`, \`PanelHeaderBuilderTest\`
- [ ] In-game: activate guidance on a boss source (e.g. General Graardor). Verify Recommended chip strip appears between Requirements and step body from step 1, not below the section list.
- [ ] In-game: deactivate guidance — chip strip clears.
- [ ] In-game: sources with no recommended items still hide the strip (no empty section).

## Notes

- Supersedes #573.
- Closes #599.