### PR TITLE
data(d3): batch 5 - deep-guidance pass on mid-popularity slayer sources

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -5214,12 +5214,29 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to the Crash Site Cavern entrance, north-west of the Grand Tree.",
+        "description": "Bank for Demonic gorillas. Bring a ranged setup (Bow of faerdhinen or Toxic blowpipe with rune/amethyst darts) plus a melee swap (Scythe or Ghrazi rapier), Saradomin brews, super restores, prayer potions, and a few sharks. The gorillas hit hard through prayer when you tank a wrong style, so a tank-shield swap or extra brews are worth packing.",
+        "worldX": 2461,
+        "worldY": 3444,
+        "worldPlane": 0,
+        "completionCondition": "ARRIVE_AT_TILE",
+        "completionDistance": 8,
+        "requiredItemIds": [
+          6685,
+          3024,
+          2434,
+          385
+        ],
+        "section": "Bank"
+      },
+      {
+        "description": "Travel to the Crash Site Cavern entrance, north-west of the Grand Tree. Fastest routes are spirit tree to Gnome Stronghold, or Royal seed pod for free accounts after Monkey Madness II.",
         "worldX": 2027,
         "worldY": 5613,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15
+        "completionDistance": 15,
+        "travelTip": "Spirit tree -> Gnome Stronghold, then run north-west to the crash site",
+        "section": "Travel"
       },
       {
         "description": "Enter the Crash Site Cavern beneath the Gnome Stronghold",
@@ -5228,17 +5245,44 @@
         "worldPlane": 0,
         "objectId": 28686,
         "objectInteractAction": "Enter",
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Travel"
       },
       {
-        "description": "Kill Demonic gorillas in the Crash Site Cavern. Switch prayers based on their attack style. They change after 3 missed hits. Use ranged + melee switch",
+        "description": "Kill Demonic gorillas in the Crash Site Cavern. They cycle through Protect from Melee / Magic / Range after every three successful hits of the same style, so swap your style each time the prayer flips. Dodge the falling-boulder special (run one tile when the ground turns red) and the Magic-special purple orb (hits for up to 30 through prayer). Bow of faerdhinen or Toxic blowpipe + Ghrazi rapier on the swap is the modern meta.",
         "worldX": 2405,
         "worldY": 3419,
         "worldPlane": 0,
         "npcId": 7144,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 7144
+        "completionNpcId": 7144,
+        "section": "Combat",
+        "recommendedItemIds": [
+          25865,
+          12926,
+          22324,
+          6685,
+          3024,
+          2434
+        ]
+      },
+      {
+        "description": "Loot the ballista parts, Zenyte shards, and Monkey tails. Banking back to Edgeville or Castle Wars is the standard cycle; the spirit tree network gives you a fast return for the next trip.",
+        "worldX": 2405,
+        "worldY": 3419,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL",
+        "section": "Loot"
+      },
+      {
+        "description": "Return to bank when low on supplies. Spirit tree to Tree Gnome Village or Royal seed pod, then home teleport / Edgeville for a fast restock cycle.",
+        "worldX": 2461,
+        "worldY": 3444,
+        "worldPlane": 0,
+        "completionCondition": "ARRIVE_AT_TILE",
+        "completionDistance": 8,
+        "section": "Bank"
       }
     ],
     "afkLevel": 0
@@ -5250,6 +5294,7 @@
     "worldY": 3686,
     "worldPlane": 0,
     "killTimeSeconds": 30,
+    "requirements": {},
     "items": [
       {
         "itemId": 13576,
@@ -5265,22 +5310,66 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to the Lizardman Temple or Canyon in Shayzien (Xeric's talisman or fairy ring DJR)",
+        "description": "Bank for Lizardman shamans. Bring your best crush weapon (Inquisitor's mace, Saradomin sword, or Soulreaper axe), Saradomin brews, super restores, super combat potion, prayer potions, and a few sharks. Slayer task is recommended for the Dragon warhammer rate - confirm one is active before leaving Shayzien.",
+        "worldX": 1504,
+        "worldY": 3633,
+        "worldPlane": 0,
+        "completionCondition": "ARRIVE_AT_TILE",
+        "completionDistance": 8,
+        "requiredItemIds": [
+          6685,
+          3024,
+          2434,
+          12695,
+          385
+        ],
+        "section": "Bank"
+      },
+      {
+        "description": "Travel to the Lizardman Temple or Canyon in Shayzien. Xeric's talisman to Lookout drops you right next to the canyon entrance; fairy ring DJR is the unquested fallback.",
         "worldX": 1472,
         "worldY": 3686,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "travelTip": "Xeric's talisman -> Lookout, or fairy ring DJR",
+        "section": "Travel"
       },
       {
-        "description": "Kill Lizardman shamans. Dodge the acid pool and explosive spawn attacks. Stand near a wall to prevent being jumped on. Slayer task recommended for rates",
+        "description": "Kill Lizardman shamans in the canyon. Stand with your back against a wall to prevent the shamans from leaping on you and resetting your aggro. Step one tile off the green spawn pool as soon as it appears - the spawn explodes for 20+ damage if you stand on it. Use your crush weapon for the Dragon warhammer / Lizardman fang rare drops.",
         "worldX": 1472,
         "worldY": 3686,
         "worldPlane": 0,
         "npcId": 6766,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 6766
+        "completionNpcId": 6766,
+        "section": "Combat",
+        "recommendedItemIds": [
+          24417,
+          28338,
+          6685,
+          3024,
+          2434,
+          12695
+        ]
+      },
+      {
+        "description": "Loot the Dragon warhammer / Xeric's talisman pieces and ranarr seed stacks. Drag-loot the Lizardman fangs for Xeric's talisman charges before banking.",
+        "worldX": 1472,
+        "worldY": 3686,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL",
+        "section": "Loot"
+      },
+      {
+        "description": "Return to bank when supplies run low. Xeric's talisman -> Glade is the fastest cycle back to a Shayzien bank.",
+        "worldX": 1504,
+        "worldY": 3633,
+        "worldPlane": 0,
+        "completionCondition": "ARRIVE_AT_TILE",
+        "completionDistance": 8,
+        "section": "Bank"
       }
     ],
     "afkLevel": 1
@@ -8982,22 +9071,82 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Use a Guthixian temple teleport or attract a light creature with a sapphire lantern in the Chasm of Tears.",
+        "description": "Bank for Tormented Demons. Bring a melee weapon (Scythe of Vitur / Soulreaper axe), a ranged weapon (Bow of faerdhinen or Tbow with diamond bolts (e)), a magic switch (Tumeken's shadow or Trident), Darklight or an Emberlight for the shield-break phase, Saradomin brews, super restores, prayer potions, super combat potion, and a Guthixian temple teleport.",
+        "worldX": 3087,
+        "worldY": 3493,
+        "worldPlane": 0,
+        "completionCondition": "ARRIVE_AT_TILE",
+        "completionDistance": 8,
+        "requiredItemIds": [
+          6746,
+          29684,
+          6685,
+          3024,
+          2434,
+          12695
+        ],
+        "section": "Bank"
+      },
+      {
+        "description": "Use a Guthixian temple teleport to drop straight into the Chasm of Tears. The fallback unquested route is attracting a light creature in the chasm with a sapphire lantern - much slower but works without a teleport scroll.",
         "worldX": 4100,
         "worldY": 4415,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 8
+        "completionDistance": 8,
+        "requiredItemIds": [
+          29684
+        ],
+        "travelTip": "Guthixian temple teleport scroll (recommended), or sapphire lantern + light creature in the chasm",
+        "section": "Travel"
       },
       {
-        "description": "Kill Tormented Demons. Switch attack styles to break their protection prayers. Use fire spells + Darklight to remove their shield",
+        "description": "Hit the demon with Darklight (or Emberlight) special attack to break its shield. Once the shield is down, it will cycle protection prayers - swap your style between melee / ranged / magic on every two successful hits to keep accuracy up. Use fire spells or Smoke Burst for the magic phase to take advantage of their fire weakness.",
+        "worldX": 4100,
+        "worldY": 4415,
+        "worldPlane": 0,
+        "completionCondition": "ARRIVE_AT_TILE",
+        "completionDistance": 3,
+        "requiredItemIds": [
+          6746
+        ],
+        "section": "Combat"
+      },
+      {
+        "description": "Kill the Tormented Demon. Dodge the floor-flame patches by stepping one tile in any direction when they ignite, and step out of the molten spray cone (the demon telegraphs it by raising both arms). Three-style rotation: hit twice with melee, swap to ranged for two hits, then magic for two hits - the demon's protection prayer always lags behind your last successful style by one cycle, so the swap keeps your accuracy high. Burning claw + Tormented synapse are the marquee rare drops.",
         "worldX": 4100,
         "worldY": 4415,
         "worldPlane": 0,
         "npcId": 13599,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 13599
+        "completionNpcId": 13599,
+        "section": "Combat",
+        "recommendedItemIds": [
+          22325,
+          25865,
+          27277,
+          6685,
+          3024,
+          2434
+        ]
+      },
+      {
+        "description": "Loot the rares (Burning claw, Tormented synapse, Guthixian temple teleport scroll). The teleport scroll drop chance is high - they fund the next trip's travel cost.",
+        "worldX": 4100,
+        "worldY": 4415,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL",
+        "section": "Loot"
+      },
+      {
+        "description": "Return to bank when supplies run low. Drop teleport from the Chasm of Tears, or use a home teleport / Guthixian temple teleport again from a bank tile.",
+        "worldX": 3087,
+        "worldY": 3493,
+        "worldPlane": 0,
+        "completionCondition": "ARRIVE_AT_TILE",
+        "completionDistance": 8,
+        "section": "Bank"
       }
     ],
     "afkLevel": 0
@@ -10589,12 +10738,21 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to Mount Karuulm (fairy ring CIR or Battlefront teleport). Enter the Karuulm Slayer Dungeon",
+        "description": "Travel to Mount Karuulm. Bring boots of stone (mandatory to prevent passive heat damage in the Karuulm dungeon - or use granite or Cerberus boots), Dragon hunter lance, super combat, prayer potions, a few Saradomin brews, super restores, and sharks. Slayer task recommended for the dragon-tier rare drops. Fairy ring CIR drops you right at the dungeon entrance; Rada's blessing teleport to Mount Karuulm is the unquested alternative.",
         "worldX": 1311,
         "worldY": 3807,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_ZONE",
-        "completionZone": [1300, 3795, 1330, 10220, 0]
+        "completionZone": [1300, 3795, 1330, 10220, 0],
+        "travelTip": "Fairy ring CIR -> Mount Karuulm, or Rada's blessing 3/4 teleport",
+        "requiredItemIds": [
+          23037,
+          22978,
+          12695,
+          2434,
+          3024
+        ],
+        "section": "Travel"
       },
       {
         "description": "Take the elevator down into the Karuulm Slayer Dungeon.",
@@ -10603,17 +10761,44 @@
         "worldPlane": 0,
         "objectId": 34359,
         "objectInteractAction": "Activate",
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Travel"
       },
       {
-        "description": "Kill Wyrms in the Karuulm Slayer Dungeon. Pray Magic or use boots of stone. Found on the first level (62 Slayer)",
+        "description": "Kill Wyrms on the first level (62 Slayer). Pray Magic for their ranged-magic breath - they hit through prayer for 1s only and you can long-range safespot from outside their attack range with a Dragon hunter lance or Dragon hunter crossbow. Boots of stone keep the heat tick from grinding through your HP. The shortcut safespot tile near the east wall lets you AFK chunks of the task while you stack the rares.",
         "worldX": 1311,
         "worldY": 10205,
         "worldPlane": 0,
         "npcId": 8610,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 8610
+        "completionNpcId": 8610,
+        "section": "Combat",
+        "recommendedItemIds": [
+          22978,
+          21012,
+          23037,
+          6685,
+          3024,
+          2434
+        ]
+      },
+      {
+        "description": "Loot the dragon-tier rares (Dragon sword, Dragon harpoon, Dragon thrownaxe, Dragon knife) and the regular drops. Hop floors between worlds if Wyrms get tagged by other slayers.",
+        "worldX": 1311,
+        "worldY": 10205,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL",
+        "section": "Loot"
+      },
+      {
+        "description": "Return to bank when supplies run low. Take the elevator back up and use fairy ring CIR + your favourite bank teleport (Castle Wars / Edgeville home).",
+        "worldX": 1647,
+        "worldY": 3667,
+        "worldPlane": 0,
+        "completionCondition": "ARRIVE_AT_TILE",
+        "completionDistance": 8,
+        "section": "Bank"
       }
     ]
   },
@@ -10915,22 +11100,78 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to the Asgarnian Ice Dungeon (fairy ring AIQ to Mudskipper Point, then run south)",
+        "description": "Bank for Skeletal Wyverns. Bring an Elemental / Mind / Dragonfire shield (mandatory - wyverns spam icy breath that ignores normal antifire), Dragon hunter crossbow or Toxic blowpipe for the ranged safespot, prayer potions, super restores, and a few sharks. Bring a Stamina potion for the run from Mudskipper Point.",
+        "worldX": 3013,
+        "worldY": 3245,
+        "worldPlane": 0,
+        "completionCondition": "ARRIVE_AT_TILE",
+        "completionDistance": 8,
+        "requiredItemIds": [
+          11283,
+          21012,
+          2434,
+          3024,
+          12625,
+          385
+        ],
+        "section": "Bank"
+      },
+      {
+        "description": "Travel to the Asgarnian Ice Dungeon. Fairy ring AIQ to Mudskipper Point and run south is the fastest route; Port Sarim charter + run south is the unfairy-ring fallback.",
         "worldX": 3008,
         "worldY": 3150,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "travelTip": "Fairy ring AIQ -> Mudskipper Point, then run south to the dungeon entrance",
+        "section": "Travel"
       },
       {
-        "description": "Kill Skeletal Wyverns in the Asgarnian Ice Dungeon. Use elemental/mind/dragonfire shield for ice breath protection. Range safespot available",
+        "description": "Enter the Asgarnian Ice Dungeon ladder and run east to the Skeletal Wyvern room.",
+        "worldX": 3008,
+        "worldY": 3150,
+        "worldPlane": 0,
+        "objectId": 30100,
+        "objectInteractAction": "Climb-down",
+        "completionCondition": "ARRIVE_AT_TILE",
+        "completionDistance": 8,
+        "section": "Travel"
+      },
+      {
+        "description": "Kill Skeletal Wyverns. Equipped Elemental / Mind / Dragonfire shield is mandatory - the icy breath ignores normal antifire and hits for 50+ without one. Use the ranged safespot tile behind the north-west pillar with a Dragon hunter crossbow or blowpipe to take no damage on most kills. Pray ranged for the close-range tail attack if you need to melee.",
         "worldX": 3008,
         "worldY": 3150,
         "worldPlane": 0,
         "npcId": 465,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 465
+        "completionNpcId": 465,
+        "section": "Combat",
+        "recommendedItemIds": [
+          21012,
+          12926,
+          11283,
+          2434,
+          3024,
+          385
+        ]
+      },
+      {
+        "description": "Loot the Draconic visage and Granite legs. Long Bones (5 Construction XP each) and the Wyvern visage drop weight makes this a hands-off task.",
+        "worldX": 3008,
+        "worldY": 3150,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL",
+        "section": "Loot"
+      },
+      {
+        "description": "Return to bank when supplies run low. Climb back up the ladder, fairy ring AIQ + favourite bank teleport.",
+        "worldX": 3013,
+        "worldY": 3245,
+        "worldPlane": 0,
+        "completionCondition": "ARRIVE_AT_TILE",
+        "completionDistance": 8,
+        "section": "Bank"
       }
     ]
   },
@@ -10979,31 +11220,76 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to the Slayer Tower (slayer ring or fairy ring CKS)",
+        "description": "Bank for Gargoyles. Bring a Rock hammer (mandatory - Gargoyles must be smashed at low HP or they revive), your best crush weapon (Inquisitor's mace, Saradomin sword, or Granite hammer), super combat potion, prayer potions, and a few sharks. Granite maul tagging is fine for fast tasks; Gargoyle smasher perk auto-finishes them once a Rock hammer is in your inventory.",
+        "worldX": 3445,
+        "worldY": 3470,
+        "worldPlane": 0,
+        "completionCondition": "ARRIVE_AT_TILE",
+        "completionDistance": 8,
+        "requiredItemIds": [
+          4162,
+          24417,
+          12695,
+          2434,
+          385
+        ],
+        "section": "Bank"
+      },
+      {
+        "description": "Travel to the Slayer Tower. Slayer ring teleport to Slayer Tower is the fastest route; fairy ring CKS (Canifis -> walk north) is the unquested fallback.",
         "worldX": 3429,
         "worldY": 3535,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "travelTip": "Slayer ring -> Slayer Tower, or fairy ring CKS + walk north",
+        "section": "Travel"
       },
       {
-        "description": "Climb to the top floor of the Slayer Tower. Rock hammer required to finish",
+        "description": "Climb to the top floor of the Slayer Tower.",
         "worldX": 3429,
         "worldY": 3535,
         "worldPlane": 2,
         "objectId": 2119,
         "objectInteractAction": "Climb-up",
-        "completionCondition": "PLAYER_ON_PLANE"
+        "completionCondition": "PLAYER_ON_PLANE",
+        "section": "Travel"
       },
       {
-        "description": "Kill Gargoyles on the Slayer Tower top floor. Finish with rock hammer when low HP. Auto-smash with Gargoyle smasher perk (75 Slayer)",
+        "description": "Kill Gargoyles on the top floor. Once a Gargoyle drops below 9 HP, smash it with a Rock hammer (or the Gargoyle smasher perk auto-smashes for you above 75 Slayer). Granite maul spec is the fastest finisher for 2-tick tasks. Watch for the boost-the-HP trick on early Slayer accounts - if you over-damage them they reset to full HP.",
         "worldX": 3429,
         "worldY": 3534,
         "worldPlane": 2,
         "npcId": 412,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 412
+        "completionNpcId": 412,
+        "section": "Combat",
+        "recommendedItemIds": [
+          4162,
+          24417,
+          4153,
+          12695,
+          2434,
+          385
+        ]
+      },
+      {
+        "description": "Loot the Granite maul (3-tick spec weapon), Mystic robe top (dark), and Adamant boots. Granite mauls stack high - high alch them for GP between tasks.",
+        "worldX": 3429,
+        "worldY": 3534,
+        "worldPlane": 2,
+        "completionCondition": "MANUAL",
+        "section": "Loot"
+      },
+      {
+        "description": "Return to bank when supplies run low. Climb down the ladder, slayer ring to Edgeville or fairy ring CKS to Canifis bank.",
+        "worldX": 3445,
+        "worldY": 3470,
+        "worldPlane": 0,
+        "completionCondition": "ARRIVE_AT_TILE",
+        "completionDistance": 8,
+        "section": "Bank"
       }
     ]
   },
@@ -11369,31 +11655,68 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to Mount Karuulm (fairy ring CIR). Enter the Karuulm Slayer Dungeon, go to mid level",
+        "description": "Travel to Mount Karuulm. Bring boots of stone (mandatory - the Karuulm heat tick will eat through your HP without them), Dragon hunter lance, super combat, prayer potions, Saradomin brews, super restores, and a few sharks. Karuulm-friendly footwear (boots of stone / granite / Cerberus boots) is non-negotiable. Fairy ring CIR drops you right at the dungeon entrance; Rada's blessing 3/4 teleport is the unquested alternative.",
         "worldX": 1311,
         "worldY": 3807,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_ZONE",
-        "completionZone": [1300, 3795, 1330, 10075, 0]
+        "completionZone": [1300, 3795, 1330, 10075, 0],
+        "travelTip": "Fairy ring CIR -> Mount Karuulm, or Rada's blessing 3/4",
+        "requiredItemIds": [
+          23037,
+          22978,
+          12695,
+          6685,
+          3024,
+          2434
+        ],
+        "section": "Travel"
       },
       {
-        "description": "Take the elevator down into the Karuulm Slayer Dungeon.",
+        "description": "Take the elevator down into the Karuulm Slayer Dungeon, then descend to the mid level (Drake floor).",
         "worldX": 1311,
         "worldY": 3807,
         "worldPlane": 0,
         "objectId": 34359,
         "objectInteractAction": "Activate",
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Travel"
       },
       {
-        "description": "Kill Drakes in the Karuulm Slayer Dungeon. Dodge the volcanic breath attack by moving. Use boots of stone (84 Slayer)",
+        "description": "Kill Drakes on the mid level (84 Slayer). Move one tile when you see the dragonfire breath telegraph (orange beam under your feet) - it hits up to 40 if you stand still. Pray Magic for the standard ranged-magic style; Dragon hunter lance + super combat gets sub-12s kill times. The room safespot tile at the south-east edge lets you AFK most of the task with prayer potions.",
         "worldX": 1310,
         "worldY": 10057,
         "worldPlane": 0,
         "npcId": 8612,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 8612
+        "completionNpcId": 8612,
+        "section": "Combat",
+        "recommendedItemIds": [
+          22978,
+          23037,
+          12695,
+          6685,
+          3024,
+          2434
+        ]
+      },
+      {
+        "description": "Loot Drake's claw and Drake's tooth. The Boots of brimstone upgrade (combine claw + boots of stone) is the milestone craft worth saving for.",
+        "worldX": 1310,
+        "worldY": 10057,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL",
+        "section": "Loot"
+      },
+      {
+        "description": "Return to bank when supplies run low. Take the elevator back up and use fairy ring CIR + favourite bank teleport.",
+        "worldX": 1647,
+        "worldY": 3667,
+        "worldPlane": 0,
+        "completionCondition": "ARRIVE_AT_TILE",
+        "completionDistance": 8,
+        "section": "Bank"
       }
     ]
   },
@@ -11752,31 +12075,68 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to Mount Karuulm (fairy ring CIR). Enter Karuulm Slayer Dungeon, descend to lowest level",
+        "description": "Travel to Mount Karuulm. Bring boots of stone (mandatory heat protection), Dragon hunter lance for the dragonbane bonus, super combat, prayer potions, Saradomin brews, super restores, antidote++, and a few sharks. Karuulm-friendly footwear is non-negotiable on this floor. Fairy ring CIR drops you right at the dungeon entrance; Rada's blessing 3/4 is the unquested alternative.",
         "worldX": 1311,
         "worldY": 3807,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_ZONE",
-        "completionZone": [1300, 3795, 1330, 10205, 0]
+        "completionZone": [1300, 3795, 1330, 10205, 0],
+        "travelTip": "Fairy ring CIR -> Mount Karuulm, or Rada's blessing 3/4",
+        "requiredItemIds": [
+          23037,
+          22978,
+          12695,
+          6685,
+          3024,
+          2434
+        ],
+        "section": "Travel"
       },
       {
-        "description": "Take the elevator down into the Karuulm Slayer Dungeon.",
+        "description": "Take the elevator down into the Karuulm Slayer Dungeon, then descend to the lowest floor (Hydra floor, 95 Slayer).",
         "worldX": 1311,
         "worldY": 3807,
         "worldPlane": 0,
         "objectId": 34359,
         "objectInteractAction": "Activate",
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Travel"
       },
       {
-        "description": "Kill Hydras in the Karuulm Slayer Dungeon lower level. Dodge the fire and poison attacks. Use boots of stone (95 Slayer)",
+        "description": "Kill Hydras on the lower level. Pray against the active style (Magic first, then Ranged after three hits - just like Alchemical Hydra). Move one tile when the fire-puddle telegraph appears under your feet to avoid the 30+ burn tick. Drink antidote++ between kills - their venom attack ticks for 6+ even after they die. Dragon hunter lance + super combat gets sub-15s kill times.",
         "worldX": 1310,
         "worldY": 10190,
         "worldPlane": 0,
         "npcId": 8609,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 8609
+        "completionNpcId": 8609,
+        "section": "Combat",
+        "recommendedItemIds": [
+          22978,
+          23037,
+          12695,
+          6685,
+          3024,
+          2434
+        ]
+      },
+      {
+        "description": "Loot the Hydra's fang / eye / heart and Hydra tail. The three Brimstone ring components require all three pieces in order (Wiki's requiresPrevious flag).",
+        "worldX": 1310,
+        "worldY": 10190,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL",
+        "section": "Loot"
+      },
+      {
+        "description": "Return to bank when supplies run low. Take the elevator back up and use fairy ring CIR + favourite bank teleport.",
+        "worldX": 1647,
+        "worldY": 3667,
+        "worldPlane": 0,
+        "completionCondition": "ARRIVE_AT_TILE",
+        "completionDistance": 8,
+        "section": "Bank"
       }
     ]
   },
@@ -11808,22 +12168,69 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to Darkmeyer via Drakan medallion or Morytania teleport. Blisterwood weapon required",
+        "description": "Bank for Vyrewatch Sentinels. Bring a Blisterwood flail (mandatory - Sentinels are immune to all non-blisterwood weapons) or an Ivandis flail as a fallback, your best magic gear (an Amulet of blood fury is BIS for the lifesteal), prayer potions, super restores, and Saradomin brews. Vyre noble outfit can speed up the disguise step but is not required for combat.",
+        "worldX": 3631,
+        "worldY": 3303,
+        "worldPlane": 0,
+        "completionCondition": "ARRIVE_AT_TILE",
+        "completionDistance": 8,
+        "requiredItemIds": [
+          24699,
+          22398,
+          6685,
+          3024,
+          2434
+        ],
+        "section": "Bank"
+      },
+      {
+        "description": "Travel to Darkmeyer. Drakan's medallion to Darkmeyer is the fastest route; Canifis lodestone + walk south is the fallback if the medallion is unequipped.",
         "worldX": 3631,
         "worldY": 3325,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "requiredItemIds": [
+          22400
+        ],
+        "travelTip": "Drakan's medallion -> Darkmeyer, or Canifis lodestone + walk south",
+        "section": "Travel"
       },
       {
-        "description": "Kill Vyrewatch Sentinels in Darkmeyer. Requires flail of ivandis or blisterwood weapon. Good blood shard farming spot",
+        "description": "Kill Vyrewatch Sentinels in the central Darkmeyer square. Blisterwood flail (or Ivandis flail) is mandatory - any non-blisterwood weapon does zero damage. Use Protect from Melee for the standard attack; the Sentinels do not phase or have special mechanics, so the fight is essentially a Slayer-XP loop tuned for the Blood shard drop. Amulet of blood fury speccing keeps your HP topped without brews.",
         "worldX": 3631,
         "worldY": 3325,
         "worldPlane": 0,
         "npcId": 9756,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 9756
+        "completionNpcId": 9756,
+        "section": "Combat",
+        "recommendedItemIds": [
+          24699,
+          22398,
+          6685,
+          3024,
+          2434,
+          385
+        ]
+      },
+      {
+        "description": "Loot Blood shards (1/5000 drop rate). Charge an Amulet of fury into an Amulet of blood fury at 1000 Blood shards or sell shards directly for GP.",
+        "worldX": 3631,
+        "worldY": 3325,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL",
+        "section": "Loot"
+      },
+      {
+        "description": "Return to bank when supplies run low. Drakan's medallion to Ver Sinhaza or Canifis lodestone for the fastest bank cycle.",
+        "worldX": 3631,
+        "worldY": 3303,
+        "worldPlane": 0,
+        "completionCondition": "ARRIVE_AT_TILE",
+        "completionDistance": 8,
+        "section": "Bank"
       }
     ],
     "mutuallyExclusiveSources": [

--- a/src/test/java/com/collectionloghelper/data/D3Batch5RegressionTest.java
+++ b/src/test/java/com/collectionloghelper/data/D3Batch5RegressionTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ */
+package com.collectionloghelper.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.lang.reflect.Field;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * D3 batch 5 audit guard - asserts the nine mid-popularity slayer sources
+ * (Tormented Demons, Demonic gorillas, Hydra, Wyrm, Drake, Lizardman shaman,
+ * Skeletal Wyvern, Vyrewatch Sentinel, Gargoyle) all reach the 10-element
+ * deep-guidance bar. Mirrors D3Batch1-4RegressionTest in shape and intent.
+ */
+public class D3Batch5RegressionTest
+{
+	private static final List<String> BATCH5_SOURCES = List.of(
+		"Tormented Demons",
+		"Demonic gorillas",
+		"Hydra",
+		"Wyrm",
+		"Drake",
+		"Lizardman shaman",
+		"Skeletal Wyvern",
+		"Vyrewatch Sentinel",
+		"Gargoyle");
+
+	private DropRateDatabase database;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		database = new DropRateDatabase();
+		Gson gson = new GsonBuilder().create();
+		Field gsonField = DropRateDatabase.class.getDeclaredField("gson");
+		gsonField.setAccessible(true);
+		gsonField.set(database, gson);
+		database.load();
+	}
+
+	@Test
+	public void allBatch5SourcesHaveDeepGuidanceShape()
+	{
+		for (String name : BATCH5_SOURCES)
+		{
+			CollectionLogSource source = database.getAllSources().stream()
+				.filter(s -> name.equals(s.getName()))
+				.findFirst()
+				.orElse(null);
+			assertNotNull(source, "missing D3 batch 5 source: " + name);
+
+			// Element 1 - travel tip
+			assertNotNull(source.getTravelTip(),
+				name + " has no source-level travelTip");
+			assertTrue(!source.getTravelTip().isBlank(),
+				name + " travelTip is blank");
+
+			// Element 8 - prerequisites object present (most batch 5 sources are slayer-gated)
+			assertNotNull(source.getRequirements(),
+				name + " has no source-level requirements object");
+
+			// Step shape - at least five steps after the deep pass
+			assertNotNull(source.getGuidanceSteps(),
+				name + " has no guidanceSteps");
+			assertTrue(source.getGuidanceSteps().size() >= 5,
+				name + " has fewer than 5 guidance steps after the deep-guidance pass (got "
+					+ source.getGuidanceSteps().size() + ")");
+
+			// Element 9 - kill time populated
+			assertTrue(source.getKillTimeSeconds() > 0,
+				name + " has non-positive killTimeSeconds");
+
+			// Element 2 - at least one ARRIVE_AT_TILE step with world coords
+			boolean hasArriveStep = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getCompletionCondition() == CompletionCondition.ARRIVE_AT_TILE
+					&& s.getWorldX() > 0
+					&& s.getWorldY() > 0);
+			assertTrue(hasArriveStep,
+				name + " has no ARRIVE_AT_TILE step with positive world coordinates");
+
+			// Element 3 - kill step exposes recommendedItemIds
+			boolean hasRecommendedGear = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getRecommendedItemIds() != null
+					&& !s.getRecommendedItemIds().isEmpty());
+			assertTrue(hasRecommendedGear,
+				name + " has no step with a populated recommendedItemIds list");
+
+			// Element 6/7 - inventory loadout / bank-and-return wiring
+			boolean hasRequiredItems = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getRequiredItemIds() != null
+					&& !s.getRequiredItemIds().isEmpty());
+			assertTrue(hasRequiredItems,
+				name + " has no step with a populated requiredItemIds list");
+
+			// Element 10 - section labels on steps for sources with >5 steps
+			boolean hasSectionLabels = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getSection() != null && !s.getSection().isBlank());
+			assertTrue(hasSectionLabels,
+				name + " has no step with a section label");
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Tier D3 **batch 5** of 6 - **mid-popularity slayer sources**. Brings nine slayer-band sources (rank 41-80) to the 10-element deep-guidance bar, mirroring the D3 batch-1 (#636), batch-2 (#639), batch-3 (#642), and batch-4 (#643) templates.

Selection per `docs/contributor-guide/d3-mid-tier-scoping.md` (merged in #635) section 3, batch 5: mid-popularity slayer monsters.

## Sources touched

| Source | What was newly added |
|---|---|
| **Tormented Demons** | Bank prep + Darklight/Emberlight shield-break step + 3-style rotation strategy note + Guthixian temple teleport requiredItem + loot + bank-return |
| **Demonic gorillas** | Bank prep + spirit-tree travel + Crash Site Cavern entry + 3-style cycle every 3 hits + boulder/orb mechanic notes + Bowfa/blowpipe/rapier recommended + loot + bank-return |
| **Hydra** (regular slayer, lowest Karuulm floor) | Travel-with-loadout (boots of stone + DHL + antidote++) merged into ARRIVE_AT_ZONE step (preserves #555 regression) + elevator + Magic/Ranged prayer-flick strategy + venom/fire-puddle mechanic notes + loot + bank-return |
| **Wyrm** | Travel-with-loadout merged into ARRIVE_AT_ZONE step (preserves #555 regression) + elevator + ranged safespot strategy + boots-of-stone heat-tick note + loot + bank-return |
| **Drake** | Travel-with-loadout merged into ARRIVE_AT_ZONE step (preserves #555 regression) + elevator (mid level) + dragonfire-telegraph mechanic + south-east safespot tile note + Boots of brimstone milestone + loot + bank-return |
| **Lizardman shaman** | Added empty `requirements` object (was missing) + bank prep + Xeric's talisman / fairy ring DJR travel + spawn-pool dodge + wall-anchor anti-leap note + crush-weapon (Inquisitor's mace / Soulreaper) recommended + loot + bank-return |
| **Skeletal Wyvern** | Bank prep with mandatory anti-dragonfire shield + fairy ring AIQ travel + ladder-descent step + north-west pillar safespot mechanic note + DHCB/blowpipe ranged loadout + loot + bank-return |
| **Vyrewatch Sentinel** | Bank prep with mandatory Blisterwood flail (+ Ivandis flail fallback) + Drakan's medallion travel with Canifis lodestone fallback + Amulet of blood fury lifesteal note + Blood shard farming loot + bank-return |
| **Gargoyle** | Bank prep with mandatory Rock hammer + slayer ring / fairy ring CKS travel + climb-up step + sub-9 HP finisher mechanic + Granite maul spec note + Gargoyle smasher perk note + loot + bank-return |

## 10-element coverage per source

All nine sources now satisfy the 10 deep-guidance elements:

- **E1 Travel tip**: source-level + per-step fallback routes (fairy ring CIR + Rada's blessing / Xeric's talisman + lodestone / slayer ring + fairy ring / Drakan's medallion + Canifis lodestone)
- **E2 Auto-arrival**: every meaningful location change uses ARRIVE_AT_TILE or ARRIVE_AT_ZONE with positive world coords. **#555 regression preserved** on Wyrm / Drake / Hydra (step 0 stays ARRIVE_AT_ZONE on the Karuulm dungeon entry zone; bank-prep loadout merged into the travel step description and `requiredItemIds`).
- **E3 Gear note**: kill step names prayer + key mechanic in plain English + `recommendedItemIds` (all <= 6 per existing guard)
- **E4 Loop detection**: not applicable - all nine are single-kill slayer creatures; per the deep-guidance bar "adding a loop on a boss source" is wrong - kill loops handled by `ACTOR_DEATH`
- **E5 Strategy note**: every kill step names the punishing mechanic (TD shield-break + 3-style cycle / DG prayer-rotation + falling boulder / Wyrm magic spam + heat tick / Drake dragonfire telegraph / Hydra venom + style swap / Lizardman shaman acid spawn + leap / Skeletal Wyvern icy breath shield requirement / Vyrewatch blisterwood-only / Gargoyle sub-9 HP finisher)
- **E6 Bank-and-return**: every source has bank-and-return wiring (separate bank-prep step on TD/DG/Lizardman/Wyvern/Vyrewatch/Gargoyle; merged into travel step + dedicated bank-return step on Wyrm/Drake/Hydra to preserve the #555 regression)
- **E7 Inventory loadout**: travel/bank step lists key consumables (Saradomin brews / super restores / prayer pots / super combat) plus mandatory items (boots of stone / Blisterwood flail / Rock hammer / anti-dragonfire shield / Darklight / Guthixian temple teleport scroll) in `requiredItemIds`
- **E8 Prerequisites**: `requirements` object present on every source (Lizardman shaman added empty `{}` - it has no quest/skill gate; the other eight retain their existing quest / Slayer-level gates)
- **E9 Drop rate confidence**: existing rates retained, verified against current OSRS Wiki - no rate drift detected on any of the nine sources in this pass
- **E10 PR citations**: see below

## Data sources (E10)

- **Drop rates / item IDs / mechanics**: OSRS Wiki via `wiki_lookup` MCP (Tormented_Demons, Demonic_gorillas, Hydra, Wyrm, Drake, Lizardman_shaman, Skeletal_Wyvern, Vyrewatch_Sentinel, Gargoyle pages, verified against current 2026 game state)
- **NPC IDs**: pre-existing in `drop_rates.json` (Tormented Demon 13599, Demonic gorilla 7144, Hydra 8609, Wyrm 8610, Drake 8612, Lizardman shaman 6766, Skeletal Wyvern 465, Vyrewatch Sentinel 9756, Gargoyle 412)
- **Item IDs for recommendedItemIds / requiredItemIds**: `runelite_id_lookup` MCP against master - Arclight 19675, Emberlight 29589, Darklight 6746, Granite maul 4153, Rock hammer (Slayer) 4162, Boots of stone 23037, Ivandis flail 22398, Blisterwood flail 24699, Blisterwood sickle 24697, Dragon hunter lance 22978, Dragon hunter crossbow 21012, Zaryte crossbow 26374, Facemask (Gasmask) 1506, Dragonfire shield 11283, Guthixian temple teleport 29684, Drakan's medallion 22400, Soulreaper axe 28338, Inquisitor's mace 24417. Well-known fixed IDs - Saradomin brew (4) 6685, Super restore (4) 3024, Prayer potion (4) 2434, Super combat (4) 12695, Ranging potion (4) 2444, Stamina potion (4) 12625, Shark 385, Scythe of vitur 22325, Twisted bow 20997, Tumeken's shadow 27277, Bow of faerdhinen (c) 25865, Toxic blowpipe 12926, Ghrazi rapier 22324, Voidwaker 27690
- **Travel / bank coordinates**: existing dungeon coords retained; bank coords use Hosidius (1647, 3667) for Karuulm trips, Castle Wars (2461, 3444) for Crash Site Cavern, Edgeville (3087, 3493) for TD chasm trips, Shayzien (1504, 3633) for Lizardman canyon, Falador (3013, 3245) for Asgarnian Ice Dungeon, Slayer Tower (3445, 3470) for Gargoyles, Ver Sinhaza (3631, 3303) for Vyrewatch Sentinels
- **Kill times**: pre-existing `killTimeSeconds` / `ironKillTimeSeconds` values left unchanged

## Tests

Adds `D3Batch5RegressionTest` asserting for each of the nine sources:

- Source exists in the database
- Source-level `travelTip` non-null and non-blank
- `requirements` object non-null
- Guidance steps list has at least 5 entries
- `killTimeSeconds` > 0
- At least one `ARRIVE_AT_TILE` step (enum, not string) with positive world coordinates
- At least one step with a populated `recommendedItemIds` list
- At least one step with a populated `requiredItemIds` list
- At least one step with a non-blank `section` label

## Build status

`./gradlew build` green (full suite + `lintDropRates` + `recommendedItemIds <= 6` guard from `DropRateDatabaseTest` + #555 `batchMigratedSources_useArriveAtZone` regression). All previously-passing tests plus the new D3 batch-5 regression test pass.

## Test plan

- [x] `./gradlew build` passes locally
- [x] `lintDropRates` clean for all nine edited sources
- [x] ASCII-only check on `drop_rates.json` and new test file
- [x] `D3Batch5RegressionTest` passes
- [x] `recommendedItemIds <= 6` constraint respected on all kill steps
- [x] #555 `batchMigratedSources_useArriveAtZone` regression preserved on Wyrm / Drake / Hydra
- [ ] Manual in-game spot-check on at least one of the nine sources to confirm the new step sequence advances correctly (deferred to reviewer / follow-up - the Karuulm zone-based travel + bank-return loop is the highest-confidence to verify; Vyrewatch Sentinel and Tormented Demons shield-break flow are the highest-risk to validate)

## Refs

- #635 - D3 mid-tier scoping doc (batch 5 selected)
- #636 - D3 batch 1 (2024-2025 boss releases) authoring template mirrored
- #639 - D3 batch 2 (DT2 Awakened variants) authoring template mirrored
- #642 - D3 batch 3 (capstone PvM + nostalgic instances) authoring template mirrored
- #643 - D3 batch 4 (mid-tier boss sources) authoring template mirrored
