### PR TITLE
data(c6-b3): diary shortcuts on CoX-Kourend / Graardor-Fremennik / Vorkath-Fremennik (stacks on #630)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -119,6 +119,13 @@
         "conditionalAlternatives": [
           {
             "requirements": {
+              "diaries": ["FREMENNIK_HARD"]
+            },
+            "description": "Trollheim teleport not required: use the Fremennik Hard diary unlocks (e.g. Lighthouse-area transport) plus the Goblin Village agility shortcut to reach the God Wars Dungeon entrance overland",
+            "travelTip": "Fremennik Hard diary route -> Goblin Village shortcut -> GWD"
+          },
+          {
+            "requirements": {
               "pohTeleports": ["JEWELLERY_BOX_FANCY"]
             },
             "description": "POH jewellery box -> Combat bracelet -> Warriors' Guild, then run north via Death Plateau to the God Wars Dungeon entrance",
@@ -892,10 +899,17 @@
         "conditionalAlternatives": [
           {
             "requirements": {
+              "diaries": ["FREMENNIK_HARD"]
+            },
+            "description": "Fremennik cape teleport directly to Rellekka, then run north to the docks and sail to Ungael via Torfinn (Lighthouse-via-Rellekka route)",
+            "travelTip": "Fremennik cape -> Rellekka -> run north to docks -> Torfinn"
+          },
+          {
+            "requirements": {
               "pohTeleports": ["MOUNTED_GLORY"]
             },
-            "description": "POH mounted glory -> Edgeville fallback, then use a games necklace or other transport north to Rellekka docks and sail to Ungael",
-            "travelTip": "POH mounted glory -> Edgeville -> route north to Rellekka docks"
+            "description": "POH mounted glory -> Edgeville fallback, then onward to Rellekka docks via available northern transport (no Fremennik teleport assumed) and sail to Ungael",
+            "travelTip": "POH mounted glory -> Edgeville -> onward to Rellekka docks"
           }
         ],
         "section": "Travel"
@@ -5297,6 +5311,13 @@
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
         "conditionalAlternatives": [
+          {
+            "requirements": {
+              "diaries": ["KOUREND_HARD"]
+            },
+            "description": "Kourend Hard diary: use the Xeric's Heart teleport inside Lovakengj to land roughly two tiles from the Chambers of Xeric prep room. Bring Tbow or Bow of faerdhinen, full brews/restores, Salve (ei) for Vasa/Vespula, and a Dragon claws or Bandos godsword spec for Olm head phases",
+            "travelTip": "Kourend Hard: Xeric's Heart teleport (Lovakengj) -> 2 tiles to prep room"
+          },
           {
             "requirements": {
               "pohTeleports": ["XERICS_TALISMAN"]

--- a/src/test/java/com/collectionloghelper/data/C6B2RegressionTest.java
+++ b/src/test/java/com/collectionloghelper/data/C6B2RegressionTest.java
@@ -148,13 +148,15 @@ public class C6B2RegressionTest
 			GuidanceStep firstStep = source.getGuidanceSteps().get(0);
 			List<ConditionalAlternative> alternatives = firstStep.getConditionalAlternatives();
 			assertNotNull(alternatives, name + ": first step must declare conditionalAlternatives");
-			assertEquals(
-				1,
-				alternatives.size(),
-				name + ": expected exactly one conditional alternative for the POH-teleport route; found "
-					+ alternatives.size());
+			assertFalse(
+				alternatives.isEmpty(),
+				name + ": expected at least one conditional alternative for the POH-teleport route");
 
-			ConditionalAlternative alt = alternatives.get(0);
+			ConditionalAlternative alt = findPohAlternative(alternatives, expectedPoh);
+			assertNotNull(alt,
+				name + ": expected a conditional alternative with pohTeleports = " + expectedPoh
+					+ ", but none matched (other alternatives may exist via later batches)");
+
 			SourceRequirements altReqs = alt.getRequirements();
 			assertNotNull(altReqs, name + ": conditional alternative must declare requirements");
 			assertNotNull(altReqs.getPohTeleports(), name + ": requirements.pohTeleports must be set");
@@ -174,6 +176,25 @@ public class C6B2RegressionTest
 				alt.getTravelTip().toUpperCase().contains("POH"),
 				name + ": alternative travelTip should mention POH; got: " + alt.getTravelTip());
 		}
+	}
+
+	private static ConditionalAlternative findPohAlternative(
+		List<ConditionalAlternative> alternatives, List<String> expectedPoh)
+	{
+		for (ConditionalAlternative candidate : alternatives)
+		{
+			SourceRequirements reqs = candidate.getRequirements();
+			if (reqs == null)
+			{
+				continue;
+			}
+			List<String> pohTeleports = reqs.getPohTeleports();
+			if (pohTeleports != null && pohTeleports.equals(expectedPoh))
+			{
+				return candidate;
+			}
+		}
+		return null;
 	}
 
 	@Test

--- a/src/test/java/com/collectionloghelper/data/C6B3OverlapRegressionTest.java
+++ b/src/test/java/com/collectionloghelper/data/C6B3OverlapRegressionTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.lang.reflect.Field;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * C6 B3 (B2-overlap follow-up) regression guard — locks the C3 diary-tier
+ * conditional alternatives that had to wait for B2's POH-teleport authoring
+ * (PR #630) to land before they could be stacked ahead of the existing
+ * POH alternatives.
+ *
+ * <p>Three sources, each with one diary alternative inserted at
+ * {@code conditionalAlternatives[0]} so the sequencer evaluates it before
+ * B2's POH alternative (which shifts to index {@code [1]}):
+ *
+ * <ul>
+ *   <li>Chambers of Xeric: {@code KOUREND_HARD} -> in-Lovakengj Xeric's
+ *       Heart teleport (2 tiles from prep room).</li>
+ *   <li>General Graardor: {@code FREMENNIK_HARD} -> diary-route overland
+ *       to GWD entrance.</li>
+ *   <li>Vorkath: {@code FREMENNIK_HARD} -> Fremennik cape teleport to
+ *       Rellekka, run north to docks for Torfinn.</li>
+ * </ul>
+ *
+ * <p>Guards three properties per source:
+ * <ol>
+ *   <li>Diary alternative is at {@code conditionalAlternatives[0]} with the
+ *       expected single-entry {@code diaries} list.</li>
+ *   <li>B2's POH alternative still exists at {@code conditionalAlternatives[1]}
+ *       with its original {@code pohTeleports} value preserved.</li>
+ *   <li>The base step's {@code description} is untouched (the stacking edit
+ *       only touched {@code conditionalAlternatives}).</li>
+ * </ol>
+ *
+ * <p>Diary string format follows the existing {@code SourceRequirements.diaries}
+ * convention {@code <AREA>_<TIER>} where {@code AREA} matches a
+ * {@link com.collectionloghelper.player.DiaryRegion} enum constant
+ * ({@code KOUREND}, {@code FREMENNIK}) and {@code TIER} matches a
+ * {@link com.collectionloghelper.player.DiaryTier} enum constant
+ * ({@code HARD}).
+ */
+public class C6B3OverlapRegressionTest
+{
+	private static final String KOUREND_HARD = "KOUREND_HARD";
+	private static final String FREMENNIK_HARD = "FREMENNIK_HARD";
+
+	private DropRateDatabase database;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		database = new DropRateDatabase();
+
+		Gson gson = new GsonBuilder().create();
+		Field gsonField = DropRateDatabase.class.getDeclaredField("gson");
+		gsonField.setAccessible(true);
+		gsonField.set(database, gson);
+
+		database.load();
+	}
+
+	@Test
+	public void chambersOfXericStacksKourendHardAheadOfXericsTalisman()
+	{
+		assertStackedDiaryAndPoh(
+			"Chambers of Xeric",
+			KOUREND_HARD,
+			"XERICS_TALISMAN",
+			"Xeric's Heart",
+			"Use Xeric's talisman to teleport to Mount Quidamortem");
+	}
+
+	@Test
+	public void generalGraardorStacksFremennikHardAheadOfJewelleryBox()
+	{
+		assertStackedDiaryAndPoh(
+			"General Graardor",
+			FREMENNIK_HARD,
+			"JEWELLERY_BOX_FANCY",
+			"Goblin Village",
+			"Teleport to Trollheim and run north to the God Wars Dungeon entrance");
+	}
+
+	@Test
+	public void vorkathStacksFremennikHardAheadOfMountedGlory()
+	{
+		assertStackedDiaryAndPoh(
+			"Vorkath",
+			FREMENNIK_HARD,
+			"MOUNTED_GLORY",
+			"Fremennik cape",
+			"Travel to Rellekka docks, sail to Ungael Island via Torfinn");
+	}
+
+	@Test
+	public void vorkathMountedGloryAlternativeNoLongerClaimsGamesNecklaceRoute()
+	{
+		// Collateral fix from #630 review (MEDIUM): the original copy claimed
+		// a games necklace from Edgeville reaches Rellekka. It does not.
+		CollectionLogSource source = findSource("Vorkath");
+		assertNotNull(source, "Expected source: Vorkath");
+		GuidanceStep firstStep = source.getGuidanceSteps().get(0);
+		List<ConditionalAlternative> alternatives = firstStep.getConditionalAlternatives();
+		ConditionalAlternative pohAlt = findPohAlternative(alternatives, "MOUNTED_GLORY");
+		assertNotNull(pohAlt, "Vorkath: expected MOUNTED_GLORY POH alternative");
+
+		String desc = pohAlt.getDescription();
+		assertNotNull(desc, "Vorkath: MOUNTED_GLORY alternative must declare description");
+		assertTrue(
+			!desc.contains("games necklace"),
+			"Vorkath: MOUNTED_GLORY description must not claim a games necklace route; got: " + desc);
+		assertTrue(
+			desc.contains("onward to Rellekka docks"),
+			"Vorkath: MOUNTED_GLORY description should describe an onward Rellekka route; got: " + desc);
+	}
+
+	private void assertStackedDiaryAndPoh(
+		String sourceName,
+		String expectedDiary,
+		String expectedPohTeleport,
+		String diaryDescriptionKeyword,
+		String baseStepDescriptionSubstring)
+	{
+		CollectionLogSource source = findSource(sourceName);
+		assertNotNull(source, "Expected source: " + sourceName);
+		assertNotNull(source.getGuidanceSteps(),
+			sourceName + ": guidanceSteps must not be null");
+		assertTrue(!source.getGuidanceSteps().isEmpty(),
+			sourceName + ": guidanceSteps must not be empty");
+
+		GuidanceStep firstStep = source.getGuidanceSteps().get(0);
+
+		// (3) Base step description preserved.
+		assertNotNull(firstStep.getDescription(),
+			sourceName + ": first step description must not be null");
+		assertTrue(
+			firstStep.getDescription().contains(baseStepDescriptionSubstring),
+			sourceName + ": base step description should still contain '"
+				+ baseStepDescriptionSubstring + "'; got: " + firstStep.getDescription());
+
+		List<ConditionalAlternative> alternatives = firstStep.getConditionalAlternatives();
+		assertNotNull(alternatives,
+			sourceName + ": first step must declare conditionalAlternatives");
+		assertTrue(alternatives.size() >= 2,
+			sourceName + ": expected at least 2 conditional alternatives (diary + POH); got: "
+				+ alternatives.size());
+
+		// (1) Diary alternative at index [0].
+		ConditionalAlternative diaryAlt = alternatives.get(0);
+		SourceRequirements diaryReqs = diaryAlt.getRequirements();
+		assertNotNull(diaryReqs,
+			sourceName + ": conditionalAlternatives[0] must declare requirements");
+		assertEquals(
+			List.of(expectedDiary),
+			diaryReqs.getDiaries(),
+			sourceName + ": conditionalAlternatives[0] must declare diaries = ["
+				+ expectedDiary + "]");
+		assertNotNull(diaryAlt.getDescription(),
+			sourceName + ": diary alternative must override description");
+		assertTrue(
+			diaryAlt.getDescription().contains(diaryDescriptionKeyword),
+			sourceName + ": diary alternative description should mention '"
+				+ diaryDescriptionKeyword + "'; got: " + diaryAlt.getDescription());
+		assertNotNull(diaryAlt.getTravelTip(),
+			sourceName + ": diary alternative must override travelTip");
+
+		// (2) B2 POH alternative at index [1], preserved.
+		ConditionalAlternative pohAlt = alternatives.get(1);
+		SourceRequirements pohReqs = pohAlt.getRequirements();
+		assertNotNull(pohReqs,
+			sourceName + ": conditionalAlternatives[1] must declare requirements");
+		assertEquals(
+			List.of(expectedPohTeleport),
+			pohReqs.getPohTeleports(),
+			sourceName + ": conditionalAlternatives[1] must declare pohTeleports = ["
+				+ expectedPohTeleport + "]");
+		assertNotNull(pohAlt.getDescription(),
+			sourceName + ": POH alternative must retain description");
+		assertNotNull(pohAlt.getTravelTip(),
+			sourceName + ": POH alternative must retain travelTip");
+	}
+
+	private static ConditionalAlternative findPohAlternative(
+		List<ConditionalAlternative> alternatives, String expectedPohTeleport)
+	{
+		for (ConditionalAlternative alt : alternatives)
+		{
+			SourceRequirements reqs = alt.getRequirements();
+			if (reqs == null)
+			{
+				continue;
+			}
+			List<String> pohTeleports = reqs.getPohTeleports();
+			if (pohTeleports != null && pohTeleports.contains(expectedPohTeleport))
+			{
+				return alt;
+			}
+		}
+		return null;
+	}
+
+	private CollectionLogSource findSource(String name)
+	{
+		for (CollectionLogSource source : database.getAllSources())
+		{
+			if (name.equals(source.getName()))
+			{
+				return source;
+			}
+		}
+		return null;
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #631 (C6 B3 non-overlap) for the three top-20 sources that needed B2's POH-teleport alternatives (#630) merged first. Stacks one diary alternative ahead of the existing B2 POH alternative on each source's first travel/arrive step.

| # | Source | New diary alt | Stacked ahead of |
|---|---|---|---|
| 1 | Chambers of Xeric | `KOUREND_HARD` -> Xeric's Heart teleport (Lovakengj, ~2 tiles from prep room) | `XERICS_TALISMAN` |
| 5 | General Graardor | `FREMENNIK_HARD` -> Trollheim-teleport skip via Goblin Village agility shortcut | `JEWELLERY_BOX_FANCY` |
| 13 | Vorkath | `FREMENNIK_HARD` -> Fremennik cape to Rellekka, run north to docks for Torfinn | `MOUNTED_GLORY` |

Stacking pattern matches the scoping doc: the diary alt sits at `conditionalAlternatives[0]` so the sequencer evaluates it first; the B2 POH alt shifts to `[1]`; the base (unrestricted) step description is untouched.

### Diary enum verification

Verified against `DiaryRegion.java`:
- Kourend region constant is `KOUREND` (not the Quest Helper-era typo `KOURENG`). Diary string: `KOUREND_HARD`.
- Fremennik region constant is `FREMENNIK`. Diary string: `FREMENNIK_HARD`.

Both strings round-trip through `Varbits.DIARY_<REGION>_<TIER>` per `DiaryTierStateImpl`'s lookup.

### Collateral fix

Vorkath's existing `MOUNTED_GLORY` alternative previously read: *"POH mounted glory -> Edgeville fallback, then use a games necklace or other transport north to Rellekka docks and sail to Ungael"*. A games necklace from Edgeville doesn't go to Rellekka. Reworded to drop the games-necklace claim and describe the onward route generically. Flagged as MEDIUM in #630's review.

## Test plan

- [x] `./gradlew test --tests "com.collectionloghelper.data.C6B3OverlapRegressionTest"` passes (4 tests).
- [x] `./gradlew build` passes — full suite + `lintDropRates` green.
- [x] `C6B3OverlapRegressionTest` per source asserts: diary alt at `[0]` with expected `diaries` list, B2 POH alt at `[1]` with original `pohTeleports` preserved, base step description still contains its pre-edit substring. Adds an explicit guard that Vorkath's `MOUNTED_GLORY` description no longer mentions a games necklace and does describe an onward Rellekka route.
- [x] `C6B2RegressionTest` updated to look up the POH alternative by its `pohTeleports` value rather than asserting it is the only entry at index `[0]`. The new helper stays forward-compatible with later batches that stack additional alternatives (diary, equipped-item, etc.) ahead of the POH route.
- [x] Manual spot-check: only General Graardor was edited among the four GWD bosses sharing the Trollheim travel step (Zilyana / K'ril / Kree'arra deliberately left for later batches per scope).