### PR TITLE
feat(schema): add inventoryItemIds to SourceRequirements (mirrors B0 #623 pattern)

### DIFF
--- a/src/main/java/com/collectionloghelper/data/RequirementsChecker.java
+++ b/src/main/java/com/collectionloghelper/data/RequirementsChecker.java
@@ -50,6 +50,7 @@ public class RequirementsChecker
 	private final Client client;
 	private final PohTeleportInventory pohTeleportInventory;
 	private final EquippedItemState equippedItemState;
+	private final PlayerInventoryState playerInventoryState;
 
 	private volatile Map<String, Boolean> accessibilityCache = Collections.emptyMap();
 	private volatile Map<String, List<String>> unmetCache = Collections.emptyMap();
@@ -58,11 +59,13 @@ public class RequirementsChecker
 	@Inject
 	private RequirementsChecker(Client client,
 		PohTeleportInventory pohTeleportInventory,
-		EquippedItemState equippedItemState)
+		EquippedItemState equippedItemState,
+		PlayerInventoryState playerInventoryState)
 	{
 		this.client = client;
 		this.pohTeleportInventory = pohTeleportInventory;
 		this.equippedItemState = equippedItemState;
+		this.playerInventoryState = playerInventoryState;
 	}
 
 	/**
@@ -377,6 +380,21 @@ public class RequirementsChecker
 				if (!equippedItemState.hasEquipped(itemId))
 				{
 					unmet.add("Equipped item: " + itemId);
+				}
+			}
+		}
+
+		if (requirements.getInventoryItemIds() != null)
+		{
+			for (Integer itemId : requirements.getInventoryItemIds())
+			{
+				if (itemId == null)
+				{
+					continue;
+				}
+				if (!playerInventoryState.hasItem(itemId))
+				{
+					unmet.add("Inventory item: " + itemId);
 				}
 			}
 		}

--- a/src/main/java/com/collectionloghelper/data/SourceRequirements.java
+++ b/src/main/java/com/collectionloghelper/data/SourceRequirements.java
@@ -75,4 +75,31 @@ public class SourceRequirements
 	 */
 	@Nullable
 	List<Integer> equippedItemIds;
+
+	/**
+	 * Inventory-item requirements expressed as RuneLite {@code ItemID} integers.
+	 *
+	 * <p>Evaluated AND-wise against
+	 * {@code PlayerInventoryState.hasItem(int)}: the requirement is met only
+	 * when every listed item ID is currently present in the player's regular
+	 * inventory container. {@code null} entries inside the list are skipped.
+	 *
+	 * <p>Use this field for teleport vectors that are right-clicked from the
+	 * inventory regardless of whether the item is wieldable. Examples:
+	 * Pharaoh's sceptre's Jaltevas teleport, Crystal teleport seed, Quetzal
+	 * whistle, and Zul-andra teleport scroll all check the player's inventory,
+	 * not the equipment container. Wieldable jewellery whose canonical
+	 * teleport is from the equipment slot (Drakan's medallion, Ring of
+	 * Shadows) should continue to use {@code equippedItemIds} instead.
+	 *
+	 * <p>For an OR-semantic over multiple charge-tier variants of the same
+	 * item (e.g. Pharaoh's sceptre charges 1-5), a future
+	 * {@code inventoryItemIdsAny} field is planned but not yet authored.
+	 *
+	 * <p>{@code null} or empty when the source/alternative has no
+	 * inventory-item prerequisite. Added by the Wave-1 follow-up to close the
+	 * inventory-vs-equipped distinction left open by Tier B0.
+	 */
+	@Nullable
+	List<Integer> inventoryItemIds;
 }

--- a/src/test/java/com/collectionloghelper/data/CollectionLogSourceTest.java
+++ b/src/test/java/com/collectionloghelper/data/CollectionLogSourceTest.java
@@ -123,7 +123,7 @@ public class CollectionLogSourceTest
 	@Test
 	public void getWorldPointWithChecker_firstAccessible()
 	{
-		SourceRequirements reqs = new SourceRequirements(Collections.singletonList("DRAGON_SLAYER_II"), null, null, null, null);
+		SourceRequirements reqs = new SourceRequirements(Collections.singletonList("DRAGON_SLAYER_II"), null, null, null, null, null);
 		Waypoint wp1 = new Waypoint("Shortcut", 2500, 2600, 0, reqs);
 		Waypoint wp2 = new Waypoint("Walk", 3500, 3600, 0, null);
 
@@ -137,7 +137,7 @@ public class CollectionLogSourceTest
 	@Test
 	public void getWorldPointWithChecker_firstLocked_fallsToSecond()
 	{
-		SourceRequirements reqs = new SourceRequirements(Collections.singletonList("DRAGON_SLAYER_II"), null, null, null, null);
+		SourceRequirements reqs = new SourceRequirements(Collections.singletonList("DRAGON_SLAYER_II"), null, null, null, null, null);
 		Waypoint wp1 = new Waypoint("Shortcut", 2500, 2600, 0, reqs);
 		Waypoint wp2 = new Waypoint("Walk", 3500, 3600, 0, null);
 
@@ -151,8 +151,8 @@ public class CollectionLogSourceTest
 	@Test
 	public void getWorldPointWithChecker_allLocked_fallsToLast()
 	{
-		SourceRequirements reqs1 = new SourceRequirements(Collections.singletonList("QUEST_A"), null, null, null, null);
-		SourceRequirements reqs2 = new SourceRequirements(Collections.singletonList("QUEST_B"), null, null, null, null);
+		SourceRequirements reqs1 = new SourceRequirements(Collections.singletonList("QUEST_A"), null, null, null, null, null);
+		SourceRequirements reqs2 = new SourceRequirements(Collections.singletonList("QUEST_B"), null, null, null, null, null);
 		Waypoint wp1 = new Waypoint("Best", 1000, 1000, 0, reqs1);
 		Waypoint wp2 = new Waypoint("Alt", 2000, 2000, 0, reqs2);
 
@@ -227,7 +227,7 @@ public class CollectionLogSourceTest
 	@Test
 	public void getDisplayLocationWithChecker_allLockedFallsToLastName()
 	{
-		SourceRequirements reqs = new SourceRequirements(Collections.singletonList("QUEST_A"), null, null, null, null);
+		SourceRequirements reqs = new SourceRequirements(Collections.singletonList("QUEST_A"), null, null, null, null, null);
 		Waypoint wp1 = new Waypoint("First", 1000, 1000, 0, reqs);
 		Waypoint wp2 = new Waypoint("Last", 2000, 2000, 0, reqs);
 

--- a/src/test/java/com/collectionloghelper/data/InventoryItemsMigrationTest.java
+++ b/src/test/java/com/collectionloghelper/data/InventoryItemsMigrationTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Migration guard for the additive {@code inventoryItemIds} field on
+ * {@link SourceRequirements}.
+ *
+ * <p>This PR adds the field, evaluator wiring, and Gson coverage but performs
+ * zero pilot wiring in production data. This test walks the full production
+ * {@code drop_rates.json} and asserts that every {@link SourceRequirements}
+ * instance reached via top-level source requirements, conditional-alternative
+ * requirements (flat and nested), and waypoint requirements has a null
+ * {@code inventoryItemIds}. The first opportunity to flip a single source is a
+ * separate later data PR.
+ *
+ * <p>Mirrors {@code B1MigrationTest}, {@code B1aRegressionTest}, and
+ * {@code B1bRegressionTest}: walk the database, accumulate violations, fail
+ * with one readable message.
+ */
+public class InventoryItemsMigrationTest
+{
+	private DropRateDatabase database;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		database = new DropRateDatabase();
+
+		Gson gson = new GsonBuilder().create();
+		Field gsonField = DropRateDatabase.class.getDeclaredField("gson");
+		gsonField.setAccessible(true);
+		gsonField.set(database, gson);
+
+		database.load();
+	}
+
+	@Test
+	public void databaseLoadsAndProducesSources()
+	{
+		assertNotNull(database.getAllSources());
+		assertTrue(database.getAllSources().size() > 0,
+			"Production drop_rates.json must load at least one source");
+	}
+
+	@Test
+	public void everySourceRequirementsHasNullInventoryItemIds()
+	{
+		List<String> violations = new ArrayList<>();
+
+		for (CollectionLogSource source : database.getAllSources())
+		{
+			checkSource(source, violations);
+		}
+
+		assertTrue(violations.isEmpty(),
+			"inventoryItemIds invariant violated. No production source may set inventoryItemIds in this PR; pilot wiring lands in a follow-up data PR. Violations:\n"
+				+ String.join("\n", violations));
+	}
+
+	private static void checkSource(CollectionLogSource source, List<String> violations)
+	{
+		String sourceName = source.getName();
+		checkRequirements(sourceName + " (top-level requirements)", source.getRequirements(), violations);
+
+		// CollectionLogSource owns the requirement-bearing Waypoint list. GuidanceStep
+		// has a separate StepWaypoint list which is a lightweight overlay struct and
+		// carries no SourceRequirements, so it is not walked here.
+		List<Waypoint> sourceWaypoints = source.getWaypoints();
+		if (sourceWaypoints != null)
+		{
+			for (int w = 0; w < sourceWaypoints.size(); w++)
+			{
+				Waypoint wp = sourceWaypoints.get(w);
+				if (wp != null)
+				{
+					checkRequirements(sourceName + " waypoint " + (w + 1),
+						wp.getRequirements(), violations);
+				}
+			}
+		}
+
+		List<GuidanceStep> steps = source.getGuidanceSteps();
+		if (steps == null)
+		{
+			return;
+		}
+		for (int i = 0; i < steps.size(); i++)
+		{
+			GuidanceStep step = steps.get(i);
+			if (step == null)
+			{
+				continue;
+			}
+			String stepLabel = sourceName + " step " + (i + 1);
+
+			List<ConditionalAlternative> alts = step.getConditionalAlternatives();
+			if (alts != null)
+			{
+				for (int a = 0; a < alts.size(); a++)
+				{
+					ConditionalAlternative alt = alts.get(a);
+					if (alt == null)
+					{
+						continue;
+					}
+					checkRequirements(stepLabel + " alt " + (a + 1),
+						alt.getRequirements(), violations);
+
+					List<ConditionalAlternative> nested = alt.getNestedAlternatives();
+					if (nested != null)
+					{
+						for (int n = 0; n < nested.size(); n++)
+						{
+							ConditionalAlternative nestedAlt = nested.get(n);
+							if (nestedAlt != null)
+							{
+								checkRequirements(stepLabel + " alt " + (a + 1)
+										+ " nested " + (n + 1),
+									nestedAlt.getRequirements(), violations);
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	private static void checkRequirements(String label, SourceRequirements reqs, List<String> violations)
+	{
+		if (reqs == null)
+		{
+			return;
+		}
+		if (reqs.getInventoryItemIds() != null)
+		{
+			violations.add(label + " has non-null inventoryItemIds");
+		}
+	}
+}

--- a/src/test/java/com/collectionloghelper/data/RequirementsCheckerB0Test.java
+++ b/src/test/java/com/collectionloghelper/data/RequirementsCheckerB0Test.java
@@ -76,6 +76,9 @@ public class RequirementsCheckerB0Test
 	@Mock
 	private EquippedItemState equippedItemState;
 
+	@Mock
+	private PlayerInventoryState playerInventoryState;
+
 	private RequirementsChecker checker;
 
 	@BeforeEach
@@ -83,9 +86,10 @@ public class RequirementsCheckerB0Test
 	{
 		// The @Inject constructor is private — use reflection to construct without Guice.
 		Constructor<RequirementsChecker> ctor = RequirementsChecker.class.getDeclaredConstructor(
-			Client.class, PohTeleportInventory.class, EquippedItemState.class);
+			Client.class, PohTeleportInventory.class, EquippedItemState.class,
+			PlayerInventoryState.class);
 		ctor.setAccessible(true);
-		checker = ctor.newInstance(client, pohTeleportInventory, equippedItemState);
+		checker = ctor.newInstance(client, pohTeleportInventory, equippedItemState, playerInventoryState);
 	}
 
 	// ── null requirements ───────────────────────────────────────────────────
@@ -130,7 +134,7 @@ public class RequirementsCheckerB0Test
 		SourceRequirements req = new SourceRequirements(
 			null, null, null,
 			Arrays.asList("JEWELLERY_BOX_FANCY", "FAIRY_RING"),
-			null);
+			null, null);
 		assertFalse(checker.meetsRequirements(req));
 	}
 
@@ -140,7 +144,7 @@ public class RequirementsCheckerB0Test
 		SourceRequirements req = new SourceRequirements(
 			null, null, null,
 			Collections.emptyList(),
-			null);
+			null, null);
 		assertTrue(checker.meetsRequirements(req));
 	}
 
@@ -169,7 +173,7 @@ public class RequirementsCheckerB0Test
 		lenient().when(equippedItemState.hasEquipped(DRAKANS_MEDALLION)).thenReturn(false);
 		SourceRequirements req = new SourceRequirements(
 			null, null, null, null,
-			Arrays.asList(RING_OF_SHADOWS, DRAKANS_MEDALLION));
+			Arrays.asList(RING_OF_SHADOWS, DRAKANS_MEDALLION), null);
 		assertFalse(checker.meetsRequirements(req));
 	}
 
@@ -178,7 +182,7 @@ public class RequirementsCheckerB0Test
 	{
 		SourceRequirements req = new SourceRequirements(
 			null, null, null, null,
-			Collections.emptyList());
+			Collections.emptyList(), null);
 		assertTrue(checker.meetsRequirements(req));
 	}
 
@@ -195,7 +199,7 @@ public class RequirementsCheckerB0Test
 			Collections.singletonList(new SkillRequirement("STRENGTH", 70)),
 			null,
 			Collections.singletonList("JEWELLERY_BOX_FANCY"),
-			Collections.singletonList(RING_OF_SHADOWS));
+			Collections.singletonList(RING_OF_SHADOWS), null);
 		assertTrue(checker.meetsRequirements(req));
 	}
 
@@ -209,7 +213,7 @@ public class RequirementsCheckerB0Test
 			Collections.singletonList(new SkillRequirement("STRENGTH", 70)),
 			null,
 			Collections.singletonList("JEWELLERY_BOX_FANCY"),
-			null);
+			null, null);
 		assertFalse(checker.meetsRequirements(req));
 	}
 
@@ -221,7 +225,7 @@ public class RequirementsCheckerB0Test
 		SourceRequirements req = new SourceRequirements(
 			null, null, null,
 			Collections.singletonList("JEWELLERY_BOX_FANCY"),
-			Collections.singletonList(RING_OF_SHADOWS));
+			Collections.singletonList(RING_OF_SHADOWS), null);
 		assertFalse(checker.meetsRequirements(req));
 	}
 
@@ -243,7 +247,7 @@ public class RequirementsCheckerB0Test
 			altWithReq("Fast: POH + ring", new SourceRequirements(
 				null, null, null,
 				Collections.singletonList("JEWELLERY_BOX_FANCY"),
-				Collections.singletonList(RING_OF_SHADOWS))),
+				Collections.singletonList(RING_OF_SHADOWS), null)),
 			altWithReq("Slow: ring only", equippedReq(RING_OF_SHADOWS)));
 
 		assertEquals("Fast: POH + ring", selectFirstMatching(alts));
@@ -260,7 +264,7 @@ public class RequirementsCheckerB0Test
 			altWithReq("Fast: POH + ring", new SourceRequirements(
 				null, null, null,
 				Collections.singletonList("JEWELLERY_BOX_FANCY"),
-				Collections.singletonList(RING_OF_SHADOWS))),
+				Collections.singletonList(RING_OF_SHADOWS), null)),
 			altWithReq("Slow: ring only", equippedReq(RING_OF_SHADOWS)));
 
 		assertEquals("Slow: ring only", selectFirstMatching(alts));
@@ -286,14 +290,14 @@ public class RequirementsCheckerB0Test
 		return new SourceRequirements(
 			null, null, null,
 			Collections.singletonList(teleportName),
-			null);
+			null, null);
 	}
 
 	private static SourceRequirements equippedReq(int itemId)
 	{
 		return new SourceRequirements(
 			null, null, null, null,
-			Collections.singletonList(itemId));
+			Collections.singletonList(itemId), null);
 	}
 
 	private static ConditionalAlternative altWithReq(String description, SourceRequirements requirements)

--- a/src/test/java/com/collectionloghelper/data/RequirementsCheckerInventoryItemsTest.java
+++ b/src/test/java/com/collectionloghelper/data/RequirementsCheckerInventoryItemsTest.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data;
+
+import com.collectionloghelper.player.EquippedItemState;
+import com.collectionloghelper.player.PohTeleport;
+import com.collectionloghelper.player.PohTeleportInventory;
+import java.lang.reflect.Constructor;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import net.runelite.api.Client;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+
+/**
+ * Behaviour tests for
+ * {@link RequirementsChecker#meetsRequirements(SourceRequirements)} with the
+ * new {@code inventoryItemIds} field wired in.
+ *
+ * <p>Pairs with {@link RequirementsCheckerB0Test} (the Tier B0 PR #623 sibling)
+ * which covers the {@code pohTeleports} and {@code equippedItemIds} clauses.
+ * This class adds the same matrix for the inventory-item clause: empty list is
+ * vacuously satisfied, single-item presence is AND-tested via
+ * {@link PlayerInventoryState#hasItem(int)}, multi-item is AND across all IDs,
+ * and the field composes AND-wise with every other clause.
+ *
+ * <p>{@link PlayerInventoryState} is mocked at the concrete class level (it is
+ * a Singleton, not an interface). {@link PohTeleportInventory} and
+ * {@link EquippedItemState} mocks are present to satisfy the constructor but
+ * are not stubbed in the inventory-only tests. Strict stubbing is disabled so
+ * AND-clause short-circuiting in failure tests does not surface
+ * UnnecessaryStubbingException.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class RequirementsCheckerInventoryItemsTest
+{
+	// Pharaoh's sceptre charges-5: an inventory-teleport item that is wieldable
+	// but whose Jaltevas teleport is invoked from the inventory regardless.
+	private static final int PHARAOHS_SCEPTRE_5 = 26945;
+
+	// Quetzal whistle: inventory-only Phantom Muspah teleport, not wieldable.
+	private static final int QUETZAL_WHISTLE = 29782;
+
+	// Ring of Shadows: equipment-slot teleport (the C2 case), included here to
+	// pin the cross-field AND-semantics for the inventory + equipped combo.
+	private static final int RING_OF_SHADOWS = 28266;
+
+	@Mock
+	private Client client;
+
+	@Mock
+	private PohTeleportInventory pohTeleportInventory;
+
+	@Mock
+	private EquippedItemState equippedItemState;
+
+	@Mock
+	private PlayerInventoryState playerInventoryState;
+
+	private RequirementsChecker checker;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		// The @Inject constructor is private; reflectively construct without Guice.
+		Constructor<RequirementsChecker> ctor = RequirementsChecker.class.getDeclaredConstructor(
+			Client.class, PohTeleportInventory.class, EquippedItemState.class,
+			PlayerInventoryState.class);
+		ctor.setAccessible(true);
+		checker = ctor.newInstance(client, pohTeleportInventory, equippedItemState, playerInventoryState);
+	}
+
+	// -- Empty / vacuous case ---------------------------------------------------
+
+	@Test
+	public void meetsRequirements_emptyInventoryItemIds_isTrue()
+	{
+		SourceRequirements req = new SourceRequirements(
+			null, null, null, null, null,
+			Collections.emptyList());
+		assertTrue(checker.meetsRequirements(req));
+	}
+
+	// -- Single-item AND --------------------------------------------------------
+
+	@Test
+	public void meetsRequirements_singleInventoryItemPresent_isTrue()
+	{
+		lenient().when(playerInventoryState.hasItem(PHARAOHS_SCEPTRE_5)).thenReturn(true);
+		SourceRequirements req = inventoryReq(PHARAOHS_SCEPTRE_5);
+		assertTrue(checker.meetsRequirements(req));
+	}
+
+	@Test
+	public void meetsRequirements_singleInventoryItemAbsent_isFalse()
+	{
+		lenient().when(playerInventoryState.hasItem(PHARAOHS_SCEPTRE_5)).thenReturn(false);
+		SourceRequirements req = inventoryReq(PHARAOHS_SCEPTRE_5);
+		assertFalse(checker.meetsRequirements(req));
+	}
+
+	// -- Multi-item AND ---------------------------------------------------------
+
+	@Test
+	public void meetsRequirements_multipleInventoryItemsAllPresent_isTrue()
+	{
+		lenient().when(playerInventoryState.hasItem(PHARAOHS_SCEPTRE_5)).thenReturn(true);
+		lenient().when(playerInventoryState.hasItem(QUETZAL_WHISTLE)).thenReturn(true);
+		SourceRequirements req = new SourceRequirements(
+			null, null, null, null, null,
+			Arrays.asList(PHARAOHS_SCEPTRE_5, QUETZAL_WHISTLE));
+		assertTrue(checker.meetsRequirements(req));
+	}
+
+	@Test
+	public void meetsRequirements_multipleInventoryItemsOneMissing_isFalse()
+	{
+		lenient().when(playerInventoryState.hasItem(PHARAOHS_SCEPTRE_5)).thenReturn(true);
+		lenient().when(playerInventoryState.hasItem(QUETZAL_WHISTLE)).thenReturn(false);
+		SourceRequirements req = new SourceRequirements(
+			null, null, null, null, null,
+			Arrays.asList(PHARAOHS_SCEPTRE_5, QUETZAL_WHISTLE));
+		assertFalse(checker.meetsRequirements(req));
+	}
+
+	// -- Null entries inside the list are skipped, not NPE ---------------------
+
+	@Test
+	public void meetsRequirements_inventoryItemIdsWithNullEntry_skipsNullAndCheck()
+	{
+		lenient().when(playerInventoryState.hasItem(PHARAOHS_SCEPTRE_5)).thenReturn(true);
+		List<Integer> ids = Arrays.asList(null, PHARAOHS_SCEPTRE_5);
+		SourceRequirements req = new SourceRequirements(
+			null, null, null, null, null, ids);
+		assertTrue(checker.meetsRequirements(req));
+	}
+
+	// -- AND-semantics across multiple clauses ---------------------------------
+
+	@Test
+	public void meetsRequirements_pohAndEquippedAndInventory_allSatisfied_isTrue()
+	{
+		lenient().when(pohTeleportInventory.hasTeleport(PohTeleport.JEWELLERY_BOX_FANCY)).thenReturn(true);
+		lenient().when(equippedItemState.hasEquipped(RING_OF_SHADOWS)).thenReturn(true);
+		lenient().when(playerInventoryState.hasItem(PHARAOHS_SCEPTRE_5)).thenReturn(true);
+		SourceRequirements req = new SourceRequirements(
+			null, null, null,
+			Collections.singletonList("JEWELLERY_BOX_FANCY"),
+			Collections.singletonList(RING_OF_SHADOWS),
+			Collections.singletonList(PHARAOHS_SCEPTRE_5));
+		assertTrue(checker.meetsRequirements(req));
+	}
+
+	@Test
+	public void meetsRequirements_otherClausesSatisfiedButInventoryAbsent_isFalse()
+	{
+		lenient().when(pohTeleportInventory.hasTeleport(PohTeleport.JEWELLERY_BOX_FANCY)).thenReturn(true);
+		lenient().when(equippedItemState.hasEquipped(RING_OF_SHADOWS)).thenReturn(true);
+		lenient().when(playerInventoryState.hasItem(PHARAOHS_SCEPTRE_5)).thenReturn(false);
+		SourceRequirements req = new SourceRequirements(
+			null, null, null,
+			Collections.singletonList("JEWELLERY_BOX_FANCY"),
+			Collections.singletonList(RING_OF_SHADOWS),
+			Collections.singletonList(PHARAOHS_SCEPTRE_5));
+		assertFalse(checker.meetsRequirements(req));
+	}
+
+	@Test
+	public void meetsRequirements_inventoryPresentButPohAbsent_isFalse()
+	{
+		lenient().when(pohTeleportInventory.hasTeleport(PohTeleport.JEWELLERY_BOX_FANCY)).thenReturn(false);
+		lenient().when(playerInventoryState.hasItem(PHARAOHS_SCEPTRE_5)).thenReturn(true);
+		SourceRequirements req = new SourceRequirements(
+			null, null, null,
+			Collections.singletonList("JEWELLERY_BOX_FANCY"),
+			null,
+			Collections.singletonList(PHARAOHS_SCEPTRE_5));
+		assertFalse(checker.meetsRequirements(req));
+	}
+
+	// -- Alternative selection (mirrors GuidanceStep.resolveAlternative) -------
+
+	@Test
+	public void alternativeSelection_inventoryRouteWins_whenItemPresent()
+	{
+		lenient().when(playerInventoryState.hasItem(PHARAOHS_SCEPTRE_5)).thenReturn(true);
+
+		List<ConditionalAlternative> alts = Arrays.asList(
+			altWithReq("Fast: Pharaoh sceptre inventory", inventoryReq(PHARAOHS_SCEPTRE_5)),
+			altWithReq("Slow: walk", null));
+
+		assertEquals("Fast: Pharaoh sceptre inventory", selectFirstMatching(alts));
+	}
+
+	@Test
+	public void alternativeSelection_fallsBackWhenInventoryItemAbsent()
+	{
+		lenient().when(playerInventoryState.hasItem(PHARAOHS_SCEPTRE_5)).thenReturn(false);
+
+		List<ConditionalAlternative> alts = Arrays.asList(
+			altWithReq("Fast: Pharaoh sceptre inventory", inventoryReq(PHARAOHS_SCEPTRE_5)),
+			altWithReq("Fallback: Quetzal whistle inventory", inventoryReq(QUETZAL_WHISTLE)));
+
+		lenient().when(playerInventoryState.hasItem(QUETZAL_WHISTLE)).thenReturn(true);
+		assertEquals("Fallback: Quetzal whistle inventory", selectFirstMatching(alts));
+	}
+
+	// -- Helpers ----------------------------------------------------------------
+
+	private static SourceRequirements inventoryReq(int itemId)
+	{
+		return new SourceRequirements(
+			null, null, null, null, null,
+			Collections.singletonList(itemId));
+	}
+
+	private static ConditionalAlternative altWithReq(String description, SourceRequirements requirements)
+	{
+		return new ConditionalAlternative(
+			requirements,
+			description,
+			null, null, null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			null
+		);
+	}
+
+	private String selectFirstMatching(List<ConditionalAlternative> alts)
+	{
+		for (ConditionalAlternative alt : alts)
+		{
+			if (alt.getRequirements() != null && checker.meetsRequirements(alt.getRequirements()))
+			{
+				return alt.getDescription();
+			}
+		}
+		return null;
+	}
+}

--- a/src/test/java/com/collectionloghelper/data/SourceRequirementsB0Test.java
+++ b/src/test/java/com/collectionloghelper/data/SourceRequirementsB0Test.java
@@ -155,11 +155,11 @@ public class SourceRequirementsB0Test
 		SourceRequirements a = new SourceRequirements(
 			null, null, null,
 			Collections.singletonList("MOUNTED_GLORY"),
-			Collections.singletonList(22557));
+			Collections.singletonList(22557), null);
 		SourceRequirements b = new SourceRequirements(
 			null, null, null,
 			Collections.singletonList("MOUNTED_GLORY"),
-			Collections.singletonList(22557));
+			Collections.singletonList(22557), null);
 		assertEquals(a, b);
 		assertEquals(a.hashCode(), b.hashCode());
 	}
@@ -170,11 +170,11 @@ public class SourceRequirementsB0Test
 		SourceRequirements a = new SourceRequirements(
 			null, null, null,
 			Collections.singletonList("MOUNTED_GLORY"),
-			null);
+			null, null);
 		SourceRequirements b = new SourceRequirements(
 			null, null, null,
 			Collections.singletonList("JEWELLERY_BOX_FANCY"),
-			null);
+			null, null);
 		assertTrue(!a.equals(b));
 	}
 
@@ -188,7 +188,7 @@ public class SourceRequirementsB0Test
 			null,
 			Collections.singletonList("FREMENNIK_HARD"),
 			Arrays.asList("JEWELLERY_BOX_FANCY", "MOUNTED_GLORY"),
-			Arrays.asList(22557, 28266));
+			Arrays.asList(22557, 28266), null);
 		String json = GSON.toJson(original);
 		SourceRequirements restored = GSON.fromJson(json, SourceRequirements.class);
 		assertEquals(original, restored);

--- a/src/test/java/com/collectionloghelper/data/SourceRequirementsInventoryItemsGsonTest.java
+++ b/src/test/java/com/collectionloghelper/data/SourceRequirementsInventoryItemsGsonTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Gson deserialisation tests for the {@code inventoryItemIds} field on
+ * {@link SourceRequirements}.
+ *
+ * <p>Covers absent / null / empty / single-element / multi-element JSON shapes,
+ * legacy backwards compatibility, and Gson behaviour on malformed input. The
+ * field is purely additive: existing drop_rates.json sources that omit it must
+ * continue to deserialise with {@code getInventoryItemIds() == null}.
+ *
+ * <p>Pairs with {@link SourceRequirementsB0Test} which covers the same matrix
+ * for {@code pohTeleports} and {@code equippedItemIds} introduced by Tier B0
+ * (PR #623). This class adds the same coverage for the inventory-item field
+ * that closes the wieldable-but-used-from-inventory teleport gap left by B0.
+ */
+public class SourceRequirementsInventoryItemsGsonTest
+{
+	private static final Gson GSON = new GsonBuilder().create();
+
+	// -- Backwards compatibility -------------------------------------------------
+
+	@Test
+	public void deserialise_legacyJsonWithoutField_inventoryItemIdsIsNull()
+	{
+		String json = "{\"quests\":[\"DESERT_TREASURE_II\"]}";
+		SourceRequirements req = GSON.fromJson(json, SourceRequirements.class);
+		assertNull(req.getInventoryItemIds());
+	}
+
+	@Test
+	public void deserialise_legacyJsonWithAllPriorFields_inventoryItemIdsIsNull()
+	{
+		// Sanity guard: legacy JSON that exercises every pre-existing field must
+		// still produce a parsed object with inventoryItemIds == null.
+		String json = "{"
+			+ "\"quests\":[\"DESERT_TREASURE_II\"],"
+			+ "\"skills\":[{\"skill\":\"SLAYER\",\"level\":95}],"
+			+ "\"diaries\":[\"FREMENNIK_HARD\"],"
+			+ "\"pohTeleports\":[\"JEWELLERY_BOX_FANCY\"],"
+			+ "\"equippedItemIds\":[22557]"
+			+ "}";
+		SourceRequirements req = GSON.fromJson(json, SourceRequirements.class);
+		assertEquals(Collections.singletonList("DESERT_TREASURE_II"), req.getQuests());
+		assertNotNull(req.getSkills());
+		assertEquals(Collections.singletonList("FREMENNIK_HARD"), req.getDiaries());
+		assertEquals(Collections.singletonList("JEWELLERY_BOX_FANCY"), req.getPohTeleports());
+		assertEquals(Collections.singletonList(22557), req.getEquippedItemIds());
+		assertNull(req.getInventoryItemIds());
+	}
+
+	// -- Field-only shapes -------------------------------------------------------
+
+	@Test
+	public void deserialise_inventoryItemIdsNull_isNull()
+	{
+		String json = "{\"inventoryItemIds\":null}";
+		SourceRequirements req = GSON.fromJson(json, SourceRequirements.class);
+		assertNull(req.getInventoryItemIds());
+	}
+
+	@Test
+	public void deserialise_inventoryItemIdsEmpty_isEmptyNotNull()
+	{
+		String json = "{\"inventoryItemIds\":[]}";
+		SourceRequirements req = GSON.fromJson(json, SourceRequirements.class);
+		assertNotNull(req.getInventoryItemIds());
+		assertTrue(req.getInventoryItemIds().isEmpty());
+	}
+
+	@Test
+	public void deserialise_inventoryItemIdsSingle_oneItem()
+	{
+		// Pharaoh's sceptre charges-5 placeholder ID; value chosen for shape, not lookup.
+		String json = "{\"inventoryItemIds\":[26945]}";
+		SourceRequirements req = GSON.fromJson(json, SourceRequirements.class);
+		assertEquals(Collections.singletonList(26945), req.getInventoryItemIds());
+	}
+
+	@Test
+	public void deserialise_inventoryItemIdsMultiple_preservesOrder()
+	{
+		// Zul-andra teleport scroll + Quetzal whistle + Crystal teleport seed placeholders.
+		String json = "{\"inventoryItemIds\":[12938,29782,23959]}";
+		SourceRequirements req = GSON.fromJson(json, SourceRequirements.class);
+		assertEquals(Arrays.asList(12938, 29782, 23959), req.getInventoryItemIds());
+	}
+
+	@Test
+	public void deserialise_inventoryItemIdsNegativeId_parsed()
+	{
+		// Gson does not validate item-ID positivity at parse time; that contract
+		// lives in the evaluator (RequirementsChecker) and the lint layer above.
+		// This test pins current behaviour so a future evaluator-side guard is
+		// an explicit decision rather than an accidental break.
+		String json = "{\"inventoryItemIds\":[-1]}";
+		SourceRequirements req = GSON.fromJson(json, SourceRequirements.class);
+		assertEquals(Collections.singletonList(-1), req.getInventoryItemIds());
+	}
+
+	@Test
+	public void deserialise_inventoryItemIdsContainingString_throws()
+	{
+		// Mirrors Gson's default strict number-parsing for typed list elements.
+		String json = "{\"inventoryItemIds\":[\"not-an-int\"]}";
+		assertThrows(JsonSyntaxException.class,
+			() -> GSON.fromJson(json, SourceRequirements.class));
+	}
+
+	@Test
+	public void deserialise_inventoryItemIdsContainingFloat_throws()
+	{
+		// Gson rejects non-integer JSON numbers for the declared Integer element
+		// type. This pins current behaviour so the malformed-input contract is
+		// explicit rather than implicit.
+		String json = "{\"inventoryItemIds\":[26945.7]}";
+		assertThrows(JsonSyntaxException.class,
+			() -> GSON.fromJson(json, SourceRequirements.class));
+	}
+
+	// -- All six fields populated -----------------------------------------------
+
+	@Test
+	public void deserialise_allSixFieldsPopulated_parsesAll()
+	{
+		String json = "{"
+			+ "\"quests\":[\"TROLL_STRONGHOLD\"],"
+			+ "\"skills\":[{\"skill\":\"STRENGTH\",\"level\":70}],"
+			+ "\"diaries\":[\"FREMENNIK_HARD\"],"
+			+ "\"pohTeleports\":[\"JEWELLERY_BOX_FANCY\"],"
+			+ "\"equippedItemIds\":[22557],"
+			+ "\"inventoryItemIds\":[26945,23959]"
+			+ "}";
+		SourceRequirements req = GSON.fromJson(json, SourceRequirements.class);
+		assertEquals(Collections.singletonList("TROLL_STRONGHOLD"), req.getQuests());
+		assertEquals(1, req.getSkills().size());
+		assertEquals(Collections.singletonList("FREMENNIK_HARD"), req.getDiaries());
+		assertEquals(Collections.singletonList("JEWELLERY_BOX_FANCY"), req.getPohTeleports());
+		assertEquals(Collections.singletonList(22557), req.getEquippedItemIds());
+		assertEquals(Arrays.asList(26945, 23959), req.getInventoryItemIds());
+	}
+
+	// -- equals / hashCode -------------------------------------------------------
+
+	@Test
+	public void equals_sameInventoryItemIds_areEqual()
+	{
+		SourceRequirements a = new SourceRequirements(
+			null, null, null, null, null,
+			Arrays.asList(26945, 23959));
+		SourceRequirements b = new SourceRequirements(
+			null, null, null, null, null,
+			Arrays.asList(26945, 23959));
+		assertEquals(a, b);
+		assertEquals(a.hashCode(), b.hashCode());
+	}
+
+	@Test
+	public void equals_differingInventoryItemIds_notEqual()
+	{
+		SourceRequirements a = new SourceRequirements(
+			null, null, null, null, null,
+			Collections.singletonList(26945));
+		SourceRequirements b = new SourceRequirements(
+			null, null, null, null, null,
+			Collections.singletonList(23959));
+		assertTrue(!a.equals(b));
+	}
+
+	// -- Round-trip --------------------------------------------------------------
+
+	@Test
+	public void gsonRoundTrip_withInventoryItemIds_preservesStructure()
+	{
+		SourceRequirements original = new SourceRequirements(
+			Collections.singletonList("DESERT_TREASURE_II"),
+			null,
+			Collections.singletonList("FREMENNIK_HARD"),
+			Arrays.asList("JEWELLERY_BOX_FANCY"),
+			Arrays.asList(22557),
+			Arrays.asList(26945, 23959));
+		String json = GSON.toJson(original);
+		SourceRequirements restored = GSON.fromJson(json, SourceRequirements.class);
+		assertEquals(original, restored);
+	}
+}

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerNestedConditionalTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerNestedConditionalTest.java
@@ -431,12 +431,12 @@ public class GuidanceSequencerNestedConditionalTest
 
 	private SourceRequirements makeQuestReq(String questName)
 	{
-		return new SourceRequirements(Arrays.asList(questName), null, null, null, null);
+		return new SourceRequirements(Arrays.asList(questName), null, null, null, null, null);
 	}
 
 	private SourceRequirements makeSkillReq(String skill, int level)
 	{
-		return new SourceRequirements(null, Arrays.asList(new SkillRequirement(skill, level)), null, null, null);
+		return new SourceRequirements(null, Arrays.asList(new SkillRequirement(skill, level)), null, null, null, null);
 	}
 
 	/**

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
@@ -1431,12 +1431,12 @@ public class GuidanceSequencerTest
 
 	private SourceRequirements makeQuestRequirement(String questName)
 	{
-		return new SourceRequirements(Arrays.asList(questName), null, null, null, null);
+		return new SourceRequirements(Arrays.asList(questName), null, null, null, null, null);
 	}
 
 	private SourceRequirements makeSkillRequirement(String skill, int level)
 	{
-		return new SourceRequirements(null, Arrays.asList(new SkillRequirement(skill, level)), null, null, null);
+		return new SourceRequirements(null, Arrays.asList(new SkillRequirement(skill, level)), null, null, null, null);
 	}
 
 	private GuidanceStep makeStepWithAlternatives(String description, int worldX, int worldY,

--- a/src/test/java/com/collectionloghelper/ui/widget/SourceRequirementsHeaderTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/SourceRequirementsHeaderTest.java
@@ -30,6 +30,7 @@ import com.collectionloghelper.data.DropRateDatabase;
 import com.collectionloghelper.data.RequirementRow;
 import com.collectionloghelper.data.RequirementsChecker;
 import com.collectionloghelper.data.SkillRequirement;
+import com.collectionloghelper.data.PlayerInventoryState;
 import com.collectionloghelper.data.SourceRequirements;
 import com.collectionloghelper.player.EquippedItemState;
 import com.collectionloghelper.player.PohTeleportInventory;
@@ -91,6 +92,9 @@ public class SourceRequirementsHeaderTest
 	@Mock
 	private EquippedItemState equippedItemState;
 
+	@Mock
+	private PlayerInventoryState playerInventoryState;
+
 	private RequirementsChecker checker;
 	private DropRateDatabase database;
 
@@ -99,9 +103,10 @@ public class SourceRequirementsHeaderTest
 	{
 		Constructor<RequirementsChecker> ctor =
 			RequirementsChecker.class.getDeclaredConstructor(
-				Client.class, PohTeleportInventory.class, EquippedItemState.class);
+				Client.class, PohTeleportInventory.class, EquippedItemState.class,
+				PlayerInventoryState.class);
 		ctor.setAccessible(true);
-		checker = ctor.newInstance(client, pohTeleportInventory, equippedItemState);
+		checker = ctor.newInstance(client, pohTeleportInventory, equippedItemState, playerInventoryState);
 
 		database = new DropRateDatabase();
 		Gson gson = new GsonBuilder().create();
@@ -145,7 +150,7 @@ public class SourceRequirementsHeaderTest
 		when(client.getIntStack()).thenReturn(new int[]{2});
 
 		SourceRequirements req = new SourceRequirements(
-			Collections.singletonList("DRAGON_SLAYER_II"), null, null, null, null);
+			Collections.singletonList("DRAGON_SLAYER_II"), null, null, null, null, null);
 		CollectionLogSource source = makeSourceWithRequirements("Vorkath", req);
 
 		List<RequirementRow> rows = checker.buildRequirementRows(source);
@@ -167,7 +172,7 @@ public class SourceRequirementsHeaderTest
 		when(client.getIntStack()).thenReturn(new int[]{1});
 
 		SourceRequirements req = new SourceRequirements(
-			Collections.singletonList("DRAGON_SLAYER_II"), null, null, null, null);
+			Collections.singletonList("DRAGON_SLAYER_II"), null, null, null, null, null);
 		CollectionLogSource source = makeSourceWithRequirements("Vorkath", req);
 
 		List<RequirementRow> rows = checker.buildRequirementRows(source);
@@ -186,7 +191,7 @@ public class SourceRequirementsHeaderTest
 		when(client.getIntStack()).thenReturn(new int[]{0});
 
 		SourceRequirements req = new SourceRequirements(
-			Collections.singletonList("DRAGON_SLAYER_II"), null, null, null, null);
+			Collections.singletonList("DRAGON_SLAYER_II"), null, null, null, null, null);
 		CollectionLogSource source = makeSourceWithRequirements("Vorkath", req);
 
 		List<RequirementRow> rows = checker.buildRequirementRows(source);
@@ -208,7 +213,7 @@ public class SourceRequirementsHeaderTest
 		when(client.getRealSkillLevel(Skill.SLAYER)).thenReturn(95);
 
 		SourceRequirements req = new SourceRequirements(
-			null, Collections.singletonList(new SkillRequirement("SLAYER", 91)), null, null, null);
+			null, Collections.singletonList(new SkillRequirement("SLAYER", 91)), null, null, null, null);
 		CollectionLogSource source = makeSourceWithRequirements("Cerberus", req);
 
 		List<RequirementRow> rows = checker.buildRequirementRows(source);
@@ -230,7 +235,7 @@ public class SourceRequirementsHeaderTest
 		when(client.getRealSkillLevel(Skill.SLAYER)).thenReturn(80);
 
 		SourceRequirements req = new SourceRequirements(
-			null, Collections.singletonList(new SkillRequirement("SLAYER", 91)), null, null, null);
+			null, Collections.singletonList(new SkillRequirement("SLAYER", 91)), null, null, null, null);
 		CollectionLogSource source = makeSourceWithRequirements("Cerberus", req);
 
 		List<RequirementRow> rows = checker.buildRequirementRows(source);
@@ -252,7 +257,7 @@ public class SourceRequirementsHeaderTest
 		when(client.getVarbitValue(ArgumentMatchers.anyInt())).thenReturn(1);
 
 		SourceRequirements req = new SourceRequirements(
-			null, null, Collections.singletonList("ARDOUGNE_ELITE"), null, null);
+			null, null, Collections.singletonList("ARDOUGNE_ELITE"), null, null, null);
 		CollectionLogSource source = makeSourceWithRequirements("Zulrah", req);
 
 		List<RequirementRow> rows = checker.buildRequirementRows(source);
@@ -273,7 +278,7 @@ public class SourceRequirementsHeaderTest
 		when(client.getVarbitValue(ArgumentMatchers.anyInt())).thenReturn(0);
 
 		SourceRequirements req = new SourceRequirements(
-			null, null, Collections.singletonList("ARDOUGNE_ELITE"), null, null);
+			null, null, Collections.singletonList("ARDOUGNE_ELITE"), null, null, null);
 		CollectionLogSource source = makeSourceWithRequirements("Zulrah", req);
 
 		List<RequirementRow> rows = checker.buildRequirementRows(source);
@@ -299,7 +304,7 @@ public class SourceRequirementsHeaderTest
 		SourceRequirements req = new SourceRequirements(
 			Collections.singletonList("TROLL_STRONGHOLD"),
 			Collections.singletonList(new SkillRequirement("STRENGTH", 70)),
-			null, null, null);
+			null, null, null, null);
 		CollectionLogSource source = makeSourceWithRequirements("General Graardor", req);
 
 		List<RequirementRow> rows = checker.buildRequirementRows(source);
@@ -327,7 +332,7 @@ public class SourceRequirementsHeaderTest
 		SourceRequirements req = new SourceRequirements(
 			Collections.singletonList("TROLL_STRONGHOLD"),
 			Collections.singletonList(new SkillRequirement("STRENGTH", 70)),
-			null, null, null);
+			null, null, null, null);
 		CollectionLogSource source = makeSourceWithRequirements("General Graardor", req);
 
 		List<RequirementRow> rows = checker.buildRequirementRows(source);


### PR DESCRIPTION
## Summary

Strictly additive schema extension on `SourceRequirements`: new `@Nullable List<Integer> inventoryItemIds` field plus evaluator wiring through the existing `PlayerInventoryState.hasItem(int)`. No `drop_rates.json` changes. No production source opts in. First pilot wiring lands in a separate later data PR.

Mirrors the precedent set by #623 (B0 schema landing for `pohTeleports` + `equippedItemIds`): field-only schema slot, evaluator clause added to `checkRequirementsDetail`, Gson + behaviour + migration-guard test trio.

## Why this field is needed

The Wave-1 B1 batch closure (#628) deferred 5 inventory-teleport sources after wiki research showed their teleport vector is invoked from the regular inventory rather than the equipment slot:

| # | Source | Item |
|---|---|---|
| 4 | Tombs of Amascut | Pharaoh's sceptre |
| 14 | Zulrah | Zul-andra teleport scroll |
| 15 | Phantom Muspah | Quetzal whistle |
| 19 | The Gauntlet | Crystal teleport seed |
| 20 | Corrupted Gauntlet | Crystal teleport seed |

`equippedItemIds` only returns true for items currently in the equipment container, so it cannot express these teleport prerequisites. The local memory note on the inventory-vs-equipped categorisation lesson captures the rationale in full; the short version is that wieldability does not imply equipment-slot teleport use, and the inventory check is a separate concern.

An OR-semantic `inventoryItemIdsAny` for the multi-charge sceptre case (charges 1-5) is a second schema gap; that is left for a follow-up and is out of scope here.

## Schema

```java
@Nullable
List<Integer> inventoryItemIds;
```

JSON shape:

```json
"requirements": {
  "inventoryItemIds": [26945, 23959]
}
```

Semantics: AND across the list (player must hold every listed ID in inventory), AND-composed with the rest of `requirements`. `null` and empty are both no-ops on the evaluator side; null entries inside a populated list are skipped (parity with the existing `equippedItemIds` null guard).

## Evaluator integration

The evaluator wires the new clause through `PlayerInventoryState`, the existing `@Singleton` in `com.collectionloghelper.data` that already snapshots the player's regular inventory container via `ItemContainerChanged`. No new player-state detector is introduced; this PR reuses the existing infrastructure.

- File: `src/main/java/com/collectionloghelper/data/PlayerInventoryState.java`
- API: `boolean hasItem(int itemId)`
- Refresh trigger: existing `scanInventory(ItemContainer)` already runs on `ItemContainerChanged` for the inventory container.

## Files

Production:
- `src/main/java/com/collectionloghelper/data/SourceRequirements.java`: +1 nullable field, full javadoc covering AND semantics and the equipped-vs-inventory distinction.
- `src/main/java/com/collectionloghelper/data/RequirementsChecker.java`: +`PlayerInventoryState` constructor dependency, +`inventoryItemIds` clause in `checkRequirementsDetail`.

Tests added (3 classes):
- `SourceRequirementsInventoryItemsGsonTest` (11 cases) - Gson: absent / null / empty / single / multi / negative-id / string-element / float-element / six-fields-together + equals/hashCode + round-trip.
- `RequirementsCheckerInventoryItemsTest` (11 cases) - evaluator: empty / single-present / single-absent / multi-all-present / multi-one-missing / null-entry-skipped + 3 AND-across-clauses + 2 alternative-selection (mirrors `GuidanceStep.resolveAlternative` iteration).
- `InventoryItemsMigrationTest` (2 cases) - loads the production `drop_rates.json` and walks every source's top-level requirements, every `Waypoint.requirements`, every `ConditionalAlternative.requirements` (flat and nested), and asserts every `inventoryItemIds` is null. Mirrors `B1MigrationTest` (#637) and `B1aRegressionTest` / `B1bRegressionTest`.

Tests updated (positional-constructor drift on `@Value` `SourceRequirements`):
- `CollectionLogSourceTest`, `GuidanceSequencerTest`, `GuidanceSequencerNestedConditionalTest`, `SourceRequirementsB0Test`, `RequirementsCheckerB0Test`, `SourceRequirementsHeaderTest`.

## Confirmations

- Zero `drop_rates.json` diff. `git diff origin/master -- src/main/resources/com/collectionloghelper/drop_rates.json` is empty.
- `./gradlew build` passes locally (1543 tests + `lintDropRates` + `jacocoTestCoverageVerification`).
- New code and added lines are ASCII-only.

## Test plan

- [x] `./gradlew build` green locally
- [x] `./gradlew test --tests "*InventoryItems*"` covers the 24 new cases
- [x] `InventoryItemsMigrationTest.everySourceRequirementsHasNullInventoryItemIds` guards the zero-pilot invariant for this PR
- [x] Existing tests using the positional `SourceRequirements` constructor updated to add the new trailing `null` arg

## References

- #623 - Tier B0 additive-schema precedent (`pohTeleports` + `equippedItemIds`)
- #628 - Wave-1 B1 closure note listing the 5 deferred inventory-teleport sources that the future C-extension data PR will wire using this field
- #637 - B1 conditionTree additive-schema PR, source of the migration-guard test pattern this PR mirrors