### PR TITLE
data(b1b): Drakan's medallion C2 alternatives on ToB / ToB-HM / Nightmare / Phosani

### DIFF
--- a/docs/contributor-guide/schema-reference.md
+++ b/docs/contributor-guide/schema-reference.md
@@ -215,7 +215,7 @@ Sources can specify quest, skill, achievement-diary, POH-teleport, and equipped-
     ],
     "diaries": ["KANDARIN_ELITE"],
     "pohTeleports": ["JEWELLERY_BOX_FANCY"],
-    "equippedItemIds": [22557]
+    "equippedItemIds": [22400]
   }
 }
 ```

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -3000,12 +3000,21 @@
     ],
     "guidanceSteps": [
       {
-        "description": "Use Drakan's medallion to teleport to Slepe, or walk via Canifis",
+        "description": "Walk to Slepe via Canifis (Kharyrll teleport or fairy ring CKS, then run south through Mort'ton).",
         "worldX": 3728,
         "worldY": 3302,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "conditionalAlternatives": [
+          {
+            "requirements": {
+              "equippedItemIds": [22400]
+            },
+            "description": "Use Drakan's medallion to teleport directly to Slepe.",
+            "travelTip": "Drakan's medallion -> Slepe"
+          }
+        ]
       },
       {
         "description": "Climb down the stairs in Slepe church to enter the Sisterhood Sanctuary",
@@ -3183,12 +3192,21 @@
     ],
     "guidanceSteps": [
       {
-        "description": "Use Drakan's medallion to teleport to Slepe, or walk via Canifis",
+        "description": "Walk to Slepe via Canifis (Kharyrll teleport or fairy ring CKS, then run south through Mort'ton).",
         "worldX": 3728,
         "worldY": 3302,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "conditionalAlternatives": [
+          {
+            "requirements": {
+              "equippedItemIds": [22400]
+            },
+            "description": "Use Drakan's medallion to teleport directly to Slepe.",
+            "travelTip": "Drakan's medallion -> Slepe"
+          }
+        ]
       },
       {
         "description": "Climb down the stairs in Slepe church to enter the Sisterhood Sanctuary",
@@ -5669,7 +5687,7 @@
     ],
     "guidanceSteps": [
       {
-        "description": "Use Drakan's medallion to teleport to Ver Sinhaza. Bring Scythe of vitur (or Soulreaper axe), Tbow + diamond bolts (e) for Verzik P3, full brews/restores, Sanguinesti staff or Trident, and a Dragon dagger(p++) for the Nylocas Athanatos on Verzik P1",
+        "description": "Travel to Ver Sinhaza - Kharyrll teleport to Canifis then run south through Mort'ton. Bring Scythe of vitur (or Soulreaper axe), Tbow + diamond bolts (e) for Verzik P3, full brews/restores, Sanguinesti staff or Trident, and a Dragon dagger(p++) for the Nylocas Athanatos on Verzik P1",
         "worldX": 3650,
         "worldY": 3218,
         "worldPlane": 0,
@@ -5677,6 +5695,15 @@
         "objectInteractAction": "Enter",
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 15,
+        "conditionalAlternatives": [
+          {
+            "requirements": {
+              "equippedItemIds": [22400]
+            },
+            "description": "Use Drakan's medallion to teleport directly to Ver Sinhaza. Bring Scythe of vitur (or Soulreaper axe), Tbow + diamond bolts (e) for Verzik P3, full brews/restores, Sanguinesti staff or Trident, and a Dragon dagger(p++) for the Nylocas Athanatos on Verzik P1",
+            "travelTip": "Drakan's medallion -> Ver Sinhaza"
+          }
+        ],
         "section": "Travel"
       },
       {
@@ -5886,7 +5913,7 @@
     ],
     "guidanceSteps": [
       {
-        "description": "Use Drakan's medallion to teleport to Ver Sinhaza. Hard Mode hits noticeably harder - bring Scythe of vitur, Tbow + diamond bolts (e), Sanguinesti staff, Soulreaper axe for spec, full brews/restores and extra prayer potions; expect tighter Nylo waves and a longer Verzik fight",
+        "description": "Travel to Ver Sinhaza - Kharyrll teleport to Canifis then run south through Mort'ton. Hard Mode hits noticeably harder - bring Scythe of vitur, Tbow + diamond bolts (e), Sanguinesti staff, Soulreaper axe for spec, full brews/restores and extra prayer potions; expect tighter Nylo waves and a longer Verzik fight",
         "worldX": 3650,
         "worldY": 3218,
         "worldPlane": 0,
@@ -5894,6 +5921,15 @@
         "objectInteractAction": "Enter",
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 15,
+        "conditionalAlternatives": [
+          {
+            "requirements": {
+              "equippedItemIds": [22400]
+            },
+            "description": "Use Drakan's medallion to teleport directly to Ver Sinhaza. Hard Mode hits noticeably harder - bring Scythe of vitur, Tbow + diamond bolts (e), Sanguinesti staff, Soulreaper axe for spec, full brews/restores and extra prayer potions; expect tighter Nylo waves and a longer Verzik fight",
+            "travelTip": "Drakan's medallion -> Ver Sinhaza"
+          }
+        ],
         "section": "Travel"
       },
       {

--- a/src/test/java/com/collectionloghelper/data/B1bRegressionTest.java
+++ b/src/test/java/com/collectionloghelper/data/B1bRegressionTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * B1b regression guard — locks the Drakan's-medallion x4 C2 conditional
+ * alternatives shipped against the ToB / ToB-HM / Nightmare / Phosani sources.
+ *
+ * <p>For each of Theatre of Blood / Theatre of Blood (Hard Mode) /
+ * The Nightmare / Phosani's Nightmare the first guidance step must:
+ * <ul>
+ *   <li>Carry exactly one {@code conditionalAlternatives} entry.</li>
+ *   <li>That entry's {@code requirements.equippedItemIds} must equal
+ *       {@code [22400]} (worn Drakan's medallion ItemID — verified via the
+ *       wiki infobox + RuneLite ItemID.java + NullItemID.NULL_22401 placeholder
+ *       hint; see {@code .claude/memory/feedback_item_id_cross_validation.md}).</li>
+ *   <li>That entry must override {@code description} and {@code travelTip}.</li>
+ *   <li>The base step's description must NOT mention "Drakan's medallion" —
+ *       the base must always be a working no-equip fallback per the C6 scoping
+ *       doc §5 Q4 charge-aware-fallback rule
+ *       ({@code hasEquipped(22400)} returns true even at 0 charges, but the
+ *       teleport itself silently fails).</li>
+ * </ul>
+ *
+ * <p>Pattern mirrors {@code B1aRegressionTest} (ring of shadows on DT2 bosses).
+ */
+public class B1bRegressionTest
+{
+	private static final int DRAKANS_MEDALLION_WORN_ITEM_ID = 22400;
+
+	private static final List<String> B1B_SOURCE_NAMES = Arrays.asList(
+		"Theatre of Blood",
+		"Theatre of Blood (Hard Mode)",
+		"The Nightmare",
+		"Phosani's Nightmare"
+	);
+
+	private DropRateDatabase database;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		database = new DropRateDatabase();
+
+		Gson gson = new GsonBuilder().create();
+		Field gsonField = DropRateDatabase.class.getDeclaredField("gson");
+		gsonField.setAccessible(true);
+		gsonField.set(database, gson);
+
+		database.load();
+	}
+
+	@Test
+	public void firstStepCarriesDrakansMedallionConditionalAlternative()
+	{
+		for (String name : B1B_SOURCE_NAMES)
+		{
+			CollectionLogSource source = findSource(name);
+			assertNotNull(source, "Expected source: " + name);
+			assertNotNull(source.getGuidanceSteps(), name + ": guidanceSteps must not be null");
+			assertFalse(source.getGuidanceSteps().isEmpty(), name + ": guidanceSteps must not be empty");
+
+			GuidanceStep firstStep = source.getGuidanceSteps().get(0);
+			List<ConditionalAlternative> alternatives = firstStep.getConditionalAlternatives();
+			assertNotNull(alternatives, name + ": first step must declare conditionalAlternatives");
+			assertEquals(
+				1,
+				alternatives.size(),
+				name + ": expected exactly one conditional alternative for the Drakan's-medallion route; found "
+					+ alternatives.size());
+
+			ConditionalAlternative alt = alternatives.get(0);
+			SourceRequirements altReqs = alt.getRequirements();
+			assertNotNull(altReqs, name + ": conditional alternative must declare requirements");
+			assertNotNull(altReqs.getEquippedItemIds(), name + ": requirements.equippedItemIds must be set");
+			assertEquals(
+				List.of(DRAKANS_MEDALLION_WORN_ITEM_ID),
+				altReqs.getEquippedItemIds(),
+				name + ": expected equippedItemIds = [" + DRAKANS_MEDALLION_WORN_ITEM_ID + "]");
+
+			assertNotNull(alt.getDescription(), name + ": conditional alternative must override description");
+			assertTrue(
+				alt.getDescription().contains("Drakan's medallion"),
+				name + ": alternative description should mention Drakan's medallion; got: " + alt.getDescription());
+
+			assertNotNull(alt.getTravelTip(), name + ": conditional alternative must override travelTip");
+			assertTrue(
+				alt.getTravelTip().startsWith("Drakan's medallion"),
+				name + ": alternative travelTip should start with 'Drakan's medallion'; got: " + alt.getTravelTip());
+		}
+	}
+
+	@Test
+	public void baseStepDescriptionIsNoEquipFallback()
+	{
+		for (String name : B1B_SOURCE_NAMES)
+		{
+			CollectionLogSource source = findSource(name);
+			assertNotNull(source, "Expected source: " + name);
+
+			GuidanceStep firstStep = source.getGuidanceSteps().get(0);
+			String baseDescription = firstStep.getDescription();
+			assertNotNull(baseDescription, name + ": base step description must not be null");
+			assertFalse(
+				baseDescription.contains("Drakan's medallion"),
+				name + ": base step description must NOT mention 'Drakan's medallion' - the base must be a "
+					+ "no-equip fallback route (C6 scoping doc Q4). Got: " + baseDescription);
+
+			List<Integer> baseRequired = firstStep.getRequiredItemIds();
+			if (baseRequired != null)
+			{
+				assertFalse(
+					baseRequired.contains(DRAKANS_MEDALLION_WORN_ITEM_ID),
+					name + ": base step requiredItemIds must not include Drakan's medallion ("
+						+ DRAKANS_MEDALLION_WORN_ITEM_ID + ") - it belongs in the conditional alternative only.");
+			}
+		}
+	}
+
+	private CollectionLogSource findSource(String name)
+	{
+		for (CollectionLogSource source : database.getAllSources())
+		{
+			if (name.equals(source.getName()))
+			{
+				return source;
+			}
+		}
+		return null;
+	}
+}

--- a/src/test/java/com/collectionloghelper/data/B1bRegressionTest.java
+++ b/src/test/java/com/collectionloghelper/data/B1bRegressionTest.java
@@ -46,9 +46,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * <ul>
  *   <li>Carry exactly one {@code conditionalAlternatives} entry.</li>
  *   <li>That entry's {@code requirements.equippedItemIds} must equal
- *       {@code [22400]} (worn Drakan's medallion ItemID — verified via the
- *       wiki infobox + RuneLite ItemID.java + NullItemID.NULL_22401 placeholder
- *       hint; see {@code .claude/memory/feedback_item_id_cross_validation.md}).</li>
+ *       {@code [22400]} (worn Drakan's medallion ItemID, verified via the
+ *       wiki infobox plus RuneLite ItemID.java plus the
+ *       NullItemID.NULL_22401 placeholder-slot hint).</li>
  *   <li>That entry must override {@code description} and {@code travelTip}.</li>
  *   <li>The base step's description must NOT mention "Drakan's medallion" —
  *       the base must always be a working no-equip fallback per the C6 scoping


### PR DESCRIPTION
## Summary

- Adds one `conditionalAlternatives` entry on the first guidance step of each of the four ToB/Nightmare-family sources (Theatre of Blood, Theatre of Blood (Hard Mode), The Nightmare, Phosani's Nightmare), gated on the worn Drakan's medallion (ItemID 22400). Mirrors the B1a (Ring of shadows) shape from #625.
- Refactors each base step's description to the no-equip Canifis/Mort'ton walk route so the route silently fails closed when the medallion is at 0 charges, per the C6 scoping doc Q4 charge-aware-fallback rule.
- Bundles a one-line `schema-reference.md` fix: the 5-field requirements example landed in #624 used ItemID 22557, which is actually `WILD_CAVE_AMULET` — swapped to the now-verified Drakan's medallion ID 22400.
- New `B1bRegressionTest` mirrors `B1aRegressionTest`: locks exactly-one-alternative, equippedItemIds = [22400], overridden description + travelTip, and the no-equip-fallback invariant on the base step.

## Worn ItemID verification (22400)

The toolkit exposes RuneLite's `ItemID.java` symbolically but no item-cache definition fetcher, so worn-vs-placeholder disambiguation still requires multiple sources. Triangulated as follows:

| Signal | Result |
|---|---|
| OSRS Wiki infobox | Lists only `22400` as the canonical Drakan's medallion ID. |
| `runelite_id_lookup value=22400` | Returns `ItemID.DRAKANS_MEDALLION`. |
| `runelite_id_lookup value=22401` | Returns BOTH `ItemID.DRAKANS_MEDALLION` AND `NullItemID.NULL_22401`. The `Null*` entry is the recurring marker for placeholder/non-equippable slots in RuneLite's generated constants. |
| B1a worked example (Ring of shadows) | Lower ID `28327` = worn (charged, has `wearpos1: Ring` + `inventoryOps: Teleport` in cache2). Higher ID `28328` = placeholder. Same lower-is-worn pattern applies here. |

`equippedItemIds` is AND-semantic in `RequirementsChecker.checkRequirementsDetail` (lines 369-382); the alternative fires only when the worn ID is in the player's EQUIPMENT container.

## Test plan

- [x] `./gradlew build` is green locally (compile + Checkstyle + `lintDropRates` + JUnit including new `B1bRegressionTest` + jacoco coverage check).
- [ ] CI green on this PR.
- [ ] Manual: verify in-game that wearing a charged Drakan's medallion before opening guidance on each of the four sources triggers the alternative route (description + travelTip override visible in the panel).
- [ ] Manual: verify that holding the medallion at 0 charges or in the inventory (not equipped) keeps the base no-equip route active so guidance still progresses.

## Out of scope / follow-ups

- B1c (the remaining 5 "misc" sources in the original C6 §4 table) is blocked on a scope decision: 4 of the 5 are inventory-item routes (Zulrah scroll, Quetzal whistle, Crystal teleport seed ×2) that `equippedItemIds` cannot model, and ToA's Pharaoh's sceptre is charge-discrete (different ItemID per charge tier) which the current AND-semantic field also cannot model cleanly. Either drop inventory items from B1 scope, or extend the schema with an `equippedItemIdsAny`/inventory-equivalent field (Tier B schema change). Will record the decision in the C6 scoping doc §5 follow-ups before authoring B1c data.