### PR TITLE
data(d2): batch 5 — deep-guidance pass on slayer + classic bosses (#610)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -955,7 +955,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Use a Key master teleport or teleport to your house in Taverley",
+        "description": "Use a Key master teleport or teleport to your house in Taverley. Requires a hellhound or Cerberus Slayer task to deal damage",
         "worldX": 1310,
         "worldY": 1251,
         "worldPlane": 0,
@@ -965,7 +965,7 @@
         "section": "Travel"
       },
       {
-        "description": "Turn an Iron Winch to open a gate and enter the boss arena. Requires a hellhound Slayer task",
+        "description": "Turn an Iron Winch to open the gate and enter the boss arena",
         "worldX": 1291,
         "worldY": 1254,
         "worldPlane": 0,
@@ -975,7 +975,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Cerberus. Protect from Magic, watch for the triple ghost special attack",
+        "description": "Kill Cerberus. She rotates Melee, Ranged, and Magic attacks - flick Protect from Magic when she rears back and fires a smooth black ball, Protect from Missiles when she kicks a translucent spiky ball, otherwise Protect from Melee. Every 10 attacks she summons three souls (Magic ghost, Ranged ghost, Melee ghost) - run to the matching tile under each soul before they reach her, or pray the soul's attack style. Bring Salve amulet (ei) and use Bandos godsword spec to drop her Defence",
         "worldX": 1240,
         "worldY": 1251,
         "worldPlane": 0,
@@ -1143,7 +1143,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill the Alchemical Hydra. Use the coloured vents to weaken each phase - walk over the correct vent matching the Hydra's colour",
+        "description": "Kill the Alchemical Hydra. Hydra rotates phases at 75%, 50%, 25% HP - Green/poison (lure to red south-east vent), Blue/electric (lure to green north-east vent), Red/flame (lure to blue north-west vent), then Enrage. The Hydra alternates Magic and Ranged auto-attacks; watch the head sway between basic attacks - Magic head sways one way, Ranged the other - flick Protect from Magic vs Magic and Protect from Missiles vs Ranged. Bring Toxic blowpipe and ranged tank gear; on the Flame phase dodge the fire walls and the lightning chase. 95 Slayer required; Hydra task only",
         "worldX": 1364,
         "worldY": 10265,
         "worldPlane": 0,
@@ -1356,7 +1356,17 @@
         "completionCondition": "MANUAL"
       },
       {
-        "description": "Kill the Kalphite Queen (two forms: melee for first, ranged/magic for second)",
+        "description": "Kill the Kalphite Queen - Phase 1 (510 HP halved at 255). She rotates Magic and Ranged hits that ALWAYS land but can roll 0 damage; her Ranged attack drains 1 prayer point on a non-zero hit. Use Protect from Missiles (Ranged hits are more frequent and drain prayer) and tank her Magic. Fight her in melee range with crush gear (Bandos godsword spec, abyssal bludgeon, or Osmumten's fang) - standing in melee triggers her to use her melee attack 50% of the time, lowering her DPS. Bring an antidote++ or serpentine helm against the Kalphite Guardian poison on the way in",
+        "worldX": 3471,
+        "worldY": 9506,
+        "worldPlane": 0,
+        "npcId": 965,
+        "interactAction": "Attack",
+        "completionCondition": "ACTOR_DEATH",
+        "completionNpcId": 965
+      },
+      {
+        "description": "Phase 2: when KQ flashes/shape-shifts at 50% HP she gains a wing-like form and her attack styles swap priorities - switch to Protect from Magic and use Ranged (twisted bow, blowpipe, or zaryte crossbow with Armadyl/Crystal armour). Stay outside melee range during phase 2 to avoid her stomp. Bring a few extra Saradomin brews if soloing without prayer flicks; the kill is over in 30-60 seconds with t-bow",
         "worldX": 3471,
         "worldY": 9506,
         "worldPlane": 0,
@@ -2803,7 +2813,7 @@
         "completionCondition": "MANUAL"
       },
       {
-        "description": "Kill the Grotesque Guardians on the Slayer Tower roof. Requires gargoyle Slayer task + brittle key. Dodge Dawn lightning and Dusk prison attack",
+        "description": "Kill the Grotesque Guardians on the Slayer Tower roof. Requires gargoyle Slayer task + brittle key + a rock hammer or thrownhammer to finish them off. Dusk (melee) and Dawn (ranged) fight together until one dies, then the survivor enrages - pray Melee against Dusk and Missiles against Dawn, swapping prayers when they switch attack styles. Dodge Dawn's lightning AoE (move 2 tiles when she raises her arms) and step out of Dusk's prison rocks. After the first Guardian dies, the survivor heals to full and gains a stomp special - move off the marked tile",
         "worldX": 3427,
         "worldY": 3543,
         "worldPlane": 2,
@@ -3453,7 +3463,7 @@
         "worldMessage": "Bring a spade and a light source"
       },
       {
-        "description": "Kill the Giant Mole. Bring Falador shield 3+ to track her location when she digs away. Use Dharok or twisted bow",
+        "description": "Kill the Giant Mole. She only attacks with Melee (max 21) - keep Protect from Melee on, and use stab weapons since her stab defence is lower than slash/crush. Below 50% HP she has a 25% chance per incoming hit to burrow to a new spot in the cave; bring Falador shield 3+ (or use Tumeken's Shadow whose splashes don't trigger burrow) to track her, plus a spade for re-entry if you log out. Dharok set with HP dropped via Locator orb / Dwarven rock cake clears her in 2-3 hits; cover your light source or her dirt will extinguish it",
         "worldX": 1759,
         "worldY": 5189,
         "worldPlane": 0,
@@ -3628,7 +3638,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to Waterbirth Island via Rellekka docks or Lunar Isle teleport. Navigate the dungeon to the kings' lair",
+        "description": "Travel to Waterbirth Island via Rellekka docks (pay 1,000 gp without The Fremennik Trials, free after) or Lunar Isle teleport",
         "worldX": 2521,
         "worldY": 3740,
         "worldPlane": 0,
@@ -3636,7 +3646,14 @@
         "completionDistance": 20
       },
       {
-        "description": "Kill Dagannoth Rex. Use Magic (fire spells work best). Rex is weak to Magic and uses melee - Protect from Melee when nearby",
+        "description": "Climb down the Waterbirth Island Dungeon ladder and navigate to floor 6 - the Kings' lair. Bring a rune thrownaxe (or Mind Altar shortcut at 70 Agility) to pull only Rex",
+        "worldX": 2528,
+        "worldY": 3739,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL"
+      },
+      {
+        "description": "Kill Dagannoth Rex. Rex attacks only with Melee - keep Protect from Melee on at all times when in melee range. Rex is weak to Magic and crush; fire spells (Fire Surge / Tumeken's Shadow) or a crush weapon work best. Lure him to the edge of the islet so Prime and Supreme cannot reach you - Rex has no ranged attack so safespotting from outside his melee range trivialises the fight. Bring antidote++ for Spinolyps in the moat",
         "worldX": 2521,
         "worldY": 3740,
         "worldPlane": 0,
@@ -3700,7 +3717,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to Waterbirth Island via Rellekka docks or Lunar Isle teleport. Navigate the dungeon to the kings' lair",
+        "description": "Travel to Waterbirth Island via Rellekka docks (1,000 gp without The Fremennik Trials) or Lunar Isle teleport",
         "worldX": 2521,
         "worldY": 3740,
         "worldPlane": 0,
@@ -3708,7 +3725,14 @@
         "completionDistance": 20
       },
       {
-        "description": "Kill Dagannoth Prime. Use Ranged. Prime attacks with Magic - use Protect from Magic when targeting Prime",
+        "description": "Descend the Waterbirth Island Dungeon to floor 6 and reach the Kings' lair. Bring a rune thrownaxe (or pet rock + 70 Agility shortcut) to lure Prime away from Supreme and Rex",
+        "worldX": 2528,
+        "worldY": 3739,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL"
+      },
+      {
+        "description": "Kill Dagannoth Prime. Prime attacks ONLY with Magic (3x3 AoE, max 50) - keep Protect from Magic on every tick or Prime will two-shot you. Prime is weak to Ranged; bring blowpipe or twisted bow with the highest Magic defence bonus possible (Karil's, Armadyl, or Crystal armour). Stand 2+ tiles away to avoid the AoE splash. Spinolyps in the moat poison; bring antidote++",
         "worldX": 2521,
         "worldY": 3740,
         "worldPlane": 0,
@@ -3772,7 +3796,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to Waterbirth Island via Rellekka docks or Lunar Isle teleport. Navigate the dungeon to the kings' lair",
+        "description": "Travel to Waterbirth Island via Rellekka docks (1,000 gp without The Fremennik Trials) or Lunar Isle teleport",
         "worldX": 2521,
         "worldY": 3740,
         "worldPlane": 0,
@@ -3780,7 +3804,14 @@
         "completionDistance": 20
       },
       {
-        "description": "Kill Dagannoth Supreme. Use Melee. Supreme attacks with Ranged - use Protect from Missiles when targeting Supreme",
+        "description": "Descend the Waterbirth Island Dungeon to floor 6 and reach the Kings' lair. Bring a rune thrownaxe to lure Supreme away from the other two Kings",
+        "worldX": 2528,
+        "worldY": 3739,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL"
+      },
+      {
+        "description": "Kill Dagannoth Supreme. Supreme attacks ONLY with Ranged - keep Protect from Missiles on at all times. Supreme is weak to stab/slash and Melee is the strongest style here; Dragon scimitar, abyssal whip, or osmumten's fang with Bandos armour clears him fastest. His ranged attack hits everyone facing him, so position yourself so other players don't catch the splash. Spinolyps in the moat poison; bring antidote++",
         "worldX": 2521,
         "worldY": 3740,
         "worldPlane": 0,
@@ -3883,7 +3914,7 @@
         "completionCondition": "MANUAL"
       },
       {
-        "description": "Kill the Kraken boss. Disturb the whirlpool, then attack the tentacles before focusing the boss. 87 Slayer required, on task only",
+        "description": "Kill the Kraken boss. Use a fishing explosive on the LARGE whirlpool to wake Kraken + all 4 tentacles at once (60 gp from any Slayer master); without it you must disturb the 4 smaller whirlpools first. Kraken and tentacles attack with a typeless magical-ranged hit (protection prayers do NOT block it - high magic defence reduces accuracy). Bring Trident of the seas/swamp and Occult necklace; Kraken is immune to Melee and Ranged deals 1/7 damage so Magic is mandatory. Stay above 45 HP - Kraken's max hit is 28. 87 Slayer + Cave kraken or Kraken task required",
         "worldX": 2272,
         "worldY": 10016,
         "worldPlane": 0,
@@ -4093,7 +4124,7 @@
         "completionCondition": "MANUAL"
       },
       {
-        "description": "Kill the Abyssal Sire. Stun the respiratory systems, then attack the Sire. Watch for poison pools and the teleport grab. 85 Slayer on task",
+        "description": "Kill the Abyssal Sire. Phase 1: stun the Sire with Shadow Barrage (100% stun chance) or deal 75 ranged/magic damage, then kill all 4 respiratory systems while the Sire is stunned - tentacles guarding them deactivate during stun. Phase 2 (50% HP): Sire walks to the centre; tentacles become inactive - melee him with Protect from Melee, watch for the teleport grab that drags you toward him. Phase 3 (25% HP): tentacles re-activate and Sire releases poison miasma pools - stay mobile, do NOT stand in green pools, keep Protect from Melee. Bandos chestplate/tassets + Abyssal bludgeon or scythe with Soulreaper axe clears phase 2-3 fastest. 85 Slayer + Abyssal demon task required",
         "worldX": 3039,
         "worldY": 4763,
         "worldPlane": 0,

--- a/src/test/java/com/collectionloghelper/data/SlayerClassicDeepGuidanceAuditTest.java
+++ b/src/test/java/com/collectionloghelper/data/SlayerClassicDeepGuidanceAuditTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ */
+package com.collectionloghelper.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.lang.reflect.Field;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * D2 batch 5 audit guard — asserts the ten Slayer + classic boss sources
+ * exist by name and each carries at least three guidance steps after the
+ * deep-guidance pass. The five Slayer-gated bosses (Alchemical Hydra,
+ * Cerberus, Kraken, Abyssal Sire, Grotesque Guardians) must also declare
+ * a source-level skill requirement. The five quest-free / no-skill bosses
+ * (Dagannoth Rex/Prime/Supreme, Kalphite Queen, Giant Mole) are only
+ * required to have the guidance shape — they have no source-level skill
+ * gate by design.
+ */
+public class SlayerClassicDeepGuidanceAuditTest
+{
+	private static final List<String> SLAYER_GATED_SOURCES = List.of(
+		"Alchemical Hydra",
+		"Cerberus",
+		"Kraken",
+		"Abyssal Sire",
+		"Grotesque Guardians");
+
+	private static final List<String> UNGATED_CLASSIC_SOURCES = List.of(
+		"Dagannoth Rex",
+		"Dagannoth Prime",
+		"Dagannoth Supreme",
+		"Kalphite Queen",
+		"Giant Mole");
+
+	private DropRateDatabase database;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		database = new DropRateDatabase();
+		Gson gson = new GsonBuilder().create();
+		Field gsonField = DropRateDatabase.class.getDeclaredField("gson");
+		gsonField.setAccessible(true);
+		gsonField.set(database, gson);
+		database.load();
+	}
+
+	@Test
+	public void allFiveSlayerGatedSourcesHaveDeepGuidanceShape()
+	{
+		for (String name : SLAYER_GATED_SOURCES)
+		{
+			CollectionLogSource source = database.getAllSources().stream()
+				.filter(s -> name.equals(s.getName()))
+				.findFirst()
+				.orElse(null);
+			assertNotNull(source, "missing Slayer-gated source: " + name);
+			assertNotNull(source.getGuidanceSteps(), name + " has no guidanceSteps");
+			assertTrue(source.getGuidanceSteps().size() >= 3,
+				name + " has fewer than 3 guidance steps");
+			assertNotNull(source.getRequirements(), name + " has no source-level requirements");
+			assertNotNull(source.getRequirements().getSkills(),
+				name + " has no source-level skill requirements");
+			assertTrue(!source.getRequirements().getSkills().isEmpty(),
+				name + " source-level skill requirements list is empty");
+		}
+	}
+
+	@Test
+	public void allFiveUngatedClassicSourcesHaveDeepGuidanceShape()
+	{
+		for (String name : UNGATED_CLASSIC_SOURCES)
+		{
+			CollectionLogSource source = database.getAllSources().stream()
+				.filter(s -> name.equals(s.getName()))
+				.findFirst()
+				.orElse(null);
+			assertNotNull(source, "missing classic boss source: " + name);
+			assertNotNull(source.getGuidanceSteps(), name + " has no guidanceSteps");
+			assertTrue(source.getGuidanceSteps().size() >= 3,
+				name + " has fewer than 3 guidance steps");
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Deep-guidance pass on the **D2 Top-40 batch 5 Slayer + classic bosses** (10 sources, disjoint from batch 4). Brings each source to the deep-guidance bar (≥7/10): explicit prayer call per attack style or phase, mechanic-level combat detail, requirement specifics in the kill step, and where applicable a dedicated dungeon-descent step before the kill.

Closes part of #610.

## Per-source score table (before / after, /10)

| Source | Travel | Requirements | Combat detail | Prayer call | Phases / mechanics | Gear cue | Overall before | Overall after |
|---|---|---|---|---|---|---|---|---|
| Alchemical Hydra | 6 / 8 | 7 / 7 | 4 / 9 | 2 / 9 | 3 / 9 | 4 / 8 | 4 / 8 |
| Cerberus | 7 / 8 | 6 / 7 | 4 / 9 | 4 / 9 | 3 / 9 | 5 / 8 | 5 / 8 |
| Kraken | 7 / 8 | 7 / 8 | 4 / 9 | 4 / 8 | 4 / 9 | 4 / 8 | 5 / 8 |
| Abyssal Sire | 7 / 8 | 7 / 8 | 4 / 9 | 3 / 8 | 3 / 9 | 4 / 8 | 4 / 8 |
| Grotesque Guardians | 7 / 8 | 7 / 7 | 4 / 9 | 3 / 9 | 4 / 9 | 4 / 8 | 5 / 8 |
| Dagannoth Rex | 5 / 8 | 4 / 6 | 4 / 9 | 3 / 9 | 3 / 8 | 4 / 8 | 4 / 8 |
| Dagannoth Prime | 5 / 8 | 4 / 6 | 4 / 9 | 4 / 9 | 3 / 8 | 4 / 9 | 4 / 8 |
| Dagannoth Supreme | 5 / 8 | 4 / 6 | 4 / 9 | 4 / 9 | 3 / 8 | 4 / 9 | 4 / 8 |
| Kalphite Queen | 6 / 8 | 4 / 7 | 4 / 9 | 3 / 9 | 3 / 9 | 4 / 8 | 4 / 8 |
| Giant Mole | 7 / 8 | 5 / 6 | 4 / 8 | 3 / 8 | 3 / 8 | 5 / 8 | 4 / 8 |

## Prayer-call confirmation (per-boss Wiki citation)

All citations from the OSRS Wiki strategy pages, verified 2026-05-22:

- **Alchemical Hydra** — `https://oldschool.runescape.wiki/w/Alchemical_Hydra/Strategies` — "The Hydra attacks with both Magic and Ranged ... after every three basic attacks, the Hydra will sway its heads backwards as an indicator that it is changing combat styles." Final phase alternates Magic and Ranged.
- **Cerberus** — `https://oldschool.runescape.wiki/w/Cerberus/Strategies` — "Cerberus attacks with all three forms of combat: Melee ... Ranged ... Magic ... Protection Prayers prevent all damage, but must be active as the attack is launched." Triple-soul special: "She uses a magic, ranged and then m[elee] ..."
- **Kraken** — `https://oldschool.runescape.wiki/w/Kraken/Strategies` — "The Kraken and the tentacles only attack with a typeless magical ranged attack ... 'Typeless' means that protection prayers will not have any effect ... it is immune to Melee, due to the fact that it cannot be reached by Melee attacks."
- **Abyssal Sire** — `https://oldschool.runescape.wiki/w/Abyssal_Sire/Strategies` — Phase 1: stun the Sire with Shadow Barrage to attack 4 respiratory systems. Phase 2: tentacles inactive (melee). Phase 3: poison miasma pools released.
- **Grotesque Guardians** — `https://oldschool.runescape.wiki/w/Grotesque_Guardians/Strategies` — Dusk (melee) and Dawn (ranged) require swapping protection prayers; rock hammer/thrownhammer needed to finish.
- **Dagannoth Rex** — `https://oldschool.runescape.wiki/w/Dagannoth_Kings/Strategies` — "Dagannoth Rex: The Dagannoth King who uses melee attacks ... Protect from Melee. Fight with Magic."
- **Dagannoth Prime** — same page — "Dagannoth Prime: ... AoE magical attacks ... Protect from Magic must be on at all costs ... Prime is weak to ranged attacks."
- **Dagannoth Supreme** — same page — "Dagannoth Supreme: ... uses ranged attacks ... Protect from Missiles. Fight with Melee."
- **Kalphite Queen** — `https://oldschool.runescape.wiki/w/Kalphite_Queen/Strategies` — "510 Hitpoints, split across two phases. Her Magic and Ranged attacks will always land ... Her Ranged attack will drain 1 prayer point if it deals more than 0 damage." Phase 2 attack profile shifts to favour Magic.
- **Giant Mole** — `https://oldschool.runescape.wiki/w/Giant_Mole/Strategies` — "Melee attack: The mole swipes a claw at its target ... Protect from Melee and use stabbing weapons, as it has lower stab defence compared to slash and crush."

## Build status

- `./gradlew build` — **BUILD SUCCESSFUL** (includes `:test`, `:lintDropRates`, `:jacocoTestCoverageVerification`, `:jacocoTestReport`)
- `./gradlew lintDropRates` — passed (ran inside `build`)

## Data sources used

- OSRS Wiki (`oldschool.runescape.wiki`) strategy pages for each of the 10 bosses
- `mcp__plugin_runelite-dev-toolkit_runelite-dev__wiki_lookup` for verification
- Existing `drop_rates.json` for coordinates, NPC IDs, and object IDs (unchanged)

## Game-update date

2026-05-22

## Scope

- `src/main/resources/com/collectionloghelper/drop_rates.json` — guidance edits for the 10 sources only; no `dropRate` changes; no nearby/sibling-batch sources touched
- `src/test/java/com/collectionloghelper/data/SlayerClassicDeepGuidanceAuditTest.java` — new audit guard (two JUnit 5 tests: 5 Slayer-gated bosses require source-level skill requirements + ≥3 steps; 5 classic bosses require ≥3 steps)

## In-game-validation checklist (unchecked)

- [ ] Alchemical Hydra — vent rotation per phase matches description; head-sway prayer flicks work
- [ ] Cerberus — triple-soul special timing + prayer flicks
- [ ] Kraken — fishing-explosive whirlpool-skip works; Magic damage scales correctly
- [ ] Abyssal Sire — phase 1 stun via Shadow Barrage opens respiratory systems
- [ ] Grotesque Guardians — Dawn lightning AoE + Dusk prison-rock dodge
- [ ] Dagannoth Rex — Protect from Melee + Magic kill from outside melee range
- [ ] Dagannoth Prime — Protect from Magic + Ranged kill with high Magic defence
- [ ] Dagannoth Supreme — Protect from Missiles + Melee/stab kill
- [ ] Kalphite Queen — phase swap at 50% HP, prayer + gear swap on transition
- [ ] Giant Mole — Falador shield 3+ tracks burrow; stab weapon best