### PR TITLE
data(c6-b3): wire C3 diary shortcuts on ToA + Gauntlet x2 (non-B2-overlap subset)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -6223,6 +6223,15 @@
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
+        "conditionalAlternatives": [
+          {
+            "requirements": {
+              "diaries": ["DESERT_HARD"]
+            },
+            "description": "Pharaoh's sceptre to the Necropolis (Desert Hard diary makes the sceptre unlimited-charge, so you can spam-teleport without recharging at the desert lectern). Bring Tbow or Bow of faerdhinen, Osmumten's fang for stab phases, Tumeken's shadow if owned, full brews/restores and prayer potions; set invocations under 150 raid level for entry-mode loot",
+            "travelTip": "Pharaoh's sceptre -> Necropolis (unlimited charges via Desert Hard diary)"
+          }
+        ],
         "section": "Travel"
       },
       {
@@ -6517,6 +6526,15 @@
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
+        "conditionalAlternatives": [
+          {
+            "requirements": {
+              "diaries": ["DESERT_HARD"]
+            },
+            "description": "Pharaoh's sceptre to the Necropolis (Desert Hard diary makes the sceptre unlimited-charge, so you can spam-teleport without recharging at the desert lectern). Bring Tbow or Bow of faerdhinen, Osmumten's fang, Tumeken's shadow if owned, full brews/restores; aim for invocations totalling raid level 300-450 for solid loot efficiency before entering",
+            "travelTip": "Pharaoh's sceptre -> Necropolis (unlimited charges via Desert Hard diary)"
+          }
+        ],
         "section": "Travel"
       },
       {
@@ -6811,6 +6829,15 @@
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
+        "conditionalAlternatives": [
+          {
+            "requirements": {
+              "diaries": ["DESERT_HARD"]
+            },
+            "description": "Pharaoh's sceptre to the Necropolis (Desert Hard diary makes the sceptre unlimited-charge, so you can spam-teleport without recharging at the desert lectern). At raid level 500 bring Tumeken's shadow or Tbow, Osmumten's fang, full brews/restores, extra prayer potions and a Soulreaper axe spec; gear must be top-tier or kill times balloon",
+            "travelTip": "Pharaoh's sceptre -> Necropolis (unlimited charges via Desert Hard diary)"
+          }
+        ],
         "section": "Travel"
       },
       {
@@ -6919,7 +6946,16 @@
         "worldY": 6073,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15
+        "completionDistance": 15,
+        "conditionalAlternatives": [
+          {
+            "requirements": {
+              "diaries": ["WESTERN_ELITE"]
+            },
+            "description": "Operate the Crystal teleport seed for the rub-on-cape variant (Western Provinces Elite diary attaches the Prifddinas teleport to your max / quest / achievement cape, so you can teleport from anywhere without dedicating an inventory slot to the seed). Then run north-west to the Gauntlet portal in Lletya district",
+            "travelTip": "Cape Crystal teleport -> Prifddinas (Western Provinces Elite diary unlock)"
+          }
+        ]
       },
       {
         "description": "Talk to the Gauntlet NPC and pick Enter -> Corrupted challenge to start the harder instance",
@@ -7020,7 +7056,16 @@
         "worldY": 6073,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15
+        "completionDistance": 15,
+        "conditionalAlternatives": [
+          {
+            "requirements": {
+              "diaries": ["WESTERN_ELITE"]
+            },
+            "description": "Operate the Crystal teleport seed for the rub-on-cape variant (Western Provinces Elite diary attaches the Prifddinas teleport to your max / quest / achievement cape, so you can teleport from anywhere without dedicating an inventory slot to the seed). Then run north-west to the Gauntlet portal in Lletya district",
+            "travelTip": "Cape Crystal teleport -> Prifddinas (Western Provinces Elite diary unlock)"
+          }
+        ]
       },
       {
         "description": "Talk to the Gauntlet NPC and pick Enter -> Standard challenge to start the instance",

--- a/src/test/java/com/collectionloghelper/data/C6B3NonOverlapRegressionTest.java
+++ b/src/test/java/com/collectionloghelper/data/C6B3NonOverlapRegressionTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * C6 B3 (non-B2-overlap) regression guard — locks the C3 diary-tier
+ * conditional alternatives shipped against the three top-20 sources that do
+ * not overlap with the parallel B2 (POH-teleport) batch:
+ *
+ * <ul>
+ *   <li>Tombs of Amascut + Tombs of Amascut (300 Invocation):
+ *       {@code DESERT_HARD} unlocks unlimited-charge Pharaoh's sceptre.</li>
+ *   <li>The Gauntlet + Corrupted Gauntlet:
+ *       {@code WESTERN_ELITE} unlocks the cape Crystal-teleport variant
+ *       (Prifddinas teleport rubbed onto max/quest/achievement cape).</li>
+ * </ul>
+ *
+ * <p>The three CoX-Kourend / Graardor-Fremennik / Vorkath-Fremennik diary
+ * rows overlap with B2's POH-teleport authoring and are deferred to a
+ * post-B2 follow-up PR.
+ *
+ * <p>Each source's first guidance step must carry at least one
+ * {@code conditionalAlternatives} entry whose {@code requirements.diaries}
+ * exactly matches the expected diary string, and which overrides both
+ * {@code description} and {@code travelTip}. Pattern mirrors
+ * {@code B1aRegressionTest} (ring of shadows) and {@code B1bRegressionTest}
+ * (Drakan's medallion).
+ *
+ * <p>Diary string format follows the existing {@code SourceRequirements.diaries}
+ * convention {@code <AREA>_<TIER>}, where {@code AREA} is the
+ * {@link com.collectionloghelper.player.DiaryRegion} enum constant name
+ * ({@code WESTERN}, not the colloquial {@code WESTERN_PROVINCES}) and
+ * {@code TIER} is the {@link com.collectionloghelper.player.DiaryTier} name.
+ * The varbit lookup in {@code RequirementsChecker.resolveDiaryVarbit}
+ * resolves these against {@code Varbits.DIARY_<AREA>_<TIER>}, e.g.
+ * {@code Varbits.DIARY_WESTERN_ELITE} and {@code Varbits.DIARY_DESERT_HARD}.
+ */
+public class C6B3NonOverlapRegressionTest
+{
+	private static final String DESERT_HARD = "DESERT_HARD";
+	private static final String WESTERN_ELITE = "WESTERN_ELITE";
+
+	private static final List<String> TOA_SOURCES = Arrays.asList(
+		"Tombs of Amascut",
+		"Tombs of Amascut (300 Invocation)",
+		"Tombs of Amascut (500 Invocation)"
+	);
+
+	private static final List<String> GAUNTLET_SOURCES = Arrays.asList(
+		"The Gauntlet",
+		"Corrupted Gauntlet"
+	);
+
+	private DropRateDatabase database;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		database = new DropRateDatabase();
+
+		Gson gson = new GsonBuilder().create();
+		Field gsonField = DropRateDatabase.class.getDeclaredField("gson");
+		gsonField.setAccessible(true);
+		gsonField.set(database, gson);
+
+		database.load();
+	}
+
+	@Test
+	public void toaSourcesCarryDesertHardDiaryAlternative()
+	{
+		for (String name : TOA_SOURCES)
+		{
+			assertSourceHasDiaryAlternative(
+				name,
+				DESERT_HARD,
+				"Pharaoh's sceptre",
+				"Desert Hard diary");
+		}
+	}
+
+	@Test
+	public void gauntletSourcesCarryWesternEliteDiaryAlternative()
+	{
+		for (String name : GAUNTLET_SOURCES)
+		{
+			assertSourceHasDiaryAlternative(
+				name,
+				WESTERN_ELITE,
+				"Crystal teleport",
+				"Western Provinces Elite diary");
+		}
+	}
+
+	private void assertSourceHasDiaryAlternative(
+		String sourceName,
+		String expectedDiary,
+		String descriptionKeyword,
+		String travelTipKeyword)
+	{
+		CollectionLogSource source = findSource(sourceName);
+		assertNotNull(source, "Expected source: " + sourceName);
+		assertNotNull(source.getGuidanceSteps(),
+			sourceName + ": guidanceSteps must not be null");
+		assertTrue(!source.getGuidanceSteps().isEmpty(),
+			sourceName + ": guidanceSteps must not be empty");
+
+		GuidanceStep firstStep = source.getGuidanceSteps().get(0);
+		List<ConditionalAlternative> alternatives = firstStep.getConditionalAlternatives();
+		assertNotNull(alternatives,
+			sourceName + ": first step must declare conditionalAlternatives");
+
+		ConditionalAlternative diaryAlt = findDiaryAlternative(alternatives, expectedDiary);
+		assertNotNull(diaryAlt,
+			sourceName + ": expected a conditional alternative with diaries = ["
+				+ expectedDiary + "], but none matched");
+
+		SourceRequirements altReqs = diaryAlt.getRequirements();
+		assertNotNull(altReqs,
+			sourceName + ": diary conditional alternative must declare requirements");
+		assertEquals(
+			List.of(expectedDiary),
+			altReqs.getDiaries(),
+			sourceName + ": expected diaries = [" + expectedDiary + "]");
+
+		assertNotNull(diaryAlt.getDescription(),
+			sourceName + ": diary conditional alternative must override description");
+		assertTrue(
+			diaryAlt.getDescription().contains(descriptionKeyword),
+			sourceName + ": alternative description should mention '" + descriptionKeyword
+				+ "'; got: " + diaryAlt.getDescription());
+
+		assertNotNull(diaryAlt.getTravelTip(),
+			sourceName + ": diary conditional alternative must override travelTip");
+		assertTrue(
+			diaryAlt.getTravelTip().contains(travelTipKeyword),
+			sourceName + ": alternative travelTip should mention '" + travelTipKeyword
+				+ "'; got: " + diaryAlt.getTravelTip());
+	}
+
+	private static ConditionalAlternative findDiaryAlternative(
+		List<ConditionalAlternative> alternatives, String expectedDiary)
+	{
+		for (ConditionalAlternative alt : alternatives)
+		{
+			SourceRequirements reqs = alt.getRequirements();
+			if (reqs == null)
+			{
+				continue;
+			}
+			List<String> diaries = reqs.getDiaries();
+			if (diaries != null && diaries.contains(expectedDiary))
+			{
+				return alt;
+			}
+		}
+		return null;
+	}
+
+	private CollectionLogSource findSource(String name)
+	{
+		for (CollectionLogSource source : database.getAllSources())
+		{
+			if (name.equals(source.getName()))
+			{
+				return source;
+			}
+		}
+		return null;
+	}
+}


### PR DESCRIPTION
## Summary

Tier C6 batch B3 (C3 diary-tier wiring) — non-overlap slice. Three top-20 sources whose diary shortcut does **not** stack with the parallel B2 (POH-teleport) branches and can therefore land in isolation:

| # | Source(s) | Diary | Unlock |
|---|---|---|---|
| 4  | Tombs of Amascut + 300 Invocation + 500 Invocation | `DESERT_HARD` | Pharaoh's sceptre becomes unlimited-charge — spam-teleport to Necropolis without recharging at the desert lectern |
| 19 | The Gauntlet | `WESTERN_ELITE` | Crystal teleport seed rub-onto-cape variant (Prifddinas teleport on max / quest / achievement cape) |
| 20 | Corrupted Gauntlet | `WESTERN_ELITE` | Same cape Crystal teleport seed shortcut |

Each diary clause is authored as a `conditionalAlternatives[i]` entry on the existing travel step, using the existing `requirements.diaries` field (no schema change required — that field shipped before C6 B0).

## Deferred to a post-B2 follow-up

The remaining 3 C3 rows (CoX-Kourend, Graardor-Fremennik, Vorkath-Fremennik) overlap with B2's POH-teleport authoring. Adding a diary clause to a step that B2 is rewriting in parallel would conflict at merge time, so they are intentionally **out of scope** here. A follow-up PR after B2 merges will stack the `diaries` clause onto B2's combat-bracelet / mounted-glory `conditionalAlternatives` entries in the same guidance step.

## Diary string format note

The scoping doc colloquially writes `WESTERN_PROVINCES_ELITE`, but the actual RuneLite `Varbits` constant is `DIARY_WESTERN_ELITE` and the project's `DiaryRegion` enum is `WESTERN("WESTERN")`. The JSON therefore uses `"WESTERN_ELITE"`. `RequirementsChecker.resolveDiaryVarbit` reflects on `Varbits.DIARY_<NAME>` so the string must match the Varbits field, not the wiki page name. `DESERT_HARD` is unchanged.

## Test plan

- [x] `./gradlew test --tests C6B3NonOverlapRegressionTest` green
- [x] `./gradlew build` green (full test suite + `jacocoTestCoverageVerification` + `lintDropRates`)
- [x] No `claude` / `anthropic` / AI-attribution strings in diff
- [x] No non-ASCII characters in JSON or test sources
- [x] New regression test mirrors `B1aRegressionTest` / `B1bRegressionTest` pattern: load production JSON, walk first guidance step per source, assert the diary conditional alternative is present with `diaries = [...]` matching the expected value and overrides `description` + `travelTip`

## References

- [C6 scoping doc](https://github.com/cha-ndler/collection-log-helper/blob/master/docs/contributor-guide/c6-top-20-player-state-wiring-scoping.md) — rows 4, 19, 20; §3.2 diaries row; §4 B3 batch row
- B0 schema PR #623 (`pohTeleports` + `equippedItemIds` added; `diaries` already existed)
- B1a PR #625 (ring of shadows on DT2 — `conditionalAlternatives` pattern reference)
- B1b PR #626 (Drakan's medallion on ToB / Nightmare — same pattern)