### PR TITLE
fix(b1a): scrub tooling-path reference from B1aRegressionTest Javadoc

### DIFF
--- a/src/test/java/com/collectionloghelper/data/B1aRegressionTest.java
+++ b/src/test/java/com/collectionloghelper/data/B1aRegressionTest.java
@@ -46,9 +46,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * <ul>
  *   <li>Carry exactly one {@code conditionalAlternatives} entry.</li>
  *   <li>That entry's {@code requirements.equippedItemIds} must equal
- *       {@code [28327]} (charged Ring of shadows worn ItemID — verified via
- *       abextm cache viewer; see
- *       {@code .claude/memory/feedback_item_id_cross_validation.md}).</li>
+ *       {@code [28327]} (charged Ring of shadows worn ItemID, verified via
+ *       the abextm cache viewer plus RuneLite ItemID.java plus the
+ *       NullItemID.NULL_28328 placeholder-slot hint).</li>
  *   <li>That entry must override {@code description} and {@code travelTip}.</li>
  *   <li>The base step's description must NOT mention "Ring of Shadows" — the
  *       base must always be a working no-equip fallback per the C6 scoping


### PR DESCRIPTION
## Summary

- Removes a tooling-path reference (`internal contributor-notes path` clause) from the class Javadoc of `B1aRegressionTest`.
- Replaces with brand-agnostic verification rationale: abextm cache viewer + RuneLite ItemID.java + `NullItemID.NULL_28328` placeholder-slot hint.
- Mirrors the same 3-line scrub applied to `B1bRegressionTest` in commit 0b10c634 (#626).

This was flagged as out-of-scope follow-up in #626. Test logic and assertions are unchanged - Javadoc-only edit.

## Test plan

- [x] `./gradlew build` green (unchecked-ops warning in unrelated `GuidanceEventRouterTest` is pre-existing)
- [x] Diff verified as 3 lines changed in one file
- [x] Forbid-list grep on commit message: clean