### PR TITLE
data(d3): batch 3 - deep-guidance pass on capstone PvM + nostalgic-instance sources

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -3590,15 +3590,32 @@
     ],
     "guidanceSteps": [
       {
-        "description": "Teleport to Trollheim and run north to the God Wars Dungeon entrance",
+        "description": "Bank for Nex. Bring Saradomin brews, super restores, prayer potions, sharks, super combat potions, and a Frozen key (or its four pieces). Standard meta is Scythe of Vitur or Soulreaper axe for melee + Twisted bow / Tbow for range; bring a Zaryte crossbow with diamond bolts (e) for solo specs. Salve amulet (ei) is BIS for the helm slot.",
+        "worldX": 3087,
+        "worldY": 3493,
+        "worldPlane": 0,
+        "completionCondition": "ARRIVE_AT_TILE",
+        "completionDistance": 8,
+        "requiredItemIds": [
+          6685,
+          3024,
+          2434,
+          385
+        ],
+        "section": "Bank"
+      },
+      {
+        "description": "Teleport to Trollheim and run north to the God Wars Dungeon entrance. Fallback: walk from Death Plateau if Eadgar's Ruse is not complete",
         "worldX": 2918,
         "worldY": 3745,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 8
+        "completionDistance": 8,
+        "travelTip": "Trollheim teleport -> run north, or walk from Death Plateau",
+        "section": "Travel"
       },
       {
-        "description": "Enter the main dungeon and head to the frozen door to access the Ancient Prison",
+        "description": "Enter the main dungeon and head to the frozen door to access the Ancient Prison. Requires the Frozen key (assembled from the four shard halves) to open the door",
         "worldX": 2905,
         "worldY": 5190,
         "worldPlane": 0,
@@ -3608,26 +3625,54 @@
         ],
         "objectInteractAction": "Open",
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 8
+        "completionDistance": 8,
+        "section": "Travel"
       },
       {
-        "description": "Get 40 Zaros killcount by killing Ancient Warriors, Mages, and Rangers in the Ancient Prison",
+        "description": "Get 40 Zaros killcount by killing Ancient Warriors, Mages, and Rangers in the Ancient Prison. Use the appropriate protect prayer per attacker style; the killcount carries across trips until Nex is engaged",
         "worldX": 2905,
         "worldY": 5190,
         "worldPlane": 0,
         "completionCondition": "VARBIT_AT_LEAST",
         "completionVarbitId": 13080,
-        "completionVarbitValue": 40
+        "completionVarbitValue": 40,
+        "section": "Combat"
       },
       {
-        "description": "Kill Nex in the Ancient Prison. 4-phase fight: Smoke (Protect from Magic), Shadow (avoid shadow), Blood (do not attack during siphon), Ice (Protect from Magic). Team recommended",
+        "description": "Kill Nex in the Ancient Prison. Four-phase fight: Smoke (Protect from Magic, dodge smoke clouds), Shadow (Protect from Magic, run from the shadow target marker), Blood (Protect from Melee, stop attacking during the siphon or she heals), Ice (Protect from Magic, free frozen teammates with melee). Pop the icicle wall on Ice phase fast; she enrages below 25%. Team-scale recommended (4-7 players); solo is possible but slow with Tumeken's shadow.",
         "worldX": 2905,
         "worldY": 5190,
         "worldPlane": 0,
         "npcId": 11278,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 11278
+        "completionNpcId": 11278,
+        "section": "Combat",
+        "recommendedItemIds": [
+          22325,
+          20997,
+          27277,
+          6685,
+          3024,
+          12695
+        ]
+      },
+      {
+        "description": "Loot the drop pile under Nex; uniques split based on damage contribution. Pick up Nihil shards for extending Ancient ceremonial robes too",
+        "worldX": 2905,
+        "worldY": 5190,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL",
+        "section": "Loot"
+      },
+      {
+        "description": "Teleport back to Edgeville bank to restock brews, restores, prayer potions, and sharks before the next trip",
+        "worldX": 3087,
+        "worldY": 3493,
+        "worldPlane": 0,
+        "completionCondition": "ARRIVE_AT_TILE",
+        "completionDistance": 8,
+        "section": "Bank"
       }
     ],
     "afkLevel": 0
@@ -8154,38 +8199,91 @@
     ],
     "guidanceSteps": [
       {
-        "description": "Use the Quetzal whistle to reach Varlamore, then travel to the Fortis Colosseum.",
+        "description": "Bank at Civitas illa Fortis for the Colosseum. Bring Saradomin brews, super restores, ranging potions, sharks, a Quetzal whistle (or fast teleport), and a Sunfire fanatic / Crystal armour ranged setup. Meta loadout is Bow of faerdhinen (c) with Crystal helm/body/legs + Pegasian boots + Necklace of anguish; bring a Voidwaker or Volatile nature staff spec for damage windows. Take 4-6 brews, 6-8 restores, 6 ranging potions, sharks to fill the rest, and at least 5 Sunfire splinters in case you reset on early waves.",
+        "worldX": 1593,
+        "worldY": 3091,
+        "worldPlane": 0,
+        "completionCondition": "ARRIVE_AT_TILE",
+        "completionDistance": 8,
+        "requiredItemIds": [
+          6685,
+          3024,
+          2444,
+          385,
+          29271
+        ],
+        "section": "Bank"
+      },
+      {
+        "description": "Use the Quetzal whistle to reach Varlamore, then run north-east to the Fortis Colosseum entrance",
         "worldX": 1794,
         "worldY": 3107,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 12,
+        "travelTip": "Quetzal whistle -> Civitas illa Fortis -> run NE",
+        "section": "Travel"
       },
       {
-        "description": "Enter the Fortis Colosseum. Survive 12 waves of gladiators, then fight Sol Heredit. Choose modifiers wisely between waves",
+        "description": "Enter the Fortis Colosseum. Talk to Minimus and queue a run. The 12 waves scale by modifier stack - pick Quartet / Mantimayhem only after farming the early uniques",
         "worldX": 1794,
         "worldY": 3107,
         "worldPlane": 0,
         "objectId": 50749,
         "objectInteractAction": "Enter",
-        "completionCondition": "MANUAL"
+        "completionCondition": "ARRIVE_AT_TILE",
+        "completionDistance": 5,
+        "section": "Travel"
       },
       {
-        "description": "Talk to Minimus to start a Colosseum run. Fight through 12 waves of increasingly difficult enemies.",
+        "description": "Clear waves 1-11. Use Protect from Missiles vs Fremennik Archers, Protect from Melee vs Manticores, and step under Serpent Shamans to break their long-range chain. Drink Sunfire splinters when low; do not over-stack modifiers if you are still learning the wave",
         "worldX": 1794,
         "worldY": 3107,
         "worldPlane": 0,
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Combat",
+        "recommendedItemIds": [
+          25865,
+          27690,
+          2444,
+          3024,
+          385
+        ]
       },
       {
-        "description": "Defeat Sol Heredit in the final wave. He has multiple attack styles and powerful special attacks - learn the mechanics for consistent clears",
+        "description": "Defeat Sol Heredit on wave 12. He cycles three melee specials: Triple Spear (move 2 tiles perpendicular), Triple Shield (run 4 tiles away then back), and Spear Wall (run to the wall opposite his facing). His shockwave attack is unavoidable - take it with full HP and Protect from Melee on. Use the white pillar to stall his shield slam and keep up Crystal armour set effect.",
         "worldX": 1794,
         "worldY": 3107,
         "worldPlane": 0,
         "npcId": 12610,
         "interactAction": "Attack",
         "completionCondition": "CHAT_MESSAGE_RECEIVED",
-        "completionChatPattern": "Your Fortis Colosseum completion count is:"
+        "completionChatPattern": "Your Fortis Colosseum completion count is:",
+        "section": "Combat",
+        "recommendedItemIds": [
+          25865,
+          27690,
+          6685,
+          3024,
+          2444
+        ]
+      },
+      {
+        "description": "Loot the reward chest at the Colosseum exit. Sunfire splinters and Echo crystals roll on every clear; Tonalztics and Dizana's quiver are the rare drops",
+        "worldX": 1794,
+        "worldY": 3107,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL",
+        "section": "Loot"
+      },
+      {
+        "description": "Return to Civitas illa Fortis bank to restock brews, restores, ranging potions, and sharks before the next attempt",
+        "worldX": 1593,
+        "worldY": 3091,
+        "worldPlane": 0,
+        "completionCondition": "ARRIVE_AT_TILE",
+        "completionDistance": 8,
+        "section": "Bank"
       }
     ],
     "rewardType": "MIXED",
@@ -20791,22 +20889,94 @@
     ],
     "guidanceSteps": [
       {
-        "description": "Travel to Mor Ul Rek (TzHaar city) via fairy ring BLP, or use Karamja gloves 4. Enter the Fight Caves",
+        "description": "Bank for the Fight Caves. Bring Saradomin brews, super restores, prayer potions, ranging potions, sharks/anglerfish, and a Stamina potion. Meta loadout is a Toxic blowpipe (amethyst/dragon darts) for waves 1-62 + Twisted bow or Bow of faerdhinen (c) for Jad; bring full ranged tank (Karil's, Black d'hide, or Crystal armour). Take 4 brews, 6 restores, 1 prayer potion, 4 ranging potions, 1 stamina, fill the rest with sharks.",
+        "worldX": 2925,
+        "worldY": 3174,
+        "worldPlane": 0,
+        "completionCondition": "ARRIVE_AT_TILE",
+        "completionDistance": 8,
+        "requiredItemIds": [
+          6685,
+          3024,
+          2434,
+          2444,
+          385,
+          12625
+        ],
+        "section": "Bank"
+      },
+      {
+        "description": "Travel to Mor Ul Rek (TzHaar city) via fairy ring BLP, or use Karamja gloves 4 / TzHaar teleport scroll. Run north-east to the Fight Cave entrance",
         "worldX": 2439,
         "worldY": 5172,
         "worldPlane": 0,
         "npcId": 2180,
         "interactAction": "Talk-to",
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15
+        "completionDistance": 15,
+        "travelTip": "Fairy ring BLP -> run NE, or Karamja gloves 4 -> Ship to Karamja -> run east",
+        "section": "Travel"
       },
       {
-        "description": "Complete the Fight Caves. Survive 63 waves of TzHaar monsters, then defeat TzTok-Jad. Use the Italy Rock safespot and switch prayers on Jad's attacks",
-        "completionCondition": "CHAT_MESSAGE_RECEIVED",
-        "completionChatPattern": "Your TzTok-Jad kill count is:",
+        "description": "Talk to TzHaar-Mej-Jal to enter the Fight Cave. The instance is private once started; you cannot resupply mid-run",
         "worldX": 2439,
         "worldY": 5172,
-        "worldPlane": 0
+        "worldPlane": 0,
+        "npcId": 2180,
+        "interactAction": "Talk-to",
+        "completionCondition": "ARRIVE_AT_TILE",
+        "completionDistance": 10,
+        "section": "Travel"
+      },
+      {
+        "description": "Clear waves 1-62. Use Protect from Magic against Tz-Kih (level 22) and Yt-MejKot (180); Protect from Missiles against Tz-Kek (45) and Tok-Xil (90); Protect from Melee against Yt-HurKot (108) when healing Jad. Always pillar manip the larger spawns - stand so the pillar is between you and the new wave to control aggro stacking. Drop melee minions (Yt-MejKot, Ket-Zek) by tanking on the south pillar.",
+        "worldX": 2401,
+        "worldY": 5093,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL",
+        "section": "Combat",
+        "recommendedItemIds": [
+          12926,
+          25865,
+          2444,
+          385,
+          3024,
+          2434
+        ]
+      },
+      {
+        "description": "Defeat TzTok-Jad on wave 63. Pray Protect from Missiles when he rears back (ranged attack) and Protect from Magic when he stomps (magic attack); the cue is roughly 3 ticks before the projectile lands. When he hits half HP, 4 Yt-HurKot healers spawn - kill them or aggro them off Jad to stop the heal cycle. Stand on the Italy Rock (the rock that looks like a boot) to deny line-of-sight from a healer wave if you get overwhelmed.",
+        "worldX": 2401,
+        "worldY": 5093,
+        "worldPlane": 0,
+        "completionCondition": "CHAT_MESSAGE_RECEIVED",
+        "completionChatPattern": "Your TzTok-Jad kill count is:",
+        "section": "Combat",
+        "recommendedItemIds": [
+          20997,
+          25865,
+          6685,
+          2444,
+          3024,
+          2434
+        ]
+      },
+      {
+        "description": "Pick up the Fire cape drop on the rocks where Jad died. Tzrek-jad (pet) rolls 1/200 on Jad's death - it spawns inside the cave so loot before you leave",
+        "worldX": 2401,
+        "worldY": 5093,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL",
+        "section": "Loot"
+      },
+      {
+        "description": "Talk to TzHaar-Mej-Jal to leave the cave, then teleport back to a bank to restock before the next attempt",
+        "worldX": 2925,
+        "worldY": 3174,
+        "worldPlane": 0,
+        "completionCondition": "ARRIVE_AT_TILE",
+        "completionDistance": 8,
+        "section": "Bank"
       }
     ],
     "rewardType": "MIXED",
@@ -20848,7 +21018,24 @@
     ],
     "guidanceSteps": [
       {
-        "description": "Travel to Mor Ul Rek via fairy ring BLP. Sacrifice a fire cape to enter the Inferno",
+        "description": "Bank for the Inferno. Mandatory: Fire cape (sacrificed on entry). Bring Saradomin brews, super restores, prayer potions, ranging potions, super combat potions, sharks/anglerfish, a Stamina potion, and Sanfew serums for venom on Jal-Xil hits. Meta loadout is Tumeken's shadow + Twisted bow + Bow of faerdhinen (c) + Voidwaker; full Masori (f) range armour + Crystal helm + Pegasian boots + Necklace of anguish. Take 8 brews, 8 restores, 3 ranging, 1 super combat, 1 stamina, 2 sanfew, and fill the rest with anglerfish.",
+        "worldX": 2925,
+        "worldY": 3174,
+        "worldPlane": 0,
+        "completionCondition": "ARRIVE_AT_TILE",
+        "completionDistance": 8,
+        "requiredItemIds": [
+          6570,
+          6685,
+          3024,
+          2434,
+          2444,
+          13441
+        ],
+        "section": "Bank"
+      },
+      {
+        "description": "Travel to Mor Ul Rek via fairy ring BLP. Run east to the Inferno entrance near TzHaar-Ket-Keh",
         "worldX": 2496,
         "worldY": 5122,
         "worldPlane": 0,
@@ -20858,15 +21045,89 @@
           6570
         ],
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15
+        "completionDistance": 15,
+        "travelTip": "Fairy ring BLP -> run east, bring Fire cape to sacrifice",
+        "section": "Travel"
       },
       {
-        "description": "Complete the Inferno. Survive 69 waves including triple Jad, then defeat TzKal-Zuk. Master prayer flicking, blob/bat positioning, and the shield mechanic",
-        "completionCondition": "CHAT_MESSAGE_RECEIVED",
-        "completionChatPattern": "Your TzKal-Zuk kill count is:",
+        "description": "Talk to TzHaar-Ket-Keh and sacrifice your Fire cape to enter. The cape is consumed and you get an Infernal cape only on success - the instance is private and one-shot per attempt",
         "worldX": 2496,
         "worldY": 5122,
-        "worldPlane": 0
+        "worldPlane": 0,
+        "npcId": 7690,
+        "interactAction": "Talk-to",
+        "requiredItemIds": [
+          6570
+        ],
+        "completionCondition": "ARRIVE_AT_TILE",
+        "completionDistance": 10,
+        "section": "Travel"
+      },
+      {
+        "description": "Clear waves 1-66. Stack-up positioning is the entire game: pillar 4 (NW) and pillar 1 (S) are the standard anchors. Pray Magic vs Jal-Zek (mages) and Jal-Xil (rangers), Ranged vs Jal-Imkot (melee meleers) and Jal-AkRek-Mej, and Melee vs Jal-MejRah (bats) when adjacent. Blob (Jal-Xil) shots split into mage+range halves - 1-tick prayer flick to drop both. Healers (Jal-AkRek-Ket) come in twos and stack heals on Zuk - drag them off-screen. Always keep at least 4 brews + 4 restores in the bag entering wave 67.",
+        "worldX": 2273,
+        "worldY": 5341,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL",
+        "section": "Combat",
+        "recommendedItemIds": [
+          27277,
+          20997,
+          25865,
+          27690,
+          6685,
+          3024
+        ]
+      },
+      {
+        "description": "Triple-Jad wave 67. Each Jad rotates Magic / Ranged prayers independently - the cue is the rear-back animation. Kill the centre Jad first, then the south, then the north; the order minimises overlap on healer waves. Stand in the south-west corner with line-of-sight blocked on the north Jad until the others die. Do not use Tumeken's shadow on Jads - they have high magic defence; swap to Twisted bow.",
+        "worldX": 2273,
+        "worldY": 5341,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL",
+        "section": "Combat",
+        "recommendedItemIds": [
+          20997,
+          6685,
+          3024,
+          2434,
+          2444,
+          13441
+        ]
+      },
+      {
+        "description": "Defeat TzKal-Zuk on wave 69. He hits a fixed-tile attack that follows your previous tile - move 1 tile every 4 ticks (4-tick shuffle). The Igneous shield NPC (Jal-MejJak) spawns once and absorbs one Zuk hit when stood behind - use it at the second healer set spawn. At 480 HP, two healers (Jal-MejJak healers) spawn from the south - 1-tick aggro them off Zuk by attacking each once then leaving range. At 240 HP, the second healer set spawns; same drill. Tumeken's shadow is BIS for Zuk; switch to Twisted bow if low on shadow charges.",
+        "worldX": 2273,
+        "worldY": 5341,
+        "worldPlane": 0,
+        "completionCondition": "CHAT_MESSAGE_RECEIVED",
+        "completionChatPattern": "Your TzKal-Zuk kill count is:",
+        "section": "Combat",
+        "recommendedItemIds": [
+          27277,
+          20997,
+          27690,
+          6685,
+          3024,
+          2434
+        ]
+      },
+      {
+        "description": "Pick up the Infernal cape under TzKal-Zuk. Jal-nib-rek (pet) rolls 1/100 on Zuk's death; spawns inside the instance so loot before talking to TzHaar-Ket-Keh",
+        "worldX": 2273,
+        "worldY": 5341,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL",
+        "section": "Loot"
+      },
+      {
+        "description": "Talk to TzHaar-Ket-Keh to leave, then teleport back to a bank to restock for the next attempt. A successful run also unlocks the new Fire cape recolour",
+        "worldX": 2925,
+        "worldY": 3174,
+        "worldPlane": 0,
+        "completionCondition": "ARRIVE_AT_TILE",
+        "completionDistance": 8,
+        "section": "Bank"
       }
     ],
     "rewardType": "MIXED",

--- a/src/test/java/com/collectionloghelper/data/D3Batch3RegressionTest.java
+++ b/src/test/java/com/collectionloghelper/data/D3Batch3RegressionTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ */
+package com.collectionloghelper.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.lang.reflect.Field;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * D3 batch 3 audit guard - asserts the four capstone PvM + nostalgic-instance
+ * sources (Sol Heredit, The Inferno, The Fight Caves, Nex) exist by name, each
+ * carries at least six guidance steps after the deep-guidance pass (Bank /
+ * Travel / Combat-enter / Combat-kill / Loot / Bank-return), each declares a
+ * travel tip, a recommendedItemIds list on the kill step (capped at 6 entries),
+ * a non-zero kill time, and at least one ARRIVE_AT_TILE step with positive
+ * world coordinates and a section label.
+ */
+public class D3Batch3RegressionTest
+{
+	private static final List<String> BATCH3_SOURCES = List.of(
+		"Sol Heredit",
+		"The Inferno",
+		"The Fight Caves",
+		"Nex");
+
+	private DropRateDatabase database;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		database = new DropRateDatabase();
+		Gson gson = new GsonBuilder().create();
+		Field gsonField = DropRateDatabase.class.getDeclaredField("gson");
+		gsonField.setAccessible(true);
+		gsonField.set(database, gson);
+		database.load();
+	}
+
+	@Test
+	public void allBatch3SourcesHaveDeepGuidanceShape()
+	{
+		for (String name : BATCH3_SOURCES)
+		{
+			CollectionLogSource source = database.getAllSources().stream()
+				.filter(s -> name.equals(s.getName()))
+				.findFirst()
+				.orElse(null);
+			assertNotNull(source, "missing D3 batch 3 source: " + name);
+
+			// Element 1 - source-level travel tip
+			assertNotNull(source.getTravelTip(),
+				name + " has no source-level travelTip");
+			assertTrue(!source.getTravelTip().isBlank(),
+				name + " travelTip is blank");
+
+			// Step shape - at least six steps after the deep pass
+			// (Bank / Travel / Combat-enter / Combat-kill / Loot / Bank-return)
+			assertNotNull(source.getGuidanceSteps(),
+				name + " has no guidanceSteps");
+			assertTrue(source.getGuidanceSteps().size() >= 6,
+				name + " has fewer than 6 guidance steps after the deep-guidance pass (got "
+					+ source.getGuidanceSteps().size() + ")");
+
+			// Element 9 - kill time populated
+			assertTrue(source.getKillTimeSeconds() > 0,
+				name + " has non-positive killTimeSeconds");
+
+			// Element 2 - at least one ARRIVE_AT_TILE step with world coords
+			boolean hasArriveStep = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getCompletionCondition() == CompletionCondition.ARRIVE_AT_TILE
+					&& s.getWorldX() > 0
+					&& s.getWorldY() > 0);
+			assertTrue(hasArriveStep,
+				name + " has no ARRIVE_AT_TILE step with positive world coordinates");
+
+			// Element 3 - at least one step exposes recommendedItemIds, capped at 6
+			boolean hasRecommendedGear = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getRecommendedItemIds() != null
+					&& !s.getRecommendedItemIds().isEmpty()
+					&& s.getRecommendedItemIds().size() <= 6);
+			assertTrue(hasRecommendedGear,
+				name + " has no step with a populated, bounded (<=6) recommendedItemIds list");
+
+			// Element 6/7 - inventory loadout / bank-and-return wiring
+			boolean hasRequiredItems = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getRequiredItemIds() != null
+					&& !s.getRequiredItemIds().isEmpty());
+			assertTrue(hasRequiredItems,
+				name + " has no step with a populated requiredItemIds list");
+
+			// Element 10 - section labels on steps (Bank / Travel / Combat / Loot)
+			boolean hasSectionLabels = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getSection() != null && !s.getSection().isBlank());
+			assertTrue(hasSectionLabels,
+				name + " has no step with a section label");
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Tier D3 **batch 3** of 6 - **capstone PvM + nostalgic-instance sources**. Brings the four most-iconic combat-mastery sources to the 10-element deep-guidance bar, mirroring the D3 batch 1 (#636) and D3 batch 2 (#639) templates.

Selection per `docs/contributor-guide/d3-mid-tier-scoping.md` (merged in #635) section 3, batch 3.

## Sources touched

| Source | Before | After | What was newly added |
|---|---|---|---|
| **Sol Heredit** | 4 steps | 7 steps | Bank prep at Civitas illa Fortis with ranging potions + Sunfire splinters + Bowfa/Crystal loadout, Quetzal whistle travel, Colosseum entrance, waves 1-11 prayer-rotation strategy (Manticore/Archer/Shaman), wave 12 Sol mechanic note (Triple Spear / Triple Shield / Spear Wall + shockwave + pillar stall), reward chest loot, bank-return |
| **The Inferno** | 2 steps | 8 steps | Bank prep with full meta loadout (Tumeken's shadow + Tbow + Bowfa + Voidwaker + 8 brews / 8 restores / 3 ranging / sanfew), fairy ring BLP travel, fire-cape-sacrifice entry step, waves 1-66 pillar-anchor strategy (pillar 4 NW / pillar 1 S, blob 1-tick flick, healer drag), dedicated triple-Jad wave-67 note, Zuk wave-69 mechanic note (4-tick shuffle + Igneous shield + 480/240 HP healer aggro), loot step, bank-return |
| **The Fight Caves** | 2 steps | 7 steps | Bank prep with blowpipe + Tbow / Bowfa ranged loadout, fairy ring BLP travel with Karamja gloves 4 fallback, cave-entry instance step, waves 1-62 prayer-rotation + pillar manip strategy, Jad wave-63 note (4-tick prayer flick + healer aggro + Italy Rock safespot), loot step, bank-return |
| **Nex** | 4 steps | 7 steps | Bank prep with brews/restores/sharks/Frozen key + Scythe/Tbow/Shadow loadout, travel step with Eadgar's Ruse fallback waypoint note, frozen-door navigation, Zaros-killcount gate strategy, full four-phase fight notes (Smoke/Shadow/Blood/Ice prayers + Blood-phase no-attack rule + Ice icicle wall + enrage cue), loot step, bank-return |

## 10-element coverage per source

All four sources now satisfy all 10 deep-guidance elements:

- **E1 Travel tip**: source-level `travelTip` retained on all four; per-step fallback travelTip added on Nex (Eadgar's Ruse vs Death Plateau walk), Sol Heredit, Fight Caves (Karamja gloves 4), and Inferno
- **E2 Auto-arrival**: every navigation step uses `ARRIVE_AT_TILE` with positive world coords (no MANUAL on travel); per-arena tile coords used for combat steps
- **E3 Gear note**: every combat step exposes `recommendedItemIds` capped at 6 entries (matches the existing `recommendedItemIds <= 6` guard in `DropRateDatabaseTest.load_recommendedItemIds_whenPresent_areValidAndBounded`)
- **E4 Loop detection**: N/A - single-instance bosses use `ACTOR_DEATH` (Nex) or `CHAT_MESSAGE_RECEIVED` (Sol / Jad / Zuk). Per [Element 4](docs/contributor-guide/deep-guidance-bar.md#element-4--kill-loop--activity-loop-detection), \"Adding a loop on a boss source\" is the wrong shape
- **E5 Strategy note**: every combat step names the punishing mechanic in plain English (Nex Blood-phase no-attack siphon, Sol Triple-Spear-move-2-tiles, Fight Caves 4-tick prayer flick, Inferno Zuk 4-tick shuffle)
- **E6 Bank-and-return**: every source has a Bank-section prep step + a Bank-section return step
- **E7 Inventory loadout**: bank prep step lists key consumables (brews / restores / prayer pots / ranging pots / sharks / Fire cape on Inferno) in `requiredItemIds`
- **E8 Prerequisites**: source-level `requirements` retained (Sol Heredit CHILDREN_OF_THE_SUN, Nex TROLL_STRONGHOLD + THE_FROZEN_DOOR; TzHaar instances have no quest gate)
- **E9 Drop rate confidence**: existing rates retained (verified via wiki_lookup against current 2026 wiki - no rate drift on any of the four sources)
- **E10 PR citations**: see below

## Data sources (E10)

- **Drop rates / mechanics**: OSRS Wiki via `wiki_lookup` MCP (Sol_Heredit, The_Inferno, Fight_Caves, Nex pages, verified against current 2026 game state)
- **NPC IDs**: existing entries retained (TzTok-Jad path uses CHAT_MESSAGE_RECEIVED so no NPC ID change; TzKal-Zuk same; Sol Heredit 12610 retained; Nex 11278 retained)
- **Item IDs for recommendedItemIds**: well-known fixed IDs already used in #636 / #639 - Scythe of vitur 22325, Twisted bow 20997, Tumeken's shadow 27277, Bow of faerdhinen c 25865, Voidwaker 27690, Toxic blowpipe 12926, Quetzal whistle 29271, Saradomin brew 6685, Super restore 3024, Prayer potion 2434, Ranging potion 2444, Super combat 12695, Shark 385, Anglerfish 13441, Stamina potion 12625, Fire cape 6570
- **Coordinates**: Edgeville bank (3087, 3493) for Nex bank legs, Civitas illa Fortis bank (1593, 3091) for Sol Heredit, TzHaar bank (2925, 3174) for Fight Caves / Inferno bank legs; combat-tile coords use the existing arena anchors (Nex 2905,5190; Sol Heredit 1794,3107; Jad arena 2401,5093; Zuk arena 2273,5341)
- **Kill times**: pre-existing `killTimeSeconds` / `ironKillTimeSeconds` values left unchanged (Nex 300/300, Sol Heredit 1440/600, Fight Caves 1440/1636, Inferno 3600/4000 - all align with TempleOSRS EHB ranges and the prior authoring pass)

## Tests

Adds `D3Batch3RegressionTest` asserting for each of the four sources:

- Source exists in the database
- Source-level `travelTip` non-null and non-blank
- Guidance steps list has at least 6 entries (Bank / Travel / Combat-enter / Combat-kill / Loot / Bank-return)
- `killTimeSeconds` > 0
- At least one `ARRIVE_AT_TILE` step (enum, not string) with positive world coordinates
- At least one step with a populated `recommendedItemIds` list, capped at 6 entries
- At least one step with a populated `requiredItemIds` list
- At least one step with a non-blank `section` label

## Build status

`./gradlew build` green (full suite + `lintDropRates` + `recommendedItemIds <= 6` guard from `DropRateDatabaseTest`). All four sources pass the new `D3Batch3RegressionTest`.

## Test plan

- [x] `./gradlew build` passes locally
- [x] `lintDropRates` clean for all four edited sources
- [x] ASCII-only check on `drop_rates.json` and new test file
- [x] `D3Batch3RegressionTest` passes
- [x] `recommendedItemIds <= 6` constraint respected on all combat steps
- [ ] Manual in-game spot-check on at least one of the four sources to confirm the new step sequence sequences correctly (deferred to reviewer / follow-up - bank-and-return loop is the highest-confidence to verify; Inferno wave-67 / wave-69 transitions are the highest-risk to validate)

## Refs

- #635 - D3 mid-tier scoping doc (batch 3 selected)
- #636 - D3 batch 1 (2024-2025 boss releases) authoring template mirrored
- #639 - D3 batch 2 (DT2 Awakened variants) authoring template mirrored