### PR TITLE
fix(player-state): wire @Subscribe handlers for C1-C5 detector refresh (#611)

### DIFF
--- a/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
@@ -170,6 +170,24 @@ public class CollectionLogHelperPlugin extends Plugin
 	@Inject
 	private PluginShutdownRoutine pluginShutdownRoutine;
 
+	// Tier-C detectors. Each has @Subscribe handlers that refresh its own
+	// snapshot when the relevant game events fire; registering them on the
+	// event bus is what wires those handlers up (issue #611).
+	@Inject
+	private com.collectionloghelper.player.PohTeleportInventory pohTeleportInventory;
+
+	@Inject
+	private com.collectionloghelper.player.EquippedItemState equippedItemState;
+
+	@Inject
+	private com.collectionloghelper.player.DiaryTierState diaryTierState;
+
+	@Inject
+	private com.collectionloghelper.player.SkillCapePerkState skillCapePerkState;
+
+	@Inject
+	private com.collectionloghelper.player.PlayerQuestProgressState playerQuestProgressState;
+
 
 	private CollectionLogHelperPanel panel;
 	private NavigationButton navButton;
@@ -294,6 +312,14 @@ public class CollectionLogHelperPlugin extends Plugin
 		eventBus.register(guidance.getGuidanceEventRouter());
 		eventBus.register(guidance.getGuidanceMovementTracker());
 		eventBus.register(efficiency.getKillTimeTracker());
+
+		// Tier-C detectors: each has its own @Subscribe handlers (see issue #611)
+		// that keep its snapshot fresh in response to game events.
+		eventBus.register(pohTeleportInventory);
+		eventBus.register(equippedItemState);
+		eventBus.register(diaryTierState);
+		eventBus.register(skillCapePerkState);
+		eventBus.register(playerQuestProgressState);
 
 		// If already logged in (e.g., plugin enabled mid-session), load state
 		if (client.getGameState() == GameState.LOGGED_IN)

--- a/src/main/java/com/collectionloghelper/lifecycle/PluginShutdownRoutine.java
+++ b/src/main/java/com/collectionloghelper/lifecycle/PluginShutdownRoutine.java
@@ -92,6 +92,11 @@ public class PluginShutdownRoutine
 	private final DataModule data;
 	private final PlayerTravelCapabilities travelCapabilities;
 	private final PlayerLocationResolver playerLocationResolver;
+	private final com.collectionloghelper.player.PohTeleportInventory pohTeleportInventory;
+	private final com.collectionloghelper.player.EquippedItemState equippedItemState;
+	private final com.collectionloghelper.player.DiaryTierState diaryTierState;
+	private final com.collectionloghelper.player.SkillCapePerkState skillCapePerkState;
+	private final com.collectionloghelper.player.PlayerQuestProgressState playerQuestProgressState;
 
 	@Inject
 	public PluginShutdownRoutine(
@@ -106,7 +111,12 @@ public class PluginShutdownRoutine
 		EfficiencyModule efficiency,
 		DataModule data,
 		PlayerTravelCapabilities travelCapabilities,
-		PlayerLocationResolver playerLocationResolver)
+		PlayerLocationResolver playerLocationResolver,
+		com.collectionloghelper.player.PohTeleportInventory pohTeleportInventory,
+		com.collectionloghelper.player.EquippedItemState equippedItemState,
+		com.collectionloghelper.player.DiaryTierState diaryTierState,
+		com.collectionloghelper.player.SkillCapePerkState skillCapePerkState,
+		com.collectionloghelper.player.PlayerQuestProgressState playerQuestProgressState)
 	{
 		this.chatCommandManager = chatCommandManager;
 		this.authoringLogger = authoringLogger;
@@ -120,6 +130,11 @@ public class PluginShutdownRoutine
 		this.data = data;
 		this.travelCapabilities = travelCapabilities;
 		this.playerLocationResolver = playerLocationResolver;
+		this.pohTeleportInventory = pohTeleportInventory;
+		this.equippedItemState = equippedItemState;
+		this.diaryTierState = diaryTierState;
+		this.skillCapePerkState = skillCapePerkState;
+		this.playerQuestProgressState = playerQuestProgressState;
 	}
 
 	/**
@@ -159,6 +174,11 @@ public class PluginShutdownRoutine
 		eventBus.unregister(guidance.getGuidanceEventRouter());
 		eventBus.unregister(guidance.getGuidanceMovementTracker());
 		eventBus.unregister(efficiency.getKillTimeTracker());
+		eventBus.unregister(pohTeleportInventory);
+		eventBus.unregister(equippedItemState);
+		eventBus.unregister(diaryTierState);
+		eventBus.unregister(skillCapePerkState);
+		eventBus.unregister(playerQuestProgressState);
 		efficiency.getKillTimeTracker().reset();
 		guidance.getGuidanceCoordinator().deactivateGuidance();
 		sync.getSyncStateCoordinator().reset();

--- a/src/main/java/com/collectionloghelper/player/DiaryTierStateImpl.java
+++ b/src/main/java/com/collectionloghelper/player/DiaryTierStateImpl.java
@@ -31,6 +31,8 @@ import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.Varbits;
+import net.runelite.api.events.VarbitChanged;
+import net.runelite.client.eventbus.Subscribe;
 
 /**
  * RuneLite-backed implementation of {@link DiaryTierState}.
@@ -236,6 +238,23 @@ public class DiaryTierStateImpl implements DiaryTierState
 			}
 		}
 		log.debug("DiaryTierState refreshed");
+	}
+
+	/**
+	 * Refreshes the diary cache on any {@link VarbitChanged} event.
+	 *
+	 * <p>A broad refresh is used deliberately: filtering the event against the
+	 * 48 diary varbit IDs would require maintaining a 48-entry hot-path
+	 * {@code IntHashSet} lookup that must be kept in sync with every diary
+	 * varbit constant rename. Reading 48 client varbits per event is an
+	 * {@code O(1)} client API call per read and is dwarfed by the rest of the
+	 * varbit pipeline (Slayer task refresh, sequencer dispatch, etc.) already
+	 * running on the same event.
+	 */
+	@Subscribe
+	public void onVarbitChanged(VarbitChanged event)
+	{
+		refresh();
 	}
 
 	/** {@inheritDoc} */

--- a/src/main/java/com/collectionloghelper/player/EquippedItemStateImpl.java
+++ b/src/main/java/com/collectionloghelper/player/EquippedItemStateImpl.java
@@ -36,6 +36,8 @@ import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
 import net.runelite.api.ItemID;
+import net.runelite.api.events.ItemContainerChanged;
+import net.runelite.client.eventbus.Subscribe;
 
 /**
  * RuneLite-backed implementation of {@link EquippedItemState}.
@@ -220,6 +222,23 @@ public class EquippedItemStateImpl implements EquippedItemState
 			log.warn("EquippedItemState refresh failed", e);
 			// Retain previous snapshot rather than replacing with potentially
 			// partial data.
+		}
+	}
+
+	/**
+	 * Refreshes the equipment snapshot when the worn-items container changes.
+	 *
+	 * <p>Compares {@link ItemContainerChanged#getContainerId()} against the
+	 * {@code WORN} container id (the int-valued gameval constant). Other
+	 * containers (inventory, bank, etc.) are ignored so this handler is a
+	 * no-op for the vast majority of {@link ItemContainerChanged} events.
+	 */
+	@Subscribe
+	public void onItemContainerChanged(ItemContainerChanged event)
+	{
+		if (event.getContainerId() == net.runelite.api.gameval.InventoryID.WORN)
+		{
+			refresh();
 		}
 	}
 

--- a/src/main/java/com/collectionloghelper/player/PlayerQuestProgressState.java
+++ b/src/main/java/com/collectionloghelper/player/PlayerQuestProgressState.java
@@ -32,6 +32,8 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.Quest;
 import net.runelite.api.QuestState;
+import net.runelite.api.events.VarbitChanged;
+import net.runelite.client.eventbus.Subscribe;
 
 /**
  * Live implementation of {@link QuestProgressState}.
@@ -125,6 +127,22 @@ public class PlayerQuestProgressState implements QuestProgressState
 
 		snapshot = next;
 		log.debug("QuestProgressState refreshed: {}", next);
+	}
+
+	/**
+	 * Refreshes the quest-milestone snapshot on any {@link VarbitChanged} event.
+	 *
+	 * <p>Quest progression is driven by a mix of varplayer values (Lost City,
+	 * Plague City, Biohazard) and {@link Quest#getState(Client)} reads (RFD
+	 * sub-quests, Fairytale II, Children of the Sun). Quest varplayer/varbit
+	 * IDs span the full varbit space and change at every game update, so a
+	 * targeted filter is brittle. The full refresh is cheap (one varp read +
+	 * a small fixed number of {@code QUEST_STATUS_GET} script calls).
+	 */
+	@Subscribe
+	public void onVarbitChanged(VarbitChanged event)
+	{
+		refresh();
 	}
 
 	@Override

--- a/src/main/java/com/collectionloghelper/player/PohTeleportInventoryImpl.java
+++ b/src/main/java/com/collectionloghelper/player/PohTeleportInventoryImpl.java
@@ -32,6 +32,10 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.api.events.GameStateChanged;
+import net.runelite.api.events.VarbitChanged;
+import net.runelite.client.eventbus.Subscribe;
 
 /**
  * RuneLite-backed implementation of {@link PohTeleportInventory}.
@@ -179,6 +183,34 @@ public class PohTeleportInventoryImpl implements PohTeleportInventory
 				+ "nexus={}, digsite={}, xerics={}",
 			varbitJewelleryBoxBasic, varbitJewelleryBoxFancy, varbitJewelleryBoxOrnate,
 			varbitPortalNexus, varbitDigsitePendant, varbitXericsTalisman);
+	}
+
+	/**
+	 * Refreshes the cached POH teleport snapshot whenever any varbit changes.
+	 *
+	 * <p>A broad refresh is acceptable here: only four varbits are read per
+	 * call, each via an {@code O(1)} client API call, so the cost is negligible
+	 * compared with the brittleness of filtering on the exact POH varbit IDs
+	 * (which can churn across game updates).
+	 */
+	@Subscribe
+	public void onVarbitChanged(VarbitChanged event)
+	{
+		refresh();
+	}
+
+	/**
+	 * Refreshes the POH teleport snapshot on transition to
+	 * {@link GameState#LOGGED_IN} so the first read after login sees fresh data.
+	 * Other transitions are ignored.
+	 */
+	@Subscribe
+	public void onGameStateChanged(GameStateChanged event)
+	{
+		if (event.getGameState() == GameState.LOGGED_IN)
+		{
+			refresh();
+		}
 	}
 
 	/** {@inheritDoc} */

--- a/src/main/java/com/collectionloghelper/player/SkillCapePerkStateImpl.java
+++ b/src/main/java/com/collectionloghelper/player/SkillCapePerkStateImpl.java
@@ -37,6 +37,9 @@ import net.runelite.api.InventoryID;
 import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
 import net.runelite.api.Skill;
+import net.runelite.api.events.ItemContainerChanged;
+import net.runelite.api.events.StatChanged;
+import net.runelite.client.eventbus.Subscribe;
 
 /**
  * RuneLite-backed implementation of {@link SkillCapePerkState}.
@@ -124,6 +127,37 @@ public class SkillCapePerkStateImpl implements SkillCapePerkState
 		}
 		cache = Collections.unmodifiableMap(next);
 		log.debug("SkillCapePerkState refreshed");
+	}
+
+	/**
+	 * Refreshes the perk-availability cache when the worn or inventory container
+	 * changes. Inventory matters because a player may carry a cape they own and
+	 * swap to it on demand (Max cape teleport menu, etc.).
+	 */
+	@Subscribe
+	public void onItemContainerChanged(ItemContainerChanged event)
+	{
+		int containerId = event.getContainerId();
+		if (containerId == net.runelite.api.gameval.InventoryID.WORN
+			|| containerId == net.runelite.api.gameval.InventoryID.INV)
+		{
+			refresh();
+		}
+	}
+
+	/**
+	 * Refreshes the perk-availability cache on any {@link StatChanged} event.
+	 *
+	 * <p>Hitting level 99 in any skill unlocks a new cape perk, so a stat-level
+	 * change can flip {@link #hasPerkAvailable(SkillCapePerk)} from {@code false}
+	 * to {@code true}. {@link StatChanged} fires per-skill on level changes
+	 * (and at login bootstrap) — frequency is low enough that the {@code O(n)}
+	 * cape scan (n &lt;= number of perks) is acceptable without filtering.
+	 */
+	@Subscribe
+	public void onStatChanged(StatChanged event)
+	{
+		refresh();
 	}
 
 	/** {@inheritDoc} */

--- a/src/test/java/com/collectionloghelper/lifecycle/PluginShutdownRoutineTest.java
+++ b/src/test/java/com/collectionloghelper/lifecycle/PluginShutdownRoutineTest.java
@@ -65,6 +65,11 @@ public class PluginShutdownRoutineTest
 	@Mock private DataModule dataModule;
 	@Mock private PlayerTravelCapabilities travelCapabilities;
 	@Mock private PlayerLocationResolver playerLocationResolver;
+	@Mock private com.collectionloghelper.player.PohTeleportInventory pohTeleportInventory;
+	@Mock private com.collectionloghelper.player.EquippedItemState equippedItemState;
+	@Mock private com.collectionloghelper.player.DiaryTierState diaryTierState;
+	@Mock private com.collectionloghelper.player.SkillCapePerkState skillCapePerkState;
+	@Mock private com.collectionloghelper.player.PlayerQuestProgressState playerQuestProgressState;
 
 	@Mock private CollectionLogNetImporter collectionLogNetImporter;
 	@Mock private SyncStateCoordinator syncStateCoordinator;
@@ -117,7 +122,9 @@ public class PluginShutdownRoutineTest
 		routine = new PluginShutdownRoutine(
 			chatCommandManager, authoringLogger, syncModule, clientToolbar, overlayRegistry,
 			eventBus, sceneEventRouter, guidanceModule, efficiencyModule, dataModule,
-			travelCapabilities, playerLocationResolver);
+			travelCapabilities, playerLocationResolver,
+			pohTeleportInventory, equippedItemState, diaryTierState,
+			skillCapePerkState, playerQuestProgressState);
 	}
 
 	@Test

--- a/src/test/java/com/collectionloghelper/player/DiaryTierStateImplSubscribeTest.java
+++ b/src/test/java/com/collectionloghelper/player/DiaryTierStateImplSubscribeTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.player;
+
+import java.lang.reflect.Constructor;
+import net.runelite.api.Client;
+import net.runelite.api.Varbits;
+import net.runelite.api.events.VarbitChanged;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Verifies that {@link DiaryTierStateImpl} refreshes its snapshot on
+ * {@code VarbitChanged} events (#611).
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class DiaryTierStateImplSubscribeTest
+{
+	@Mock
+	private Client client;
+
+	private DiaryTierStateImpl detector;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		Constructor<DiaryTierStateImpl> ctor =
+			DiaryTierStateImpl.class.getDeclaredConstructor(Client.class);
+		ctor.setAccessible(true);
+		detector = ctor.newInstance(client);
+	}
+
+	@Test
+	public void onVarbitChanged_refreshesSnapshot()
+	{
+		// Arrange — Ardougne Easy is complete.
+		when(client.getVarbitValue(anyInt())).thenReturn(0);
+		when(client.getVarbitValue(Varbits.DIARY_ARDOUGNE_EASY)).thenReturn(1);
+
+		// Act
+		detector.onVarbitChanged(new VarbitChanged());
+
+		// Assert — refresh ran (reads happened) and Ardougne Easy is flagged.
+		verify(client, atLeastOnce()).getVarbitValue(Varbits.DIARY_ARDOUGNE_EASY);
+		assertTrue(detector.hasDiary(DiaryRegion.ARDOUGNE, DiaryTier.EASY));
+		assertFalse(detector.hasDiary(DiaryRegion.ARDOUGNE, DiaryTier.MEDIUM));
+	}
+}

--- a/src/test/java/com/collectionloghelper/player/EquippedItemStateImplSubscribeTest.java
+++ b/src/test/java/com/collectionloghelper/player/EquippedItemStateImplSubscribeTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.player;
+
+import java.lang.reflect.Constructor;
+import net.runelite.api.Client;
+import net.runelite.api.InventoryID;
+import net.runelite.api.Item;
+import net.runelite.api.ItemContainer;
+import net.runelite.api.ItemID;
+import net.runelite.api.events.ItemContainerChanged;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Verifies that {@link EquippedItemStateImpl} refreshes its snapshot when the
+ * worn-items container changes and ignores other container changes (#611).
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class EquippedItemStateImplSubscribeTest
+{
+	@Mock
+	private Client client;
+
+	@Mock
+	private ItemContainer container;
+
+	private EquippedItemStateImpl detector;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		Constructor<EquippedItemStateImpl> ctor =
+			EquippedItemStateImpl.class.getDeclaredConstructor(Client.class);
+		ctor.setAccessible(true);
+		detector = ctor.newInstance(client);
+	}
+
+	@Test
+	public void onItemContainerChanged_wornContainer_refreshesSnapshot()
+	{
+		// Arrange — a glory4 sitting in the (mocked) WORN container.
+		when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(container);
+		when(container.getItems()).thenReturn(new Item[]{new Item(ItemID.AMULET_OF_GLORY4, 1)});
+
+		ItemContainerChanged event =
+			new ItemContainerChanged(net.runelite.api.gameval.InventoryID.WORN, container);
+
+		// Act
+		detector.onItemContainerChanged(event);
+
+		// Assert — refresh ran and the snapshot now contains the glory.
+		verify(client, atLeastOnce()).getItemContainer(InventoryID.EQUIPMENT);
+		assertTrue(detector.hasEquipped(ItemID.AMULET_OF_GLORY4));
+		assertTrue(detector.hasTeleportItemEquipped());
+	}
+
+	@Test
+	public void onItemContainerChanged_inventoryContainer_doesNotRefresh()
+	{
+		ItemContainerChanged event =
+			new ItemContainerChanged(net.runelite.api.gameval.InventoryID.INV, container);
+
+		detector.onItemContainerChanged(event);
+
+		// Inventory changes are not the worn container — refresh should be skipped.
+		verify(client, never()).getItemContainer(any(InventoryID.class));
+		assertTrue(detector.getEquippedItems().isEmpty());
+	}
+}

--- a/src/test/java/com/collectionloghelper/player/PlayerQuestProgressStateSubscribeTest.java
+++ b/src/test/java/com/collectionloghelper/player/PlayerQuestProgressStateSubscribeTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.player;
+
+import java.lang.reflect.Constructor;
+import net.runelite.api.Client;
+import net.runelite.api.events.VarbitChanged;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Verifies that {@link PlayerQuestProgressState} refreshes its snapshot on
+ * {@code VarbitChanged} (#611).
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class PlayerQuestProgressStateSubscribeTest
+{
+	@Mock
+	private Client client;
+
+	private PlayerQuestProgressState detector;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		Constructor<PlayerQuestProgressState> ctor =
+			PlayerQuestProgressState.class.getDeclaredConstructor(Client.class);
+		ctor.setAccessible(true);
+		detector = ctor.newInstance(client);
+	}
+
+	@Test
+	public void onVarbitChanged_refreshesSnapshot()
+	{
+		// Lost City varplayer 147 at value 5 = Dramen staff crafted.
+		when(client.getVarpValue(147)).thenReturn(5);
+		when(client.getVarpValue(165)).thenReturn(0);
+		when(client.getVarpValue(68)).thenReturn(0);
+
+		detector.onVarbitChanged(new VarbitChanged());
+
+		verify(client, atLeastOnce()).getVarpValue(147);
+		assertTrue(detector.hasSubProgress(QuestSubMilestone.LOST_CITY_DRAMEN_BRANCH_CUT));
+		assertTrue(detector.hasSubProgress(QuestSubMilestone.LOST_CITY_DRAMEN_STAFF_CRAFTED));
+		assertFalse(detector.hasSubProgress(QuestSubMilestone.LOST_CITY_COMPLETE));
+	}
+}

--- a/src/test/java/com/collectionloghelper/player/PohTeleportInventoryImplSubscribeTest.java
+++ b/src/test/java/com/collectionloghelper/player/PohTeleportInventoryImplSubscribeTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.player;
+
+import com.collectionloghelper.CollectionLogHelperConfig;
+import java.lang.reflect.Constructor;
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.api.events.GameStateChanged;
+import net.runelite.api.events.VarbitChanged;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Verifies that {@link PohTeleportInventoryImpl}'s {@code @Subscribe} handlers
+ * trigger a snapshot refresh on the relevant game events (#611).
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class PohTeleportInventoryImplSubscribeTest
+{
+	@Mock
+	private Client client;
+
+	@Mock
+	private CollectionLogHelperConfig config;
+
+	private PohTeleportInventoryImpl detector;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		Constructor<PohTeleportInventoryImpl> ctor =
+			PohTeleportInventoryImpl.class.getDeclaredConstructor(Client.class, CollectionLogHelperConfig.class);
+		ctor.setAccessible(true);
+		detector = ctor.newInstance(client, config);
+	}
+
+	@Test
+	public void onVarbitChanged_refreshesSnapshot()
+	{
+		// Arrange — jewellery box at tier 2 (Fancy) so refresh sets at least one varbit flag.
+		when(client.getVarbitValue(2308)).thenReturn(2);
+		when(client.getVarbitValue(6670)).thenReturn(0);
+		when(client.getVarbitValue(6651)).thenReturn(0);
+		when(client.getVarbitValue(6617)).thenReturn(0);
+
+		// Act
+		detector.onVarbitChanged(new VarbitChanged());
+
+		// Assert — refresh ran (varbit reads happened) and state reflects the tier
+		verify(client, atLeastOnce()).getVarbitValue(2308);
+		assertTrue(detector.hasTeleport(PohTeleport.JEWELLERY_BOX_FANCY));
+		assertFalse(detector.hasTeleport(PohTeleport.JEWELLERY_BOX_ORNATE));
+	}
+
+	@Test
+	public void onGameStateChanged_loggedIn_refreshesSnapshot()
+	{
+		when(client.getVarbitValue(2308)).thenReturn(3); // ornate
+		when(client.getVarbitValue(6670)).thenReturn(0);
+		when(client.getVarbitValue(6651)).thenReturn(0);
+		when(client.getVarbitValue(6617)).thenReturn(0);
+
+		GameStateChanged event = new GameStateChanged();
+		event.setGameState(GameState.LOGGED_IN);
+		detector.onGameStateChanged(event);
+
+		verify(client, atLeastOnce()).getVarbitValue(2308);
+		assertTrue(detector.hasTeleport(PohTeleport.JEWELLERY_BOX_ORNATE));
+	}
+
+	@Test
+	public void onGameStateChanged_loginScreen_doesNotRefresh()
+	{
+		GameStateChanged event = new GameStateChanged();
+		event.setGameState(GameState.LOGIN_SCREEN);
+		detector.onGameStateChanged(event);
+
+		// No varbit reads should have happened — refresh skipped for non-LOGGED_IN
+		verify(client, never()).getVarbitValue(anyInt());
+	}
+}

--- a/src/test/java/com/collectionloghelper/player/SkillCapePerkStateImplSubscribeTest.java
+++ b/src/test/java/com/collectionloghelper/player/SkillCapePerkStateImplSubscribeTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.player;
+
+import java.lang.reflect.Constructor;
+import net.runelite.api.Client;
+import net.runelite.api.InventoryID;
+import net.runelite.api.ItemContainer;
+import net.runelite.api.Skill;
+import net.runelite.api.events.ItemContainerChanged;
+import net.runelite.api.events.StatChanged;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Verifies that {@link SkillCapePerkStateImpl} refreshes its snapshot on
+ * {@code ItemContainerChanged} (worn + inventory) and {@code StatChanged} (#611).
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class SkillCapePerkStateImplSubscribeTest
+{
+	@Mock
+	private Client client;
+
+	@Mock
+	private ItemContainer container;
+
+	private SkillCapePerkStateImpl detector;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		Constructor<SkillCapePerkStateImpl> ctor =
+			SkillCapePerkStateImpl.class.getDeclaredConstructor(Client.class);
+		ctor.setAccessible(true);
+		detector = ctor.newInstance(client);
+	}
+
+	@Test
+	public void onItemContainerChanged_wornContainer_refreshesSnapshot()
+	{
+		when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(null);
+		when(client.getRealSkillLevel(any(Skill.class))).thenReturn(0);
+
+		ItemContainerChanged event =
+			new ItemContainerChanged(net.runelite.api.gameval.InventoryID.WORN, container);
+
+		detector.onItemContainerChanged(event);
+
+		verify(client, atLeastOnce()).getItemContainer(InventoryID.EQUIPMENT);
+	}
+
+	@Test
+	public void onItemContainerChanged_inventoryContainer_refreshesSnapshot()
+	{
+		when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(null);
+		when(client.getRealSkillLevel(any(Skill.class))).thenReturn(0);
+
+		ItemContainerChanged event =
+			new ItemContainerChanged(net.runelite.api.gameval.InventoryID.INV, container);
+
+		detector.onItemContainerChanged(event);
+
+		// INV is also relevant for cape ownership-via-swap, so refresh should fire.
+		verify(client, atLeastOnce()).getItemContainer(InventoryID.EQUIPMENT);
+	}
+
+	@Test
+	public void onItemContainerChanged_unrelatedContainer_doesNotRefresh()
+	{
+		// BANK is neither WORN nor INV — refresh must be skipped.
+		ItemContainerChanged event =
+			new ItemContainerChanged(net.runelite.api.gameval.InventoryID.BANK, container);
+
+		detector.onItemContainerChanged(event);
+
+		verify(client, never()).getItemContainer(any(InventoryID.class));
+	}
+
+	@Test
+	public void onStatChanged_refreshesSnapshot()
+	{
+		when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(null);
+		when(client.getRealSkillLevel(Skill.MAGIC)).thenReturn(99);
+		when(client.getRealSkillLevel(argThat(s -> s != null && s != Skill.MAGIC))).thenReturn(0);
+
+		StatChanged event = new StatChanged(Skill.MAGIC, 13_034_431, 99, 99);
+		detector.onStatChanged(event);
+
+		// Refresh ran and now MAGIC_CAPE perk is available via the 99-level owned-status fallback.
+		verify(client, atLeastOnce()).getRealSkillLevel(any(Skill.class));
+		assertTrue(detector.hasPerkAvailable(SkillCapePerk.MAGIC_SPELLBOOK_SWAP));
+	}
+
+}


### PR DESCRIPTION
## Summary

Wires each Tier-C player-state detector with its own `@Subscribe` handlers so its snapshot stays fresh from game events, instead of relying on the in-paint defensive refresh added in #608 (which only ran while the C7 debug overlay was visible).

## Per-detector trigger

| Detector | Event(s) | Filter |
| --- | --- | --- |
| `PohTeleportInventoryImpl` (C1) | `VarbitChanged`, `GameStateChanged` | Broad on VarbitChanged (4 varbit reads); only `LOGGED_IN` on GameStateChanged |
| `EquippedItemStateImpl` (C2) | `ItemContainerChanged` | `gameval.InventoryID.WORN` only |
| `DiaryTierStateImpl` (C3) | `VarbitChanged` | Broad (filtering 48 diary varbits is brittle) |
| `SkillCapePerkStateImpl` (C4) | `ItemContainerChanged`, `StatChanged` | WORN + INV (swap-on-demand); StatChanged is unfiltered |
| `PlayerQuestProgressState` (C5) | `VarbitChanged` | Broad (quest varplayer IDs span the full space) |

## Routing decision

**Direct `@Subscribe` on each impl class.** Each detector owns a distinct event-policy mix (filter rules, broad-refresh tolerances, GameState gating) that does not generalize across detectors, so expanding the existing `VarbitChangeRouter` callback surface would just add five new opaque `Runnable` callbacks without reducing the total `@Subscribe` surface. The impls were already injected by interface elsewhere (`@ImplementedBy`, `@Singleton`); the plugin now also injects them and registers them on the event bus alongside the existing trackers/routers in `startUp()`, mirroring `eventBus.register(efficiency.getKillTimeTracker())` and `eventBus.register(guidance.getGuidanceMovementTracker())`. Unregistration is added to `PluginShutdownRoutine.tearDown()` for symmetry.

## Test plan

- [x] `PohTeleportInventoryImplSubscribeTest`: `onVarbitChanged` triggers a refresh (varbits read, snapshot reflects values); `onGameStateChanged(LOGGED_IN)` refreshes; `onGameStateChanged(LOGIN_SCREEN)` is a no-op.
- [x] `EquippedItemStateImplSubscribeTest`: WORN container triggers refresh (snapshot picks up the test glory); INV container is a no-op.
- [x] `DiaryTierStateImplSubscribeTest`: `VarbitChanged` triggers refresh and snapshot reflects the seeded varbit.
- [x] `SkillCapePerkStateImplSubscribeTest`: WORN and INV both trigger refresh; BANK does not; `StatChanged` triggers refresh and the 99-level fallback flips a perk to available.
- [x] `PlayerQuestProgressStateSubscribeTest`: `VarbitChanged` refreshes the Lost City milestones from the seeded varplayer value.
- [x] `PluginShutdownRoutineTest` updated for the expanded constructor.
- [x] `./gradlew build` is green (JaCoCo + drop-rate lint + full test suite).

## Notes

- The in-paint `PlayerCapabilityDebugOverlay.refreshDetectionSources()` defensive refresh added in #608 stays in place as belt-and-suspenders. It can be removed in a follow-up once C6 (wiring C1-C5 into the top-20 sources) confirms the event-driven path covers every non-overlay consumer.
- All five detectors' existing `refresh()` bodies already touch only client-thread-safe APIs (`client.getVarbitValue`, `client.getItemContainer`, `Quest.getState(client)`, `client.getRealSkillLevel`), so running them inside RuneLite `@Subscribe` handlers (client thread) is safe.

Closes #611