### PR TITLE
fix(ui): swap step-text JLabel for JTextArea to stop wrap-boundary glyph drop

### DIFF
--- a/src/main/java/com/collectionloghelper/ui/widget/StepProgressView.java
+++ b/src/main/java/com/collectionloghelper/ui/widget/StepProgressView.java
@@ -45,6 +45,7 @@ import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JTextArea;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
 import net.runelite.client.game.ItemManager;
@@ -94,37 +95,23 @@ public class StepProgressView extends JPanel
 	/** Tooltip suffix appended to items whose status is IN_BANK. */
 	private static final String IN_BANK_TOOLTIP_SUFFIX = " ℹ in bank";
 
-	/**
-	 * Inner-width budget (px) used to force Swing's JLabel HTML renderer to
-	 * word-wrap long step descriptions.
-	 *
-	 * <p>RuneLite's {@code PluginPanel.PANEL_WIDTH} is 225px. The shell panel
-	 * adds a 6px empty border on each side (12px total) and this widget adds a
-	 * 1px line border plus a 6px empty border on each side (~14px total). When
-	 * scrollable content is present the vertical scrollbar consumes another
-	 * 17px ({@code PluginPanel.SCROLLBAR_WIDTH}). That leaves roughly
-	 * {@code 225 - 12 - 14 - 17 = 182px} of usable label width in the worst
-	 * case.
-	 *
-	 * <p>An earlier #497 fix used 220px, which is wider than the worst-case
-	 * usable space. When Swing's HTML renderer is asked to lay out at a width
-	 * larger than the paint-clip region, glyphs past the clip get dropped
-	 * silently (no end-of-string ellipsis), producing the mid-string
-	 * truncation reported in #575 (e.g. "Enter the Bandos boss room and
-	 * Graardor" — missing "kill General"). 170px sits a few px below the
-	 * worst-case usable width so the JLabel never asks the layout engine for
-	 * more horizontal space than the panel can actually paint, matching the
-	 * conservative wrap width used by {@link com.collectionloghelper.ui.ItemDetailPanel}.
-	 */
-	private static final int PANEL_TEXT_WRAP_WIDTH_PX = 170;
-
 	private static final Color BG = new Color(25, 35, 55);
 	private static final Color SECTION_HEADER_FG = new Color(200, 200, 200);
 	private static final Color SECTION_HEADER_ACTIVE_FG = new Color(80, 180, 255);
 
 	private final ItemManager itemManager;
 
-	private final JLabel stepProgressLabel;
+	/**
+	 * Step-description widget. JTextArea (not JLabel) because Swing's HTML
+	 * renderer drops glyphs at pixel-clip wrap boundaries inside long step text
+	 * (#575: mid-string truncation, #580 follow-up: char drop at the wrap point).
+	 * JTextArea word-wraps natively from the component's actual width with no
+	 * pixel arithmetic, so the rendered text always equals the input verbatim.
+	 *
+	 * <p>Configured to look and behave like the prior label: read-only,
+	 * non-focusable, no border, panel-matching background, RuneLite small font.
+	 */
+	private final JTextArea stepProgressArea;
 	/**
 	 * B.5.1 chip strip — rendered directly below the step-progress label in the
 	 * flat layout. Each chip is a 28x28 item icon with a colored border reflecting
@@ -173,11 +160,18 @@ public class StepProgressView extends JPanel
 		setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
 		setVisible(false);
 
-		stepProgressLabel = new JLabel();
-		stepProgressLabel.setFont(FontManager.getRunescapeSmallFont());
-		stepProgressLabel.setForeground(new Color(80, 180, 255));
-		stepProgressLabel.setAlignmentX(LEFT_ALIGNMENT);
-		add(stepProgressLabel);
+		stepProgressArea = new JTextArea();
+		stepProgressArea.setEditable(false);
+		stepProgressArea.setFocusable(false);
+		stepProgressArea.setLineWrap(true);
+		stepProgressArea.setWrapStyleWord(true);
+		stepProgressArea.setOpaque(true);
+		stepProgressArea.setBackground(BG);
+		stepProgressArea.setForeground(new Color(80, 180, 255));
+		stepProgressArea.setFont(FontManager.getRunescapeSmallFont());
+		stepProgressArea.setBorder(BorderFactory.createEmptyBorder());
+		stepProgressArea.setAlignmentX(LEFT_ALIGNMENT);
+		add(stepProgressArea);
 
 		// B.5.1 chip strip — directly below the step description label
 		chipPanel = new RequiredItemsChipPanel(itemManager);
@@ -499,18 +493,13 @@ public class StepProgressView extends JPanel
 
 		SwingUtilities.invokeLater(() ->
 		{
-			// Wrap inside a fixed-width <body> so Swing actually word-wraps long
-			// step descriptions instead of stretching the JLabel's preferred width
-			// past the panel's clip region — visible on clue tiers with long
-			// step text such as "Buy a sleek hairband from the Falador hairdresser",
-			// where the unwrapped label rendered outside the panel box (#483).
-			// HTML-escape the description so any future text containing reserved
-			// characters (<, >, &) does not corrupt the rendered output. The
-			// step number/total are plain integers and are safe to inline.
-			stepProgressLabel.setText(
-				"<html><body style='width:" + PANEL_TEXT_WRAP_WIDTH_PX + "px'>Step "
-					+ current + "/" + total + ": " + escapeHtml(description)
-					+ "</body></html>");
+			// Plain-text setText on a JTextArea word-wraps from the actual rendered
+			// width — no HTML, no pixel-width budget, no escaping needed. Previous
+			// JLabel + <html><body width=...> approach dropped glyphs at the wrap
+			// boundary when the rendered width exceeded the panel's clip region
+			// (#575: "Enter the Bandos boss room and Graardor" missing "kill
+			// General"; #580 follow-up dropped "Kill" → "K" on the next attempt).
+			stepProgressArea.setText("Step " + current + "/" + total + ": " + description);
 			nextStepButton.setVisible(isManual);
 
 			if (groups.isEmpty())
@@ -929,35 +918,6 @@ public class StepProgressView extends JPanel
 			BufferedImage scaled = scaleImage(asyncImage, 28, 28);
 			iconLabel.setIcon(new ImageIcon(scaled));
 		}
-	}
-
-	/**
-	 * Escapes HTML reserved characters in plain-text input so it can be safely
-	 * embedded inside a Swing HTML-rendered JLabel body. Returns an empty string
-	 * for {@code null} input. Used only for the step-description text which is
-	 * authored as plain text in {@code drop_rates.json} but might one day include
-	 * characters that the HTML renderer would otherwise interpret as markup.
-	 */
-	static String escapeHtml(String input)
-	{
-		if (input == null)
-		{
-			return "";
-		}
-		StringBuilder out = new StringBuilder(input.length());
-		for (int i = 0; i < input.length(); i++)
-		{
-			char c = input.charAt(i);
-			switch (c)
-			{
-				case '&': out.append("&amp;"); break;
-				case '<': out.append("&lt;"); break;
-				case '>': out.append("&gt;"); break;
-				case '"': out.append("&quot;"); break;
-				default: out.append(c); break;
-			}
-		}
-		return out.toString();
 	}
 
 	private static BufferedImage scaleImage(BufferedImage source, int width, int height)

--- a/src/test/java/com/collectionloghelper/ui/widget/StepProgressViewTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/StepProgressViewTest.java
@@ -38,6 +38,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JTextArea;
 import javax.swing.SwingUtilities;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -177,57 +178,46 @@ public class StepProgressViewTest
 	 * test fails before the panel ever ships.
 	 */
 	@Test
-	public void showStep_longDescription_fullTextPresentInRenderedHtml() throws Exception
+	public void showStep_longDescription_fullTextPresentVerbatim() throws Exception
 	{
 		String longDescription = "Enter the Bandos boss room and kill General Graardor";
 		view.showStep(4, 5, longDescription, false, Collections.emptyList());
 		flushEdt();
 
-		JLabel label = findStepProgressLabel(view);
-		assertNotNull( label,"Step-progress label must be present");
-		String rendered = label.getText();
-		assertNotNull( rendered,"Step-progress label text must be set");
+		JTextArea area = findStepProgressArea(view);
+		assertNotNull(area, "Step-progress text area must be present");
+		String rendered = area.getText();
+		assertNotNull(rendered, "Step-progress text must be set");
 		assertTrue(
-			rendered.contains(longDescription),"Rendered label must contain full description verbatim — "
-			+ "no mid-string truncation (#575). Actual: " + rendered);
+			rendered.contains(longDescription),
+			"Rendered text must contain full description verbatim — no mid-string truncation (#575). Actual: "
+				+ rendered);
 	}
 
 	/**
-	 * Reserved HTML characters in the description must be escaped, otherwise the
-	 * Swing HTML renderer would either treat them as markup or silently corrupt
-	 * the output. This contract is asserted by checking that the rendered label
-	 * text escapes &lt;, &gt;, and &amp; rather than passing them through raw.
+	 * Description text is now rendered as plain text by a {@link JTextArea}, so
+	 * reserved characters that the prior HTML-rendered JLabel had to escape
+	 * (&lt;, &gt;, &amp;) must now appear verbatim. This pins the contract so a
+	 * future revert to HTML rendering — which would re-introduce both the wrap
+	 * truncation bug (#575) and the need for escaping — surfaces immediately.
 	 */
 	@Test
-	public void showStep_descriptionWithHtmlReservedChars_escapesThem() throws Exception
+	public void showStep_descriptionWithReservedChars_renderedVerbatim() throws Exception
 	{
 		String descriptionWithMarkup = "Use <halberd> & break the door";
 		view.showStep(1, 1, descriptionWithMarkup, false, Collections.emptyList());
 		flushEdt();
 
-		JLabel label = findStepProgressLabel(view);
-		assertNotNull( label,"Step-progress label must be present");
-		String rendered = label.getText();
+		JTextArea area = findStepProgressArea(view);
+		assertNotNull(area, "Step-progress text area must be present");
+		String rendered = area.getText();
 		assertNotNull(rendered);
 		assertTrue(
-			rendered.contains("&lt;halberd&gt;"),"Reserved '<' character must be escaped. Actual: " + rendered);
+			rendered.contains("<halberd>"),
+			"'<halberd>' must appear verbatim (no HTML escaping). Actual: " + rendered);
 		assertTrue(
-			rendered.contains("&amp;"),"Reserved '&' character must be escaped. Actual: " + rendered);
-	}
-
-	/**
-	 * Pure helper-level test for the HTML escape function. Keeps the contract
-	 * pinned independently of the EDT-driven render path so it surfaces clearly
-	 * if the escape logic is ever broken.
-	 */
-	@Test
-	public void escapeHtml_handlesAllReservedCharsAndNull()
-	{
-		assertEquals("", StepProgressView.escapeHtml(null));
-		assertEquals("plain text", StepProgressView.escapeHtml("plain text"));
-		assertEquals("&lt;b&gt;bold&lt;/b&gt;", StepProgressView.escapeHtml("<b>bold</b>"));
-		assertEquals("a &amp; b", StepProgressView.escapeHtml("a & b"));
-		assertEquals("she said &quot;hi&quot;", StepProgressView.escapeHtml("she said \"hi\""));
+			rendered.contains("& break"),
+			"'&' must appear verbatim (no HTML escaping). Actual: " + rendered);
 	}
 
 	// ── Required-items subsection tests (B.5.1) ─────────────────────────────
@@ -738,13 +728,13 @@ public class StepProgressViewTest
 	 * the StepProgressView itself (constructed first in the BoxLayout). Used by
 	 * the #575 wrap-regression tests.
 	 */
-	private static JLabel findStepProgressLabel(StepProgressView view)
+	private static JTextArea findStepProgressArea(StepProgressView view)
 	{
 		for (Component c : view.getComponents())
 		{
-			if (c instanceof JLabel)
+			if (c instanceof JTextArea)
 			{
-				return (JLabel) c;
+				return (JTextArea) c;
 			}
 		}
 		return null;


### PR DESCRIPTION
## Summary

Resolves cha-ndler/collection-log-helper#575 (re-opened after PR #580's follow-up regression). Swaps the side-panel step-description widget from `JLabel` + `<html><body style='width:Npx'>` to a plain-text `JTextArea` so Swing word-wraps from the actual rendered width — no HTML, no pixel-width budget, no glyphs lost at the wrap boundary.

## Why #580's approach kept failing

| Attempt | Approach | Failure mode |
|---|---|---|
| original | `<html><body width=220>` JLabel | Mid-string truncation: "Enter the Bandos boss room and **Graardor**" (missing "kill General") |
| #580 | Lowered to `width=170`, added `escapeHtml` | Char drop at wrap boundary: "Kill" → "K" on Graardor's kill step |
| **this PR** | `JTextArea` plain-text wrap | No pixel arithmetic, no HTML renderer, no clip — text always equals input verbatim |

Swing's HTML renderer drops glyphs that fall past the paint-clip region when the requested layout width exceeds the actual paint width. Both #580 and the original bug are surfaces of the same root cause; any width-tuning fix is fragile by construction.

## What changed

| File | Change |
|---|---|
| `StepProgressView.java` | Replace `JLabel stepProgressLabel` with `JTextArea stepProgressArea`. Configure: read-only, non-focusable, line-wrap, wrap-by-word, panel-matching background, RuneLite small font, no border. Remove `PANEL_TEXT_WRAP_WIDTH_PX` constant and `escapeHtml` helper. |
| `StepProgressViewTest.java` | Helper renamed `findStepProgressLabel` → `findStepProgressArea`. Long-description test asserts verbatim text via JTextArea. Reserved-chars test flipped — descriptions are now rendered as plain text, so `<halberd>` and `&` appear verbatim (the test pins this contract so a future revert to HTML rendering surfaces immediately). Obsolete `escapeHtml_*` test removed (helper is gone). |

Diff: +56 / −106 across 2 files.

## Test plan

- [x] `./gradlew test` — **1391/1391 passing** (was 1392; one test removed for the deleted `escapeHtml` helper).
- [ ] Reviewer: in-client validation — activate guidance on **General Graardor**, verify panel renders "Enter the Bandos boss room and kill General Graardor" verbatim with clean word-wrap (no missing words, no char drops).
- [ ] Reviewer: also spot-check **Kree'arra** (verbose "mithril grapple" kill step) and one clue tier with long step text.
- [ ] Reviewer: visual parity — confirm font, colour, alignment, and panel-fit look the same as before.

Closes cha-ndler/collection-log-helper#575