### PR TITLE
fix(data): correct K'ril prayer call to Protect from Melee

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -453,7 +453,7 @@
         "section": "Combat"
       },
       {
-        "description": "Kill K'ril Tsutsaroth. Protect from Magic, eat through Balfrug + Tstanon prayer drain, watch for K'ril's curse mechanic which drains your prayer.",
+        "description": "Kill K'ril Tsutsaroth. Protect from Melee, eat through Balfrug + Tstanon prayer drain, watch for K'ril's curse special which strips your prayer in one hit.",
         "worldX": 2914,
         "worldY": 5350,
         "worldPlane": 2,


### PR DESCRIPTION
## Summary

Post-merge review on #612 (D2 batch 1 — GWD deep-guidance) flagged the K'ril Tsutsaroth kill-step prayer call as wrong. The step instructed `Protect from Magic`, but Wiki strategy and current meta call for `Protect from Melee` — K'ril's melee swing is his single hardest hit (49+ through depleted prayer), and the curse special is exactly why melee is the right pray: when prayer drops, his melee becomes lethal.

## Change

One-line description edit on the K'ril Tsutsaroth source in `src/main/resources/com/collectionloghelper/drop_rates.json`:

- before: `Kill K'ril Tsutsaroth. Protect from Magic, eat through Balfrug + Tstanon prayer drain, watch for K'ril's curse mechanic which drains your prayer.`
- after: `Kill K'ril Tsutsaroth. Protect from Melee, eat through Balfrug + Tstanon prayer drain, watch for K'ril's curse special which strips your prayer in one hit.`

Citation: [OSRS Wiki — K'ril Tsutsaroth/Strategies](https://oldschool.runescape.wiki/w/K%27ril_Tsutsaroth/Strategies) — recommends Protect from Melee for the boss.

## Test plan

- [x] `./gradlew test --tests GwdDeepGuidanceAuditTest` passes (shape-only assertions unaffected)
- [ ] No other sources touched; diff is a single line