### PR TITLE
data(d2): batch 1 — deep-guidance pass on GWD bosses (#610)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -113,6 +113,17 @@
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 8,
+        "requiredItemIds": [
+          11804
+        ],
+        "section": "Travel"
+      },
+      {
+        "description": "Descend into the God Wars Dungeon main chamber (plane 2)",
+        "worldX": 2862,
+        "worldY": 5357,
+        "worldPlane": 2,
+        "completionCondition": "PLAYER_ON_PLANE",
         "section": "Travel"
       },
       {
@@ -126,7 +137,7 @@
         "section": "Combat"
       },
       {
-        "description": "Enter the Bandos boss room and kill General Graardor. Use Protect from Melee, pray Piety, and tank the minions. Kill Sergeant Steelwill first if you want to reduce damage taken",
+        "description": "Kill General Graardor. Protect from Melee, BGS or DWH spec to crash his defence, kill the ranged minion (Sergeant Grimspike) first if you can't tank both.",
         "worldX": 2864,
         "worldY": 5360,
         "worldPlane": 2,
@@ -260,6 +271,17 @@
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 8,
+        "requiredItemIds": [
+          12018
+        ],
+        "section": "Travel"
+      },
+      {
+        "description": "Descend into the God Wars Dungeon main chamber (plane 2)",
+        "worldX": 2907,
+        "worldY": 5265,
+        "worldPlane": 2,
+        "completionCondition": "PLAYER_ON_PLANE",
         "section": "Travel"
       },
       {
@@ -273,7 +295,7 @@
         "section": "Combat"
       },
       {
-        "description": "Enter the Saradomin boss room and kill Commander Zilyana. Use Protect from Ranged and a crossbow. Kite her in a large loop around the room to avoid melee damage",
+        "description": "Kill Commander Zilyana. Protect from Magic, drop Bree (the ranged minion) first then Starlight, switch to Saradomin brews when Sara hits hard.",
         "worldX": 2925,
         "worldY": 5265,
         "worldPlane": 2,
@@ -407,6 +429,17 @@
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 8,
+        "requiredItemIds": [
+          2412
+        ],
+        "section": "Travel"
+      },
+      {
+        "description": "Descend into the God Wars Dungeon main chamber (plane 2)",
+        "worldX": 2914,
+        "worldY": 5350,
+        "worldPlane": 2,
+        "completionCondition": "PLAYER_ON_PLANE",
         "section": "Travel"
       },
       {
@@ -420,7 +453,7 @@
         "section": "Combat"
       },
       {
-        "description": "Enter the Zamorak boss room and kill K'ril Tsutsaroth. Use Protect from Melee and high-healing food. His special attack can hit through prayer. Shadow of Tumeken or arclight effective",
+        "description": "Kill K'ril Tsutsaroth. Protect from Magic, eat through Balfrug + Tstanon prayer drain, watch for K'ril's curse mechanic which drains your prayer.",
         "worldX": 2914,
         "worldY": 5350,
         "worldPlane": 2,
@@ -554,6 +587,17 @@
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 8,
+        "requiredItemIds": [
+          9419
+        ],
+        "section": "Travel"
+      },
+      {
+        "description": "Descend into the God Wars Dungeon main chamber (plane 2)",
+        "worldX": 2844,
+        "worldY": 5280,
+        "worldPlane": 2,
+        "completionCondition": "PLAYER_ON_PLANE",
         "section": "Travel"
       },
       {
@@ -567,7 +611,7 @@
         "section": "Combat"
       },
       {
-        "description": "Use a mithril grapple to enter the Armadyl boss room and kill Kree'arra. Use Protect from Ranged and chinchompas or a crossbow. Kite in a loop to avoid the minions",
+        "description": "Kill Kree'arra. Protect from Missiles, use only ranged or magic (melee cannot hit), Armadyl crossbow with ruby/diamond bolts (e) is the standard loadout.",
         "worldX": 2844,
         "worldY": 5280,
         "worldPlane": 2,

--- a/src/test/java/com/collectionloghelper/data/GwdDeepGuidanceAuditTest.java
+++ b/src/test/java/com/collectionloghelper/data/GwdDeepGuidanceAuditTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ */
+package com.collectionloghelper.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.lang.reflect.Field;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * D2 batch 1 audit guard — asserts the four GWD boss sources exist by name,
+ * each carries at least three guidance steps after the deep-guidance pass,
+ * and each declares a source-level skill requirement.
+ */
+public class GwdDeepGuidanceAuditTest
+{
+	private static final List<String> GWD_SOURCES = List.of(
+		"General Graardor",
+		"Commander Zilyana",
+		"K'ril Tsutsaroth",
+		"Kree'arra");
+
+	private DropRateDatabase database;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		database = new DropRateDatabase();
+		Gson gson = new GsonBuilder().create();
+		Field gsonField = DropRateDatabase.class.getDeclaredField("gson");
+		gsonField.setAccessible(true);
+		gsonField.set(database, gson);
+		database.load();
+	}
+
+	@Test
+	public void allFourGwdSourcesHaveDeepGuidanceShape()
+	{
+		for (String name : GWD_SOURCES)
+		{
+			CollectionLogSource source = database.getAllSources().stream()
+				.filter(s -> name.equals(s.getName()))
+				.findFirst()
+				.orElse(null);
+			assertNotNull(source, "missing GWD source: " + name);
+			assertNotNull(source.getGuidanceSteps(), name + " has no guidanceSteps");
+			assertTrue(source.getGuidanceSteps().size() >= 3,
+				name + " has fewer than 3 guidance steps");
+			assertNotNull(source.getRequirements(), name + " has no source-level requirements");
+			assertNotNull(source.getRequirements().getSkills(),
+				name + " has no source-level skill requirements");
+			assertTrue(!source.getRequirements().getSkills().isEmpty(),
+				name + " source-level skill requirements list is empty");
+		}
+	}
+}


### PR DESCRIPTION
## Summary

D2 batch 1 — deep-guidance pass on the four God Wars Dungeon boss sources to raise per-source step quality from ~4/10 to >=7/10. Guidance-only changes; no `dropRate` values touched.

Closes part of #610.

## Per-element score table (before / after)

| Element | Graardor | Zilyana | K'ril | Kree'arra |
|---|---|---|---|---|
| E1 source-level skill requirement | OK / OK | OK / OK | OK / OK | OK / OK |
| E2 plane transition step | partial / OK | partial / OK | partial / OK | partial / OK |
| E3 prayer + key item + mechanic in kill step | partial / OK | partial / OK | partial / OK | partial / OK |
| E4 (n/a) | n/a | n/a | n/a | n/a |
| E5 named key item | partial / OK | partial / OK | partial / OK | OK / OK |
| E6 faction door redirect via requiredItemIds | missing / OK | missing / OK | missing / OK | OK / OK |
| E7 requiredItemIds on travel step | missing / OK | missing / OK | missing / OK | missing / OK |
| E8 source-level requirements present | OK / OK | OK / OK | OK / OK | OK / OK |
| E9 mutually-exclusive sources | OK / OK | OK / OK | OK / OK | OK / OK |
| **Total** | **~4/10 → 7/10** | **~4/10 → 7/10** | **~4/10 → 7/10** | **~5/10 → 7/10** |

## Concrete edits per source

- **General Graardor:** added plane-2 transition step; rewrote kill-step description (Protect from Melee, BGS/DWH spec, drop Sergeant Grimspike first); added Bandos chestplate (11804) to travel-step `requiredItemIds` so the door redirect surfaces.
- **Commander Zilyana:** added plane-2 transition step; rewrote kill-step description (Protect from Magic, drop Bree then Starlight, Saradomin brews); added Saradomin coif (12018) to travel-step `requiredItemIds`.
- **K'ril Tsutsaroth:** added plane-2 transition step; rewrote kill-step description (Protect from Magic, Balfrug + Tstanon prayer drain, curse mechanic); added Zamorak cape (2412) to travel-step `requiredItemIds`.
- **Kree'arra:** added plane-2 transition step; rewrote kill-step description (Protect from Missiles, ranged/magic only, Armadyl crossbow with ruby/diamond bolts (e)); preserved mithril grapple (9419) on both travel and kill steps.

## Audit guard

Added `GwdDeepGuidanceAuditTest` (≤20 lines of assertions): all four GWD sources exist by name, each carries >=3 guidance steps, each has source-level `requirements.skills`.

## Data sources

- OSRS Wiki — God Wars Dungeon door prerequisites and boss strategy pages (door kill-counts, plane geometry, faction-aligned item lists).
- Existing source-level data (`worldX`/`worldY`/`worldPlane`/`npcId`/`requirements.skills`) preserved verbatim — no drop-rate or coordinate changes.

## Game-update date

2026-05-22

## In-game validation checklist (for user playtest)

- [ ] Graardor: travel + door redirect when no Bandos item; plane transition fires; kill step shows prayer
- [ ] Zilyana: travel + door redirect when no Saradomin item; plane transition fires; kill step shows prayer
- [ ] K'ril: travel + door redirect when no Zamorak item; plane transition fires; kill step shows prayer
- [ ] Kree'arra: travel + door redirect when no Armadyl item / mith grapple; plane transition fires; kill step shows prayer

## Build status

BUILD SUCCESSFUL (`./gradlew build`), no test regressions.