### PR TITLE
feat(schema): B1 Phase 1+2 - additive conditionTree composable conditions (no pilot)

### DIFF
--- a/src/main/java/com/collectionloghelper/data/GuidanceStep.java
+++ b/src/main/java/com/collectionloghelper/data/GuidanceStep.java
@@ -29,6 +29,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import com.collectionloghelper.data.condition.ConditionNode;
 import javax.annotation.Nullable;
 import lombok.Value;
 
@@ -264,6 +265,27 @@ public class GuidanceStep
 	@Nullable
 	String dynamicTargetEvaluator;
 
+	/**
+	 * Optional composable boolean tree (AND / OR / NOT over the 11 atomic
+	 * {@link CompletionCondition} leaves) describing when this step is
+	 * complete (B1 Phase 1+2).
+	 *
+	 * <p>When non-null, the tree wins over the flat {@link #completionCondition}
+	 * enum + supporting fields. When null (the default for all 225 existing
+	 * sources), the legacy flat-enum path runs unchanged.
+	 *
+	 * <p>JSON shape is documented in
+	 * {@link com.collectionloghelper.data.condition.ConditionNodeDeserializer}.
+	 * Authors should only set this field when the step's completion is genuinely
+	 * conjunctive or disjunctive over multiple atomic conditions; a single-leaf
+	 * tree adds no value over the flat enum.
+	 *
+	 * <p>Phase 1+2 lands the schema and evaluator; no production source sets
+	 * this field. Phase 3 (separate PR) introduces the first pilot wiring.
+	 */
+	@Nullable
+	ConditionNode conditionTree;
+
 	public int getCompletionDistance()
 	{
 		return completionDistance > 0 ? completionDistance : 5;
@@ -490,7 +512,8 @@ public class GuidanceStep
 			null, // merged steps don't carry alternatives (already resolved)
 			this.section,
 			null, // waypoints: merged steps inherit null; authors set waypoints on the base step
-			this.dynamicTargetEvaluator
+			this.dynamicTargetEvaluator,
+			this.conditionTree // tree is inherited from base; alternatives do not override it in B1
 		);
 	}
 }

--- a/src/main/java/com/collectionloghelper/data/condition/AndNode.java
+++ b/src/main/java/com/collectionloghelper/data/condition/AndNode.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data.condition;
+
+import java.util.Collections;
+import java.util.List;
+import lombok.Value;
+
+/**
+ * Conjunction: satisfied when every child evaluates true. Short-circuits
+ * on the first {@code false} child.
+ *
+ * <p>An empty child list is treated as <em>vacuously true</em>, matching the
+ * boolean-algebra identity for AND over zero operands. Authors should not
+ * ship empty-child trees in production data; the deserializer logs a warning
+ * but accepts them for test fixtures.
+ */
+@Value
+public class AndNode implements ConditionNode
+{
+	List<ConditionNode> children;
+
+	@Override
+	public boolean evaluate(ConditionEvaluationContext ctx)
+	{
+		if (children == null || children.isEmpty())
+		{
+			return true;
+		}
+		for (ConditionNode child : children)
+		{
+			if (child == null || !child.evaluate(ctx))
+			{
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/** Children list, defensively wrapped (never null, unmodifiable). */
+	public List<ConditionNode> childrenView()
+	{
+		return children == null ? Collections.emptyList() : Collections.unmodifiableList(children);
+	}
+}

--- a/src/main/java/com/collectionloghelper/data/condition/ConditionEvaluationContext.java
+++ b/src/main/java/com/collectionloghelper/data/condition/ConditionEvaluationContext.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data.condition;
+
+import com.collectionloghelper.data.PlayerCollectionState;
+import com.collectionloghelper.data.PlayerInventoryState;
+import javax.annotation.Nullable;
+import lombok.Value;
+import net.runelite.api.coords.WorldPoint;
+
+/**
+ * Snapshot of live state passed to {@link ConditionNode#evaluate}.
+ *
+ * <p>Aggregates the five input sources the flat-enum
+ * {@link com.collectionloghelper.guidance.CompletionChecker} reads today:
+ * <ul>
+ *   <li>{@link PlayerInventoryState} - for inventory/equipment checks.</li>
+ *   <li>{@link PlayerCollectionState} - for ITEM_OBTAINED checks against the
+ *       collection log.</li>
+ *   <li>{@link WorldPoint} player location - for ARRIVE_AT_TILE,
+ *       ARRIVE_AT_ZONE, PLAYER_ON_PLANE.</li>
+ *   <li>Last in-flight event values - last NPC death id, last chat message,
+ *       last varbit snapshot map - so event-driven leaves can be evaluated
+ *       inside the same tick the event fired.</li>
+ * </ul>
+ *
+ * <p>All event fields are {@code @Nullable}. Tree evaluation MUST handle the
+ * "no event yet this tick" case by returning false from the affected leaf,
+ * matching the legacy behaviour of
+ * {@link com.collectionloghelper.guidance.CompletionChecker#isStepAlreadySatisfied}
+ * which returns false for event-driven conditions.
+ *
+ * <p>For varbits, callers pass a single {@code lastVarbitId} +
+ * {@code lastVarbitValue}; the leaf only matches when the id matches and
+ * the value clears its threshold. This mirrors the existing
+ * {@code isVarbitAtLeastSatisfying(step, varbitId, value)} signature.
+ */
+@Value
+public class ConditionEvaluationContext
+{
+	PlayerInventoryState inventoryState;
+	PlayerCollectionState collectionState;
+
+	@Nullable
+	WorldPoint playerLocation;
+
+	/** Item id from the most recent collection-log obtained event, or -1. */
+	int lastObtainedItemId;
+
+	/** NPC id from the most recent ACTOR_DEATH event, or -1. */
+	int lastDeadNpcId;
+
+	/** NPC id from the most recent NPC_TALKED_TO event, or -1. */
+	int lastInteractedNpcId;
+
+	/** Chat message text from the most recent CHAT_MESSAGE_RECEIVED event, or null. */
+	@Nullable
+	String lastChatMessage;
+
+	/** Varbit id from the most recent varbit-change event, or -1. */
+	int lastVarbitId;
+
+	/** Varbit value from the most recent varbit-change event, or 0. */
+	int lastVarbitValue;
+
+	/**
+	 * Builds a context that only carries player-state inputs (no in-flight
+	 * events). Event-driven leaves will evaluate to false. Convenience for
+	 * fast-forward / skip-chain evaluation where only persistent state is
+	 * relevant.
+	 */
+	public static ConditionEvaluationContext stateOnly(
+		PlayerInventoryState inventoryState,
+		PlayerCollectionState collectionState,
+		@Nullable WorldPoint playerLocation)
+	{
+		return new ConditionEvaluationContext(
+			inventoryState, collectionState, playerLocation,
+			-1, -1, -1, null, -1, 0);
+	}
+}

--- a/src/main/java/com/collectionloghelper/data/condition/ConditionNode.java
+++ b/src/main/java/com/collectionloghelper/data/condition/ConditionNode.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data.condition;
+
+/**
+ * One node in a boolean tree composed over the 11 atomic
+ * {@link com.collectionloghelper.data.CompletionCondition} leaves.
+ *
+ * <p>Tier B1 Phase 1+2 - additive schema only. Existing 225 sources continue
+ * to use the flat enum + supporting fields on
+ * {@link com.collectionloghelper.data.GuidanceStep}; a step opts in to a
+ * composable tree by setting its {@code conditionTree} field.
+ *
+ * <p>Implementations: {@link AndNode}, {@link OrNode}, {@link NotNode},
+ * {@link LeafNode}. The set is intentionally closed.
+ *
+ * <p>See {@code docs/contributor-guide/b1-composable-conditions-scoping.md}
+ * for the full design rationale (Option B - additive sibling field).
+ */
+public interface ConditionNode
+{
+	/**
+	 * Evaluates the node against the supplied context. The context aggregates
+	 * the live state that the existing flat-enum
+	 * {@link com.collectionloghelper.guidance.CompletionChecker} already reads
+	 * (player location, inventory, collection log, last varbit / chat / NPC
+	 * death event).
+	 *
+	 * <p>Evaluation must be pure: no caches mutated, no events fired, no
+	 * side effects on the context.
+	 *
+	 * @param ctx the snapshot of live state against which to evaluate
+	 * @return true if the boolean expression rooted at this node is satisfied
+	 */
+	boolean evaluate(ConditionEvaluationContext ctx);
+}

--- a/src/main/java/com/collectionloghelper/data/condition/ConditionNodeDeserializer.java
+++ b/src/main/java/com/collectionloghelper/data/condition/ConditionNodeDeserializer.java
@@ -1,0 +1,331 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data.condition;
+
+import com.collectionloghelper.data.CompletionCondition;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Gson adapter that deserialises the {@code conditionTree} JSON shape into a
+ * {@link ConditionNode} tree.
+ *
+ * <p>Discriminator is the single recognised top-level key on each object:
+ * <ul>
+ *   <li>{@code and} - array of child trees, builds {@link AndNode}.</li>
+ *   <li>{@code or} - array of child trees, builds {@link OrNode}.</li>
+ *   <li>{@code not} - single child tree, builds {@link NotNode}.</li>
+ *   <li>leaf-type-keys (lower-case form of each {@link CompletionCondition}
+ *       enum value), builds {@link LeafNode}.</li>
+ * </ul>
+ *
+ * <p>Leaf shapes:
+ * <pre>
+ *   { "item_obtained": 12345 }
+ *   { "inventory_has_item": 12345, "count": 2 }
+ *   { "inventory_not_has_item": 12345 }
+ *   { "arrive_at_tile": [3200, 3200, 0], "distance": 5 }
+ *   { "arrive_at_zone": [3200, 3200, 3210, 3210, 0] }
+ *   { "npc_talked_to": 1234 }
+ *   { "actor_death": 1234 }
+ *   { "actor_death": 0, "npc_ids": [2042, 2043, 2044] }
+ *   { "player_on_plane": 2 }
+ *   { "chat_message_received": "You have completed.*" }
+ *   { "varbit_at_least": 1234, "value": 5 }
+ *   { "manual": true }
+ * </pre>
+ *
+ * <p>Unknown discriminators raise {@link JsonParseException}. Empty AND/OR
+ * child lists and null NOT children parse successfully (the node's
+ * {@code evaluate} method handles the vacuous case explicitly).
+ */
+@Slf4j
+public class ConditionNodeDeserializer implements JsonDeserializer<ConditionNode>
+{
+	private static final String KEY_AND = "and";
+	private static final String KEY_OR = "or";
+	private static final String KEY_NOT = "not";
+
+	private static final String LEAF_ITEM_OBTAINED = "item_obtained";
+	private static final String LEAF_INVENTORY_HAS_ITEM = "inventory_has_item";
+	private static final String LEAF_INVENTORY_NOT_HAS_ITEM = "inventory_not_has_item";
+	private static final String LEAF_ARRIVE_AT_TILE = "arrive_at_tile";
+	private static final String LEAF_ARRIVE_AT_ZONE = "arrive_at_zone";
+	private static final String LEAF_NPC_TALKED_TO = "npc_talked_to";
+	private static final String LEAF_ACTOR_DEATH = "actor_death";
+	private static final String LEAF_PLAYER_ON_PLANE = "player_on_plane";
+	private static final String LEAF_CHAT_MESSAGE_RECEIVED = "chat_message_received";
+	private static final String LEAF_VARBIT_AT_LEAST = "varbit_at_least";
+	private static final String LEAF_MANUAL = "manual";
+
+	@Override
+	public ConditionNode deserialize(JsonElement element, Type typeOfT, JsonDeserializationContext context)
+	{
+		if (element == null || element.isJsonNull())
+		{
+			return null;
+		}
+		if (!element.isJsonObject())
+		{
+			throw new JsonParseException("conditionTree node must be a JSON object, got: " + element);
+		}
+		JsonObject obj = element.getAsJsonObject();
+
+		if (obj.has(KEY_AND))
+		{
+			return new AndNode(parseChildList(obj.get(KEY_AND), context, KEY_AND));
+		}
+		if (obj.has(KEY_OR))
+		{
+			return new OrNode(parseChildList(obj.get(KEY_OR), context, KEY_OR));
+		}
+		if (obj.has(KEY_NOT))
+		{
+			JsonElement childEl = obj.get(KEY_NOT);
+			ConditionNode child = childEl == null || childEl.isJsonNull()
+				? null
+				: deserialize(childEl, ConditionNode.class, context);
+			return new NotNode(child);
+		}
+		return parseLeaf(obj);
+	}
+
+	private List<ConditionNode> parseChildList(JsonElement childrenEl, JsonDeserializationContext context, String key)
+	{
+		if (childrenEl == null || childrenEl.isJsonNull())
+		{
+			log.warn("conditionTree '{}' has null children; treating as empty", key);
+			return new ArrayList<>();
+		}
+		if (!childrenEl.isJsonArray())
+		{
+			throw new JsonParseException("conditionTree '" + key + "' must be a JSON array, got: " + childrenEl);
+		}
+		JsonArray arr = childrenEl.getAsJsonArray();
+		List<ConditionNode> out = new ArrayList<>(arr.size());
+		for (JsonElement e : arr)
+		{
+			out.add(deserialize(e, ConditionNode.class, context));
+		}
+		return out;
+	}
+
+	private ConditionNode parseLeaf(JsonObject obj)
+	{
+		// Each leaf-type key is mutually exclusive: the first match wins.
+		if (obj.has(LEAF_ITEM_OBTAINED))
+		{
+			return leaf(CompletionCondition.ITEM_OBTAINED).itemId(intAt(obj, LEAF_ITEM_OBTAINED)).build();
+		}
+		if (obj.has(LEAF_INVENTORY_HAS_ITEM))
+		{
+			return leaf(CompletionCondition.INVENTORY_HAS_ITEM)
+				.itemId(intAt(obj, LEAF_INVENTORY_HAS_ITEM))
+				.count(optionalInt(obj, "count"))
+				.build();
+		}
+		if (obj.has(LEAF_INVENTORY_NOT_HAS_ITEM))
+		{
+			return leaf(CompletionCondition.INVENTORY_NOT_HAS_ITEM)
+				.itemId(intAt(obj, LEAF_INVENTORY_NOT_HAS_ITEM))
+				.build();
+		}
+		if (obj.has(LEAF_ARRIVE_AT_TILE))
+		{
+			return leaf(CompletionCondition.ARRIVE_AT_TILE)
+				.tile(intArrayAt(obj, LEAF_ARRIVE_AT_TILE, 3))
+				.distance(optionalInt(obj, "distance"))
+				.build();
+		}
+		if (obj.has(LEAF_ARRIVE_AT_ZONE))
+		{
+			return leaf(CompletionCondition.ARRIVE_AT_ZONE)
+				.zone(intArrayAt(obj, LEAF_ARRIVE_AT_ZONE, 5))
+				.build();
+		}
+		if (obj.has(LEAF_NPC_TALKED_TO))
+		{
+			return leaf(CompletionCondition.NPC_TALKED_TO)
+				.npcId(intAt(obj, LEAF_NPC_TALKED_TO))
+				.build();
+		}
+		if (obj.has(LEAF_ACTOR_DEATH))
+		{
+			int primary = intAt(obj, LEAF_ACTOR_DEATH);
+			return leaf(CompletionCondition.ACTOR_DEATH)
+				.npcId(primary)
+				.npcIds(optionalIntList(obj, "npc_ids"))
+				.build();
+		}
+		if (obj.has(LEAF_PLAYER_ON_PLANE))
+		{
+			return leaf(CompletionCondition.PLAYER_ON_PLANE)
+				.plane(intAt(obj, LEAF_PLAYER_ON_PLANE))
+				.build();
+		}
+		if (obj.has(LEAF_CHAT_MESSAGE_RECEIVED))
+		{
+			return leaf(CompletionCondition.CHAT_MESSAGE_RECEIVED)
+				.chatPattern(stringAt(obj, LEAF_CHAT_MESSAGE_RECEIVED))
+				.build();
+		}
+		if (obj.has(LEAF_VARBIT_AT_LEAST))
+		{
+			return leaf(CompletionCondition.VARBIT_AT_LEAST)
+				.varbitId(intAt(obj, LEAF_VARBIT_AT_LEAST))
+				.varbitValue(optionalInt(obj, "value"))
+				.build();
+		}
+		if (obj.has(LEAF_MANUAL))
+		{
+			return leaf(CompletionCondition.MANUAL).build();
+		}
+		throw new JsonParseException("conditionTree node has no recognised discriminator key: " + obj);
+	}
+
+	private static int intAt(JsonObject obj, String key)
+	{
+		JsonElement el = obj.get(key);
+		if (el == null || el.isJsonNull() || !el.isJsonPrimitive())
+		{
+			throw new JsonParseException("conditionTree '" + key + "' must be a primitive int");
+		}
+		return el.getAsInt();
+	}
+
+	private static Integer optionalInt(JsonObject obj, String key)
+	{
+		JsonElement el = obj.get(key);
+		if (el == null || el.isJsonNull() || !el.isJsonPrimitive())
+		{
+			return null;
+		}
+		return el.getAsInt();
+	}
+
+	private static String stringAt(JsonObject obj, String key)
+	{
+		JsonElement el = obj.get(key);
+		if (el == null || el.isJsonNull() || !el.isJsonPrimitive())
+		{
+			throw new JsonParseException("conditionTree '" + key + "' must be a primitive string");
+		}
+		return el.getAsString();
+	}
+
+	private static int[] intArrayAt(JsonObject obj, String key, int expectedLength)
+	{
+		JsonElement el = obj.get(key);
+		if (el == null || !el.isJsonArray())
+		{
+			throw new JsonParseException("conditionTree '" + key + "' must be a JSON array of length " + expectedLength);
+		}
+		JsonArray arr = el.getAsJsonArray();
+		if (arr.size() != expectedLength)
+		{
+			throw new JsonParseException("conditionTree '" + key + "' must have exactly " + expectedLength
+				+ " entries, got " + arr.size());
+		}
+		int[] out = new int[expectedLength];
+		for (int i = 0; i < expectedLength; i++)
+		{
+			out[i] = arr.get(i).getAsInt();
+		}
+		return out;
+	}
+
+	private static List<Integer> optionalIntList(JsonObject obj, String key)
+	{
+		JsonElement el = obj.get(key);
+		if (el == null || el.isJsonNull())
+		{
+			return null;
+		}
+		if (!el.isJsonArray())
+		{
+			throw new JsonParseException("conditionTree '" + key + "' must be a JSON array");
+		}
+		JsonArray arr = el.getAsJsonArray();
+		List<Integer> out = new ArrayList<>(arr.size());
+		for (JsonElement e : arr)
+		{
+			out.add(e.getAsInt());
+		}
+		return out;
+	}
+
+	private static LeafBuilder leaf(CompletionCondition type)
+	{
+		return new LeafBuilder(type);
+	}
+
+	/** Minimal fluent builder for {@link LeafNode}; deserializer-internal. */
+	private static final class LeafBuilder
+	{
+		private final CompletionCondition type;
+		private Integer itemId;
+		private Integer count;
+		private int[] tile;
+		private Integer distance;
+		private int[] zone;
+		private Integer npcId;
+		private List<Integer> npcIds;
+		private Integer plane;
+		private String chatPattern;
+		private Integer varbitId;
+		private Integer varbitValue;
+
+		LeafBuilder(CompletionCondition type)
+		{
+			this.type = type;
+		}
+
+		LeafBuilder itemId(Integer v) { this.itemId = v; return this; }
+		LeafBuilder count(Integer v) { this.count = v; return this; }
+		LeafBuilder tile(int[] v) { this.tile = v; return this; }
+		LeafBuilder distance(Integer v) { this.distance = v; return this; }
+		LeafBuilder zone(int[] v) { this.zone = v; return this; }
+		LeafBuilder npcId(Integer v) { this.npcId = v; return this; }
+		LeafBuilder npcIds(List<Integer> v) { this.npcIds = v; return this; }
+		LeafBuilder plane(Integer v) { this.plane = v; return this; }
+		LeafBuilder chatPattern(String v) { this.chatPattern = v; return this; }
+		LeafBuilder varbitId(Integer v) { this.varbitId = v; return this; }
+		LeafBuilder varbitValue(Integer v) { this.varbitValue = v; return this; }
+
+		LeafNode build()
+		{
+			return new LeafNode(type, itemId, count, tile, distance, zone,
+				npcId, npcIds, plane, chatPattern, varbitId, varbitValue);
+		}
+	}
+}

--- a/src/main/java/com/collectionloghelper/data/condition/ConditionNodes.java
+++ b/src/main/java/com/collectionloghelper/data/condition/ConditionNodes.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data.condition;
+
+import com.collectionloghelper.data.CompletionCondition;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Static factories for terse {@link ConditionNode} construction in tests and
+ * (eventually) Phase 3 pilot wiring. Not used in the deserialization path.
+ */
+public final class ConditionNodes
+{
+	private ConditionNodes() { }
+
+	public static AndNode and(ConditionNode... children)
+	{
+		return new AndNode(Arrays.asList(children));
+	}
+
+	public static OrNode or(ConditionNode... children)
+	{
+		return new OrNode(Arrays.asList(children));
+	}
+
+	public static NotNode not(ConditionNode child)
+	{
+		return new NotNode(child);
+	}
+
+	public static LeafNode itemObtained(int itemId)
+	{
+		return new LeafNode(CompletionCondition.ITEM_OBTAINED, itemId,
+			null, null, null, null, null, null, null, null, null, null);
+	}
+
+	public static LeafNode inventoryHasItem(int itemId, int count)
+	{
+		return new LeafNode(CompletionCondition.INVENTORY_HAS_ITEM, itemId, count,
+			null, null, null, null, null, null, null, null, null);
+	}
+
+	public static LeafNode inventoryNotHasItem(int itemId)
+	{
+		return new LeafNode(CompletionCondition.INVENTORY_NOT_HAS_ITEM, itemId,
+			null, null, null, null, null, null, null, null, null, null);
+	}
+
+	public static LeafNode arriveAtTile(int x, int y, int plane, int distance)
+	{
+		return new LeafNode(CompletionCondition.ARRIVE_AT_TILE, null, null,
+			new int[]{x, y, plane}, distance, null, null, null, null, null, null, null);
+	}
+
+	public static LeafNode arriveAtZone(int minX, int minY, int maxX, int maxY, int plane)
+	{
+		return new LeafNode(CompletionCondition.ARRIVE_AT_ZONE, null, null, null, null,
+			new int[]{minX, minY, maxX, maxY, plane}, null, null, null, null, null, null);
+	}
+
+	public static LeafNode npcTalkedTo(int npcId)
+	{
+		return new LeafNode(CompletionCondition.NPC_TALKED_TO, null, null, null, null, null,
+			npcId, null, null, null, null, null);
+	}
+
+	public static LeafNode actorDeath(int npcId)
+	{
+		return new LeafNode(CompletionCondition.ACTOR_DEATH, null, null, null, null, null,
+			npcId, null, null, null, null, null);
+	}
+
+	public static LeafNode actorDeath(int primaryNpcId, List<Integer> alternateIds)
+	{
+		return new LeafNode(CompletionCondition.ACTOR_DEATH, null, null, null, null, null,
+			primaryNpcId, alternateIds, null, null, null, null);
+	}
+
+	public static LeafNode playerOnPlane(int plane)
+	{
+		return new LeafNode(CompletionCondition.PLAYER_ON_PLANE, null, null, null, null, null,
+			null, null, plane, null, null, null);
+	}
+
+	public static LeafNode chatMessageReceived(String pattern)
+	{
+		return new LeafNode(CompletionCondition.CHAT_MESSAGE_RECEIVED, null, null, null, null, null,
+			null, null, null, pattern, null, null);
+	}
+
+	public static LeafNode varbitAtLeast(int varbitId, int value)
+	{
+		return new LeafNode(CompletionCondition.VARBIT_AT_LEAST, null, null, null, null, null,
+			null, null, null, null, varbitId, value);
+	}
+
+	public static LeafNode manual()
+	{
+		return new LeafNode(CompletionCondition.MANUAL, null, null, null, null, null,
+			null, null, null, null, null, null);
+	}
+}

--- a/src/main/java/com/collectionloghelper/data/condition/LeafNode.java
+++ b/src/main/java/com/collectionloghelper/data/condition/LeafNode.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data.condition;
+
+import com.collectionloghelper.data.CompletionCondition;
+import com.collectionloghelper.data.Zone;
+import java.util.List;
+import java.util.regex.Pattern;
+import javax.annotation.Nullable;
+import lombok.Value;
+import net.runelite.api.coords.WorldPoint;
+
+/**
+ * Wraps a single atomic {@link CompletionCondition} value plus its supporting
+ * fields. Leaf evaluation mirrors the legacy
+ * {@link com.collectionloghelper.guidance.CompletionChecker} branches exactly,
+ * so a leaf carrying e.g. {@code INVENTORY_HAS_ITEM} with {@code itemId=12345}
+ * is satisfied under exactly the same player-state as the flat-enum form.
+ *
+ * <p>Supporting fields use boxed wrapper types where "absent" matters: a
+ * leaf for {@code INVENTORY_HAS_ITEM} only ever populates {@code itemId} and
+ * (optionally) {@code count}; all other fields stay null. The deserializer
+ * builds these via the leaf-type-key in the JSON shape; see
+ * {@link ConditionNodeDeserializer}.
+ *
+ * <p>Event-driven leaves ({@code ACTOR_DEATH}, {@code NPC_TALKED_TO},
+ * {@code CHAT_MESSAGE_RECEIVED}, {@code VARBIT_AT_LEAST},
+ * {@code ITEM_OBTAINED}) read their inputs from
+ * {@link ConditionEvaluationContext}'s last-event fields. When no event is
+ * present (the {@code lastXxx} field is at its sentinel) they return false.
+ * This matches legacy behaviour: in fast-forward / skip-chain evaluation
+ * those conditions cannot be satisfied without an in-flight event.
+ *
+ * <p>{@code MANUAL} leaves always return false from {@link #evaluate} - by
+ * definition the player advances them from the panel, never the tree.
+ */
+@Value
+public class LeafNode implements ConditionNode
+{
+	CompletionCondition type;
+
+	/** Item id for ITEM_OBTAINED / INVENTORY_HAS_ITEM / INVENTORY_NOT_HAS_ITEM. */
+	@Nullable
+	Integer itemId;
+
+	/** Count for INVENTORY_HAS_ITEM (defaults to 1 when null). */
+	@Nullable
+	Integer count;
+
+	/** Tile [x, y, plane] for ARRIVE_AT_TILE. */
+	@Nullable
+	int[] tile;
+
+	/** Distance threshold for ARRIVE_AT_TILE (defaults to 5 when null). */
+	@Nullable
+	Integer distance;
+
+	/** Zone [minX, minY, maxX, maxY, plane] for ARRIVE_AT_ZONE. */
+	@Nullable
+	int[] zone;
+
+	/** Primary NPC id for NPC_TALKED_TO / ACTOR_DEATH. */
+	@Nullable
+	Integer npcId;
+
+	/** Additional NPC ids for ACTOR_DEATH (multi-form bosses). */
+	@Nullable
+	List<Integer> npcIds;
+
+	/** Plane for PLAYER_ON_PLANE. */
+	@Nullable
+	Integer plane;
+
+	/** Chat pattern for CHAT_MESSAGE_RECEIVED. */
+	@Nullable
+	String chatPattern;
+
+	/** Varbit id for VARBIT_AT_LEAST. */
+	@Nullable
+	Integer varbitId;
+
+	/** Threshold for VARBIT_AT_LEAST. */
+	@Nullable
+	Integer varbitValue;
+
+	@Override
+	public boolean evaluate(ConditionEvaluationContext ctx)
+	{
+		if (type == null || ctx == null)
+		{
+			return false;
+		}
+		switch (type)
+		{
+			case ITEM_OBTAINED:
+				return evaluateItemObtained(ctx);
+			case INVENTORY_HAS_ITEM:
+				return evaluateInventoryHasItem(ctx);
+			case INVENTORY_NOT_HAS_ITEM:
+				return evaluateInventoryNotHasItem(ctx);
+			case ARRIVE_AT_TILE:
+				return evaluateArriveAtTile(ctx);
+			case ARRIVE_AT_ZONE:
+				return evaluateArriveAtZone(ctx);
+			case NPC_TALKED_TO:
+				return evaluateNpcTalkedTo(ctx);
+			case ACTOR_DEATH:
+				return evaluateActorDeath(ctx);
+			case PLAYER_ON_PLANE:
+				return evaluatePlayerOnPlane(ctx);
+			case CHAT_MESSAGE_RECEIVED:
+				return evaluateChatMessage(ctx);
+			case VARBIT_AT_LEAST:
+				return evaluateVarbitAtLeast(ctx);
+			case MANUAL:
+				return false;
+			default:
+				return false;
+		}
+	}
+
+	private boolean evaluateItemObtained(ConditionEvaluationContext ctx)
+	{
+		if (itemId == null)
+		{
+			return false;
+		}
+		// Honour an in-flight obtained event when present, otherwise consult
+		// the persistent collection-log state. The OR matches the legacy
+		// CompletionChecker which can satisfy on either signal.
+		if (ctx.getLastObtainedItemId() == itemId)
+		{
+			return true;
+		}
+		return ctx.getCollectionState() != null
+			&& ctx.getCollectionState().isItemObtained(itemId);
+	}
+
+	private boolean evaluateInventoryHasItem(ConditionEvaluationContext ctx)
+	{
+		if (itemId == null || ctx.getInventoryState() == null)
+		{
+			return false;
+		}
+		int needed = count != null && count > 0 ? count : 1;
+		return ctx.getInventoryState().hasItemCount(itemId, needed);
+	}
+
+	private boolean evaluateInventoryNotHasItem(ConditionEvaluationContext ctx)
+	{
+		if (itemId == null || ctx.getInventoryState() == null)
+		{
+			return false;
+		}
+		return !ctx.getInventoryState().hasItem(itemId);
+	}
+
+	private boolean evaluateArriveAtTile(ConditionEvaluationContext ctx)
+	{
+		WorldPoint player = ctx.getPlayerLocation();
+		if (tile == null || tile.length < 3 || player == null)
+		{
+			return false;
+		}
+		int targetPlane = tile[2];
+		if (player.getPlane() != targetPlane)
+		{
+			return false;
+		}
+		int radius = distance != null && distance > 0 ? distance : 5;
+		WorldPoint target = new WorldPoint(tile[0], tile[1], targetPlane);
+		return player.distanceTo2D(target) <= radius;
+	}
+
+	private boolean evaluateArriveAtZone(ConditionEvaluationContext ctx)
+	{
+		WorldPoint player = ctx.getPlayerLocation();
+		if (zone == null || zone.length != 5 || player == null)
+		{
+			return false;
+		}
+		Zone z = new Zone(zone[0], zone[1], zone[2], zone[3], zone[4]);
+		return z.contains(player);
+	}
+
+	private boolean evaluateNpcTalkedTo(ConditionEvaluationContext ctx)
+	{
+		return npcId != null && ctx.getLastInteractedNpcId() == npcId;
+	}
+
+	private boolean evaluateActorDeath(ConditionEvaluationContext ctx)
+	{
+		int dead = ctx.getLastDeadNpcId();
+		if (dead < 0)
+		{
+			return false;
+		}
+		if (npcId != null && dead == npcId)
+		{
+			return true;
+		}
+		if (npcIds != null)
+		{
+			for (int id : npcIds)
+			{
+				if (id == dead)
+				{
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	private boolean evaluatePlayerOnPlane(ConditionEvaluationContext ctx)
+	{
+		WorldPoint player = ctx.getPlayerLocation();
+		return plane != null && player != null && player.getPlane() == plane;
+	}
+
+	private boolean evaluateChatMessage(ConditionEvaluationContext ctx)
+	{
+		String message = ctx.getLastChatMessage();
+		if (message == null || chatPattern == null)
+		{
+			return false;
+		}
+		// Compile per evaluate: trees fire at most once per tick and only when
+		// CHAT_MESSAGE_RECEIVED leaves are present, so the cost is negligible
+		// and keeping the leaf immutable+stateless simplifies equals/hashCode.
+		Pattern p = Pattern.compile(chatPattern);
+		return p.matcher(message).find();
+	}
+
+	private boolean evaluateVarbitAtLeast(ConditionEvaluationContext ctx)
+	{
+		return varbitId != null
+			&& varbitValue != null
+			&& ctx.getLastVarbitId() == varbitId
+			&& ctx.getLastVarbitValue() >= varbitValue;
+	}
+}

--- a/src/main/java/com/collectionloghelper/data/condition/NotNode.java
+++ b/src/main/java/com/collectionloghelper/data/condition/NotNode.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data.condition;
+
+import lombok.Value;
+
+/**
+ * Negation: satisfied when its single child evaluates false.
+ *
+ * <p>A null child is treated as false to keep evaluation total - the negation
+ * of "nothing" is true. Authors should not ship null-child NOT nodes.
+ */
+@Value
+public class NotNode implements ConditionNode
+{
+	ConditionNode child;
+
+	@Override
+	public boolean evaluate(ConditionEvaluationContext ctx)
+	{
+		if (child == null)
+		{
+			return true;
+		}
+		return !child.evaluate(ctx);
+	}
+}

--- a/src/main/java/com/collectionloghelper/data/condition/OrNode.java
+++ b/src/main/java/com/collectionloghelper/data/condition/OrNode.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data.condition;
+
+import java.util.Collections;
+import java.util.List;
+import lombok.Value;
+
+/**
+ * Disjunction: satisfied when any child evaluates true. Short-circuits on
+ * the first {@code true} child.
+ *
+ * <p>An empty child list is treated as <em>vacuously false</em>, matching the
+ * boolean-algebra identity for OR over zero operands. Authors should not
+ * ship empty-child trees in production data.
+ */
+@Value
+public class OrNode implements ConditionNode
+{
+	List<ConditionNode> children;
+
+	@Override
+	public boolean evaluate(ConditionEvaluationContext ctx)
+	{
+		if (children == null || children.isEmpty())
+		{
+			return false;
+		}
+		for (ConditionNode child : children)
+		{
+			if (child != null && child.evaluate(ctx))
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/** Children list, defensively wrapped (never null, unmodifiable). */
+	public List<ConditionNode> childrenView()
+	{
+		return children == null ? Collections.emptyList() : Collections.unmodifiableList(children);
+	}
+}

--- a/src/main/java/com/collectionloghelper/guidance/bosses/CerberusGuidance.java
+++ b/src/main/java/com/collectionloghelper/guidance/bosses/CerberusGuidance.java
@@ -98,7 +98,8 @@ public class CerberusGuidance implements BossGuidance
 			null,              // conditionalAlternatives
 			"Travel",          // section
 			null,              // waypoints
-			null               // dynamicTargetEvaluator
+			null,              // dynamicTargetEvaluator
+			null               // conditionTree
 		);
 
 		GuidanceStep gateStep = new GuidanceStep(
@@ -133,7 +134,8 @@ public class CerberusGuidance implements BossGuidance
 			null,              // conditionalAlternatives
 			"Travel",          // section
 			null,              // waypoints
-			null               // dynamicTargetEvaluator
+			null,              // dynamicTargetEvaluator
+			null               // conditionTree
 		);
 
 		GuidanceStep killStep = new GuidanceStep(
@@ -167,7 +169,8 @@ public class CerberusGuidance implements BossGuidance
 			null,              // conditionalAlternatives
 			"Combat",          // section
 			null,              // waypoints
-			null               // dynamicTargetEvaluator
+			null,              // dynamicTargetEvaluator
+			null               // conditionTree
 		);
 
 		return Arrays.asList(travelStep, gateStep, killStep);

--- a/src/test/java/com/collectionloghelper/data/CollectionLogSourceTest.java
+++ b/src/test/java/com/collectionloghelper/data/CollectionLogSourceTest.java
@@ -383,7 +383,8 @@ public class CollectionLogSourceTest
 			null,           // conditionalAlternatives
 			null,           // section
 			null,           // waypoints
-			null            // dynamicTargetEvaluator
+			null,            // dynamicTargetEvaluator
+			null            // conditionTree
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/data/GuidanceStepSectionTest.java
+++ b/src/test/java/com/collectionloghelper/data/GuidanceStepSectionTest.java
@@ -153,7 +153,8 @@ public class GuidanceStepSectionTest
 			null,   // conditionalAlternatives
 			section,
 			null, // waypoints
-			null  // dynamicTargetEvaluator
+			null,  // dynamicTargetEvaluator
+			null  // conditionTree
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/data/GuidanceStepTest.java
+++ b/src/test/java/com/collectionloghelper/data/GuidanceStepTest.java
@@ -333,7 +333,8 @@ public class GuidanceStepTest
 			null,           // conditionalAlternatives
 			null, // section
 			null, // waypoints
-			null  // dynamicTargetEvaluator
+			null,  // dynamicTargetEvaluator
+			null  // conditionTree
 		);
 	}
 
@@ -368,7 +369,8 @@ public class GuidanceStepTest
 			null,           // conditionalAlternatives
 			null, // section
 			null, // waypoints
-			null  // dynamicTargetEvaluator
+			null,  // dynamicTargetEvaluator
+			null  // conditionTree
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/data/condition/B1GuidanceStepIntegrationTest.java
+++ b/src/test/java/com/collectionloghelper/data/condition/B1GuidanceStepIntegrationTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data.condition;
+
+import com.collectionloghelper.data.CompletionCondition;
+import com.collectionloghelper.data.GuidanceStep;
+import com.collectionloghelper.data.PlayerCollectionState;
+import com.collectionloghelper.data.PlayerInventoryState;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * B1 Phase 1+2 integration: synthetic {@link GuidanceStep} carrying a
+ * non-null {@code conditionTree}. Verifies the contract Phase 3 will
+ * dispatch against:
+ * <ul>
+ *   <li>{@link GuidanceStep#getConditionTree()} round-trips the tree.</li>
+ *   <li>The tree's {@link ConditionNode#evaluate} drives a true/false answer
+ *       independent of the legacy flat {@code completionCondition} enum.</li>
+ *   <li>Legacy fields remain populated and accessible on the same step, so
+ *       Phase 3 can prefer the tree while keeping the flat enum as a
+ *       fall-through.</li>
+ *   <li>A step authored as JSON (full inline shape) deserialises with the
+ *       tree present and the flat enum unchanged.</li>
+ * </ul>
+ */
+public class B1GuidanceStepIntegrationTest
+{
+	private final Gson gson = new GsonBuilder()
+		.registerTypeAdapter(ConditionNode.class, new ConditionNodeDeserializer())
+		.create();
+
+	// -- Synthetic step with conditionTree set --------------------------------
+
+	@Test
+	public void conditionTree_wins_inventoryHasBothCoinsAndShark() throws Exception
+	{
+		ConditionNode tree = ConditionNodes.and(
+			ConditionNodes.inventoryHasItem(995, 1),
+			ConditionNodes.inventoryHasItem(385, 1));
+
+		GuidanceStep step = makeStepWithTree(tree, CompletionCondition.MANUAL);
+
+		// Tree round-trips.
+		assertNotNull(step.getConditionTree());
+		assertEquals(tree, step.getConditionTree());
+
+		// Legacy field is still observable (Phase 3 dispatcher uses this when
+		// the tree is null).
+		assertEquals(CompletionCondition.MANUAL, step.getCompletionCondition());
+
+		// Tree drives the actual answer when wired into evaluation.
+		PlayerInventoryState inv = newInventory();
+		seedInventory(inv, Map.of(995, 1, 385, 1));
+		ConditionEvaluationContext ctx = ConditionEvaluationContext.stateOnly(
+			inv, newCollection(), null);
+		assertTrue(step.getConditionTree().evaluate(ctx),
+			"tree should be satisfied when both items present");
+
+		seedInventory(inv, Map.of(995, 1));
+		assertFalse(step.getConditionTree().evaluate(ctx),
+			"tree should be unsatisfied when only coins present");
+	}
+
+	@Test
+	public void conditionTree_disagreesFromLegacyEnum_treeIsOwnAuthority() throws Exception
+	{
+		// Legacy enum says ITEM_OBTAINED of item 99999 (player has not obtained).
+		// Tree says: OR(inventory_has 995, manual=false). With coins, OR is true.
+		// The point is the tree's truth value is independent of the legacy enum,
+		// proving Phase 3 can swap dispatch source without coupling the two.
+		ConditionNode tree = ConditionNodes.or(
+			ConditionNodes.inventoryHasItem(995, 1),
+			ConditionNodes.manual());
+
+		GuidanceStep step = makeStepWithTree(tree, CompletionCondition.ITEM_OBTAINED);
+
+		PlayerInventoryState inv = newInventory();
+		seedInventory(inv, Map.of(995, 50));
+		ConditionEvaluationContext ctx = ConditionEvaluationContext.stateOnly(
+			inv, newCollection(), null);
+
+		assertTrue(step.getConditionTree().evaluate(ctx),
+			"tree (OR with inventory) should be true even though the legacy ITEM_OBTAINED would be false");
+	}
+
+	@Test
+	public void legacyStep_noConditionTree_stayssNull() throws Exception
+	{
+		GuidanceStep step = makeStepWithTree(null, CompletionCondition.MANUAL);
+		assertNull(step.getConditionTree(),
+			"a step authored without conditionTree must keep the field null - this is the "
+				+ "default behaviour for all 225 existing sources");
+	}
+
+	// -- Authored-as-JSON round-trip ------------------------------------------
+
+	@Test
+	public void inlineJson_withConditionTree_deserialisesWithBothFields() throws Exception
+	{
+		// Minimal JSON that mirrors how a future Phase 3 pilot step would be
+		// authored: flat enum kept for backwards-compat, tree added on top.
+		String json = "{"
+			+ "\"description\":\"Synthetic test step\","
+			+ "\"completionCondition\":\"MANUAL\","
+			+ "\"conditionTree\":{\"and\":[{\"inventory_has_item\":995},{\"player_on_plane\":0}]}"
+			+ "}";
+
+		GuidanceStep step = gson.fromJson(json, GuidanceStep.class);
+
+		assertNotNull(step);
+		assertEquals(CompletionCondition.MANUAL, step.getCompletionCondition());
+		assertNotNull(step.getConditionTree(),
+			"conditionTree must deserialise into a ConditionNode tree via the registered adapter");
+		assertTrue(step.getConditionTree() instanceof AndNode,
+			"root must be AndNode; got " + step.getConditionTree().getClass().getSimpleName());
+		assertEquals(2, ((AndNode) step.getConditionTree()).getChildren().size());
+	}
+
+	@Test
+	public void inlineJson_withoutConditionTree_keepsFieldNull()
+	{
+		String json = "{\"description\":\"legacy step\",\"completionCondition\":\"MANUAL\"}";
+		GuidanceStep step = gson.fromJson(json, GuidanceStep.class);
+
+		assertNotNull(step);
+		assertNull(step.getConditionTree(),
+			"a step authored without the conditionTree key must keep the field null");
+		assertEquals(CompletionCondition.MANUAL, step.getCompletionCondition());
+	}
+
+	// -- Helpers --------------------------------------------------------------
+
+	private static GuidanceStep makeStepWithTree(ConditionNode tree, CompletionCondition flat)
+	{
+		return new GuidanceStep(
+			"Synthetic step",
+			null, 0, 0, 0,
+			0, null, null, null, null, null, null, null, null,
+			flat,
+			0, 0, 0, 0, null, null,
+			0, null, null, null, null, null,
+			0, 0, false, 0, null, null, 0, 0, null, null, null, null, null,
+			null /* waypoints */, null /* dynamicTargetEvaluator */,
+			tree
+		);
+	}
+
+	private static PlayerInventoryState newInventory() throws Exception
+	{
+		Constructor<PlayerInventoryState> c = PlayerInventoryState.class.getDeclaredConstructor();
+		c.setAccessible(true);
+		return c.newInstance();
+	}
+
+	private static PlayerCollectionState newCollection() throws Exception
+	{
+		Constructor<?> c = PlayerCollectionState.class.getDeclaredConstructors()[0];
+		c.setAccessible(true);
+		Object[] args = new Object[c.getParameterCount()];
+		return (PlayerCollectionState) c.newInstance(args);
+	}
+
+	private static void seedInventory(PlayerInventoryState inv, Map<Integer, Integer> idsAndCounts) throws Exception
+	{
+		Class<?> snapshotClass = Class.forName("com.collectionloghelper.data.PlayerInventoryState$InventorySnapshot");
+		Constructor<?> sctor = snapshotClass.getDeclaredConstructor(Set.class, Map.class);
+		sctor.setAccessible(true);
+		Set<Integer> ids = new HashSet<>(idsAndCounts.keySet());
+		Object snapshot = sctor.newInstance(ids, new HashMap<>(idsAndCounts));
+
+		Field f = PlayerInventoryState.class.getDeclaredField("snapshot");
+		f.setAccessible(true);
+		f.set(inv, snapshot);
+	}
+}

--- a/src/test/java/com/collectionloghelper/data/condition/B1MigrationTest.java
+++ b/src/test/java/com/collectionloghelper/data/condition/B1MigrationTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data.condition;
+
+import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.data.DropRateDatabase;
+import com.collectionloghelper.data.GuidanceStep;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * B1 Phase 1+2 migration guard.
+ *
+ * <p>The B1 schema landing is strictly additive: a new {@code conditionTree}
+ * slot on {@link GuidanceStep}, but zero existing production sources opt in.
+ * This test loads the full production {@code drop_rates.json} and asserts that
+ * every step on every source has a null {@code conditionTree}. Phase 3 (a
+ * separate later PR) is the first opportunity to flip a single source.
+ *
+ * <p>Mirrors the B2 / B3 / B5 regression-guard pattern: walk the database,
+ * accumulate violations, fail with one readable message.
+ */
+public class B1MigrationTest
+{
+	private DropRateDatabase database;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		database = new DropRateDatabase();
+
+		Gson gson = new GsonBuilder().create();
+		Field gsonField = DropRateDatabase.class.getDeclaredField("gson");
+		gsonField.setAccessible(true);
+		gsonField.set(database, gson);
+
+		database.load();
+	}
+
+	@Test
+	public void everyStepHasNullConditionTree()
+	{
+		List<String> violations = new ArrayList<>();
+
+		for (CollectionLogSource source : database.getAllSources())
+		{
+			List<GuidanceStep> steps = source.getGuidanceSteps();
+			if (steps == null)
+			{
+				continue;
+			}
+			for (int i = 0; i < steps.size(); i++)
+			{
+				GuidanceStep step = steps.get(i);
+				if (step == null)
+				{
+					continue;
+				}
+				if (step.getConditionTree() != null)
+				{
+					violations.add(source.getName() + " step " + (i + 1)
+						+ " has non-null conditionTree; Phase 1+2 must not pilot any source");
+				}
+			}
+		}
+
+		assertTrue(violations.isEmpty(),
+			"B1 Phase 1+2 invariant violated. No production source may set conditionTree until Phase 3. Violations:\n"
+				+ String.join("\n", violations));
+	}
+
+	@Test
+	public void databaseLoadsAndProducesSources()
+	{
+		assertNotNull(database.getAllSources());
+		assertTrue(database.getAllSources().size() > 0,
+			"Production drop_rates.json must load at least one source");
+	}
+}

--- a/src/test/java/com/collectionloghelper/data/condition/ConditionNodeDeserializerTest.java
+++ b/src/test/java/com/collectionloghelper/data/condition/ConditionNodeDeserializerTest.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data.condition;
+
+import com.collectionloghelper.data.CompletionCondition;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonParseException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+/**
+ * Verifies the JSON shape of {@link ConditionNodeDeserializer}:
+ * one round-trip case per leaf type, plus composite + edge cases.
+ */
+public class ConditionNodeDeserializerTest
+{
+	private final Gson gson = new GsonBuilder()
+		.registerTypeAdapter(ConditionNode.class, new ConditionNodeDeserializer())
+		.create();
+
+	// -- Leaf shapes ----------------------------------------------------------
+
+	@Test
+	public void leaf_itemObtained()
+	{
+		LeafNode leaf = (LeafNode) gson.fromJson("{\"item_obtained\":12345}", ConditionNode.class);
+		assertEquals(CompletionCondition.ITEM_OBTAINED, leaf.getType());
+		assertEquals(12345, leaf.getItemId());
+	}
+
+	@Test
+	public void leaf_inventoryHasItem_withCount()
+	{
+		LeafNode leaf = (LeafNode) gson.fromJson(
+			"{\"inventory_has_item\":995,\"count\":3}", ConditionNode.class);
+		assertEquals(CompletionCondition.INVENTORY_HAS_ITEM, leaf.getType());
+		assertEquals(995, leaf.getItemId());
+		assertEquals(3, leaf.getCount());
+	}
+
+	@Test
+	public void leaf_inventoryHasItem_noCountDefaultsNull()
+	{
+		LeafNode leaf = (LeafNode) gson.fromJson(
+			"{\"inventory_has_item\":995}", ConditionNode.class);
+		assertEquals(995, leaf.getItemId());
+		assertNull(leaf.getCount());
+	}
+
+	@Test
+	public void leaf_inventoryNotHasItem()
+	{
+		LeafNode leaf = (LeafNode) gson.fromJson(
+			"{\"inventory_not_has_item\":4151}", ConditionNode.class);
+		assertEquals(CompletionCondition.INVENTORY_NOT_HAS_ITEM, leaf.getType());
+		assertEquals(4151, leaf.getItemId());
+	}
+
+	@Test
+	public void leaf_arriveAtTile()
+	{
+		LeafNode leaf = (LeafNode) gson.fromJson(
+			"{\"arrive_at_tile\":[3200,3300,1],\"distance\":7}", ConditionNode.class);
+		assertEquals(CompletionCondition.ARRIVE_AT_TILE, leaf.getType());
+		assertArrayEquals(new int[]{3200, 3300, 1}, leaf.getTile());
+		assertEquals(7, leaf.getDistance());
+	}
+
+	@Test
+	public void leaf_arriveAtZone()
+	{
+		LeafNode leaf = (LeafNode) gson.fromJson(
+			"{\"arrive_at_zone\":[3200,3300,3210,3310,0]}", ConditionNode.class);
+		assertEquals(CompletionCondition.ARRIVE_AT_ZONE, leaf.getType());
+		assertArrayEquals(new int[]{3200, 3300, 3210, 3310, 0}, leaf.getZone());
+	}
+
+	@Test
+	public void leaf_npcTalkedTo()
+	{
+		LeafNode leaf = (LeafNode) gson.fromJson(
+			"{\"npc_talked_to\":1234}", ConditionNode.class);
+		assertEquals(CompletionCondition.NPC_TALKED_TO, leaf.getType());
+		assertEquals(1234, leaf.getNpcId());
+	}
+
+	@Test
+	public void leaf_actorDeath_withAlternateIds()
+	{
+		LeafNode leaf = (LeafNode) gson.fromJson(
+			"{\"actor_death\":2042,\"npc_ids\":[2043,2044]}", ConditionNode.class);
+		assertEquals(CompletionCondition.ACTOR_DEATH, leaf.getType());
+		assertEquals(2042, leaf.getNpcId());
+		assertEquals(2, leaf.getNpcIds().size());
+		assertEquals(2043, leaf.getNpcIds().get(0));
+	}
+
+	@Test
+	public void leaf_playerOnPlane()
+	{
+		LeafNode leaf = (LeafNode) gson.fromJson(
+			"{\"player_on_plane\":2}", ConditionNode.class);
+		assertEquals(CompletionCondition.PLAYER_ON_PLANE, leaf.getType());
+		assertEquals(2, leaf.getPlane());
+	}
+
+	@Test
+	public void leaf_chatMessageReceived()
+	{
+		LeafNode leaf = (LeafNode) gson.fromJson(
+			"{\"chat_message_received\":\"You have.*\"}", ConditionNode.class);
+		assertEquals(CompletionCondition.CHAT_MESSAGE_RECEIVED, leaf.getType());
+		assertEquals("You have.*", leaf.getChatPattern());
+	}
+
+	@Test
+	public void leaf_varbitAtLeast()
+	{
+		LeafNode leaf = (LeafNode) gson.fromJson(
+			"{\"varbit_at_least\":4567,\"value\":5}", ConditionNode.class);
+		assertEquals(CompletionCondition.VARBIT_AT_LEAST, leaf.getType());
+		assertEquals(4567, leaf.getVarbitId());
+		assertEquals(5, leaf.getVarbitValue());
+	}
+
+	@Test
+	public void leaf_manual()
+	{
+		LeafNode leaf = (LeafNode) gson.fromJson(
+			"{\"manual\":true}", ConditionNode.class);
+		assertEquals(CompletionCondition.MANUAL, leaf.getType());
+	}
+
+	// -- Composite shapes -----------------------------------------------------
+
+	@Test
+	public void composite_and_twoLeaves()
+	{
+		ConditionNode node = gson.fromJson(
+			"{\"and\":[{\"inventory_has_item\":995},{\"player_on_plane\":0}]}",
+			ConditionNode.class);
+		assertInstanceOf(AndNode.class, node);
+		AndNode and = (AndNode) node;
+		assertEquals(2, and.getChildren().size());
+		assertInstanceOf(LeafNode.class, and.getChildren().get(0));
+		assertInstanceOf(LeafNode.class, and.getChildren().get(1));
+	}
+
+	@Test
+	public void composite_or_threeLeaves()
+	{
+		ConditionNode node = gson.fromJson(
+			"{\"or\":[{\"item_obtained\":1},{\"item_obtained\":2},{\"item_obtained\":3}]}",
+			ConditionNode.class);
+		assertInstanceOf(OrNode.class, node);
+		OrNode or = (OrNode) node;
+		assertEquals(3, or.getChildren().size());
+	}
+
+	@Test
+	public void composite_not_singleChild()
+	{
+		ConditionNode node = gson.fromJson(
+			"{\"not\":{\"inventory_has_item\":995}}", ConditionNode.class);
+		assertInstanceOf(NotNode.class, node);
+		NotNode not = (NotNode) node;
+		assertInstanceOf(LeafNode.class, not.getChild());
+	}
+
+	@Test
+	public void composite_nested_andOrNot()
+	{
+		ConditionNode node = gson.fromJson(
+			"{\"and\":["
+				+ "{\"or\":[{\"item_obtained\":1},{\"item_obtained\":2}]},"
+				+ "{\"not\":{\"inventory_has_item\":3}}"
+				+ "]}", ConditionNode.class);
+		assertInstanceOf(AndNode.class, node);
+		AndNode and = (AndNode) node;
+		assertInstanceOf(OrNode.class, and.getChildren().get(0));
+		assertInstanceOf(NotNode.class, and.getChildren().get(1));
+	}
+
+	// -- Edge cases -----------------------------------------------------------
+
+	@Test
+	public void edge_andEmptyChildren_parsesAsVacuouslyTrue()
+	{
+		ConditionNode node = gson.fromJson("{\"and\":[]}", ConditionNode.class);
+		assertInstanceOf(AndNode.class, node);
+		assertTrue(((AndNode) node).getChildren().isEmpty());
+	}
+
+	@Test
+	public void edge_orEmptyChildren_parsesAsVacuouslyFalse()
+	{
+		ConditionNode node = gson.fromJson("{\"or\":[]}", ConditionNode.class);
+		assertInstanceOf(OrNode.class, node);
+		assertTrue(((OrNode) node).getChildren().isEmpty());
+	}
+
+	@Test
+	public void edge_notNullChild()
+	{
+		ConditionNode node = gson.fromJson("{\"not\":null}", ConditionNode.class);
+		assertInstanceOf(NotNode.class, node);
+		assertNull(((NotNode) node).getChild());
+	}
+
+	@Test
+	public void edge_unknownDiscriminator_throws()
+	{
+		assertThrows(JsonParseException.class,
+			() -> gson.fromJson("{\"frobnicate\":1}", ConditionNode.class));
+	}
+
+	@Test
+	public void edge_arriveAtTileWrongArrayLength_throws()
+	{
+		assertThrows(JsonParseException.class,
+			() -> gson.fromJson("{\"arrive_at_tile\":[3200,3300]}", ConditionNode.class));
+	}
+
+	@Test
+	public void edge_arriveAtZoneWrongArrayLength_throws()
+	{
+		assertThrows(JsonParseException.class,
+			() -> gson.fromJson("{\"arrive_at_zone\":[3200,3300,3210]}", ConditionNode.class));
+	}
+
+	@Test
+	public void edge_nonObjectRoot_throws()
+	{
+		assertThrows(JsonParseException.class,
+			() -> gson.fromJson("[1,2,3]", ConditionNode.class));
+	}
+
+	@Test
+	public void edge_nullJsonReturnsNull()
+	{
+		ConditionNode node = gson.fromJson("null", ConditionNode.class);
+		assertNull(node);
+	}
+
+	@Test
+	public void edge_andChildrenMustBeArray()
+	{
+		assertThrows(JsonParseException.class,
+			() -> gson.fromJson("{\"and\":42}", ConditionNode.class));
+	}
+
+	@Test
+	public void edge_itemObtainedMustBeInt()
+	{
+		// Non-numeric string for an int leaf field surfaces as either a Gson
+		// JsonParseException or a wrapped NumberFormatException depending on the
+		// JsonElement.getAsInt() path; either signals a malformed leaf.
+		assertThrows(RuntimeException.class,
+			() -> gson.fromJson("{\"item_obtained\":\"foo\"}", ConditionNode.class));
+	}
+}

--- a/src/test/java/com/collectionloghelper/data/condition/ConditionNodeEvaluatorTest.java
+++ b/src/test/java/com/collectionloghelper/data/condition/ConditionNodeEvaluatorTest.java
@@ -1,0 +1,335 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data.condition;
+
+import com.collectionloghelper.data.PlayerCollectionState;
+import com.collectionloghelper.data.PlayerInventoryState;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import net.runelite.api.coords.WorldPoint;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Boolean truth-table verification for {@link ConditionNode#evaluate}.
+ *
+ * <p>Builds reflective {@link PlayerInventoryState} / {@link PlayerCollectionState}
+ * snapshots so leaves operate against a real state object, then verifies AND/OR/NOT
+ * short-circuiting and the vacuous-empty cases.
+ */
+public class ConditionNodeEvaluatorTest
+{
+	private PlayerInventoryState inventory;
+	private PlayerCollectionState collection;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		Constructor<PlayerInventoryState> invCtor = PlayerInventoryState.class.getDeclaredConstructor();
+		invCtor.setAccessible(true);
+		inventory = invCtor.newInstance();
+
+		// Use the single-arg test constructor on PlayerCollectionState; fall back to a no-arg
+		// reflective build if not present. We only need a working isItemObtained() in this test.
+		collection = newCollectionState();
+	}
+
+	private static PlayerCollectionState newCollectionState() throws Exception
+	{
+		// PlayerCollectionState's @Inject constructor takes (Client, ConfigManager, DropRateDatabase).
+		// All branches we exercise (isItemObtained, markItemObtained) only touch the obtainedItemIds
+		// set, so passing nulls here is safe for this leaf-evaluation test.
+		Constructor<?> c = PlayerCollectionState.class.getDeclaredConstructors()[0];
+		c.setAccessible(true);
+		Object[] args = new Object[c.getParameterCount()];
+		return (PlayerCollectionState) c.newInstance(args);
+	}
+
+	private static void seedInventory(PlayerInventoryState inv, Map<Integer, Integer> idsAndCounts) throws Exception
+	{
+		// Build the inner InventorySnapshot via reflection so the test does not depend
+		// on the Item / ItemContainer mocking surface.
+		Class<?> snapshotClass = Class.forName("com.collectionloghelper.data.PlayerInventoryState$InventorySnapshot");
+		Constructor<?> sctor = snapshotClass.getDeclaredConstructor(Set.class, Map.class);
+		sctor.setAccessible(true);
+		Set<Integer> ids = new HashSet<>(idsAndCounts.keySet());
+		Object snapshot = sctor.newInstance(ids, new HashMap<>(idsAndCounts));
+
+		Field snapField = PlayerInventoryState.class.getDeclaredField("snapshot");
+		snapField.setAccessible(true);
+		snapField.set(inv, snapshot);
+	}
+
+	private static void seedObtained(PlayerCollectionState state, int... itemIds) throws Exception
+	{
+		Field f = PlayerCollectionState.class.getDeclaredField("obtainedItemIds");
+		f.setAccessible(true);
+		@SuppressWarnings("unchecked")
+		Set<Integer> set = (Set<Integer>) f.get(state);
+		for (int id : itemIds)
+		{
+			set.add(id);
+		}
+	}
+
+	private ConditionEvaluationContext ctx()
+	{
+		return ConditionEvaluationContext.stateOnly(inventory, collection, null);
+	}
+
+	private ConditionEvaluationContext ctxAt(WorldPoint p)
+	{
+		return ConditionEvaluationContext.stateOnly(inventory, collection, p);
+	}
+
+	// -- Leaves ---------------------------------------------------------------
+
+	@Test
+	public void leaf_inventoryHasItem_satisfied() throws Exception
+	{
+		seedInventory(inventory, Map.of(995, 50000));
+		assertTrue(ConditionNodes.inventoryHasItem(995, 1).evaluate(ctx()));
+		assertTrue(ConditionNodes.inventoryHasItem(995, 1000).evaluate(ctx()));
+	}
+
+	@Test
+	public void leaf_inventoryHasItem_insufficientCount() throws Exception
+	{
+		seedInventory(inventory, Map.of(995, 5));
+		assertFalse(ConditionNodes.inventoryHasItem(995, 100).evaluate(ctx()));
+	}
+
+	@Test
+	public void leaf_inventoryHasItem_missingItem()
+	{
+		assertFalse(ConditionNodes.inventoryHasItem(995, 1).evaluate(ctx()));
+	}
+
+	@Test
+	public void leaf_inventoryNotHasItem_trueWhenMissing()
+	{
+		assertTrue(ConditionNodes.inventoryNotHasItem(995).evaluate(ctx()));
+	}
+
+	@Test
+	public void leaf_inventoryNotHasItem_falseWhenPresent() throws Exception
+	{
+		seedInventory(inventory, Map.of(995, 1));
+		assertFalse(ConditionNodes.inventoryNotHasItem(995).evaluate(ctx()));
+	}
+
+	@Test
+	public void leaf_itemObtained_fromCollectionState() throws Exception
+	{
+		seedObtained(collection, 12345);
+		assertTrue(ConditionNodes.itemObtained(12345).evaluate(ctx()));
+	}
+
+	@Test
+	public void leaf_itemObtained_fromInFlightEvent()
+	{
+		ConditionEvaluationContext c = new ConditionEvaluationContext(
+			inventory, collection, null, 12345, -1, -1, null, -1, 0);
+		assertTrue(ConditionNodes.itemObtained(12345).evaluate(c));
+	}
+
+	@Test
+	public void leaf_arriveAtTile_withinRadius()
+	{
+		WorldPoint here = new WorldPoint(3200, 3200, 0);
+		assertTrue(ConditionNodes.arriveAtTile(3201, 3199, 0, 5).evaluate(ctxAt(here)));
+	}
+
+	@Test
+	public void leaf_arriveAtTile_wrongPlane()
+	{
+		WorldPoint here = new WorldPoint(3200, 3200, 0);
+		assertFalse(ConditionNodes.arriveAtTile(3200, 3200, 1, 5).evaluate(ctxAt(here)));
+	}
+
+	@Test
+	public void leaf_playerOnPlane()
+	{
+		WorldPoint upstairs = new WorldPoint(3200, 3200, 2);
+		assertTrue(ConditionNodes.playerOnPlane(2).evaluate(ctxAt(upstairs)));
+		assertFalse(ConditionNodes.playerOnPlane(0).evaluate(ctxAt(upstairs)));
+	}
+
+	@Test
+	public void leaf_actorDeath_primaryId()
+	{
+		ConditionEvaluationContext c = new ConditionEvaluationContext(
+			inventory, collection, null, -1, 2042, -1, null, -1, 0);
+		assertTrue(ConditionNodes.actorDeath(2042).evaluate(c));
+	}
+
+	@Test
+	public void leaf_actorDeath_alternateId()
+	{
+		ConditionEvaluationContext c = new ConditionEvaluationContext(
+			inventory, collection, null, -1, 2044, -1, null, -1, 0);
+		assertTrue(ConditionNodes.actorDeath(2042, Arrays.asList(2043, 2044)).evaluate(c));
+	}
+
+	@Test
+	public void leaf_chatMessage_regexMatch()
+	{
+		ConditionEvaluationContext c = new ConditionEvaluationContext(
+			inventory, collection, null, -1, -1, -1,
+			"You have completed the quest!", -1, 0);
+		assertTrue(ConditionNodes.chatMessageReceived("You have completed.*").evaluate(c));
+	}
+
+	@Test
+	public void leaf_varbitAtLeast_idMatchesAndValueCrosses()
+	{
+		ConditionEvaluationContext c = new ConditionEvaluationContext(
+			inventory, collection, null, -1, -1, -1, null, 4567, 10);
+		assertTrue(ConditionNodes.varbitAtLeast(4567, 5).evaluate(c));
+		assertFalse(ConditionNodes.varbitAtLeast(4567, 50).evaluate(c));
+		assertFalse(ConditionNodes.varbitAtLeast(9999, 5).evaluate(c));
+	}
+
+	@Test
+	public void leaf_manual_alwaysFalse()
+	{
+		assertFalse(ConditionNodes.manual().evaluate(ctx()));
+	}
+
+	// -- AND truth table ------------------------------------------------------
+
+	@Test
+	public void and_allTrue_true() throws Exception
+	{
+		seedInventory(inventory, Map.of(995, 100, 4151, 1));
+		assertTrue(ConditionNodes.and(
+			ConditionNodes.inventoryHasItem(995, 1),
+			ConditionNodes.inventoryHasItem(4151, 1)).evaluate(ctx()));
+	}
+
+	@Test
+	public void and_anyFalse_false() throws Exception
+	{
+		seedInventory(inventory, Map.of(995, 100));
+		assertFalse(ConditionNodes.and(
+			ConditionNodes.inventoryHasItem(995, 1),
+			ConditionNodes.inventoryHasItem(4151, 1)).evaluate(ctx()));
+	}
+
+	@Test
+	public void and_emptyChildren_vacuouslyTrue()
+	{
+		assertTrue(new AndNode(Collections.emptyList()).evaluate(ctx()));
+	}
+
+	@Test
+	public void and_shortCircuitsOnFirstFalse()
+	{
+		final boolean[] secondCalled = {false};
+		ConditionNode tripwire = c -> { secondCalled[0] = true; return true; };
+		ConditionNode falsy = c -> false;
+		new AndNode(Arrays.asList(falsy, tripwire)).evaluate(ctx());
+		assertFalse(secondCalled[0], "AND must short-circuit after first false child");
+	}
+
+	// -- OR truth table -------------------------------------------------------
+
+	@Test
+	public void or_anyTrue_true() throws Exception
+	{
+		seedInventory(inventory, Map.of(995, 100));
+		assertTrue(ConditionNodes.or(
+			ConditionNodes.inventoryHasItem(4151, 1),
+			ConditionNodes.inventoryHasItem(995, 1)).evaluate(ctx()));
+	}
+
+	@Test
+	public void or_allFalse_false()
+	{
+		assertFalse(ConditionNodes.or(
+			ConditionNodes.inventoryHasItem(4151, 1),
+			ConditionNodes.inventoryHasItem(995, 1)).evaluate(ctx()));
+	}
+
+	@Test
+	public void or_emptyChildren_vacuouslyFalse()
+	{
+		assertFalse(new OrNode(Collections.emptyList()).evaluate(ctx()));
+	}
+
+	@Test
+	public void or_shortCircuitsOnFirstTrue()
+	{
+		final boolean[] secondCalled = {false};
+		ConditionNode tripwire = c -> { secondCalled[0] = true; return true; };
+		ConditionNode truthy = c -> true;
+		new OrNode(Arrays.asList(truthy, tripwire)).evaluate(ctx());
+		assertFalse(secondCalled[0], "OR must short-circuit after first true child");
+	}
+
+	// -- NOT truth table ------------------------------------------------------
+
+	@Test
+	public void not_invertsChildTrue()
+	{
+		assertFalse(ConditionNodes.not(c -> true).evaluate(ctx()));
+	}
+
+	@Test
+	public void not_invertsChildFalse()
+	{
+		assertTrue(ConditionNodes.not(c -> false).evaluate(ctx()));
+	}
+
+	@Test
+	public void not_nullChild_returnsTrue()
+	{
+		assertTrue(new NotNode(null).evaluate(ctx()));
+	}
+
+	// -- Nested boolean expression --------------------------------------------
+
+	@Test
+	public void nested_andOfOrAndNot_consistent() throws Exception
+	{
+		seedInventory(inventory, Map.of(995, 1000));
+		// (has-coins AND NOT has-shark) OR has-rune-scim -> true (first conjunct true)
+		ConditionNode expr = ConditionNodes.or(
+			ConditionNodes.and(
+				ConditionNodes.inventoryHasItem(995, 1),
+				ConditionNodes.not(ConditionNodes.inventoryHasItem(385, 1))),
+			ConditionNodes.inventoryHasItem(1333, 1));
+		assertTrue(expr.evaluate(ctx()));
+	}
+}

--- a/src/test/java/com/collectionloghelper/guidance/DynamicItemObjectTierResolverTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/DynamicItemObjectTierResolverTest.java
@@ -297,7 +297,8 @@ public class DynamicItemObjectTierResolverTest
 			null,           // conditionalAlternatives
 			null,           // section
 			null,           // waypoints
-			null            // dynamicTargetEvaluator
+			null,            // dynamicTargetEvaluator
+			null            // conditionTree
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/guidance/DynamicTargetEvaluatorDispatchTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/DynamicTargetEvaluatorDispatchTest.java
@@ -419,7 +419,8 @@ public class DynamicTargetEvaluatorDispatchTest
 			null,  // conditionalAlternatives
 			null,  // section
 			null,  // waypoints
-			evaluatorKey  // dynamicTargetEvaluator
+			evaluatorKey,  // dynamicTargetEvaluator
+			null  // conditionTree
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/guidance/DynamicTargetManagerTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/DynamicTargetManagerTest.java
@@ -252,7 +252,8 @@ public class DynamicTargetManagerTest
 			null,  // conditionalAlternatives
 			null,  // section
 			null,  // waypoints
-			evaluatorKey  // dynamicTargetEvaluator
+			evaluatorKey,  // dynamicTargetEvaluator
+			null  // conditionTree
 		);
 	}
 

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorDescriptionTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorDescriptionTest.java
@@ -302,7 +302,8 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 			null,           // conditionalAlternatives
 			null, // section
 			null, // waypoints
-			null  // dynamicTargetEvaluator
+			null,  // dynamicTargetEvaluator
+			null  // conditionTree
 		);
 	}
 

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorNpcIdTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorNpcIdTest.java
@@ -309,7 +309,8 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 			null,           // conditionalAlternatives
 			null, // section
 			null, // waypoints
-			null  // dynamicTargetEvaluator
+			null,  // dynamicTargetEvaluator
+			null  // conditionTree
 		);
 	}
 

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerNestedConditionalTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerNestedConditionalTest.java
@@ -492,7 +492,8 @@ public class GuidanceSequencerNestedConditionalTest
 			null,           // conditionalAlternatives
 			null, // section
 			null, // waypoints
-			null  // dynamicTargetEvaluator
+			null,  // dynamicTargetEvaluator
+			null  // conditionTree
 		);
 	}
 
@@ -527,7 +528,8 @@ public class GuidanceSequencerNestedConditionalTest
 			alternatives,
 			null, // section
 			null, // waypoints
-			null  // dynamicTargetEvaluator
+			null,  // dynamicTargetEvaluator
+			null  // conditionTree
 		);
 	}
 

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
@@ -120,7 +120,8 @@ public class GuidanceSequencerTest
 			null,           // conditionalAlternatives
 			null, // section
 			null, // waypoints
-			null  // dynamicTargetEvaluator
+			null,  // dynamicTargetEvaluator
+			null  // conditionTree
 		);
 	}
 
@@ -154,7 +155,8 @@ public class GuidanceSequencerTest
 			null,  // conditionalAlternatives
 			null, // section
 			null, // waypoints
-			null  // dynamicTargetEvaluator
+			null,  // dynamicTargetEvaluator
+			null  // conditionTree
 		);
 	}
 
@@ -188,7 +190,8 @@ public class GuidanceSequencerTest
 			null,  // conditionalAlternatives
 			null, // section
 			null, // waypoints
-			null  // dynamicTargetEvaluator
+			null,  // dynamicTargetEvaluator
+			null  // conditionTree
 		);
 	}
 
@@ -222,7 +225,8 @@ public class GuidanceSequencerTest
 			null,  // conditionalAlternatives
 			null, // section
 			null, // waypoints
-			null  // dynamicTargetEvaluator
+			null,  // dynamicTargetEvaluator
+			null  // conditionTree
 		);
 	}
 
@@ -256,7 +260,8 @@ public class GuidanceSequencerTest
 			null,  // conditionalAlternatives
 			null, // section
 			null, // waypoints
-			null  // dynamicTargetEvaluator
+			null,  // dynamicTargetEvaluator
+			null  // conditionTree
 		);
 	}
 
@@ -290,7 +295,8 @@ public class GuidanceSequencerTest
 			null,  // conditionalAlternatives
 			null, // section
 			null, // waypoints
-			null  // dynamicTargetEvaluator
+			null,  // dynamicTargetEvaluator
+			null  // conditionTree
 		);
 	}
 
@@ -324,7 +330,8 @@ public class GuidanceSequencerTest
 			null,  // conditionalAlternatives
 			null, // section
 			null, // waypoints
-			null  // dynamicTargetEvaluator
+			null,  // dynamicTargetEvaluator
+			null  // conditionTree
 		);
 	}
 
@@ -358,7 +365,8 @@ public class GuidanceSequencerTest
 			null,  // conditionalAlternatives
 			null, // section
 			null, // waypoints
-			null  // dynamicTargetEvaluator
+			null,  // dynamicTargetEvaluator
+			null  // conditionTree
 		);
 	}
 
@@ -393,7 +401,8 @@ public class GuidanceSequencerTest
 			null,  // conditionalAlternatives
 			null, // section
 			null, // waypoints
-			null  // dynamicTargetEvaluator
+			null,  // dynamicTargetEvaluator
+			null  // conditionTree
 		);
 	}
 
@@ -427,7 +436,8 @@ public class GuidanceSequencerTest
 			null,  // conditionalAlternatives
 			null, // section
 			null, // waypoints
-			null  // dynamicTargetEvaluator
+			null,  // dynamicTargetEvaluator
+			null  // conditionTree
 		);
 	}
 
@@ -461,7 +471,8 @@ public class GuidanceSequencerTest
 			null,  // conditionalAlternatives
 			null, // section
 			null, // waypoints
-			null  // dynamicTargetEvaluator
+			null,  // dynamicTargetEvaluator
+			null  // conditionTree
 		);
 	}
 
@@ -495,7 +506,8 @@ public class GuidanceSequencerTest
 			null,  // conditionalAlternatives
 			null, // section
 			null, // waypoints
-			null  // dynamicTargetEvaluator
+			null,  // dynamicTargetEvaluator
+			null  // conditionTree
 		);
 	}
 
@@ -983,7 +995,8 @@ public class GuidanceSequencerTest
 			null,  // conditionalAlternatives
 			null, // section
 			null, // waypoints
-			null  // dynamicTargetEvaluator
+			null,  // dynamicTargetEvaluator
+			null  // conditionTree
 		);
 
 		List<GuidanceStep> steps = Arrays.asList(
@@ -1457,7 +1470,8 @@ public class GuidanceSequencerTest
 			alternatives,
 			null, // section
 			null, // waypoints
-			null  // dynamicTargetEvaluator
+			null,  // dynamicTargetEvaluator
+			null  // conditionTree
 		);
 	}
 
@@ -1693,7 +1707,8 @@ public class GuidanceSequencerTest
 			Collections.emptyList(),  // empty list of alternatives
 			null, // section
 			null, // waypoints
-			null  // dynamicTargetEvaluator
+			null,  // dynamicTargetEvaluator
+			null  // conditionTree
 		);
 
 		List<GuidanceStep> steps = Arrays.asList(step);

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerWaypointTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerWaypointTest.java
@@ -132,7 +132,8 @@ public class GuidanceSequencerWaypointTest
 			null, // conditionalAlternatives
 			null, // section
 			waypoints,
-			null  // dynamicTargetEvaluator
+			null,  // dynamicTargetEvaluator
+			null  // conditionTree
 		);
 	}
 
@@ -169,7 +170,8 @@ public class GuidanceSequencerWaypointTest
 			null,
 			null,
 			null, // waypoints
-			null  // dynamicTargetEvaluator
+			null,  // dynamicTargetEvaluator
+			null  // conditionTree
 		);
 	}
 
@@ -282,7 +284,8 @@ public class GuidanceSequencerWaypointTest
 			null,
 			null,
 			null, // waypoints = null
-			null  // dynamicTargetEvaluator
+			null,  // dynamicTargetEvaluator
+			null  // conditionTree
 		);
 
 		AtomicBoolean stepAdvanced = new AtomicBoolean(false);
@@ -332,7 +335,8 @@ public class GuidanceSequencerWaypointTest
 			null,
 			null,
 			Collections.emptyList(), // waypoints = empty list
-			null  // dynamicTargetEvaluator
+			null,  // dynamicTargetEvaluator
+			null  // conditionTree
 		);
 
 		AtomicBoolean stepAdvanced = new AtomicBoolean(false);

--- a/src/test/java/com/collectionloghelper/guidance/RequiredItemResolverTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/RequiredItemResolverTest.java
@@ -653,7 +653,8 @@ public class RequiredItemResolverTest
 			null,  // conditionalAlternatives
 			null, // section
 			null, // waypoints
-			null  // dynamicTargetEvaluator
+			null,  // dynamicTargetEvaluator
+			null  // conditionTree
 		);
 	}
 
@@ -693,7 +694,8 @@ public class RequiredItemResolverTest
 			null,  // conditionalAlternatives
 			null,  // section
 			null,  // waypoints
-			null   // dynamicTargetEvaluator
+			null,   // dynamicTargetEvaluator
+			null   // conditionTree
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/guidance/bosses/BossGuidanceDispatchTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/bosses/BossGuidanceDispatchTest.java
@@ -103,7 +103,8 @@ public class BossGuidanceDispatchTest
 			0, 0, 0, 0, null, null,
 			0, null, null, null, null, null,
 			0, 0, false, 0, null, null, 0, 0, null, null, null, null, null,
-			null /* waypoints */, null /* dynamicTargetEvaluator */
+			null /* waypoints */, null /* dynamicTargetEvaluator */,
+			null /* conditionTree */
 		);
 	}
 

--- a/src/test/java/com/collectionloghelper/guidance/dynamic/WintertodtBrazierEvaluatorTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/dynamic/WintertodtBrazierEvaluatorTest.java
@@ -232,7 +232,8 @@ public class WintertodtBrazierEvaluatorTest
 			null,  // conditionalAlternatives
 			null,  // section
 			null,  // waypoints
-			DynamicTargetEvaluatorRegistry.WINTERTODT_ACTIVE_BRAZIER  // dynamicTargetEvaluator
+			DynamicTargetEvaluatorRegistry.WINTERTODT_ACTIVE_BRAZIER,  // dynamicTargetEvaluator
+			null  // conditionTree
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/lifecycle/GuidanceEventRouterTest.java
+++ b/src/test/java/com/collectionloghelper/lifecycle/GuidanceEventRouterTest.java
@@ -143,7 +143,8 @@ public class GuidanceEventRouterTest
 			null,  // conditionalAlternatives
 			null, // section
 			null, // waypoints
-			null  // dynamicTargetEvaluator
+			null,  // dynamicTargetEvaluator
+			null  // conditionTree
 		);
 	}
 

--- a/src/test/java/com/collectionloghelper/ui/widget/BankScanIntegrationTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/BankScanIntegrationTest.java
@@ -345,7 +345,8 @@ public class BankScanIntegrationTest
 			null, // conditionalAlternatives
 			null, // section
 			null, // waypoints
-			null  // dynamicTargetEvaluator
+			null,  // dynamicTargetEvaluator
+			null  // conditionTree
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/ui/widget/StepProgressViewTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/StepProgressViewTest.java
@@ -1185,7 +1185,8 @@ public class StepProgressViewTest
 			null, null, null, null,
 			section,
 			null, // waypoints
-			null  // dynamicTargetEvaluator
+			null,  // dynamicTargetEvaluator
+			null  // conditionTree
 		);
 	}
 
@@ -1214,7 +1215,8 @@ public class StepProgressViewTest
 			null, null, null, null,
 			null, // section
 			null, // waypoints
-			null   // dynamicTargetEvaluator
+			null,   // dynamicTargetEvaluator
+			null   // conditionTree
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/ui/widget/StepSectionGrouperTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/StepSectionGrouperTest.java
@@ -76,7 +76,8 @@ public class StepSectionGrouperTest
 			null, null, null, null,
 			section,
 			null, // waypoints
-			null  // dynamicTargetEvaluator
+			null,  // dynamicTargetEvaluator
+			null  // conditionTree
 		);
 	}
 


### PR DESCRIPTION
## Summary

Lands the schema + evaluator for **composable boolean trees** (AND / OR / NOT over the 11 atomic `CompletionCondition` leaves) on `GuidanceStep`. Strictly additive — a single new `@Nullable ConditionNode conditionTree` slot, zero production sources opt in. Phase 3 (the first pilot wiring) is a separate later PR.

Cites:
- **#634** — B1 composable-conditions design + migration plan.
- **#623** — B0 precedent for additive-schema landing (pohTeleports + equippedItemIds).

## Files added

**Production (`src/main/java/com/collectionloghelper/data/condition/`):**
- `ConditionNode` — interface (`evaluate(ctx) -> boolean`)
- `AndNode` / `OrNode` / `NotNode` / `LeafNode` — Lombok `@Value` implementations
- `ConditionEvaluationContext` — snapshot of `PlayerInventoryState` / `PlayerCollectionState` / `WorldPoint` / last-event fields (chat, varbit, npc-death, npc-talked, item-obtained)
- `ConditionNodeDeserializer` — Gson `JsonDeserializer<ConditionNode>` (single discriminator key per node, leaf-type keys mirror lower-cased `CompletionCondition` enum values)
- `ConditionNodes` — terse static factories for test fixtures and (eventually) Phase 3 wiring

**Tests (`src/test/java/com/collectionloghelper/data/condition/`):**
- `ConditionNodeDeserializerTest` — **26 cases** (one per leaf shape, AND/OR/NOT composites, nested expressions, edge cases: empty AND/OR, null NOT child, unknown discriminator, wrong array lengths, malformed primitives, non-object root)
- `ConditionNodeEvaluatorTest` — **22 cases** (per-leaf truth, AND/OR/NOT truth tables, explicit short-circuit verification via tripwire children, vacuous-empty cases)
- `B1MigrationTest` — **2 cases** (loads production `drop_rates.json`, asserts every step on every source has `conditionTree == null` — Phase 1+2 invariant guard)
- `B1GuidanceStepIntegrationTest` — **5 cases** (synthetic step with tree set, JSON round-trip via registered adapter, tree-vs-legacy-enum independence)

**60 new test cases total.**

## Files modified

- `GuidanceStep.java` — single new `@Nullable ConditionNode conditionTree` field appended to the positional constructor; `mergeAlternative` inherits the tree from the base step (alternatives do not override it in B1)
- `CerberusGuidance.java` — three `new GuidanceStep(...)` callsites updated with the explicit `null` slot
- **19 test classes** updated for the constructor-arity migration: every `new GuidanceStep(...)` callsite gets a trailing `, null` in the new `conditionTree` slot. This is a forward-compatible `@Value` extension — null is the default for all 225 existing sources

## Zero production data changes

`drop_rates.json` is untouched. `B1MigrationTest.everyStepHasNullConditionTree` enforces this as a regression guard until Phase 3.

## Constructor-arity migration notes

`GuidanceStep` is `@lombok.Value`, so the new field becomes a positional constructor argument. **19 test files** carried `new GuidanceStep(...)` callsites that needed an explicit trailing `null` in the new slot. No reflective `getDeclaredConstructor(...)` lookup on `GuidanceStep` exists in the codebase, so no field-count assertions had to be adjusted.

## Build status

- `./gradlew build` — **PASS** (`compileJava`, `compileTestJava`, `test` (1516+ tests), `lintDropRates`, `jar`, `jacocoTestReport`, `jacocoTestCoverageVerification`)
- 60/60 new B1 condition tests pass
- No pre-existing tests regressed

## Phase 3 (separate PR)

The first pilot will:
1. Register `ConditionNodeDeserializer` on `DropRateDatabase`'s Gson instance
2. Teach `CompletionChecker` to prefer `step.getConditionTree()` over the flat-enum dispatch when the tree is non-null
3. Wire the first production source as a single-leaf-rooted tree, then expand

## Test plan

- [x] Unit: 60 new condition tests pass
- [x] Regression: `B1MigrationTest` confirms no production source sets conditionTree
- [x] Integration: synthetic `GuidanceStep` with conditionTree round-trips via Gson with adapter registered
- [x] Build: `./gradlew build` green
- [x] No `drop_rates.json` diff