### PR TITLE
feat(schema): B0 — add pohTeleports + equippedItemIds to SourceRequirements

### DIFF
--- a/src/main/java/com/collectionloghelper/data/RequirementsChecker.java
+++ b/src/main/java/com/collectionloghelper/data/RequirementsChecker.java
@@ -24,6 +24,9 @@
  */
 package com.collectionloghelper.data;
 
+import com.collectionloghelper.player.EquippedItemState;
+import com.collectionloghelper.player.PohTeleport;
+import com.collectionloghelper.player.PohTeleportInventory;
 import java.awt.Color;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
@@ -45,15 +48,21 @@ import net.runelite.api.Varbits;
 public class RequirementsChecker
 {
 	private final Client client;
+	private final PohTeleportInventory pohTeleportInventory;
+	private final EquippedItemState equippedItemState;
 
 	private volatile Map<String, Boolean> accessibilityCache = Collections.emptyMap();
 	private volatile Map<String, List<String>> unmetCache = Collections.emptyMap();
 	private volatile boolean fairyRingAccess = false;
 
 	@Inject
-	private RequirementsChecker(Client client)
+	private RequirementsChecker(Client client,
+		PohTeleportInventory pohTeleportInventory,
+		EquippedItemState equippedItemState)
 	{
 		this.client = client;
+		this.pohTeleportInventory = pohTeleportInventory;
+		this.equippedItemState = equippedItemState;
 	}
 
 	/**
@@ -333,6 +342,41 @@ public class RequirementsChecker
 				catch (IllegalArgumentException e)
 				{
 					log.warn("Unknown skill enum: {}", skillReq.getSkill());
+				}
+			}
+		}
+
+		if (requirements.getPohTeleports() != null)
+		{
+			for (String teleportName : requirements.getPohTeleports())
+			{
+				try
+				{
+					PohTeleport teleport = PohTeleport.valueOf(teleportName);
+					if (!pohTeleportInventory.hasTeleport(teleport))
+					{
+						unmet.add("POH teleport: " + formatEnumName(teleportName));
+					}
+				}
+				catch (IllegalArgumentException e)
+				{
+					log.warn("Unknown POH teleport enum: {}", teleportName);
+					unmet.add("POH teleport: " + formatEnumName(teleportName));
+				}
+			}
+		}
+
+		if (requirements.getEquippedItemIds() != null)
+		{
+			for (Integer itemId : requirements.getEquippedItemIds())
+			{
+				if (itemId == null)
+				{
+					continue;
+				}
+				if (!equippedItemState.hasEquipped(itemId))
+				{
+					unmet.add("Equipped item: " + itemId);
 				}
 			}
 		}

--- a/src/main/java/com/collectionloghelper/data/SourceRequirements.java
+++ b/src/main/java/com/collectionloghelper/data/SourceRequirements.java
@@ -25,6 +25,7 @@
 package com.collectionloghelper.data;
 
 import java.util.List;
+import javax.annotation.Nullable;
 import lombok.Value;
 
 @Value
@@ -38,4 +39,40 @@ public class SourceRequirements
 	 * May be {@code null} when the source has no diary prerequisites.
 	 */
 	List<String> diaries;
+
+	/**
+	 * POH-fixture teleport requirements, e.g. {@code "MOUNTED_GLORY"},
+	 * {@code "JEWELLERY_BOX_FANCY"}. Each entry must be a
+	 * {@link com.collectionloghelper.player.PohTeleport} enum constant name.
+	 *
+	 * <p>Evaluated AND-wise against
+	 * {@code PohTeleportInventory.hasTeleport(...)}: the requirement is met
+	 * only when every listed teleport is available. Unrecognised names are
+	 * treated as unmet and logged.
+	 *
+	 * <p>{@code null} or empty when the source/alternative has no POH-fixture
+	 * prerequisite. Added by Tier B0 as a C6 prerequisite.
+	 */
+	@Nullable
+	List<String> pohTeleports;
+
+	/**
+	 * Equipped-item requirements expressed as RuneLite {@code ItemID} integers.
+	 *
+	 * <p>Evaluated AND-wise against
+	 * {@code EquippedItemState.hasEquipped(int)}: the requirement is met
+	 * only when every listed item ID is currently in the player's equipment
+	 * container.
+	 *
+	 * <p>Charge-aware fallback (e.g. an equipped Drakan's medallion at 0
+	 * charges) is the responsibility of the authoring layer — a conditional
+	 * alternative that depends on a chargeable equip should always be paired
+	 * with a non-equipped fallback alternative. See C6 §5 Q4 in
+	 * {@code docs/contributor-guide/c6-top-20-player-state-wiring-scoping.md}.
+	 *
+	 * <p>{@code null} or empty when the source/alternative has no equipped-item
+	 * prerequisite. Added by Tier B0 as a C6 prerequisite.
+	 */
+	@Nullable
+	List<Integer> equippedItemIds;
 }

--- a/src/test/java/com/collectionloghelper/data/CollectionLogSourceTest.java
+++ b/src/test/java/com/collectionloghelper/data/CollectionLogSourceTest.java
@@ -123,7 +123,7 @@ public class CollectionLogSourceTest
 	@Test
 	public void getWorldPointWithChecker_firstAccessible()
 	{
-		SourceRequirements reqs = new SourceRequirements(Collections.singletonList("DRAGON_SLAYER_II"), null, null);
+		SourceRequirements reqs = new SourceRequirements(Collections.singletonList("DRAGON_SLAYER_II"), null, null, null, null);
 		Waypoint wp1 = new Waypoint("Shortcut", 2500, 2600, 0, reqs);
 		Waypoint wp2 = new Waypoint("Walk", 3500, 3600, 0, null);
 
@@ -137,7 +137,7 @@ public class CollectionLogSourceTest
 	@Test
 	public void getWorldPointWithChecker_firstLocked_fallsToSecond()
 	{
-		SourceRequirements reqs = new SourceRequirements(Collections.singletonList("DRAGON_SLAYER_II"), null, null);
+		SourceRequirements reqs = new SourceRequirements(Collections.singletonList("DRAGON_SLAYER_II"), null, null, null, null);
 		Waypoint wp1 = new Waypoint("Shortcut", 2500, 2600, 0, reqs);
 		Waypoint wp2 = new Waypoint("Walk", 3500, 3600, 0, null);
 
@@ -151,8 +151,8 @@ public class CollectionLogSourceTest
 	@Test
 	public void getWorldPointWithChecker_allLocked_fallsToLast()
 	{
-		SourceRequirements reqs1 = new SourceRequirements(Collections.singletonList("QUEST_A"), null, null);
-		SourceRequirements reqs2 = new SourceRequirements(Collections.singletonList("QUEST_B"), null, null);
+		SourceRequirements reqs1 = new SourceRequirements(Collections.singletonList("QUEST_A"), null, null, null, null);
+		SourceRequirements reqs2 = new SourceRequirements(Collections.singletonList("QUEST_B"), null, null, null, null);
 		Waypoint wp1 = new Waypoint("Best", 1000, 1000, 0, reqs1);
 		Waypoint wp2 = new Waypoint("Alt", 2000, 2000, 0, reqs2);
 
@@ -227,7 +227,7 @@ public class CollectionLogSourceTest
 	@Test
 	public void getDisplayLocationWithChecker_allLockedFallsToLastName()
 	{
-		SourceRequirements reqs = new SourceRequirements(Collections.singletonList("QUEST_A"), null, null);
+		SourceRequirements reqs = new SourceRequirements(Collections.singletonList("QUEST_A"), null, null, null, null);
 		Waypoint wp1 = new Waypoint("First", 1000, 1000, 0, reqs);
 		Waypoint wp2 = new Waypoint("Last", 2000, 2000, 0, reqs);
 

--- a/src/test/java/com/collectionloghelper/data/RequirementsCheckerB0Test.java
+++ b/src/test/java/com/collectionloghelper/data/RequirementsCheckerB0Test.java
@@ -1,0 +1,332 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data;
+
+import com.collectionloghelper.player.EquippedItemState;
+import com.collectionloghelper.player.PohTeleport;
+import com.collectionloghelper.player.PohTeleportInventory;
+import java.lang.reflect.Constructor;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import net.runelite.api.Client;
+import net.runelite.api.Skill;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+
+/**
+ * Tier B0 — behaviour tests for
+ * {@link RequirementsChecker#meetsRequirements(SourceRequirements)} with the
+ * new {@code pohTeleports} and {@code equippedItemIds} fields wired in.
+ *
+ * <p>Covers AND-semantics across all field clauses and alternative-selection
+ * (first-match wins) — the latter exercises the same iteration order the
+ * sequencer uses in {@link GuidanceStep#resolveAlternative(RequirementsChecker)}.
+ *
+ * <p>{@link PohTeleportInventory} and {@link EquippedItemState} are mocked at
+ * the interface level. The {@link Client} mock backs the existing skill clause.
+ * Strict stubbing is disabled because the AND-clause short-circuits skip later
+ * stubs in failure tests.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class RequirementsCheckerB0Test
+{
+	private static final int RING_OF_SHADOWS = 28266;
+	private static final int DRAKANS_MEDALLION = 22557;
+
+	@Mock
+	private Client client;
+
+	@Mock
+	private PohTeleportInventory pohTeleportInventory;
+
+	@Mock
+	private EquippedItemState equippedItemState;
+
+	private RequirementsChecker checker;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		// The @Inject constructor is private — use reflection to construct without Guice.
+		Constructor<RequirementsChecker> ctor = RequirementsChecker.class.getDeclaredConstructor(
+			Client.class, PohTeleportInventory.class, EquippedItemState.class);
+		ctor.setAccessible(true);
+		checker = ctor.newInstance(client, pohTeleportInventory, equippedItemState);
+	}
+
+	// ── null requirements ───────────────────────────────────────────────────
+
+	@Test
+	public void meetsRequirements_nullArg_isTrue()
+	{
+		assertTrue(checker.meetsRequirements(null));
+	}
+
+	// ── pohTeleports clause ─────────────────────────────────────────────────
+
+	@Test
+	public void meetsRequirements_pohTeleportPresent_isTrue()
+	{
+		lenient().when(pohTeleportInventory.hasTeleport(PohTeleport.JEWELLERY_BOX_FANCY)).thenReturn(true);
+		SourceRequirements req = pohReq("JEWELLERY_BOX_FANCY");
+		assertTrue(checker.meetsRequirements(req));
+	}
+
+	@Test
+	public void meetsRequirements_pohTeleportAbsent_isFalse()
+	{
+		lenient().when(pohTeleportInventory.hasTeleport(PohTeleport.MOUNTED_GLORY)).thenReturn(false);
+		SourceRequirements req = pohReq("MOUNTED_GLORY");
+		assertFalse(checker.meetsRequirements(req));
+	}
+
+	@Test
+	public void meetsRequirements_unknownPohTeleportEnum_isFalse()
+	{
+		// Unknown enum names are rejected (treated as unmet) — see RequirementsChecker.
+		SourceRequirements req = pohReq("DOES_NOT_EXIST");
+		assertFalse(checker.meetsRequirements(req));
+	}
+
+	@Test
+	public void meetsRequirements_multiplePohTeleports_andSemantics()
+	{
+		lenient().when(pohTeleportInventory.hasTeleport(PohTeleport.JEWELLERY_BOX_FANCY)).thenReturn(true);
+		lenient().when(pohTeleportInventory.hasTeleport(PohTeleport.FAIRY_RING)).thenReturn(false);
+		SourceRequirements req = new SourceRequirements(
+			null, null, null,
+			Arrays.asList("JEWELLERY_BOX_FANCY", "FAIRY_RING"),
+			null);
+		assertFalse(checker.meetsRequirements(req));
+	}
+
+	@Test
+	public void meetsRequirements_emptyPohTeleports_isTrue()
+	{
+		SourceRequirements req = new SourceRequirements(
+			null, null, null,
+			Collections.emptyList(),
+			null);
+		assertTrue(checker.meetsRequirements(req));
+	}
+
+	// ── equippedItemIds clause ──────────────────────────────────────────────
+
+	@Test
+	public void meetsRequirements_equippedItemPresent_isTrue()
+	{
+		lenient().when(equippedItemState.hasEquipped(RING_OF_SHADOWS)).thenReturn(true);
+		SourceRequirements req = equippedReq(RING_OF_SHADOWS);
+		assertTrue(checker.meetsRequirements(req));
+	}
+
+	@Test
+	public void meetsRequirements_equippedItemAbsent_isFalse()
+	{
+		lenient().when(equippedItemState.hasEquipped(RING_OF_SHADOWS)).thenReturn(false);
+		SourceRequirements req = equippedReq(RING_OF_SHADOWS);
+		assertFalse(checker.meetsRequirements(req));
+	}
+
+	@Test
+	public void meetsRequirements_multipleEquippedItems_andSemantics()
+	{
+		lenient().when(equippedItemState.hasEquipped(RING_OF_SHADOWS)).thenReturn(true);
+		lenient().when(equippedItemState.hasEquipped(DRAKANS_MEDALLION)).thenReturn(false);
+		SourceRequirements req = new SourceRequirements(
+			null, null, null, null,
+			Arrays.asList(RING_OF_SHADOWS, DRAKANS_MEDALLION));
+		assertFalse(checker.meetsRequirements(req));
+	}
+
+	@Test
+	public void meetsRequirements_emptyEquippedItemIds_isTrue()
+	{
+		SourceRequirements req = new SourceRequirements(
+			null, null, null, null,
+			Collections.emptyList());
+		assertTrue(checker.meetsRequirements(req));
+	}
+
+	// ── AND-semantics across multiple fields ────────────────────────────────
+
+	@Test
+	public void meetsRequirements_skillAndPohAndEquipped_allSatisfied_isTrue()
+	{
+		lenient().when(client.getRealSkillLevel(Skill.STRENGTH)).thenReturn(80);
+		lenient().when(pohTeleportInventory.hasTeleport(PohTeleport.JEWELLERY_BOX_FANCY)).thenReturn(true);
+		lenient().when(equippedItemState.hasEquipped(RING_OF_SHADOWS)).thenReturn(true);
+		SourceRequirements req = new SourceRequirements(
+			null,
+			Collections.singletonList(new SkillRequirement("STRENGTH", 70)),
+			null,
+			Collections.singletonList("JEWELLERY_BOX_FANCY"),
+			Collections.singletonList(RING_OF_SHADOWS));
+		assertTrue(checker.meetsRequirements(req));
+	}
+
+	@Test
+	public void meetsRequirements_skillSatisfiedButPohAbsent_isFalse()
+	{
+		lenient().when(client.getRealSkillLevel(Skill.STRENGTH)).thenReturn(80);
+		lenient().when(pohTeleportInventory.hasTeleport(PohTeleport.JEWELLERY_BOX_FANCY)).thenReturn(false);
+		SourceRequirements req = new SourceRequirements(
+			null,
+			Collections.singletonList(new SkillRequirement("STRENGTH", 70)),
+			null,
+			Collections.singletonList("JEWELLERY_BOX_FANCY"),
+			null);
+		assertFalse(checker.meetsRequirements(req));
+	}
+
+	@Test
+	public void meetsRequirements_pohSatisfiedButEquippedAbsent_isFalse()
+	{
+		lenient().when(pohTeleportInventory.hasTeleport(PohTeleport.JEWELLERY_BOX_FANCY)).thenReturn(true);
+		lenient().when(equippedItemState.hasEquipped(RING_OF_SHADOWS)).thenReturn(false);
+		SourceRequirements req = new SourceRequirements(
+			null, null, null,
+			Collections.singletonList("JEWELLERY_BOX_FANCY"),
+			Collections.singletonList(RING_OF_SHADOWS));
+		assertFalse(checker.meetsRequirements(req));
+	}
+
+	// ── Alternative selection — first matching alternative wins ─────────────
+	//
+	// These tests mirror the iteration loop in
+	// GuidanceStep.resolveAlternative(checker): the first alternative whose
+	// requirements pass meetsRequirements() is selected. We assert this by
+	// matching directly against meetsRequirements() in the same order, which
+	// is what the sequencer does.
+
+	@Test
+	public void alternativeSelection_pohEquippedRouteWins_whenBothPresent()
+	{
+		lenient().when(pohTeleportInventory.hasTeleport(PohTeleport.JEWELLERY_BOX_FANCY)).thenReturn(true);
+		lenient().when(equippedItemState.hasEquipped(RING_OF_SHADOWS)).thenReturn(true);
+
+		List<ConditionalAlternative> alts = Arrays.asList(
+			altWithReq("Fast: POH + ring", new SourceRequirements(
+				null, null, null,
+				Collections.singletonList("JEWELLERY_BOX_FANCY"),
+				Collections.singletonList(RING_OF_SHADOWS))),
+			altWithReq("Slow: ring only", equippedReq(RING_OF_SHADOWS)));
+
+		assertEquals("Fast: POH + ring", selectFirstMatching(alts));
+	}
+
+	@Test
+	public void alternativeSelection_fallsBackToSecondAlt_whenFirstNewFieldUnmet()
+	{
+		// Player has the ring but no POH teleport — slow route wins.
+		lenient().when(pohTeleportInventory.hasTeleport(PohTeleport.JEWELLERY_BOX_FANCY)).thenReturn(false);
+		lenient().when(equippedItemState.hasEquipped(RING_OF_SHADOWS)).thenReturn(true);
+
+		List<ConditionalAlternative> alts = Arrays.asList(
+			altWithReq("Fast: POH + ring", new SourceRequirements(
+				null, null, null,
+				Collections.singletonList("JEWELLERY_BOX_FANCY"),
+				Collections.singletonList(RING_OF_SHADOWS))),
+			altWithReq("Slow: ring only", equippedReq(RING_OF_SHADOWS)));
+
+		assertEquals("Slow: ring only", selectFirstMatching(alts));
+	}
+
+	@Test
+	public void alternativeSelection_noMatch_returnsNull()
+	{
+		lenient().when(pohTeleportInventory.hasTeleport(PohTeleport.JEWELLERY_BOX_FANCY)).thenReturn(false);
+		lenient().when(equippedItemState.hasEquipped(RING_OF_SHADOWS)).thenReturn(false);
+
+		List<ConditionalAlternative> alts = Arrays.asList(
+			altWithReq("POH route", pohReq("JEWELLERY_BOX_FANCY")),
+			altWithReq("Equipped route", equippedReq(RING_OF_SHADOWS)));
+
+		assertEquals(null, selectFirstMatching(alts));
+	}
+
+	// ── Helpers ─────────────────────────────────────────────────────────────
+
+	private static SourceRequirements pohReq(String teleportName)
+	{
+		return new SourceRequirements(
+			null, null, null,
+			Collections.singletonList(teleportName),
+			null);
+	}
+
+	private static SourceRequirements equippedReq(int itemId)
+	{
+		return new SourceRequirements(
+			null, null, null, null,
+			Collections.singletonList(itemId));
+	}
+
+	private static ConditionalAlternative altWithReq(String description, SourceRequirements requirements)
+	{
+		return new ConditionalAlternative(
+			requirements,
+			description,
+			null, null, null,  // worldX, worldY, worldPlane
+			null,              // travelTip
+			null,              // npcId
+			null,              // interactAction
+			null,              // objectId
+			null,              // completionCondition
+			null,              // completionDistance
+			null,              // completionNpcId
+			null               // nestedAlternatives
+		);
+	}
+
+	/**
+	 * Mirrors {@link GuidanceStep#resolveAlternative} selection logic against
+	 * the same checker — returns the description of the first matching alt, or
+	 * {@code null} when none match.
+	 */
+	private String selectFirstMatching(List<ConditionalAlternative> alts)
+	{
+		for (ConditionalAlternative alt : alts)
+		{
+			if (alt.getRequirements() != null && checker.meetsRequirements(alt.getRequirements()))
+			{
+				return alt.getDescription();
+			}
+		}
+		return null;
+	}
+}

--- a/src/test/java/com/collectionloghelper/data/SourceRequirementsB0Test.java
+++ b/src/test/java/com/collectionloghelper/data/SourceRequirementsB0Test.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tier B0 — value-type tests for {@link SourceRequirements#getPohTeleports()} and
+ * {@link SourceRequirements#getEquippedItemIds()}.
+ *
+ * <p>Covers Gson deserialisation with the new fields absent / null / empty /
+ * populated, plus equals/hashCode for the extended value type. Backwards
+ * compatibility check: existing JSON without the new fields must deserialise
+ * unchanged with the new fields {@code null}.
+ */
+public class SourceRequirementsB0Test
+{
+	private static final Gson GSON = new GsonBuilder().create();
+
+	// ── Backwards compatibility ────────────────────────────────────────────────
+
+	@Test
+	public void deserialise_legacyJsonWithoutNewFields_pohTeleportsIsNull()
+	{
+		String json = "{\"quests\":[\"TROLL_STRONGHOLD\"]}";
+		SourceRequirements req = GSON.fromJson(json, SourceRequirements.class);
+		assertNull(req.getPohTeleports());
+		assertNull(req.getEquippedItemIds());
+	}
+
+	@Test
+	public void deserialise_legacyJsonWithoutNewFields_existingFieldsParse()
+	{
+		String json = "{\"quests\":[\"DESERT_TREASURE_II\"],\"skills\":[{\"skill\":\"SLAYER\",\"level\":95}],"
+			+ "\"diaries\":[\"FREMENNIK_HARD\"]}";
+		SourceRequirements req = GSON.fromJson(json, SourceRequirements.class);
+		assertEquals(Collections.singletonList("DESERT_TREASURE_II"), req.getQuests());
+		assertNotNull(req.getSkills());
+		assertEquals(1, req.getSkills().size());
+		assertEquals(Collections.singletonList("FREMENNIK_HARD"), req.getDiaries());
+		assertNull(req.getPohTeleports());
+		assertNull(req.getEquippedItemIds());
+	}
+
+	// ── pohTeleports field ─────────────────────────────────────────────────────
+
+	@Test
+	public void deserialise_pohTeleportsNull_isNull()
+	{
+		String json = "{\"pohTeleports\":null}";
+		SourceRequirements req = GSON.fromJson(json, SourceRequirements.class);
+		assertNull(req.getPohTeleports());
+	}
+
+	@Test
+	public void deserialise_pohTeleportsEmpty_isEmptyNotNull()
+	{
+		String json = "{\"pohTeleports\":[]}";
+		SourceRequirements req = GSON.fromJson(json, SourceRequirements.class);
+		assertNotNull(req.getPohTeleports());
+		assertTrue(req.getPohTeleports().isEmpty());
+	}
+
+	@Test
+	public void deserialise_pohTeleportsPopulated_preservesOrder()
+	{
+		String json = "{\"pohTeleports\":[\"JEWELLERY_BOX_FANCY\",\"MOUNTED_GLORY\"]}";
+		SourceRequirements req = GSON.fromJson(json, SourceRequirements.class);
+		assertEquals(Arrays.asList("JEWELLERY_BOX_FANCY", "MOUNTED_GLORY"), req.getPohTeleports());
+	}
+
+	// ── equippedItemIds field ──────────────────────────────────────────────────
+
+	@Test
+	public void deserialise_equippedItemIdsNull_isNull()
+	{
+		String json = "{\"equippedItemIds\":null}";
+		SourceRequirements req = GSON.fromJson(json, SourceRequirements.class);
+		assertNull(req.getEquippedItemIds());
+	}
+
+	@Test
+	public void deserialise_equippedItemIdsEmpty_isEmptyNotNull()
+	{
+		String json = "{\"equippedItemIds\":[]}";
+		SourceRequirements req = GSON.fromJson(json, SourceRequirements.class);
+		assertNotNull(req.getEquippedItemIds());
+		assertTrue(req.getEquippedItemIds().isEmpty());
+	}
+
+	@Test
+	public void deserialise_equippedItemIdsPopulated_preservesOrder()
+	{
+		String json = "{\"equippedItemIds\":[22557,28266]}";
+		SourceRequirements req = GSON.fromJson(json, SourceRequirements.class);
+		assertEquals(Arrays.asList(22557, 28266), req.getEquippedItemIds());
+	}
+
+	// ── All five fields together ──────────────────────────────────────────────
+
+	@Test
+	public void deserialise_allFiveFieldsPopulated_parsesAll()
+	{
+		String json = "{"
+			+ "\"quests\":[\"TROLL_STRONGHOLD\"],"
+			+ "\"skills\":[{\"skill\":\"STRENGTH\",\"level\":70}],"
+			+ "\"diaries\":[\"FREMENNIK_HARD\"],"
+			+ "\"pohTeleports\":[\"JEWELLERY_BOX_FANCY\"],"
+			+ "\"equippedItemIds\":[22557]"
+			+ "}";
+		SourceRequirements req = GSON.fromJson(json, SourceRequirements.class);
+		assertEquals(Collections.singletonList("TROLL_STRONGHOLD"), req.getQuests());
+		assertEquals(1, req.getSkills().size());
+		assertEquals(Collections.singletonList("FREMENNIK_HARD"), req.getDiaries());
+		assertEquals(Collections.singletonList("JEWELLERY_BOX_FANCY"), req.getPohTeleports());
+		assertEquals(Collections.singletonList(22557), req.getEquippedItemIds());
+	}
+
+	// ── equals / hashCode ─────────────────────────────────────────────────────
+
+	@Test
+	public void equals_sameNewFields_areEqual()
+	{
+		SourceRequirements a = new SourceRequirements(
+			null, null, null,
+			Collections.singletonList("MOUNTED_GLORY"),
+			Collections.singletonList(22557));
+		SourceRequirements b = new SourceRequirements(
+			null, null, null,
+			Collections.singletonList("MOUNTED_GLORY"),
+			Collections.singletonList(22557));
+		assertEquals(a, b);
+		assertEquals(a.hashCode(), b.hashCode());
+	}
+
+	@Test
+	public void equals_differingPohTeleports_notEqual()
+	{
+		SourceRequirements a = new SourceRequirements(
+			null, null, null,
+			Collections.singletonList("MOUNTED_GLORY"),
+			null);
+		SourceRequirements b = new SourceRequirements(
+			null, null, null,
+			Collections.singletonList("JEWELLERY_BOX_FANCY"),
+			null);
+		assertTrue(!a.equals(b));
+	}
+
+	// ── Round-trip ─────────────────────────────────────────────────────────────
+
+	@Test
+	public void gsonRoundTrip_withNewFields_preservesStructure()
+	{
+		SourceRequirements original = new SourceRequirements(
+			Collections.singletonList("DESERT_TREASURE_II"),
+			null,
+			Collections.singletonList("FREMENNIK_HARD"),
+			Arrays.asList("JEWELLERY_BOX_FANCY", "MOUNTED_GLORY"),
+			Arrays.asList(22557, 28266));
+		String json = GSON.toJson(original);
+		SourceRequirements restored = GSON.fromJson(json, SourceRequirements.class);
+		assertEquals(original, restored);
+	}
+}

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerNestedConditionalTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerNestedConditionalTest.java
@@ -431,12 +431,12 @@ public class GuidanceSequencerNestedConditionalTest
 
 	private SourceRequirements makeQuestReq(String questName)
 	{
-		return new SourceRequirements(Arrays.asList(questName), null, null);
+		return new SourceRequirements(Arrays.asList(questName), null, null, null, null);
 	}
 
 	private SourceRequirements makeSkillReq(String skill, int level)
 	{
-		return new SourceRequirements(null, Arrays.asList(new SkillRequirement(skill, level)), null);
+		return new SourceRequirements(null, Arrays.asList(new SkillRequirement(skill, level)), null, null, null);
 	}
 
 	/**

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
@@ -1418,12 +1418,12 @@ public class GuidanceSequencerTest
 
 	private SourceRequirements makeQuestRequirement(String questName)
 	{
-		return new SourceRequirements(Arrays.asList(questName), null, null);
+		return new SourceRequirements(Arrays.asList(questName), null, null, null, null);
 	}
 
 	private SourceRequirements makeSkillRequirement(String skill, int level)
 	{
-		return new SourceRequirements(null, Arrays.asList(new SkillRequirement(skill, level)), null);
+		return new SourceRequirements(null, Arrays.asList(new SkillRequirement(skill, level)), null, null, null);
 	}
 
 	private GuidanceStep makeStepWithAlternatives(String description, int worldX, int worldY,

--- a/src/test/java/com/collectionloghelper/ui/widget/SourceRequirementsHeaderTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/SourceRequirementsHeaderTest.java
@@ -31,6 +31,8 @@ import com.collectionloghelper.data.RequirementRow;
 import com.collectionloghelper.data.RequirementsChecker;
 import com.collectionloghelper.data.SkillRequirement;
 import com.collectionloghelper.data.SourceRequirements;
+import com.collectionloghelper.player.EquippedItemState;
+import com.collectionloghelper.player.PohTeleportInventory;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import java.lang.reflect.Constructor;
@@ -83,6 +85,12 @@ public class SourceRequirementsHeaderTest
 	@Mock
 	private Client client;
 
+	@Mock
+	private PohTeleportInventory pohTeleportInventory;
+
+	@Mock
+	private EquippedItemState equippedItemState;
+
 	private RequirementsChecker checker;
 	private DropRateDatabase database;
 
@@ -90,9 +98,10 @@ public class SourceRequirementsHeaderTest
 	public void setUp() throws Exception
 	{
 		Constructor<RequirementsChecker> ctor =
-			RequirementsChecker.class.getDeclaredConstructor(Client.class);
+			RequirementsChecker.class.getDeclaredConstructor(
+				Client.class, PohTeleportInventory.class, EquippedItemState.class);
 		ctor.setAccessible(true);
-		checker = ctor.newInstance(client);
+		checker = ctor.newInstance(client, pohTeleportInventory, equippedItemState);
 
 		database = new DropRateDatabase();
 		Gson gson = new GsonBuilder().create();
@@ -136,7 +145,7 @@ public class SourceRequirementsHeaderTest
 		when(client.getIntStack()).thenReturn(new int[]{2});
 
 		SourceRequirements req = new SourceRequirements(
-			Collections.singletonList("DRAGON_SLAYER_II"), null, null);
+			Collections.singletonList("DRAGON_SLAYER_II"), null, null, null, null);
 		CollectionLogSource source = makeSourceWithRequirements("Vorkath", req);
 
 		List<RequirementRow> rows = checker.buildRequirementRows(source);
@@ -158,7 +167,7 @@ public class SourceRequirementsHeaderTest
 		when(client.getIntStack()).thenReturn(new int[]{1});
 
 		SourceRequirements req = new SourceRequirements(
-			Collections.singletonList("DRAGON_SLAYER_II"), null, null);
+			Collections.singletonList("DRAGON_SLAYER_II"), null, null, null, null);
 		CollectionLogSource source = makeSourceWithRequirements("Vorkath", req);
 
 		List<RequirementRow> rows = checker.buildRequirementRows(source);
@@ -177,7 +186,7 @@ public class SourceRequirementsHeaderTest
 		when(client.getIntStack()).thenReturn(new int[]{0});
 
 		SourceRequirements req = new SourceRequirements(
-			Collections.singletonList("DRAGON_SLAYER_II"), null, null);
+			Collections.singletonList("DRAGON_SLAYER_II"), null, null, null, null);
 		CollectionLogSource source = makeSourceWithRequirements("Vorkath", req);
 
 		List<RequirementRow> rows = checker.buildRequirementRows(source);
@@ -199,7 +208,7 @@ public class SourceRequirementsHeaderTest
 		when(client.getRealSkillLevel(Skill.SLAYER)).thenReturn(95);
 
 		SourceRequirements req = new SourceRequirements(
-			null, Collections.singletonList(new SkillRequirement("SLAYER", 91)), null);
+			null, Collections.singletonList(new SkillRequirement("SLAYER", 91)), null, null, null);
 		CollectionLogSource source = makeSourceWithRequirements("Cerberus", req);
 
 		List<RequirementRow> rows = checker.buildRequirementRows(source);
@@ -221,7 +230,7 @@ public class SourceRequirementsHeaderTest
 		when(client.getRealSkillLevel(Skill.SLAYER)).thenReturn(80);
 
 		SourceRequirements req = new SourceRequirements(
-			null, Collections.singletonList(new SkillRequirement("SLAYER", 91)), null);
+			null, Collections.singletonList(new SkillRequirement("SLAYER", 91)), null, null, null);
 		CollectionLogSource source = makeSourceWithRequirements("Cerberus", req);
 
 		List<RequirementRow> rows = checker.buildRequirementRows(source);
@@ -243,7 +252,7 @@ public class SourceRequirementsHeaderTest
 		when(client.getVarbitValue(ArgumentMatchers.anyInt())).thenReturn(1);
 
 		SourceRequirements req = new SourceRequirements(
-			null, null, Collections.singletonList("ARDOUGNE_ELITE"));
+			null, null, Collections.singletonList("ARDOUGNE_ELITE"), null, null);
 		CollectionLogSource source = makeSourceWithRequirements("Zulrah", req);
 
 		List<RequirementRow> rows = checker.buildRequirementRows(source);
@@ -264,7 +273,7 @@ public class SourceRequirementsHeaderTest
 		when(client.getVarbitValue(ArgumentMatchers.anyInt())).thenReturn(0);
 
 		SourceRequirements req = new SourceRequirements(
-			null, null, Collections.singletonList("ARDOUGNE_ELITE"));
+			null, null, Collections.singletonList("ARDOUGNE_ELITE"), null, null);
 		CollectionLogSource source = makeSourceWithRequirements("Zulrah", req);
 
 		List<RequirementRow> rows = checker.buildRequirementRows(source);
@@ -290,7 +299,7 @@ public class SourceRequirementsHeaderTest
 		SourceRequirements req = new SourceRequirements(
 			Collections.singletonList("TROLL_STRONGHOLD"),
 			Collections.singletonList(new SkillRequirement("STRENGTH", 70)),
-			null);
+			null, null, null);
 		CollectionLogSource source = makeSourceWithRequirements("General Graardor", req);
 
 		List<RequirementRow> rows = checker.buildRequirementRows(source);
@@ -318,7 +327,7 @@ public class SourceRequirementsHeaderTest
 		SourceRequirements req = new SourceRequirements(
 			Collections.singletonList("TROLL_STRONGHOLD"),
 			Collections.singletonList(new SkillRequirement("STRENGTH", 70)),
-			null);
+			null, null, null);
 		CollectionLogSource source = makeSourceWithRequirements("General Graardor", req);
 
 		List<RequirementRow> rows = checker.buildRequirementRows(source);


### PR DESCRIPTION
## Summary

C6 prerequisite (per `docs/contributor-guide/c6-top-20-player-state-wiring-scoping.md` §3.2). Adds two new `@Nullable` list fields to `SourceRequirements` so subsequent C-tier data PRs can author POH-teleport and equipped-item-gated alternatives:

- **`pohTeleports: List<String>`** — `PohTeleport` enum names (`MOUNTED_GLORY`, `JEWELLERY_BOX_FANCY`, etc.); AND-evaluated against `PohTeleportInventory.hasTeleport(...)`.
- **`equippedItemIds: List<Integer>`** — RuneLite `ItemID` integers; AND-evaluated against `EquippedItemState.hasEquipped(int)`.

`RequirementsChecker.checkRequirementsDetail()` gains the two new AND-clauses; both fields participate in the same first-match-wins iteration the sequencer uses for `ConditionalAlternative` selection. Existing JSON parses unchanged — both fields default to `null` when absent (verified by Gson round-trip).

No `drop_rates.json` edits. No ROADMAP changes. No new `diaries`/`diary` field — `SourceRequirements.diaries` already exists (C6 §3.2 explicitly says no schema work needed for it).

## Notes for reviewers

- **Constructor signature change**: `RequirementsChecker` now injects `PohTeleportInventory` and `EquippedItemState` alongside `Client`. Guice resolves all three transparently — no production caller constructs `RequirementsChecker` directly. Tests that reflected on the old `(Client.class)` constructor (`SourceRequirementsHeaderTest`) were migrated to the new 3-arg form.
- **Charge-aware fallback** is *not* in this schema PR. Per C6 §5 Q4, B1 authoring is responsible for pairing each chargeable-equip alternative (Drakan's medallion / ring of shadows / Quetzal whistle) with a no-equipped fallback alternative; a 0-charge medallion still returns `true` from `hasEquipped(int)`. Reviewers of subsequent B1 PRs should enforce this.
- **Diary gating** is unchanged. `diaries` was previously surfaced in `buildRequirementRows()` for display but not gated by `checkRequirementsDetail()`; that gap is orthogonal to B0 and will be addressed (if needed) by B3 when the first diary-gated alternative lands.
- **Migration of existing test fixtures**: 4 test files were touched only to extend `new SourceRequirements(...)` callsites with two trailing `null` args, matching the `@Value`-generated all-args constructor's new arity.

## Test plan

- [x] `./gradlew build` green (jacoco coverage verification + lintDropRates included)
- [x] `SourceRequirementsB0Test` — 12 tests passing (Gson absent/null/empty/populated for each new field, legacy 3-field JSON still parses, equals/hashCode/round-trip)
- [x] `RequirementsCheckerB0Test` — 16 tests passing (AND-semantics, alternative-selection)
- [x] Full pre-existing suite still passes (no regression in `GuidanceSequencerTest`, `CollectionLogSourceTest`, `SourceRequirementsHeaderTest`)
- [ ] Smoke-test downstream: B1 should be able to author one trial alternative using both new fields before merging the schema PR (deferred — opt-in once B1 is in flight)

## References

- C6 scoping: `docs/contributor-guide/c6-top-20-player-state-wiring-scoping.md`
- C1 (POH teleport detector): #470
- C2 (equipped item state): #463
- Live `@Subscribe` lifecycle wiring: #616
