### PR TITLE
data(c6-b2): wire C1 POH-teleport alternatives on 8 top-20 sources

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -116,6 +116,15 @@
         "requiredItemIds": [
           11804
         ],
+        "conditionalAlternatives": [
+          {
+            "requirements": {
+              "pohTeleports": ["JEWELLERY_BOX_FANCY"]
+            },
+            "description": "POH jewellery box -> Combat bracelet -> Warriors' Guild, then run north via Death Plateau to the God Wars Dungeon entrance",
+            "travelTip": "POH Combat bracelet -> Warriors' Guild -> run north to GWD"
+          }
+        ],
         "section": "Travel"
       },
       {
@@ -273,6 +282,15 @@
         "completionDistance": 8,
         "requiredItemIds": [
           12018
+        ],
+        "conditionalAlternatives": [
+          {
+            "requirements": {
+              "pohTeleports": ["JEWELLERY_BOX_FANCY"]
+            },
+            "description": "POH jewellery box -> Combat bracelet -> Warriors' Guild, then run north via Death Plateau to the God Wars Dungeon entrance",
+            "travelTip": "POH Combat bracelet -> Warriors' Guild -> run north to GWD"
+          }
         ],
         "section": "Travel"
       },
@@ -432,6 +450,15 @@
         "requiredItemIds": [
           2412
         ],
+        "conditionalAlternatives": [
+          {
+            "requirements": {
+              "pohTeleports": ["JEWELLERY_BOX_FANCY"]
+            },
+            "description": "POH jewellery box -> Combat bracelet -> Warriors' Guild, then run north via Death Plateau to the God Wars Dungeon entrance",
+            "travelTip": "POH Combat bracelet -> Warriors' Guild -> run north to GWD"
+          }
+        ],
         "section": "Travel"
       },
       {
@@ -590,6 +617,15 @@
         "requiredItemIds": [
           9419
         ],
+        "conditionalAlternatives": [
+          {
+            "requirements": {
+              "pohTeleports": ["JEWELLERY_BOX_FANCY"]
+            },
+            "description": "POH jewellery box -> Combat bracelet -> Warriors' Guild, then run north via Death Plateau to the God Wars Dungeon entrance",
+            "travelTip": "POH Combat bracelet -> Warriors' Guild -> run north to GWD"
+          }
+        ],
         "section": "Travel"
       },
       {
@@ -736,6 +772,15 @@
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 15,
         "travelTip": "Zul-andra teleport scroll (fastest), or fairy ring BJS + run east",
+        "conditionalAlternatives": [
+          {
+            "requirements": {
+              "pohTeleports": ["FAIRY_RING"]
+            },
+            "description": "Use the POH superior garden fairy ring (dramen/lunar staff equipped) to dial AKQ, then run east to Zul-Andra",
+            "travelTip": "POH superior garden fairy ring -> AKQ -> run east to Zul-Andra"
+          }
+        ],
         "section": "Travel"
       },
       {
@@ -844,6 +889,15 @@
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 15,
         "travelTip": "Lunar Isle teleport + talk to banker, Rellekka house portal, or Fremennik sea boots",
+        "conditionalAlternatives": [
+          {
+            "requirements": {
+              "pohTeleports": ["MOUNTED_GLORY"]
+            },
+            "description": "POH mounted glory -> Edgeville fallback, then use a games necklace or other transport north to Rellekka docks and sail to Ungael",
+            "travelTip": "POH mounted glory -> Edgeville -> route north to Rellekka docks"
+          }
+        ],
         "section": "Travel"
       },
       {
@@ -1245,7 +1299,16 @@
         "worldY": 4382,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15
+        "completionDistance": 15,
+        "conditionalAlternatives": [
+          {
+            "requirements": {
+              "pohTeleports": ["JEWELLERY_BOX_FANCY"]
+            },
+            "description": "POH jewellery box -> Games necklace -> Wilderness Volcano, then run south to the lever room and pull the lever to enter the Corporeal Beast cave",
+            "travelTip": "POH Games necklace -> Wilderness Volcano -> south to lever room"
+          }
+        ]
       },
       {
         "description": "Enter the cave to reach the underground lair",
@@ -5233,6 +5296,15 @@
         "objectInteractAction": "Enter",
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
+        "conditionalAlternatives": [
+          {
+            "requirements": {
+              "pohTeleports": ["XERICS_TALISMAN"]
+            },
+            "description": "POH mounted Xeric's talisman -> Xeric's Glade, then run south to the Chambers of Xeric entrance. Bring Tbow or Bow of faerdhinen, full brews/restores, Salve (ei) for Vasa/Vespula, and a Dragon claws or Bandos godsword spec for Olm head phases",
+            "travelTip": "POH mounted Xeric's talisman -> Xeric's Glade -> run south to CoX"
+          }
+        ],
         "section": "Travel"
       },
       {

--- a/src/test/java/com/collectionloghelper/data/C6B2RegressionTest.java
+++ b/src/test/java/com/collectionloghelper/data/C6B2RegressionTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * C6 B2 regression guard - locks the C1 POH-teleport conditional alternatives
+ * shipped on the eight top-20 sources with POH-teleport applicability per the
+ * C6 scoping doc (sections 2 and 4):
+ *
+ * <ul>
+ *   <li>Chambers of Xeric: mounted {@code XERICS_TALISMAN} -&gt; Xeric's Glade.</li>
+ *   <li>General Graardor / Commander Zilyana / K'ril Tsutsaroth / Kree'arra:
+ *       shared {@code JEWELLERY_BOX_FANCY} -&gt; Combat bracelet -&gt; Warriors' Guild.</li>
+ *   <li>Vorkath: {@code MOUNTED_GLORY} -&gt; Edgeville fallback when no
+ *       Fremennik-tier teleport is available.</li>
+ *   <li>Zulrah: {@code FAIRY_RING} in the superior garden -&gt; AKQ ring.</li>
+ *   <li>Corporeal Beast: {@code JEWELLERY_BOX_FANCY} -&gt; Games necklace -&gt;
+ *       Wilderness Volcano.</li>
+ * </ul>
+ *
+ * <p>For each source the first guidance step must:
+ * <ul>
+ *   <li>Carry exactly one {@code conditionalAlternatives} entry.</li>
+ *   <li>That entry's {@code requirements.pohTeleports} must equal the expected
+ *       single-element list of {@link com.collectionloghelper.player.PohTeleport}
+ *       enum-name strings.</li>
+ *   <li>That entry must override both {@code description} and {@code travelTip}.</li>
+ *   <li>The base step's description (and any base {@code requiredItemIds}) must
+ *       be untouched relative to its pre-B2 wording, so the no-POH fallback
+ *       route still works.</li>
+ * </ul>
+ *
+ * <p>Pattern mirrors {@code B1aRegressionTest} and {@code B1bRegressionTest}.
+ */
+public class C6B2RegressionTest
+{
+	private static final String JEWELLERY_BOX_FANCY = "JEWELLERY_BOX_FANCY";
+	private static final String MOUNTED_GLORY = "MOUNTED_GLORY";
+	private static final String FAIRY_RING = "FAIRY_RING";
+	private static final String XERICS_TALISMAN = "XERICS_TALISMAN";
+
+	/**
+	 * Per-source expectations: source name -&gt; expected pohTeleports list.
+	 * Insertion order is preserved for stable failure reporting.
+	 */
+	private static final Map<String, List<String>> EXPECTED_POH_BY_SOURCE = buildExpected();
+
+	private static Map<String, List<String>> buildExpected()
+	{
+		Map<String, List<String>> map = new LinkedHashMap<>();
+		map.put("Chambers of Xeric", List.of(XERICS_TALISMAN));
+		map.put("General Graardor", List.of(JEWELLERY_BOX_FANCY));
+		map.put("Commander Zilyana", List.of(JEWELLERY_BOX_FANCY));
+		map.put("K'ril Tsutsaroth", List.of(JEWELLERY_BOX_FANCY));
+		map.put("Kree'arra", List.of(JEWELLERY_BOX_FANCY));
+		map.put("Vorkath", List.of(MOUNTED_GLORY));
+		map.put("Zulrah", List.of(FAIRY_RING));
+		map.put("Corporeal Beast", List.of(JEWELLERY_BOX_FANCY));
+		return map;
+	}
+
+	/**
+	 * Per-source expected base-step description tokens that MUST still appear
+	 * in the unmodified base step. These are the unrestricted-fallback markers
+	 * that prove the base route was not rewritten by the B2 edit.
+	 */
+	private static final Map<String, String> EXPECTED_BASE_DESCRIPTION_MARKER = buildBaseMarkers();
+
+	private static Map<String, String> buildBaseMarkers()
+	{
+		Map<String, String> map = new LinkedHashMap<>();
+		map.put("Chambers of Xeric", "Xeric's talisman to teleport to Mount Quidamortem");
+		map.put("General Graardor", "Teleport to Trollheim");
+		map.put("Commander Zilyana", "Teleport to Trollheim");
+		map.put("K'ril Tsutsaroth", "Teleport to Trollheim");
+		map.put("Kree'arra", "Teleport to Trollheim");
+		map.put("Vorkath", "Rellekka docks");
+		map.put("Zulrah", "Zul-andra teleport scroll or fairy ring BJS");
+		map.put("Corporeal Beast", "games necklace to teleport to the Corporeal Beast cave");
+		return map;
+	}
+
+	private DropRateDatabase database;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		database = new DropRateDatabase();
+
+		Gson gson = new GsonBuilder().create();
+		Field gsonField = DropRateDatabase.class.getDeclaredField("gson");
+		gsonField.setAccessible(true);
+		gsonField.set(database, gson);
+
+		database.load();
+	}
+
+	@Test
+	public void firstStepCarriesPohTeleportConditionalAlternative()
+	{
+		for (Map.Entry<String, List<String>> entry : EXPECTED_POH_BY_SOURCE.entrySet())
+		{
+			String name = entry.getKey();
+			List<String> expectedPoh = entry.getValue();
+
+			CollectionLogSource source = findSource(name);
+			assertNotNull(source, "Expected source: " + name);
+			assertNotNull(source.getGuidanceSteps(), name + ": guidanceSteps must not be null");
+			assertFalse(source.getGuidanceSteps().isEmpty(), name + ": guidanceSteps must not be empty");
+
+			GuidanceStep firstStep = source.getGuidanceSteps().get(0);
+			List<ConditionalAlternative> alternatives = firstStep.getConditionalAlternatives();
+			assertNotNull(alternatives, name + ": first step must declare conditionalAlternatives");
+			assertEquals(
+				1,
+				alternatives.size(),
+				name + ": expected exactly one conditional alternative for the POH-teleport route; found "
+					+ alternatives.size());
+
+			ConditionalAlternative alt = alternatives.get(0);
+			SourceRequirements altReqs = alt.getRequirements();
+			assertNotNull(altReqs, name + ": conditional alternative must declare requirements");
+			assertNotNull(altReqs.getPohTeleports(), name + ": requirements.pohTeleports must be set");
+			assertEquals(
+				expectedPoh,
+				altReqs.getPohTeleports(),
+				name + ": expected pohTeleports = " + expectedPoh
+					+ " but got " + altReqs.getPohTeleports());
+
+			assertNotNull(alt.getDescription(), name + ": conditional alternative must override description");
+			assertTrue(
+				alt.getDescription().toUpperCase().contains("POH"),
+				name + ": alternative description should mention POH; got: " + alt.getDescription());
+
+			assertNotNull(alt.getTravelTip(), name + ": conditional alternative must override travelTip");
+			assertTrue(
+				alt.getTravelTip().toUpperCase().contains("POH"),
+				name + ": alternative travelTip should mention POH; got: " + alt.getTravelTip());
+		}
+	}
+
+	@Test
+	public void baseStepDescriptionIsUntouched()
+	{
+		for (Map.Entry<String, String> entry : EXPECTED_BASE_DESCRIPTION_MARKER.entrySet())
+		{
+			String name = entry.getKey();
+			String expectedMarker = entry.getValue();
+
+			CollectionLogSource source = findSource(name);
+			assertNotNull(source, "Expected source: " + name);
+
+			GuidanceStep firstStep = source.getGuidanceSteps().get(0);
+			String baseDescription = firstStep.getDescription();
+			assertNotNull(baseDescription, name + ": base step description must not be null");
+			assertTrue(
+				baseDescription.contains(expectedMarker),
+				name + ": base step description must still contain the original fallback wording '"
+					+ expectedMarker + "'. Got: " + baseDescription);
+		}
+	}
+
+	@Test
+	public void expectedPohSourcesArePresentInDatabase()
+	{
+		// Sanity: all 8 declared sources actually exist in the loaded JSON.
+		for (String name : EXPECTED_POH_BY_SOURCE.keySet())
+		{
+			assertNotNull(findSource(name), "Expected source missing from drop_rates.json: " + name);
+		}
+		// Cardinality lock so future renames or removals trip this test.
+		assertEquals(8, EXPECTED_POH_BY_SOURCE.size(),
+			"C6 B2 covers exactly 8 sources per the scoping doc Section 4");
+	}
+
+	private CollectionLogSource findSource(String name)
+	{
+		for (CollectionLogSource source : database.getAllSources())
+		{
+			if (name.equals(source.getName()))
+			{
+				return source;
+			}
+		}
+		return null;
+	}
+
+	// Unused convenience for readability of the expected list shape.
+	@SuppressWarnings("unused")
+	private static List<String> sources()
+	{
+		return Arrays.asList(
+			"Chambers of Xeric",
+			"General Graardor",
+			"Commander Zilyana",
+			"K'ril Tsutsaroth",
+			"Kree'arra",
+			"Vorkath",
+			"Zulrah",
+			"Corporeal Beast"
+		);
+	}
+}


### PR DESCRIPTION
## Summary

C6 batch B2: wires C1 POH-teleport routes (via the `requirements.pohTeleports` field from the B0 schema PR #623) into `drop_rates.json` for the 8 top-20 sources flagged as C1-applicable in the [C6 scoping doc](docs/contributor-guide/c6-top-20-player-state-wiring-scoping.md) (§2, §4).

Each new alternative is a single `conditionalAlternatives` entry on the existing travel/arrive step. The base step (Trollheim teleport, Zul-andra scroll, Rellekka docks, walk from Mount Quidamortem, Games necklace inventory item) is left untouched as the no-POH fallback per §3.3.

## Sources touched

| # | Source | POH teleport | Destination |
|---|---|---|---|
| 1  | Chambers of Xeric   | `XERICS_TALISMAN`     | Xeric's Glade, run south to CoX entrance |
| 5  | General Graardor    | `JEWELLERY_BOX_FANCY` | Combat bracelet -> Warriors' Guild |
| 6  | Commander Zilyana   | `JEWELLERY_BOX_FANCY` | Combat bracelet -> Warriors' Guild |
| 7  | K'ril Tsutsaroth    | `JEWELLERY_BOX_FANCY` | Combat bracelet -> Warriors' Guild |
| 8  | Kree'arra           | `JEWELLERY_BOX_FANCY` | Combat bracelet -> Warriors' Guild |
| 13 | Vorkath             | `MOUNTED_GLORY`       | Edgeville fallback (when no Fremennik-tier teleport) |
| 14 | Zulrah              | `FAIRY_RING`          | AKQ in superior garden + dramen/lunar staff |
| 18 | Corporeal Beast     | `JEWELLERY_BOX_FANCY` | Games necklace -> Wilderness Volcano -> lever room |

All four GWD bosses share the same Combat bracelet -> Warriors' Guild alternative, authored independently on each source's travel step. For Vorkath the `MOUNTED_GLORY` alternative is the lower-priority fallback; a Fremennik diary/cape Rellekka-teleport entry will be stacked on top in the upcoming B3 batch.

Validated against `PohTeleport.java` enum constants (`XERICS_TALISMAN`, `JEWELLERY_BOX_FANCY`, `MOUNTED_GLORY`, `FAIRY_RING` all exist) and mirrors the conditional-alternative pattern established by recent PRs #625 (Ring of Shadows DT2) and #626 (Drakan's medallion ToB/ToB-HM/Nightmare/Phosani).

## Tests

New `C6B2RegressionTest` (mirrors `B1aRegressionTest` / `B1bRegressionTest`) loads the production JSON and locks three invariants per source:

1. The first guidance step carries exactly one `conditionalAlternatives` entry with the expected `requirements.pohTeleports`.
2. That entry overrides both `description` and `travelTip` (both mentioning "POH").
3. The base step description still contains its original fallback marker text, so the no-POH fallback route is untouched.

Plus a cardinality lock (8 sources) so future renames/removals trip the test.

## Test plan

- [x] `./gradlew test` green (full suite, including new `C6B2RegressionTest`)
- [x] `./gradlew build` green (jar + lintDropRates + jacoco verification)
- [x] No forbidden terms in repo-facing diff
- [x] No em-dashes / smart quotes / NBSP in JSON or Java