### PR TITLE
fix(overlay): render C1-C5 detection state in C7 debug overlay (#486)

### DIFF
--- a/src/main/java/com/collectionloghelper/overlay/PlayerCapabilityDebugOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/PlayerCapabilityDebugOverlay.java
@@ -188,6 +188,15 @@ public class PlayerCapabilityDebugOverlay extends OverlayPanel
 			return null;
 		}
 
+		// #486 Pass-3 fix: the C1–C5 state sources have no event-subscriber that
+		// calls refresh() yet, so without a pull here their snapshots stay empty
+		// even on a maxed account. Overlay paint runs on the client thread, so
+		// it is safe to invoke refresh() directly. Each refresh() is internally
+		// try/catch-guarded and retains the previous snapshot on failure; we
+		// wrap them defensively anyway so a single bad source cannot break the
+		// overlay paint pass.
+		refreshDetectionSources();
+
 		panelComponent.getChildren().clear();
 		panelComponent.getChildren().add(TitleComponent.builder()
 			.text("CLH Capability Debug")
@@ -207,6 +216,40 @@ public class PlayerCapabilityDebugOverlay extends OverlayPanel
 		safeRender("Quest sub-milestones", this::renderQuestSubMilestones);
 
 		return super.render(graphics);
+	}
+
+	/**
+	 * Pull-refresh each C1–C5 state source on the overlay paint thread (which
+	 * is the client thread for RuneLite overlays). Each call is wrapped so a
+	 * thrown exception in one source cannot prevent the rest from refreshing.
+	 *
+	 * <p>This is the diagnostic-overlay's workaround for the missing event-driven
+	 * refresh wiring on the underlying detector classes (PR #461, #462, #463,
+	 * #470). Once those classes gain proper {@code @Subscribe} handlers in
+	 * lifecycle routers, this pull can be removed without changing the overlay
+	 * output — but until then it is what makes the C1–C5 rows actually show
+	 * the player's live state.
+	 */
+	private void refreshDetectionSources()
+	{
+		tryRefresh(pohTeleportInventory::refresh);
+		tryRefresh(equippedItemState::refresh);
+		tryRefresh(diaryTierState::refresh);
+		tryRefresh(skillCapePerkState::refresh);
+		tryRefresh(questProgressState::refresh);
+	}
+
+	private static void tryRefresh(Runnable refresher)
+	{
+		try
+		{
+			refresher.run();
+		}
+		catch (Exception ignored)
+		{
+			// Snapshot retained by the source's own catch block; rendering
+			// continues so the remaining sections still show fresh data.
+		}
 	}
 
 	// -------------------------------------------------------------------------

--- a/src/test/java/com/collectionloghelper/overlay/PlayerCapabilityDebugOverlayTest.java
+++ b/src/test/java/com/collectionloghelper/overlay/PlayerCapabilityDebugOverlayTest.java
@@ -68,7 +68,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -441,6 +444,44 @@ public class PlayerCapabilityDebugOverlayTest
 
 		assertTrue(
 			panelLeftStrings().contains("(none completed)"),"expected '(none completed)' placeholder when no sub-milestones complete");
+	}
+
+	// -------------------------------------------------------------------------
+	// #486 Pass-3 — overlay paint pulls a fresh snapshot from each state source
+	// -------------------------------------------------------------------------
+
+	@Test
+	public void render_invokesRefreshOnEachDetectionSource()
+	{
+		enableWithBaseStubs();
+
+		overlay.render(realGraphics);
+
+		// Each C1–C5 source must be refreshed during paint so the overlay shows
+		// live state even when nothing else in the plugin has wired refresh()
+		// into event handlers yet (#486 Pass-3 verdict).
+		verify(pohTeleportInventory, atLeastOnce()).refresh();
+		verify(equippedItemState, atLeastOnce()).refresh();
+		verify(diaryTierState, atLeastOnce()).refresh();
+		verify(skillCapePerkState, atLeastOnce()).refresh();
+		verify(questProgressState, atLeastOnce()).refresh();
+	}
+
+	@Test
+	public void render_refreshThrowing_doesNotBreakRemainingSources()
+	{
+		enableWithBaseStubs();
+		doThrow(new RuntimeException("simulated refresh failure"))
+			.when(equippedItemState).refresh();
+
+		// Must not bubble out of render; subsequent refreshes still run.
+		Dimension result = overlay.render(realGraphics);
+		assertNotNull(result);
+
+		verify(pohTeleportInventory, atLeastOnce()).refresh();
+		verify(diaryTierState, atLeastOnce()).refresh();
+		verify(skillCapePerkState, atLeastOnce()).refresh();
+		verify(questProgressState, atLeastOnce()).refresh();
 	}
 
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Pass-3 in-game re-validation of the C7 debug overlay found that C1/C2/C3 rows still rendered as empty / zero / labels-only despite PR #583 adding the section headings. Root cause (per the diagnosis comment on #486): the underlying Tier-C state sources (`PohTeleportInventoryImpl`, `EquippedItemStateImpl`, `DiaryTierStateImpl`, `SkillCapePerkStateImpl`, `PlayerQuestProgressState`) have no event-subscriber wiring that calls their `refresh()` methods, so their snapshots stay empty and the overlay faithfully renders the empty state.

This PR makes the diagnostic overlay self-sufficient: at the start of every paint, it pulls a fresh snapshot from each C1-C5 state source on the client thread before rendering. The existing rendering blocks then show live data.

### What each section now shows on a populated account

- **C1 - POH Teleports**: one row per detected `PohTeleport` value, with `yes` markers.
- **C2 - Equipped**: `Items equipped: N` count plus a sample item ID for sanity-check.
- **C3 - Diary tiers**: per region, the highest completed `DiaryTier` (e.g. `Ardougne ELITE`, `Desert HARD`, others `-`).
- **C4 - Cape perks**: one row per available `SkillCapePerk`, or `(none available)`.
- **C5 - Quest sub-milestones**: one row per active `QuestSubMilestone`, capped at 8 with a `(+N more)` overflow indicator, or `(none completed)`.

Each refresh is individually try/catch-guarded so a single failing source cannot break the rest of the overlay paint.

This is a diagnostic-overlay-only workaround. Once the underlying detectors gain proper `@Subscribe` handlers in lifecycle routers, the in-render pull can be removed without changing observed overlay output.

Closes #486

## Test plan

- [x] `./gradlew build` green
- [x] New `render_invokesRefreshOnEachDetectionSource` test verifies all five state sources are refreshed during paint
- [x] New `render_refreshThrowing_doesNotBreakRemainingSources` test verifies a thrown refresh on one source does not prevent the others from refreshing or kill the paint
- [x] Existing C1-C5 section tests still green
- [ ] In-game smoke test on a populated account: confirm C1/C2/C3 rows show non-empty values