### PR TITLE
data(b1a): wire Ring of Shadows C2 alternatives on DT2 bosses

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -1592,14 +1592,20 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Use Ring of Shadows to teleport to Ghorrock Dungeon, or travel via Weiss Salt Mine. Bring crush weapon (Bandos godsword or Inquisitor's mace), Saradomin brews, super restores, and a pickaxe for the salt vents.",
+        "description": "Travel to Ghorrock Prison via the Weiss Salt Mine. Bring crush weapon (Bandos godsword or Inquisitor's mace), Saradomin brews, super restores, and a pickaxe for the salt vents.",
         "worldX": 2846,
         "worldY": 3938,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
-        "requiredItemIds": [
-          28327
+        "conditionalAlternatives": [
+          {
+            "requirements": {
+              "equippedItemIds": [28327]
+            },
+            "description": "Use Ring of Shadows -> Ghorrock Dungeon to teleport directly. Bring crush weapon (Bandos godsword or Inquisitor's mace), Saradomin brews, super restores, and a pickaxe for the salt vents.",
+            "travelTip": "Ring of Shadows -> Ghorrock Dungeon"
+          }
         ],
         "section": "Travel"
       },
@@ -1744,14 +1750,20 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Use Ring of Shadows to teleport to The Scar, or take the rowboat in the Wizards' Tower basement. Bring ranged setup (Bow of faerdhinen or Twisted bow with diamond bolts (e)) or magic with Tumeken's shadow, prayer potions, and Saradomin brews.",
+        "description": "Travel to The Scar by taking the rowboat in the Wizards' Tower basement. Bring ranged setup (Bow of faerdhinen or Twisted bow with diamond bolts (e)) or magic with Tumeken's shadow, prayer potions, and Saradomin brews.",
         "worldX": 3104,
         "worldY": 3162,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
-        "requiredItemIds": [
-          28327
+        "conditionalAlternatives": [
+          {
+            "requirements": {
+              "equippedItemIds": [28327]
+            },
+            "description": "Use Ring of Shadows -> The Scar to teleport directly. Bring ranged setup (Bow of faerdhinen or Twisted bow with diamond bolts (e)) or magic with Tumeken's shadow, prayer potions, and Saradomin brews.",
+            "travelTip": "Ring of Shadows -> The Scar"
+          }
         ],
         "section": "Travel"
       },
@@ -1894,15 +1906,23 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Use Ring of Shadows to teleport to Lassar Undercity, or enter the sinkhole north-west of Camdozaal. Bring the blackstone fragment (required to start the fight), ranged setup (Bow of faerdhinen or Twisted bow with diamond bolts (e)), prayer potions, and Saradomin brews.",
+        "description": "Travel to Lassar Undercity by entering the sinkhole north-west of Camdozaal. Bring the blackstone fragment (required to start the fight), ranged setup (Bow of faerdhinen or Twisted bow with diamond bolts (e)), prayer potions, and Saradomin brews.",
         "worldX": 3007,
         "worldY": 3477,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
         "requiredItemIds": [
-          28327,
           28357
+        ],
+        "conditionalAlternatives": [
+          {
+            "requirements": {
+              "equippedItemIds": [28327]
+            },
+            "description": "Use Ring of Shadows -> Lassar Undercity to teleport directly. Bring the blackstone fragment (required to start the fight), ranged setup (Bow of faerdhinen or Twisted bow with diamond bolts (e)), prayer potions, and Saradomin brews.",
+            "travelTip": "Ring of Shadows -> Lassar Undercity"
+          }
         ],
         "section": "Travel"
       },
@@ -2053,14 +2073,20 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Use Ring of Shadows to teleport to The Stranglewood, or walk from the Kourend Woodland. Bring slash weapon (Saeldor or Soulreaper axe) since Vardorvis is weakest to slash, prayer potions, Saradomin brews, and high-tier melee armour.",
+        "description": "Travel to The Stranglewood by walking from the Kourend Woodland. Bring slash weapon (Saeldor or Soulreaper axe) since Vardorvis is weakest to slash, prayer potions, Saradomin brews, and high-tier melee armour.",
         "worldX": 1175,
         "worldY": 3424,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
-        "requiredItemIds": [
-          28327
+        "conditionalAlternatives": [
+          {
+            "requirements": {
+              "equippedItemIds": [28327]
+            },
+            "description": "Use Ring of Shadows -> The Stranglewood to teleport directly. Bring slash weapon (Saeldor or Soulreaper axe) since Vardorvis is weakest to slash, prayer potions, Saradomin brews, and high-tier melee armour.",
+            "travelTip": "Ring of Shadows -> The Stranglewood"
+          }
         ],
         "section": "Travel"
       },

--- a/src/test/java/com/collectionloghelper/data/B1aRegressionTest.java
+++ b/src/test/java/com/collectionloghelper/data/B1aRegressionTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * B1a regression guard — locks the ring-of-shadows ×4 C2 conditional
+ * alternatives shipped against the DT2 boss sources.
+ *
+ * <p>For each of Vardorvis / Duke Sucellus / The Leviathan / The Whisperer the
+ * first guidance step must:
+ * <ul>
+ *   <li>Carry exactly one {@code conditionalAlternatives} entry.</li>
+ *   <li>That entry's {@code requirements.equippedItemIds} must equal
+ *       {@code [28327]} (charged Ring of shadows worn ItemID — verified via
+ *       abextm cache viewer; see
+ *       {@code .claude/memory/feedback_item_id_cross_validation.md}).</li>
+ *   <li>That entry must override {@code description} and {@code travelTip}.</li>
+ *   <li>The base step's description must NOT mention "Ring of Shadows" — the
+ *       base must always be a working no-equip fallback per the C6 scoping
+ *       doc §5 Q4 charge-aware-fallback rule (the ring's uncharged variant
+ *       28329 is a different ItemID and would not satisfy
+ *       {@code hasEquipped(28327)}).</li>
+ * </ul>
+ *
+ * <p>Pattern mirrors B2/B3/B5 regression guards: load the production JSON,
+ * iterate the named sources, assert each invariant, accumulate violations for
+ * a single readable failure message.
+ */
+public class B1aRegressionTest
+{
+	private static final int RING_OF_SHADOWS_CHARGED_ITEM_ID = 28327;
+
+	private static final List<String> B1A_SOURCE_NAMES = Arrays.asList(
+		"Vardorvis",
+		"Duke Sucellus",
+		"The Leviathan",
+		"The Whisperer"
+	);
+
+	private DropRateDatabase database;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		database = new DropRateDatabase();
+
+		Gson gson = new GsonBuilder().create();
+		Field gsonField = DropRateDatabase.class.getDeclaredField("gson");
+		gsonField.setAccessible(true);
+		gsonField.set(database, gson);
+
+		database.load();
+	}
+
+	@Test
+	public void firstStepCarriesRingOfShadowsConditionalAlternative()
+	{
+		for (String name : B1A_SOURCE_NAMES)
+		{
+			CollectionLogSource source = findSource(name);
+			assertNotNull(source, "Expected source: " + name);
+			assertNotNull(source.getGuidanceSteps(), name + ": guidanceSteps must not be null");
+			assertFalse(source.getGuidanceSteps().isEmpty(), name + ": guidanceSteps must not be empty");
+
+			GuidanceStep firstStep = source.getGuidanceSteps().get(0);
+			List<ConditionalAlternative> alternatives = firstStep.getConditionalAlternatives();
+			assertNotNull(alternatives, name + ": first step must declare conditionalAlternatives");
+			assertEquals(
+				1,
+				alternatives.size(),
+				name + ": expected exactly one conditional alternative for the ring-of-shadows route; found "
+					+ alternatives.size());
+
+			ConditionalAlternative alt = alternatives.get(0);
+			SourceRequirements altReqs = alt.getRequirements();
+			assertNotNull(altReqs, name + ": conditional alternative must declare requirements");
+			assertNotNull(altReqs.getEquippedItemIds(), name + ": requirements.equippedItemIds must be set");
+			assertEquals(
+				List.of(RING_OF_SHADOWS_CHARGED_ITEM_ID),
+				altReqs.getEquippedItemIds(),
+				name + ": expected equippedItemIds = [" + RING_OF_SHADOWS_CHARGED_ITEM_ID + "]");
+
+			assertNotNull(alt.getDescription(), name + ": conditional alternative must override description");
+			assertTrue(
+				alt.getDescription().contains("Ring of Shadows"),
+				name + ": alternative description should mention Ring of Shadows; got: " + alt.getDescription());
+
+			assertNotNull(alt.getTravelTip(), name + ": conditional alternative must override travelTip");
+			assertTrue(
+				alt.getTravelTip().startsWith("Ring of Shadows"),
+				name + ": alternative travelTip should start with 'Ring of Shadows'; got: " + alt.getTravelTip());
+		}
+	}
+
+	@Test
+	public void baseStepDescriptionIsNoEquipFallback()
+	{
+		for (String name : B1A_SOURCE_NAMES)
+		{
+			CollectionLogSource source = findSource(name);
+			assertNotNull(source, "Expected source: " + name);
+
+			GuidanceStep firstStep = source.getGuidanceSteps().get(0);
+			String baseDescription = firstStep.getDescription();
+			assertNotNull(baseDescription, name + ": base step description must not be null");
+			assertFalse(
+				baseDescription.contains("Ring of Shadows"),
+				name + ": base step description must NOT mention 'Ring of Shadows' — the base must be a "
+					+ "no-equip fallback route (§5 Q4). Got: " + baseDescription);
+
+			List<Integer> baseRequired = firstStep.getRequiredItemIds();
+			if (baseRequired != null)
+			{
+				assertFalse(
+					baseRequired.contains(RING_OF_SHADOWS_CHARGED_ITEM_ID),
+					name + ": base step requiredItemIds must not include ring of shadows ("
+						+ RING_OF_SHADOWS_CHARGED_ITEM_ID + ") — it belongs in the conditional alternative only.");
+			}
+		}
+	}
+
+	private CollectionLogSource findSource(String name)
+	{
+		for (CollectionLogSource source : database.getAllSources())
+		{
+			if (name.equals(source.getName()))
+			{
+				return source;
+			}
+		}
+		return null;
+	}
+}


### PR DESCRIPTION
## Summary

First B1 sub-batch — wires Ring of Shadows C2 equipped-item conditional alternatives on the four DT2 boss sources. Builds directly on the B0 schema landed in #623 and the C6 scoping doc in #621.

**Sources touched (4):** Vardorvis, Duke Sucellus, The Leviathan, The Whisperer.

For each source the first travel step gains a `conditionalAlternatives[0]` entry gated on:

```json
"requirements": { "equippedItemIds": [28327] }
```

ItemID `28327` is the charged Ring of Shadows worn form (verified via the abextm cache viewer — `wearpos1: Ring(12)`, `inventoryOps` includes `Wear` + `Teleport`, `placeholderLinkedItem: 28328`). The placeholder (28328) and the uncharged variant (28329) are deliberately not in the gate — `EquippedItemState.hasEquipped(28327)` only fires when the player is actively wearing a charged ring.

The alternative overrides `description` and `travelTip` to the ring-specific direct-teleport route; the base step now describes the no-equip fallback path:

| Source | Base route (no-equip fallback) | Ring-equipped alternative |
|---|---|---|
| Vardorvis | Walk from Kourend Woodland | Ring of Shadows -> The Stranglewood |
| Duke Sucellus | Weiss Salt Mine | Ring of Shadows -> Ghorrock Dungeon |
| The Leviathan | Rowboat in Wizards' Tower basement | Ring of Shadows -> The Scar |
| The Whisperer | Camdozaal sinkhole | Ring of Shadows -> Lassar Undercity |

## Charge-aware fallback (§5 Q4 of the C6 scoping doc)

`EquippedItemState.hasEquipped(int)` is a strict membership check on the EQUIPMENT container snapshot, and the uncharged Ring of Shadows is a distinct ItemID (`28329`). A player wearing an uncharged ring would *not* satisfy the gate, so the base step is authored as a complete working route rather than a "Ring of Shadows OR walk" combined description. This matches the §5 Q4 rule that every chargeable-equip alternative must pair with a usable no-equip fallback.

Whisperer's base step keeps `requiredItemIds: [28357]` (blackstone fragment) — only the ring (`28327`) is removed, since it's no longer pinned as required when the player is on the fallback route.

## Audit-test guard

`B1aRegressionTest` (2 tests):

- `firstStepCarriesRingOfShadowsConditionalAlternative` — each source's first guidance step has exactly one `conditionalAlternatives` entry; its `requirements.equippedItemIds == [28327]`; description + travelTip are non-null and mention "Ring of Shadows".
- `baseStepDescriptionIsNoEquipFallback` — base step description must not contain "Ring of Shadows"; base `requiredItemIds` (if non-null) must not contain `28327`.

Pattern mirrors B2/B3/B5 regression guards.

## Test plan

- [x] `./gradlew build` — green (`BUILD SUCCESSFUL in 23s`, 9 tasks).
- [x] Forbid-list scan of the diff returns no hits.
- [x] ItemID `28327` verified via `runelite_id_lookup` MCP + abextm cache viewer (see new memory file `feedback_item_id_cross_validation.md`).
- [ ] In-client smoke verification — equip a charged ring on each DT2 boss page, confirm the conditional description fires; unequip, confirm the base fallback description shows.

## Follow-ups (deferred)

- B1b (Drakan's medallion ×4) and B1c (5 misc) still need ItemID verification before authoring — the kickoff brief listed several wrong IDs (Drakan = `22557` is actually `WILD_CAVE_AMULET`; Quetzal whistle = `28464` is actually `DT2_SCAR_MAZE_LIGHT_LURE`). Bundle the schema-reference example fix (#624 used `22557`) into the B1b PR rather than churning #624.