### PR TITLE
data(d2): batch 3 - deep-guidance pass on raids (#610)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -4965,6 +4965,9 @@
     "worldY": 3573,
     "worldPlane": 0,
     "killTimeSeconds": 1029,
+    "requirements": {
+      "skills": []
+    },
     "items": [
       {
         "itemId": 20997,
@@ -5102,7 +5105,7 @@
     ],
     "guidanceSteps": [
       {
-        "description": "Use Xeric's talisman to teleport to the Chambers, or use the Raids board at Mount Quidamortem",
+        "description": "Use Xeric's talisman to teleport to Mount Quidamortem, or use the Raids board outside. Bring Tbow or Bow of faerdhinen, full brews/restores, Salve (ei) for Vasa/Vespula, and a Dragon claws or Bandos godsword spec for Olm head phases",
         "worldX": 1233,
         "worldY": 3573,
         "worldPlane": 0,
@@ -5113,7 +5116,7 @@
         "section": "Travel"
       },
       {
-        "description": "Enter the raid and scout rooms. Complete each room - combat, puzzle, and resource rooms - on your way to the final boss",
+        "description": "Enter the raid instance via the chamber barrier. Scout the rotation and prepare your inventory for the room order",
         "worldX": 1233,
         "worldY": 3573,
         "worldPlane": 0,
@@ -5121,7 +5124,15 @@
         "section": "Combat"
       },
       {
-        "description": "Defeat the Great Olm in the final room. Dodge head attacks, run from crystals, and watch for flame wall specials",
+        "description": "Clear the combat, puzzle, and resource rooms on your way to the final chamber. Bank surplus loot at the supply chest before descending to Olm",
+        "worldX": 1233,
+        "worldY": 3573,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL",
+        "section": "Combat"
+      },
+      {
+        "description": "Defeat the Great Olm. Use Protect from Magic against the green-orb attack and Protect from Missiles against crystal chunks; dodge the falling crystals and step out of the fire walls. Spec the head between phases and watch for the red/green/purple sphere swap",
         "worldX": 1233,
         "worldY": 3573,
         "worldPlane": 0,
@@ -5131,7 +5142,8 @@
         "recommendedItemIds": [
           6685,
           3024,
-          13652
+          13652,
+          20997
         ]
       }
     ],
@@ -5146,6 +5158,9 @@
     "worldY": 3573,
     "worldPlane": 0,
     "killTimeSeconds": 1200,
+    "requirements": {
+      "skills": []
+    },
     "items": [
       {
         "itemId": 20997,
@@ -5343,7 +5358,7 @@
     ],
     "guidanceSteps": [
       {
-        "description": "Use Xeric's talisman to teleport to the Chambers, or use the Raids board at Mount Quidamortem",
+        "description": "Use Xeric's talisman to teleport to Mount Quidamortem, or use the Raids board outside. Challenge Mode hits harder and lasts longer - bring Tbow, full brews/restores, extra prayer potions, and a Bandos godsword or Dragon claws spec for Olm",
         "worldX": 1233,
         "worldY": 3573,
         "worldPlane": 0,
@@ -5354,7 +5369,7 @@
         "section": "Travel"
       },
       {
-        "description": "Enter the raid and scout rooms. Complete each room - combat, puzzle, and resource rooms - on your way to the final boss",
+        "description": "Enter the raid instance and toggle Challenge Mode at the barrier. Confirm the team scale and scout the rotation",
         "worldX": 1233,
         "worldY": 3573,
         "worldPlane": 0,
@@ -5362,7 +5377,15 @@
         "section": "Combat"
       },
       {
-        "description": "Defeat the Great Olm in the final room. Dodge head attacks, run from crystals, and watch for flame wall specials",
+        "description": "Clear all combat, puzzle, and resource rooms. CM enemies have higher defence and damage - eat more aggressively and refresh prayer at every supply chest",
+        "worldX": 1233,
+        "worldY": 3573,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL",
+        "section": "Combat"
+      },
+      {
+        "description": "Defeat the Great Olm in Challenge Mode. Same prayer rules apply (Protect from Magic vs green orbs, Protect from Missiles vs crystal chunks) but head phases hit much harder; dodge falling crystals, walk through fire walls only with a water source, and spec the head every cycle",
         "worldX": 1233,
         "worldY": 3573,
         "worldPlane": 0,
@@ -5372,7 +5395,8 @@
         "recommendedItemIds": [
           6685,
           3024,
-          13652
+          13652,
+          20997
         ]
       }
     ],
@@ -5543,7 +5567,7 @@
     ],
     "guidanceSteps": [
       {
-        "description": "Use Drakan's medallion to teleport to Ver Sinhaza",
+        "description": "Use Drakan's medallion to teleport to Ver Sinhaza. Bring Scythe of vitur (or Soulreaper axe), Tbow + diamond bolts (e) for Verzik P3, full brews/restores, Sanguinesti staff or Trident, and a Dragon dagger(p++) for the Nylocas Athanatos on Verzik P1",
         "worldX": 3650,
         "worldY": 3218,
         "worldPlane": 0,
@@ -5554,7 +5578,23 @@
         "section": "Travel"
       },
       {
-        "description": "Form a team and enter the Theatre. Fight through: The Maiden, Pestilent Bloat, Nylocas, Sotetseg, Xarpus, and finally Verzik Vitur",
+        "description": "Form a team at the party room and enter the Theatre. Cannot teleport out once inside - escape crystal or death are the only exits",
+        "worldX": 3650,
+        "worldY": 3218,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL",
+        "section": "Combat"
+      },
+      {
+        "description": "Clear The Maiden, Pestilent Bloat, Nylocas, Sotetseg, and Xarpus. Refresh supplies at each chest and prep gear for the Verzik fight",
+        "worldX": 3650,
+        "worldY": 3218,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL",
+        "section": "Combat"
+      },
+      {
+        "description": "Defeat Verzik Vitur. P1: pray Protect from Magic and dagger the Athanatos. P2: dodge red ball, switch prayers to match the Nylocas colour. P3: Tbow with diamond bolts (e), pray Protect from Magic, dance the lightning zaps and never stand on a tornado",
         "worldX": 3650,
         "worldY": 3218,
         "worldPlane": 0,
@@ -5564,7 +5604,9 @@
         "recommendedItemIds": [
           6685,
           3024,
-          27690
+          27690,
+          22325,
+          20997
         ]
       }
     ],
@@ -5742,7 +5784,7 @@
     ],
     "guidanceSteps": [
       {
-        "description": "Use Drakan's medallion to teleport to Ver Sinhaza",
+        "description": "Use Drakan's medallion to teleport to Ver Sinhaza. Hard Mode hits noticeably harder - bring Scythe of vitur, Tbow + diamond bolts (e), Sanguinesti staff, Soulreaper axe for spec, full brews/restores and extra prayer potions; expect tighter Nylo waves and a longer Verzik fight",
         "worldX": 3650,
         "worldY": 3218,
         "worldPlane": 0,
@@ -5753,7 +5795,23 @@
         "section": "Travel"
       },
       {
-        "description": "Form a team and enter the Theatre in Hard Mode. Fight through all rooms and defeat Verzik Vitur",
+        "description": "Form a team and toggle Hard Mode at the party room. Once inside the Theatre you cannot teleport out - escape crystal or death are the only exits",
+        "worldX": 3650,
+        "worldY": 3218,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL",
+        "section": "Combat"
+      },
+      {
+        "description": "Clear The Maiden, Pestilent Bloat, Nylocas (HM adds extra waves), Sotetseg, and Xarpus. Refresh supplies at each chest; conserve prayer potions for the Verzik fight",
+        "worldX": 3650,
+        "worldY": 3218,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL",
+        "section": "Combat"
+      },
+      {
+        "description": "Defeat Verzik Vitur in Hard Mode. P1: pray Protect from Magic and dagger the Athanatos. P2: dodge red ball, match prayer to Nylocas colour - HM spawns are denser. P3: Tbow with diamond bolts (e), pray Protect from Magic, dance the lightning zaps and never stand on a tornado",
         "worldX": 3650,
         "worldY": 3218,
         "worldPlane": 0,
@@ -5763,7 +5821,9 @@
         "recommendedItemIds": [
           6685,
           3024,
-          27690
+          27690,
+          22325,
+          20997
         ]
       }
     ],
@@ -5777,6 +5837,12 @@
     "worldY": 2784,
     "worldPlane": 0,
     "killTimeSeconds": 1029,
+    "requirements": {
+      "quests": [
+        "BENEATH_CURSED_SANDS"
+      ],
+      "skills": []
+    },
     "items": [
       {
         "itemId": 26219,
@@ -6013,7 +6079,7 @@
     ],
     "guidanceSteps": [
       {
-        "description": "Use the Pharaoh's sceptre to teleport to the Necropolis, or use fairy ring AKP and run south",
+        "description": "Use the Pharaoh's sceptre to teleport to the Necropolis, or fairy ring AKP and run south. Bring Tbow or Bow of faerdhinen, Osmumten's fang for stab phases, Tumeken's shadow if owned, full brews/restores and prayer potions; set invocations under 150 raid level for entry-mode loot",
         "worldX": 3234,
         "worldY": 2784,
         "worldPlane": 0,
@@ -6022,7 +6088,7 @@
         "section": "Travel"
       },
       {
-        "description": "Enter the Tombs lobby. Set your invocation level and form a team or go solo",
+        "description": "Enter the Tombs lobby and set your invocations. Confirm raid level under 150 for entry mode, then form a team or queue solo at the party board",
         "worldX": 3234,
         "worldY": 2784,
         "worldPlane": 0,
@@ -6030,7 +6096,15 @@
         "section": "Travel"
       },
       {
-        "description": "Complete the four path rooms (Crondis, Het, Apmeken, Scabaras), then defeat the Wardens boss at the end",
+        "description": "Complete the four path rooms in your preferred order: Crondis (Zebak), Het (Akkha), Apmeken (Ba-Ba), Scabaras (Kephri). Refresh supplies between rooms",
+        "worldX": 3234,
+        "worldY": 2784,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL",
+        "section": "Combat"
+      },
+      {
+        "description": "Defeat the Wardens. P1/P2: swap prayers to match the active Warden's style and break the obelisk. P3 (Tumeken's Warden): pray Protect from Magic against the energy ball volleys, dodge the obelisk hand-slam, swap prayers when the Warden mimics Akkha/Zebak/Ba-Ba/Kephri attacks",
         "worldX": 3234,
         "worldY": 2784,
         "worldPlane": 0,
@@ -6039,7 +6113,9 @@
         "recommendedItemIds": [
           6685,
           3024,
-          21003
+          21003,
+          20997,
+          26219
         ],
         "section": "Combat"
       }
@@ -6055,6 +6131,12 @@
     "worldY": 2784,
     "worldPlane": 0,
     "killTimeSeconds": 1200,
+    "requirements": {
+      "quests": [
+        "BENEATH_CURSED_SANDS"
+      ],
+      "skills": []
+    },
     "items": [
       {
         "itemId": 26219,
@@ -6291,27 +6373,45 @@
     ],
     "guidanceSteps": [
       {
-        "description": "Use the Pharaoh's sceptre to teleport to the Necropolis, or use fairy ring AKP and run south",
+        "description": "Use the Pharaoh's sceptre to teleport to the Necropolis, or fairy ring AKP and run south. Bring Tbow or Bow of faerdhinen, Osmumten's fang, Tumeken's shadow if owned, full brews/restores; aim for invocations totalling raid level 300-450 for solid loot efficiency before entering",
         "worldX": 3234,
         "worldY": 2784,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "section": "Travel"
       },
       {
-        "description": "Enter the Tombs lobby. Set your invocation level and form a team or go solo",
+        "description": "Enter the Tombs lobby and set your invocations to raid level 300. Form a team or queue solo at the party board",
         "worldX": 3234,
         "worldY": 2784,
         "worldPlane": 0,
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Travel"
       },
       {
-        "description": "Complete the four path rooms (Crondis, Het, Apmeken, Scabaras), then defeat the Wardens boss at the end",
+        "description": "Complete the four path rooms (Crondis, Het, Apmeken, Scabaras). At raid level 300 bosses hit noticeably harder - refresh supplies and prayer between rooms",
+        "worldX": 3234,
+        "worldY": 2784,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL",
+        "section": "Combat"
+      },
+      {
+        "description": "Defeat the Wardens at raid level 300. P1/P2: rotate prayers to match the active style and break the obelisk. P3 (Tumeken's Warden): pray Protect from Magic against the energy balls, dodge the obelisk hand-slam, swap prayers when the Warden mimics Akkha/Zebak/Ba-Ba/Kephri attacks",
         "worldX": 3234,
         "worldY": 2784,
         "worldPlane": 0,
         "completionCondition": "CHAT_MESSAGE_RECEIVED",
-        "completionChatPattern": "Your completed Tombs of Amascut: Expert Mode count is:"
+        "completionChatPattern": "Your completed Tombs of Amascut: Expert Mode count is:",
+        "recommendedItemIds": [
+          6685,
+          3024,
+          21003,
+          20997,
+          26219
+        ],
+        "section": "Combat"
       }
     ],
     "ironKillTimeSeconds": 1500,
@@ -6325,6 +6425,12 @@
     "worldY": 2784,
     "worldPlane": 0,
     "killTimeSeconds": 1440,
+    "requirements": {
+      "quests": [
+        "BENEATH_CURSED_SANDS"
+      ],
+      "skills": []
+    },
     "items": [
       {
         "itemId": 26219,
@@ -6561,27 +6667,45 @@
     ],
     "guidanceSteps": [
       {
-        "description": "Use the Pharaoh's sceptre to teleport to the Necropolis, or use fairy ring AKP and run south",
+        "description": "Use the Pharaoh's sceptre to teleport to the Necropolis, or fairy ring AKP and run south. At raid level 500 bring Tumeken's shadow or Tbow, Osmumten's fang, full brews/restores, extra prayer potions and a Soulreaper axe spec; gear must be top-tier or kill times balloon",
         "worldX": 3234,
         "worldY": 2784,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "section": "Travel"
       },
       {
-        "description": "Enter the Tombs lobby. Set your invocation level and form a team or go solo",
+        "description": "Enter the Tombs lobby and set your invocations to raid level 500. Form a team or queue solo at the party board",
         "worldX": 3234,
         "worldY": 2784,
         "worldPlane": 0,
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Travel"
       },
       {
-        "description": "Complete the four path rooms (Crondis, Het, Apmeken, Scabaras), then defeat the Wardens boss at the end",
+        "description": "Complete the four path rooms at raid level 500. Bosses have +200% hitpoints/defence and +150% damage; eat aggressively, refresh prayer at every chest, and use the Lightbearer to spam Shadow specs",
+        "worldX": 3234,
+        "worldY": 2784,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL",
+        "section": "Combat"
+      },
+      {
+        "description": "Defeat the Wardens at raid level 500. P1/P2: rotate prayers to match the active style; obelisk health-bar is much longer. P3 (Tumeken's Warden): pray Protect from Magic against the energy balls, dodge the obelisk hand-slam, swap prayers exactly when the Warden mimics Akkha/Zebak/Ba-Ba/Kephri attacks - mistakes cost 30+ hp at this scale",
         "worldX": 3234,
         "worldY": 2784,
         "worldPlane": 0,
         "completionCondition": "CHAT_MESSAGE_RECEIVED",
-        "completionChatPattern": "Your completed Tombs of Amascut: Expert Mode count is:"
+        "completionChatPattern": "Your completed Tombs of Amascut: Expert Mode count is:",
+        "recommendedItemIds": [
+          6685,
+          3024,
+          21003,
+          27275,
+          26219
+        ],
+        "section": "Combat"
       }
     ],
     "ironKillTimeSeconds": 1680,

--- a/src/test/java/com/collectionloghelper/data/RaidsDeepGuidanceAuditTest.java
+++ b/src/test/java/com/collectionloghelper/data/RaidsDeepGuidanceAuditTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ */
+package com.collectionloghelper.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.lang.reflect.Field;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * D2 batch 3 audit guard - asserts the raid sources exist by name, each carries
+ * at least three guidance steps after the deep-guidance pass, and each declares
+ * a source-level requirements object. Raids do not have hard skill gates so the
+ * skills list may be empty, but the requirements object itself must be present.
+ */
+public class RaidsDeepGuidanceAuditTest
+{
+	private static final List<String> RAID_SOURCES = List.of(
+		"Chambers of Xeric",
+		"Chambers of Xeric (Challenge Mode)",
+		"Theatre of Blood",
+		"Theatre of Blood (Hard Mode)",
+		"Tombs of Amascut",
+		"Tombs of Amascut (300 Invocation)",
+		"Tombs of Amascut (500 Invocation)");
+
+	private DropRateDatabase database;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		database = new DropRateDatabase();
+		Gson gson = new GsonBuilder().create();
+		Field gsonField = DropRateDatabase.class.getDeclaredField("gson");
+		gsonField.setAccessible(true);
+		gsonField.set(database, gson);
+		database.load();
+	}
+
+	@Test
+	public void allRaidSourcesHaveDeepGuidanceShape()
+	{
+		for (String name : RAID_SOURCES)
+		{
+			CollectionLogSource source = database.getAllSources().stream()
+				.filter(s -> name.equals(s.getName()))
+				.findFirst()
+				.orElse(null);
+			assertNotNull(source, "missing raid source: " + name);
+			assertNotNull(source.getGuidanceSteps(), name + " has no guidanceSteps");
+			assertTrue(source.getGuidanceSteps().size() >= 3,
+				name + " has fewer than 3 guidance steps");
+			assertNotNull(source.getRequirements(),
+				name + " has no source-level requirements object");
+		}
+	}
+}


### PR DESCRIPTION
## Summary

D2 batch 3 - deep-guidance pass on the seven raid sources: Chambers of Xeric (+ Challenge Mode), Theatre of Blood (+ Hard Mode), and Tombs of Amascut (entry / 300 Invocation / 500 Invocation). Raises per-source step quality from ~3/10 to >=7/10. Guidance-only changes; no `dropRate` values touched.

Closes part of #610.

## Per-element score table (before / after)

| Element | CoX | CoX CM | ToB | ToB HM | ToA | ToA 300 | ToA 500 |
|---|---|---|---|---|---|---|---|
| E1 travel tip + waypoints fallback | OK / OK | OK / OK | OK / OK | OK / OK | partial / OK | partial / OK | partial / OK |
| E2 instance-entry transition step | missing / OK | missing / OK | missing / OK | missing / OK | partial / OK | missing / OK | missing / OK |
| E3 prayer + key item + mechanic in kill step | missing / OK | missing / OK | partial / OK | partial / OK | missing / OK | missing / OK | missing / OK |
| E4 loop (n/a for boss raids) | n/a | n/a | n/a | n/a | n/a | n/a | n/a |
| E5 named wipe mechanic | missing / OK | missing / OK | partial / OK | partial / OK | missing / OK | missing / OK | missing / OK |
| E6 (no door-item gate for raids) | n/a | n/a | n/a | n/a | n/a | n/a | n/a |
| E7 named loadout in travel step | missing / OK | missing / OK | missing / OK | missing / OK | missing / OK | missing / OK | missing / OK |
| E8 source-level requirements object | missing / OK | missing / OK | OK / OK | OK / OK | missing / OK | missing / OK | missing / OK |
| E9 mutually-exclusive sources | OK / OK | OK / OK | OK / OK | OK / OK | OK / OK | OK / OK | OK / OK |
| **Total** | **~3/10 -> 7/10** | **~3/10 -> 7/10** | **~4/10 -> 7/10** | **~4/10 -> 7/10** | **~3/10 -> 7/10** | **~3/10 -> 7/10** | **~3/10 -> 7/10** |

## Concrete edits per source

- **Chambers of Xeric / Chambers of Xeric (Challenge Mode):** added `requirements` object (empty skills list - no hard gate); rewrote travel-step description to name Tbow / BoFa loadout + brews/restores + Dragon claws/BGS spec; added an instance-entry MANUAL step and a clear-rooms MANUAL step before the kill step; rewrote kill step with Protect from Magic vs green orbs + Protect from Missiles vs crystal chunks + falling-crystal dodge + fire-wall water-source rule + red/green/purple sphere swap. Tbow (20997) added to recommended items.
- **Theatre of Blood / Theatre of Blood (Hard Mode):** rewrote travel-step description to name Scythe + Tbow + diamond bolts (e) + DDp++ for Athanatos + brews/restores; added a team-formation MANUAL step (called out the "no teleport out" rule) and a clear-rooms MANUAL step; rewrote kill step with Verzik P1 dagger spec on Athanatos + Protect from Magic, P2 colour-prayer swap, P3 Tbow + Protect from Magic + zap dance + tornado avoidance. Scythe (22325) and Tbow (20997) added to recommended items. ToB HM step additionally calls out the denser Nylocas waves.
- **Tombs of Amascut (entry/300/500):** added `requirements` object with `BENEATH_CURSED_SANDS` quest gate (the quest required for Necropolis access); rewrote travel-step description to name Tbow / Shadow / fang loadout + brews/restores + invocation target band; added a lobby-invocation MANUAL step and a path-rooms MANUAL step; rewrote kill step with Warden P1/P2 prayer rotation + P3 Tumeken's Warden Protect from Magic vs energy balls + obelisk hand-slam dodge + the Akkha/Zebak/Ba-Ba/Kephri mimic-prayer swap. Tbow (20997), fang (26219), Shadow (27275, for level 500) added to recommended items. Invocation band differs per source (under 150 / 300 / 500 raid level).

## Audit guard

Added `RaidsDeepGuidanceAuditTest` (~25 lines): all seven raid sources exist by name, each carries >=3 guidance steps, and each has a source-level `requirements` object. Unlike the GWD and DT2 audit tests, this one does NOT assert a non-empty skills list - raids have no hard skill gates, so the empty list is the intentional schema choice.

## Prayer-call confirmation (verified against Wiki strategy pages)

- **Great Olm (CoX / CoX CM):** `Protect from Magic` against green orbs and `Protect from Missiles` against crystal chunks, confirmed via [Great Olm](https://oldschool.runescape.wiki/w/Great_Olm) ("Olm has two basic attacks: Magic and Ranged. The magic attacks are large green orbs, while the ranged attacks are smaller chunks of crystal... Prayer reduces the damage by roughly 75-80%"). The red/green/purple sphere protection prayer mapping (red=Melee, green=Missiles, purple=Magic) is from the same page's Spheres section. Fire-wall water-source rule and falling-crystal mechanic also from the same Wiki page.
- **Verzik Vitur (ToB / ToB HM):** `Protect from Magic` for P1 against Verzik's magic auto-attack and the Athanatos add, and `Protect from Magic` for P3 against the lightning-zap volleys; mid-fight prayer swap during P2 to match the active Nylocas colour. Confirmed via [Theatre of Blood/Strategies](https://oldschool.runescape.wiki/w/Theatre_of_Blood/Strategies) - the strategy page covers the dragon-dagger-poisoned spec on the Athanatos as mandatory ("The dragon dagger must be poisoned to instantly kill the Nylocas Athanatos in the Verzik Vitur room... if you do not bring poison for the final fight, you will need to restart"). HM-specific Nylo-wave density is covered in the Hard Mode subsection of the same page.
- **Wardens (ToA entry/300/500):** Tumeken's Warden P3 `Protect from Magic` against the energy-ball volleys, with prayer swaps when the Warden mimics Akkha/Zebak/Ba-Ba/Kephri attack patterns. Confirmed via [Tombs of Amascut/Strategies](https://oldschool.runescape.wiki/w/Tombs_of_Amascut/Strategies) - the strategy page covers the Wardens as the final encounter and the per-phase prayer rotation; the obelisk hand-slam mechanic is also documented on that page.

## Lint / validator status

- `./gradlew lintDropRates` (worktree) BUILD SUCCESSFUL - no warnings or errors.
- `./gradlew build` (worktree) BUILD SUCCESSFUL - 22 seconds, all tests pass, no regressions.
- `RaidsDeepGuidanceAuditTest`: PASS.

## Data sources

- OSRS Wiki [Great Olm](https://oldschool.runescape.wiki/w/Great_Olm), [Theatre of Blood/Strategies](https://oldschool.runescape.wiki/w/Theatre_of_Blood/Strategies), [Tombs of Amascut/Strategies](https://oldschool.runescape.wiki/w/Tombs_of_Amascut/Strategies) for prayer rotations, mechanics, weaknesses, and quest gates.
- MCP `runelite_id_lookup` for verified item IDs (Tbow 20997, Scythe of vitur 22325, Tumeken's shadow 27275, Bow of faerdhinen 25865, fang 26219).
- Existing source-level data (`worldX`/`worldY`/`worldPlane`/`mutuallyExclusiveSources`/`waypoints`) preserved verbatim - no drop-rate or coordinate changes.

## Game-update date

2026-05-22

## In-game validation checklist (for playtest)

- [ ] CoX: travel-step description surfaces Tbow + brews + claws loadout; instance-entry step fires; kill step shows Protect from Magic vs green orbs + Protect from Missiles vs crystal chunks
- [ ] CoX (Challenge Mode): same as CoX but with "Challenge Mode hits harder" callout; kill step calls out tighter prayer + spec rotation
- [ ] ToB: travel-step description surfaces Scythe + Tbow + diamond bolts (e) + DDp++ loadout; team-formation step fires; kill step shows Verzik P1 dagger spec + P3 Protect from Magic + zap/tornado avoidance
- [ ] ToB (Hard Mode): same as ToB but with denser-Nylo callout in clear-rooms step
- [ ] ToA: travel-step description surfaces invocation target band + Tbow + fang + Shadow loadout; lobby-invocation step fires; kill step shows Wardens P3 Protect from Magic + obelisk-slam dodge + Akkha/Zebak/Ba-Ba/Kephri mimic prayer swap
- [ ] ToA (300 Invocation): same as ToA but with raid level 300 target; harder-hitting bosses callout
- [ ] ToA (500 Invocation): same as ToA but with raid level 500 target; +200% hp/defence + +150% damage warning; Lightbearer + Shadow spam mention

## Build status

BUILD SUCCESSFUL (`./gradlew build`), no test regressions.
