### PR TITLE
feat(data): B1 Phase 4 pilot - conditionTree on Wintertodt brazier step

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -7975,7 +7975,13 @@
         "completionCondition": "MANUAL",
         "section": "Skilling",
         "loopBackToStep": 2,
-        "loopCount": 5
+        "loopCount": 5,
+        "conditionTree": {
+          "or": [
+            { "chat_message_received": "The Wintertodt has been subdued" },
+            { "chat_message_received": "Your Wintertodt subdued count is:" }
+          ]
+        }
       },
       {
         "description": "When Wintertodt's health hits zero, claim Supply crates from the box. Aim for 500+ points per game (4 crates) or 850+ (5 crates / Pyromancer outfit fast). Open crates for the Pyromancer outfit, Bruma torch, Warm gloves, Tome of fire pages, and Phoenix pet",

--- a/src/test/java/com/collectionloghelper/data/WintertodtConditionTreePilotTest.java
+++ b/src/test/java/com/collectionloghelper/data/WintertodtConditionTreePilotTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data;
+
+import com.collectionloghelper.data.condition.ConditionNode;
+import com.collectionloghelper.data.condition.LeafNode;
+import com.collectionloghelper.data.condition.OrNode;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * B1 Phase 4 pilot - structural regression guard for the {@code Wintertodt}
+ * brazier-light / pyromancer-heal step's {@code conditionTree}.
+ *
+ * <p>The pilot rationale (see scoping doc section 4) is that the legacy flat
+ * enum coerces a disjunctive completion ("the round finished from the player's
+ * point of view") into a single {@code MANUAL} step. The actual round-end
+ * signal in Wintertodt is one of two chat messages: a global notice that the
+ * boss has been subdued, or the per-player points tally that fires only for
+ * players who scored at least 500. Either is sufficient to advance the step.
+ *
+ * <p>Tree authored on this step:
+ *
+ * <pre>
+ * "conditionTree": {
+ *   "or": [
+ *     { "chat_message_received": "The Wintertodt has been subdued" },
+ *     { "chat_message_received": "Your Wintertodt subdued count is:" }
+ *   ]
+ * }
+ * </pre>
+ *
+ * <p>This test is intentionally structural. The live evaluator is exercised
+ * by {@code ConditionNodeEvaluatorTest}; here we only assert that
+ * {@code drop_rates.json} parses into the expected tree shape and that the
+ * legacy flat field is preserved for the fall-through path. Mirrors
+ * {@code TroubleBrewingConditionTreePilotTest}, which is the Phase 3 pilot.
+ */
+public class WintertodtConditionTreePilotTest
+{
+	private static final String SOURCE_NAME = "Wintertodt";
+	private static final String SUBDUED_GLOBAL_PATTERN = "The Wintertodt has been subdued";
+	private static final String SUBDUED_PERSONAL_PATTERN = "Your Wintertodt subdued count is:";
+
+	private DropRateDatabase database;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		database = new DropRateDatabase();
+
+		// Stock Gson. The conditionTree adapter is wired via @JsonAdapter on
+		// GuidanceStep.conditionTree, so no manual registration is needed -
+		// matching what RuneLite supplies via @Inject in production.
+		Gson gson = new GsonBuilder().create();
+		Field gsonField = DropRateDatabase.class.getDeclaredField("gson");
+		gsonField.setAccessible(true);
+		gsonField.set(database, gson);
+
+		database.load();
+	}
+
+	@Test
+	public void wintertodtSourceLoads()
+	{
+		CollectionLogSource source = findWintertodt();
+		assertNotNull(source, SOURCE_NAME + " must be present in drop_rates.json");
+		assertNotNull(source.getGuidanceSteps(),
+			SOURCE_NAME + " must have guidance steps");
+		assertTrue(source.getGuidanceSteps().size() >= 1,
+			SOURCE_NAME + " must have at least one guidance step");
+	}
+
+	@Test
+	public void brazierStep_hasDisjunctiveConditionTree()
+	{
+		GuidanceStep brazier = findBrazierStep();
+
+		ConditionNode tree = brazier.getConditionTree();
+		assertNotNull(tree,
+			"brazier-light step must opt into conditionTree; see B1 Phase 3 scoping doc section 4");
+
+		assertTrue(tree instanceof OrNode,
+			"root must be OrNode (subdued-global OR subdued-personal); got "
+				+ tree.getClass().getSimpleName());
+
+		OrNode root = (OrNode) tree;
+		assertEquals(2, root.getChildren().size(),
+			"root OR must have exactly 2 children: the two round-end chat patterns");
+
+		// Child 0: CHAT_MESSAGE_RECEIVED for the global subdued notice.
+		ConditionNode globalChild = root.getChildren().get(0);
+		assertTrue(globalChild instanceof LeafNode,
+			"first child must be a LeafNode for CHAT_MESSAGE_RECEIVED; got "
+				+ globalChild.getClass().getSimpleName());
+		LeafNode globalLeaf = (LeafNode) globalChild;
+		assertSame(CompletionCondition.CHAT_MESSAGE_RECEIVED, globalLeaf.getType(),
+			"first leaf must be CHAT_MESSAGE_RECEIVED");
+		assertEquals(SUBDUED_GLOBAL_PATTERN, globalLeaf.getChatPattern(),
+			"first leaf must carry the global round-end subdued pattern");
+
+		// Child 1: CHAT_MESSAGE_RECEIVED for the per-player points tally.
+		ConditionNode personalChild = root.getChildren().get(1);
+		assertTrue(personalChild instanceof LeafNode,
+			"second child must be a LeafNode for CHAT_MESSAGE_RECEIVED; got "
+				+ personalChild.getClass().getSimpleName());
+		LeafNode personalLeaf = (LeafNode) personalChild;
+		assertSame(CompletionCondition.CHAT_MESSAGE_RECEIVED, personalLeaf.getType(),
+			"second leaf must be CHAT_MESSAGE_RECEIVED");
+		assertEquals(SUBDUED_PERSONAL_PATTERN, personalLeaf.getChatPattern(),
+			"second leaf must carry the per-player subdued-count pattern");
+	}
+
+	@Test
+	public void brazierStep_keepsLegacyFlatField()
+	{
+		GuidanceStep brazier = findBrazierStep();
+
+		// The flat field is preserved verbatim: anyone running on an older
+		// build, or any code path that has not yet been migrated to consult
+		// the tree, sees exactly the pre-pilot behaviour (manual advance).
+		assertSame(CompletionCondition.MANUAL, brazier.getCompletionCondition(),
+			"brazier-light step must keep MANUAL as its legacy flat condition for the fall-through path");
+	}
+
+	@Test
+	public void onlyBrazierStepCarriesConditionTree()
+	{
+		CollectionLogSource source = findWintertodt();
+		int treeCount = 0;
+		for (GuidanceStep step : source.getGuidanceSteps())
+		{
+			if (step != null && step.getConditionTree() != null)
+			{
+				treeCount++;
+			}
+		}
+		assertEquals(1, treeCount,
+			SOURCE_NAME + " must opt exactly one step (the brazier-light) into conditionTree; "
+				+ "found " + treeCount);
+	}
+
+	private CollectionLogSource findWintertodt()
+	{
+		for (CollectionLogSource source : database.getAllSources())
+		{
+			if (SOURCE_NAME.equals(source.getName()))
+			{
+				return source;
+			}
+		}
+		throw new AssertionError(SOURCE_NAME + " not found in drop_rates.json");
+	}
+
+	private GuidanceStep findBrazierStep()
+	{
+		CollectionLogSource source = findWintertodt();
+		// Find by description fragment that is unique to the brazier-light step
+		// and resilient to future step insertions earlier in the chain.
+		for (GuidanceStep step : source.getGuidanceSteps())
+		{
+			if (step != null
+				&& step.getDescription() != null
+				&& step.getDescription().toLowerCase().contains("feed kindling to the brazier"))
+			{
+				return step;
+			}
+		}
+		throw new AssertionError(
+			"Brazier-light step not found in " + SOURCE_NAME + " guidance sequence");
+	}
+}

--- a/src/test/java/com/collectionloghelper/data/condition/B1MigrationTest.java
+++ b/src/test/java/com/collectionloghelper/data/condition/B1MigrationTest.java
@@ -64,10 +64,12 @@ public class B1MigrationTest
 	 * <ul>
 	 *   <li>Trouble Brewing - victory-drop step, see
 	 *       {@code TroubleBrewingConditionTreePilotTest}.</li>
+	 *   <li>Wintertodt - brazier-light / pyromancer-heal step, see
+	 *       {@code WintertodtConditionTreePilotTest}.</li>
 	 * </ul>
 	 */
 	private static final java.util.Set<String> PHASE_3_PILOT_SOURCES =
-		java.util.Set.of("Trouble Brewing");
+		java.util.Set.of("Trouble Brewing", "Wintertodt");
 
 	private DropRateDatabase database;
 


### PR DESCRIPTION
## Summary

Second production opt-in to the `conditionTree` schema (B1, scoping doc section 4 Phase 3 candidate; Phase 4 pilot expansion). Follows:

- #634 (B1 scoping doc)
- #637 (Phase 1+2 schema landing + evaluator)
- #638 (Trouble Brewing pilot - conjunctive shape)

This PR wires the disjunctive shape on **Wintertodt**'s brazier-light / pyromancer-heal step, which today coerces "the round has ended from the player's POV" into a single `MANUAL` step. The actual round-end signal is one of two chat messages, either of which is sufficient to advance.

## OR composition shape

```json
"conditionTree": {
  "or": [
    { "chat_message_received": "The Wintertodt has been subdued" },
    { "chat_message_received": "Your Wintertodt subdued count is:" }
  ]
}
```

- First branch: global notice sent to every player in the arena at round-end.
- Second branch: per-player tally that only fires for participants who scored >= 500 (the same pattern the reward step already uses).
- Either is sufficient: AFK / low-score players who miss the personal tally still advance on the global notice; high-score players advance on whichever lands first.

## What changed

- `src/main/resources/com/collectionloghelper/drop_rates.json` - one step modified on the **Wintertodt** source (the third guidance step, brazier-light / pyromancer-heal). The legacy `"completionCondition": "MANUAL"` and the `loopBackToStep: 2, loopCount: 5` semantics are preserved verbatim; `conditionTree` is purely additive.
- `src/test/java/com/collectionloghelper/data/WintertodtConditionTreePilotTest.java` - new structural regression test mirroring `TroubleBrewingConditionTreePilotTest`: asserts the tree shape, asserts the legacy flat field is unchanged, and asserts exactly one step on the source opts into `conditionTree`.
- `src/test/java/com/collectionloghelper/data/condition/B1MigrationTest.java` - adds `"Wintertodt"` to the `PHASE_3_PILOT_SOURCES` allowlist so the global migration guard recognises this as an intentional opt-in.

Zero other sources touched. Zero changes to the 224 non-Wintertodt sources, the evaluator, the schema, or the deserializer.

## Dynamic-target evaluator coexistence

The brazier step is also the registration point for `WintertodtBrazierEvaluator` (B5 #473), which computes a dynamic target tile for the overlay arrow each tick by scanning for lit-brazier NPCs (29312 / 29313). That evaluator drives **where the overlay points**; it does not participate in completion semantics. The new `conditionTree` drives **when the step is satisfied**. They run on independent fields (`dynamicTargetEvaluator` vs `conditionTree`) and never overlap - the evaluator continues to point at the nearest lit brazier each tick, and the tree provides an automatic round-end advance so the player no longer has to click "done" manually when the boss falls.

## Test plan

- [x] `./gradlew build` passes (compile + unit tests + lintDropRates + jacoco coverage verification).
- [x] `WintertodtConditionTreePilotTest` parses the source and asserts the OR shape, both chat patterns, and exactly-one-tree.
- [x] `B1MigrationTest.onlyAllowlistedPilotsCarryConditionTree` passes with Wintertodt now in the allowlist.
- [x] ASCII-only check on the modified JSON and new test file.
- [x] Rebased on latest `origin/master` before push.