### PR TITLE
feat(schema): add inventoryItemIdsAny OR-semantic to SourceRequirements

### DIFF
--- a/src/main/java/com/collectionloghelper/data/RequirementsChecker.java
+++ b/src/main/java/com/collectionloghelper/data/RequirementsChecker.java
@@ -399,6 +399,33 @@ public class RequirementsChecker
 			}
 		}
 
+		if (requirements.getInventoryItemIdsAny() != null
+			&& !requirements.getInventoryItemIdsAny().isEmpty())
+		{
+			boolean anyHeld = false;
+			boolean sawNonNull = false;
+			for (Integer itemId : requirements.getInventoryItemIdsAny())
+			{
+				if (itemId == null)
+				{
+					continue;
+				}
+				sawNonNull = true;
+				if (playerInventoryState.hasItem(itemId))
+				{
+					anyHeld = true;
+					break;
+				}
+			}
+			// An all-null list collapses to "no real entries", which matches the
+			// vacuous-empty contract on the AND-semantic siblings: skip the check.
+			if (sawNonNull && !anyHeld)
+			{
+				unmet.add("Inventory item (any of): "
+					+ requirements.getInventoryItemIdsAny());
+			}
+		}
+
 		return unmet;
 	}
 

--- a/src/main/java/com/collectionloghelper/data/SourceRequirements.java
+++ b/src/main/java/com/collectionloghelper/data/SourceRequirements.java
@@ -93,8 +93,8 @@ public class SourceRequirements
 	 * Shadows) should continue to use {@code equippedItemIds} instead.
 	 *
 	 * <p>For an OR-semantic over multiple charge-tier variants of the same
-	 * item (e.g. Pharaoh's sceptre charges 1-5), a future
-	 * {@code inventoryItemIdsAny} field is planned but not yet authored.
+	 * item (e.g. Pharaoh's sceptre charges 1-5), use the companion
+	 * {@link #inventoryItemIdsAny} field instead.
 	 *
 	 * <p>{@code null} or empty when the source/alternative has no
 	 * inventory-item prerequisite. Added by the Wave-1 follow-up to close the
@@ -102,4 +102,41 @@ public class SourceRequirements
 	 */
 	@Nullable
 	List<Integer> inventoryItemIds;
+
+	/**
+	 * Inventory-item requirements expressed as RuneLite {@code ItemID} integers
+	 * with OR-semantics across the listed IDs.
+	 *
+	 * <p>Evaluated via {@code PlayerInventoryState.hasItem(int)} as an
+	 * any-match: the requirement is met when the player's regular inventory
+	 * contains AT LEAST ONE of the listed item IDs. {@code null} entries
+	 * inside the list are skipped. An empty list is treated as vacuously
+	 * satisfied to match the existing pattern on the AND-semantic siblings
+	 * ({@link #pohTeleports}, {@link #equippedItemIds},
+	 * {@link #inventoryItemIds}).
+	 *
+	 * <p>Use this field for inventory-teleport vectors that have multiple
+	 * functionally-equivalent charge-tier or revision variants, all of which
+	 * should satisfy the same requirement. Examples:
+	 * <ul>
+	 *   <li>Pharaoh's sceptre charges 1-5 plus Jeweled (6 IDs) for Tombs of
+	 *       Amascut's Jaltevas teleport;</li>
+	 *   <li>Quetzal whistle basic / enhanced / perfected / perfected-infinite
+	 *       for Phantom Muspah;</li>
+	 *   <li>Teleport crystal charge-tier variants for The Gauntlet and
+	 *       Corrupted Gauntlet.</li>
+	 * </ul>
+	 *
+	 * <p>The OR clause AND-combines with every other field on
+	 * {@link SourceRequirements}, including {@link #inventoryItemIds}: a
+	 * source that sets both lists requires every ID in
+	 * {@code inventoryItemIds} AND at least one ID from
+	 * {@code inventoryItemIdsAny}.
+	 *
+	 * <p>{@code null} or empty when the source/alternative has no
+	 * any-of-inventory prerequisite. Added by the Wave-7c follow-up to mirror
+	 * the AND-semantic {@link #inventoryItemIds} added in the prior PR.
+	 */
+	@Nullable
+	List<Integer> inventoryItemIdsAny;
 }

--- a/src/test/java/com/collectionloghelper/data/CollectionLogSourceTest.java
+++ b/src/test/java/com/collectionloghelper/data/CollectionLogSourceTest.java
@@ -123,7 +123,7 @@ public class CollectionLogSourceTest
 	@Test
 	public void getWorldPointWithChecker_firstAccessible()
 	{
-		SourceRequirements reqs = new SourceRequirements(Collections.singletonList("DRAGON_SLAYER_II"), null, null, null, null, null);
+		SourceRequirements reqs = new SourceRequirements(Collections.singletonList("DRAGON_SLAYER_II"), null, null, null, null, null, null);
 		Waypoint wp1 = new Waypoint("Shortcut", 2500, 2600, 0, reqs);
 		Waypoint wp2 = new Waypoint("Walk", 3500, 3600, 0, null);
 
@@ -137,7 +137,7 @@ public class CollectionLogSourceTest
 	@Test
 	public void getWorldPointWithChecker_firstLocked_fallsToSecond()
 	{
-		SourceRequirements reqs = new SourceRequirements(Collections.singletonList("DRAGON_SLAYER_II"), null, null, null, null, null);
+		SourceRequirements reqs = new SourceRequirements(Collections.singletonList("DRAGON_SLAYER_II"), null, null, null, null, null, null);
 		Waypoint wp1 = new Waypoint("Shortcut", 2500, 2600, 0, reqs);
 		Waypoint wp2 = new Waypoint("Walk", 3500, 3600, 0, null);
 
@@ -151,8 +151,8 @@ public class CollectionLogSourceTest
 	@Test
 	public void getWorldPointWithChecker_allLocked_fallsToLast()
 	{
-		SourceRequirements reqs1 = new SourceRequirements(Collections.singletonList("QUEST_A"), null, null, null, null, null);
-		SourceRequirements reqs2 = new SourceRequirements(Collections.singletonList("QUEST_B"), null, null, null, null, null);
+		SourceRequirements reqs1 = new SourceRequirements(Collections.singletonList("QUEST_A"), null, null, null, null, null, null);
+		SourceRequirements reqs2 = new SourceRequirements(Collections.singletonList("QUEST_B"), null, null, null, null, null, null);
 		Waypoint wp1 = new Waypoint("Best", 1000, 1000, 0, reqs1);
 		Waypoint wp2 = new Waypoint("Alt", 2000, 2000, 0, reqs2);
 
@@ -227,7 +227,7 @@ public class CollectionLogSourceTest
 	@Test
 	public void getDisplayLocationWithChecker_allLockedFallsToLastName()
 	{
-		SourceRequirements reqs = new SourceRequirements(Collections.singletonList("QUEST_A"), null, null, null, null, null);
+		SourceRequirements reqs = new SourceRequirements(Collections.singletonList("QUEST_A"), null, null, null, null, null, null);
 		Waypoint wp1 = new Waypoint("First", 1000, 1000, 0, reqs);
 		Waypoint wp2 = new Waypoint("Last", 2000, 2000, 0, reqs);
 

--- a/src/test/java/com/collectionloghelper/data/InventoryItemsAnyMigrationTest.java
+++ b/src/test/java/com/collectionloghelper/data/InventoryItemsAnyMigrationTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Migration guard for the additive {@code inventoryItemIdsAny} field on
+ * {@link SourceRequirements}.
+ *
+ * <p>This PR adds the field, evaluator wiring, and Gson coverage but performs
+ * zero pilot wiring in production data. This test walks the full production
+ * {@code drop_rates.json} and asserts that every {@link SourceRequirements}
+ * instance reached via top-level source requirements, conditional-alternative
+ * requirements (flat and nested), and waypoint requirements has a null
+ * {@code inventoryItemIdsAny}. The first opportunity to flip a single source
+ * is a separate later data PR that wires the 4 deferred multi-tier teleport
+ * sources (Tombs of Amascut, Phantom Muspah, The Gauntlet, Corrupted
+ * Gauntlet).
+ *
+ * <p>Mirrors {@link InventoryItemsMigrationTest} and the earlier
+ * {@code B1MigrationTest} / {@code B1aRegressionTest} / {@code B1bRegressionTest}
+ * pattern: walk the database, accumulate violations, fail with one readable
+ * message.
+ */
+public class InventoryItemsAnyMigrationTest
+{
+	private DropRateDatabase database;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		database = new DropRateDatabase();
+
+		Gson gson = new GsonBuilder().create();
+		Field gsonField = DropRateDatabase.class.getDeclaredField("gson");
+		gsonField.setAccessible(true);
+		gsonField.set(database, gson);
+
+		database.load();
+	}
+
+	@Test
+	public void databaseLoadsAndProducesSources()
+	{
+		assertNotNull(database.getAllSources());
+		assertTrue(database.getAllSources().size() > 0,
+			"Production drop_rates.json must load at least one source");
+	}
+
+	@Test
+	public void everySourceRequirementsHasNullInventoryItemIdsAny()
+	{
+		List<String> violations = new ArrayList<>();
+
+		for (CollectionLogSource source : database.getAllSources())
+		{
+			checkSource(source, violations);
+		}
+
+		assertTrue(violations.isEmpty(),
+			"inventoryItemIdsAny invariant violated. No production source may set inventoryItemIdsAny in this PR; pilot wiring lands in a follow-up data PR (Tombs of Amascut, Phantom Muspah, The Gauntlet, Corrupted Gauntlet). Violations:\n"
+				+ String.join("\n", violations));
+	}
+
+	private static void checkSource(CollectionLogSource source, List<String> violations)
+	{
+		String sourceName = source.getName();
+		checkRequirements(sourceName + " (top-level requirements)", source.getRequirements(), violations);
+
+		// CollectionLogSource owns the requirement-bearing Waypoint list. GuidanceStep
+		// has a separate StepWaypoint list which is a lightweight overlay struct and
+		// carries no SourceRequirements, so it is not walked here.
+		List<Waypoint> sourceWaypoints = source.getWaypoints();
+		if (sourceWaypoints != null)
+		{
+			for (int w = 0; w < sourceWaypoints.size(); w++)
+			{
+				Waypoint wp = sourceWaypoints.get(w);
+				if (wp != null)
+				{
+					checkRequirements(sourceName + " waypoint " + (w + 1),
+						wp.getRequirements(), violations);
+				}
+			}
+		}
+
+		List<GuidanceStep> steps = source.getGuidanceSteps();
+		if (steps == null)
+		{
+			return;
+		}
+		for (int i = 0; i < steps.size(); i++)
+		{
+			GuidanceStep step = steps.get(i);
+			if (step == null)
+			{
+				continue;
+			}
+			String stepLabel = sourceName + " step " + (i + 1);
+
+			List<ConditionalAlternative> alts = step.getConditionalAlternatives();
+			if (alts != null)
+			{
+				for (int a = 0; a < alts.size(); a++)
+				{
+					ConditionalAlternative alt = alts.get(a);
+					if (alt == null)
+					{
+						continue;
+					}
+					checkRequirements(stepLabel + " alt " + (a + 1),
+						alt.getRequirements(), violations);
+
+					List<ConditionalAlternative> nested = alt.getNestedAlternatives();
+					if (nested != null)
+					{
+						for (int n = 0; n < nested.size(); n++)
+						{
+							ConditionalAlternative nestedAlt = nested.get(n);
+							if (nestedAlt != null)
+							{
+								checkRequirements(stepLabel + " alt " + (a + 1)
+										+ " nested " + (n + 1),
+									nestedAlt.getRequirements(), violations);
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	private static void checkRequirements(String label, SourceRequirements reqs, List<String> violations)
+	{
+		if (reqs == null)
+		{
+			return;
+		}
+		if (reqs.getInventoryItemIdsAny() != null)
+		{
+			violations.add(label + " has non-null inventoryItemIdsAny");
+		}
+	}
+}

--- a/src/test/java/com/collectionloghelper/data/RequirementsCheckerB0Test.java
+++ b/src/test/java/com/collectionloghelper/data/RequirementsCheckerB0Test.java
@@ -134,7 +134,7 @@ public class RequirementsCheckerB0Test
 		SourceRequirements req = new SourceRequirements(
 			null, null, null,
 			Arrays.asList("JEWELLERY_BOX_FANCY", "FAIRY_RING"),
-			null, null);
+			null, null, null);
 		assertFalse(checker.meetsRequirements(req));
 	}
 
@@ -144,7 +144,7 @@ public class RequirementsCheckerB0Test
 		SourceRequirements req = new SourceRequirements(
 			null, null, null,
 			Collections.emptyList(),
-			null, null);
+			null, null, null);
 		assertTrue(checker.meetsRequirements(req));
 	}
 
@@ -173,7 +173,7 @@ public class RequirementsCheckerB0Test
 		lenient().when(equippedItemState.hasEquipped(DRAKANS_MEDALLION)).thenReturn(false);
 		SourceRequirements req = new SourceRequirements(
 			null, null, null, null,
-			Arrays.asList(RING_OF_SHADOWS, DRAKANS_MEDALLION), null);
+			Arrays.asList(RING_OF_SHADOWS, DRAKANS_MEDALLION), null, null);
 		assertFalse(checker.meetsRequirements(req));
 	}
 
@@ -182,7 +182,7 @@ public class RequirementsCheckerB0Test
 	{
 		SourceRequirements req = new SourceRequirements(
 			null, null, null, null,
-			Collections.emptyList(), null);
+			Collections.emptyList(), null, null);
 		assertTrue(checker.meetsRequirements(req));
 	}
 
@@ -199,7 +199,7 @@ public class RequirementsCheckerB0Test
 			Collections.singletonList(new SkillRequirement("STRENGTH", 70)),
 			null,
 			Collections.singletonList("JEWELLERY_BOX_FANCY"),
-			Collections.singletonList(RING_OF_SHADOWS), null);
+			Collections.singletonList(RING_OF_SHADOWS), null, null);
 		assertTrue(checker.meetsRequirements(req));
 	}
 
@@ -213,7 +213,7 @@ public class RequirementsCheckerB0Test
 			Collections.singletonList(new SkillRequirement("STRENGTH", 70)),
 			null,
 			Collections.singletonList("JEWELLERY_BOX_FANCY"),
-			null, null);
+			null, null, null);
 		assertFalse(checker.meetsRequirements(req));
 	}
 
@@ -225,7 +225,7 @@ public class RequirementsCheckerB0Test
 		SourceRequirements req = new SourceRequirements(
 			null, null, null,
 			Collections.singletonList("JEWELLERY_BOX_FANCY"),
-			Collections.singletonList(RING_OF_SHADOWS), null);
+			Collections.singletonList(RING_OF_SHADOWS), null, null);
 		assertFalse(checker.meetsRequirements(req));
 	}
 
@@ -247,7 +247,7 @@ public class RequirementsCheckerB0Test
 			altWithReq("Fast: POH + ring", new SourceRequirements(
 				null, null, null,
 				Collections.singletonList("JEWELLERY_BOX_FANCY"),
-				Collections.singletonList(RING_OF_SHADOWS), null)),
+				Collections.singletonList(RING_OF_SHADOWS), null, null)),
 			altWithReq("Slow: ring only", equippedReq(RING_OF_SHADOWS)));
 
 		assertEquals("Fast: POH + ring", selectFirstMatching(alts));
@@ -264,7 +264,7 @@ public class RequirementsCheckerB0Test
 			altWithReq("Fast: POH + ring", new SourceRequirements(
 				null, null, null,
 				Collections.singletonList("JEWELLERY_BOX_FANCY"),
-				Collections.singletonList(RING_OF_SHADOWS), null)),
+				Collections.singletonList(RING_OF_SHADOWS), null, null)),
 			altWithReq("Slow: ring only", equippedReq(RING_OF_SHADOWS)));
 
 		assertEquals("Slow: ring only", selectFirstMatching(alts));
@@ -290,14 +290,14 @@ public class RequirementsCheckerB0Test
 		return new SourceRequirements(
 			null, null, null,
 			Collections.singletonList(teleportName),
-			null, null);
+			null, null, null);
 	}
 
 	private static SourceRequirements equippedReq(int itemId)
 	{
 		return new SourceRequirements(
 			null, null, null, null,
-			Collections.singletonList(itemId), null);
+			Collections.singletonList(itemId), null, null);
 	}
 
 	private static ConditionalAlternative altWithReq(String description, SourceRequirements requirements)

--- a/src/test/java/com/collectionloghelper/data/RequirementsCheckerInventoryItemsAnyTest.java
+++ b/src/test/java/com/collectionloghelper/data/RequirementsCheckerInventoryItemsAnyTest.java
@@ -1,0 +1,360 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data;
+
+import com.collectionloghelper.player.EquippedItemState;
+import com.collectionloghelper.player.PohTeleport;
+import com.collectionloghelper.player.PohTeleportInventory;
+import java.lang.reflect.Constructor;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import net.runelite.api.Client;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+
+/**
+ * Behaviour tests for
+ * {@link RequirementsChecker#meetsRequirements(SourceRequirements)} with the
+ * new {@code inventoryItemIdsAny} OR-semantic field wired in.
+ *
+ * <p>Pairs with {@link RequirementsCheckerInventoryItemsTest} (the AND-semantic
+ * sibling) which covers the {@code inventoryItemIds} clause. This class adds
+ * the same matrix for the OR-semantic any-of clause: empty list is vacuously
+ * satisfied, any-one match passes, none-match fails, multi-item OR is
+ * short-circuit-friendly, and the field composes AND-wise with every other
+ * clause (including the AND-semantic {@code inventoryItemIds} sibling).
+ *
+ * <p>{@link PlayerInventoryState} is mocked at the concrete class level
+ * (Singleton, no interface). Strict stubbing is disabled so AND-clause
+ * short-circuiting in failure tests does not surface
+ * UnnecessaryStubbingException.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class RequirementsCheckerInventoryItemsAnyTest
+{
+	// Pharaoh's sceptre charges-5: one of six charge-tier variants of the
+	// Jaltevas teleport. The any-of field exists to express the OR across the
+	// full 26945..26950 set without forcing the player to hold every charge.
+	private static final int PHARAOHS_SCEPTRE_5 = 26945;
+	private static final int PHARAOHS_SCEPTRE_4 = 26946;
+	private static final int PHARAOHS_SCEPTRE_3 = 26947;
+
+	// Quetzal whistle: multi-tier inventory teleport for Phantom Muspah.
+	// Stand-in value for the basic-tier variant used in OR-vs-AND combo tests.
+	private static final int QUETZAL_WHISTLE = 29782;
+
+	// Ring of Shadows: equipment-slot teleport (the C2 case), included to pin
+	// cross-field AND-semantics for the equipped + any-of-inventory combo.
+	private static final int RING_OF_SHADOWS = 28266;
+
+	@Mock
+	private Client client;
+
+	@Mock
+	private PohTeleportInventory pohTeleportInventory;
+
+	@Mock
+	private EquippedItemState equippedItemState;
+
+	@Mock
+	private PlayerInventoryState playerInventoryState;
+
+	private RequirementsChecker checker;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		// The @Inject constructor is private; reflectively construct without Guice.
+		Constructor<RequirementsChecker> ctor = RequirementsChecker.class.getDeclaredConstructor(
+			Client.class, PohTeleportInventory.class, EquippedItemState.class,
+			PlayerInventoryState.class);
+		ctor.setAccessible(true);
+		checker = ctor.newInstance(client, pohTeleportInventory, equippedItemState, playerInventoryState);
+	}
+
+	// -- Empty / vacuous case ---------------------------------------------------
+
+	@Test
+	public void meetsRequirements_emptyInventoryItemIdsAny_isTrue()
+	{
+		SourceRequirements req = new SourceRequirements(
+			null, null, null, null, null, null,
+			Collections.emptyList());
+		assertTrue(checker.meetsRequirements(req));
+	}
+
+	// -- Single-item OR ---------------------------------------------------------
+
+	@Test
+	public void meetsRequirements_singleItemPresent_isTrue()
+	{
+		lenient().when(playerInventoryState.hasItem(PHARAOHS_SCEPTRE_5)).thenReturn(true);
+		SourceRequirements req = anyReq(PHARAOHS_SCEPTRE_5);
+		assertTrue(checker.meetsRequirements(req));
+	}
+
+	@Test
+	public void meetsRequirements_singleItemAbsent_isFalse()
+	{
+		lenient().when(playerInventoryState.hasItem(PHARAOHS_SCEPTRE_5)).thenReturn(false);
+		SourceRequirements req = anyReq(PHARAOHS_SCEPTRE_5);
+		assertFalse(checker.meetsRequirements(req));
+	}
+
+	// -- Multi-item OR ----------------------------------------------------------
+
+	@Test
+	public void meetsRequirements_multipleItemsOnePresent_isTrue()
+	{
+		// First entry absent, second present: classic any-of pass case.
+		lenient().when(playerInventoryState.hasItem(PHARAOHS_SCEPTRE_5)).thenReturn(false);
+		lenient().when(playerInventoryState.hasItem(PHARAOHS_SCEPTRE_4)).thenReturn(true);
+		lenient().when(playerInventoryState.hasItem(PHARAOHS_SCEPTRE_3)).thenReturn(false);
+		SourceRequirements req = new SourceRequirements(
+			null, null, null, null, null, null,
+			Arrays.asList(PHARAOHS_SCEPTRE_5, PHARAOHS_SCEPTRE_4, PHARAOHS_SCEPTRE_3));
+		assertTrue(checker.meetsRequirements(req));
+	}
+
+	@Test
+	public void meetsRequirements_multipleItemsNonePresent_isFalse()
+	{
+		lenient().when(playerInventoryState.hasItem(PHARAOHS_SCEPTRE_5)).thenReturn(false);
+		lenient().when(playerInventoryState.hasItem(PHARAOHS_SCEPTRE_4)).thenReturn(false);
+		lenient().when(playerInventoryState.hasItem(PHARAOHS_SCEPTRE_3)).thenReturn(false);
+		SourceRequirements req = new SourceRequirements(
+			null, null, null, null, null, null,
+			Arrays.asList(PHARAOHS_SCEPTRE_5, PHARAOHS_SCEPTRE_4, PHARAOHS_SCEPTRE_3));
+		assertFalse(checker.meetsRequirements(req));
+	}
+
+	@Test
+	public void meetsRequirements_multipleItemsAllPresent_isTrue()
+	{
+		// All-present is still a pass (OR is satisfied by at least one).
+		lenient().when(playerInventoryState.hasItem(PHARAOHS_SCEPTRE_5)).thenReturn(true);
+		lenient().when(playerInventoryState.hasItem(PHARAOHS_SCEPTRE_4)).thenReturn(true);
+		SourceRequirements req = new SourceRequirements(
+			null, null, null, null, null, null,
+			Arrays.asList(PHARAOHS_SCEPTRE_5, PHARAOHS_SCEPTRE_4));
+		assertTrue(checker.meetsRequirements(req));
+	}
+
+	// -- Null entries inside the list ------------------------------------------
+
+	@Test
+	public void meetsRequirements_nullEntryThenMatch_isTrue()
+	{
+		lenient().when(playerInventoryState.hasItem(PHARAOHS_SCEPTRE_5)).thenReturn(true);
+		List<Integer> ids = Arrays.asList(null, PHARAOHS_SCEPTRE_5);
+		SourceRequirements req = new SourceRequirements(
+			null, null, null, null, null, null, ids);
+		assertTrue(checker.meetsRequirements(req));
+	}
+
+	@Test
+	public void meetsRequirements_allNullEntries_isTrue()
+	{
+		// An all-null any-of list collapses to "no real entries", which matches
+		// the vacuous-empty contract. Skipping the check is consistent with the
+		// AND-semantic siblings' empty-list behaviour.
+		List<Integer> ids = Arrays.asList((Integer) null, (Integer) null);
+		SourceRequirements req = new SourceRequirements(
+			null, null, null, null, null, null, ids);
+		assertTrue(checker.meetsRequirements(req));
+	}
+
+	// -- AND-with-other-clauses semantics --------------------------------------
+
+	@Test
+	public void meetsRequirements_anyOfPlusEquipped_bothSatisfied_isTrue()
+	{
+		lenient().when(equippedItemState.hasEquipped(RING_OF_SHADOWS)).thenReturn(true);
+		lenient().when(playerInventoryState.hasItem(PHARAOHS_SCEPTRE_5)).thenReturn(true);
+		SourceRequirements req = new SourceRequirements(
+			null, null, null, null,
+			Collections.singletonList(RING_OF_SHADOWS),
+			null,
+			Collections.singletonList(PHARAOHS_SCEPTRE_5));
+		assertTrue(checker.meetsRequirements(req));
+	}
+
+	@Test
+	public void meetsRequirements_anyOfPasses_butEquippedFails_isFalse()
+	{
+		// OR-clause matches but the AND-combined equipped clause does not, so
+		// the overall requirement fails. Pins the AND-combination contract.
+		lenient().when(equippedItemState.hasEquipped(RING_OF_SHADOWS)).thenReturn(false);
+		lenient().when(playerInventoryState.hasItem(PHARAOHS_SCEPTRE_5)).thenReturn(true);
+		SourceRequirements req = new SourceRequirements(
+			null, null, null, null,
+			Collections.singletonList(RING_OF_SHADOWS),
+			null,
+			Collections.singletonList(PHARAOHS_SCEPTRE_5));
+		assertFalse(checker.meetsRequirements(req));
+	}
+
+	@Test
+	public void meetsRequirements_anyOfPlusPohAndQuest_allSatisfied_isTrue()
+	{
+		lenient().when(pohTeleportInventory.hasTeleport(PohTeleport.JEWELLERY_BOX_FANCY)).thenReturn(true);
+		lenient().when(playerInventoryState.hasItem(PHARAOHS_SCEPTRE_4)).thenReturn(true);
+		SourceRequirements req = new SourceRequirements(
+			null, null, null,
+			Collections.singletonList("JEWELLERY_BOX_FANCY"),
+			null,
+			null,
+			Arrays.asList(PHARAOHS_SCEPTRE_5, PHARAOHS_SCEPTRE_4));
+		assertTrue(checker.meetsRequirements(req));
+	}
+
+	// -- AND-semantic inventoryItemIds + OR-semantic inventoryItemIdsAny together
+
+	@Test
+	public void meetsRequirements_inventoryAndPlusAny_bothSatisfied_isTrue()
+	{
+		// Player must hold every ID in inventoryItemIds AND at least one ID
+		// from inventoryItemIdsAny. This is the multi-tier teleport pattern
+		// combined with a single mandatory consumable (hypothetical).
+		lenient().when(playerInventoryState.hasItem(QUETZAL_WHISTLE)).thenReturn(true);
+		lenient().when(playerInventoryState.hasItem(PHARAOHS_SCEPTRE_5)).thenReturn(false);
+		lenient().when(playerInventoryState.hasItem(PHARAOHS_SCEPTRE_4)).thenReturn(true);
+		SourceRequirements req = new SourceRequirements(
+			null, null, null, null, null,
+			Collections.singletonList(QUETZAL_WHISTLE),
+			Arrays.asList(PHARAOHS_SCEPTRE_5, PHARAOHS_SCEPTRE_4));
+		assertTrue(checker.meetsRequirements(req));
+	}
+
+	@Test
+	public void meetsRequirements_inventoryAndPasses_butAnyFails_isFalse()
+	{
+		lenient().when(playerInventoryState.hasItem(QUETZAL_WHISTLE)).thenReturn(true);
+		lenient().when(playerInventoryState.hasItem(PHARAOHS_SCEPTRE_5)).thenReturn(false);
+		lenient().when(playerInventoryState.hasItem(PHARAOHS_SCEPTRE_4)).thenReturn(false);
+		SourceRequirements req = new SourceRequirements(
+			null, null, null, null, null,
+			Collections.singletonList(QUETZAL_WHISTLE),
+			Arrays.asList(PHARAOHS_SCEPTRE_5, PHARAOHS_SCEPTRE_4));
+		assertFalse(checker.meetsRequirements(req));
+	}
+
+	@Test
+	public void meetsRequirements_anyPasses_butInventoryAndFails_isFalse()
+	{
+		lenient().when(playerInventoryState.hasItem(QUETZAL_WHISTLE)).thenReturn(false);
+		lenient().when(playerInventoryState.hasItem(PHARAOHS_SCEPTRE_5)).thenReturn(true);
+		SourceRequirements req = new SourceRequirements(
+			null, null, null, null, null,
+			Collections.singletonList(QUETZAL_WHISTLE),
+			Collections.singletonList(PHARAOHS_SCEPTRE_5));
+		assertFalse(checker.meetsRequirements(req));
+	}
+
+	// -- Alternative selection (mirrors GuidanceStep.resolveAlternative) -------
+
+	@Test
+	public void alternativeSelection_anyOfRouteWins_whenOneItemPresent()
+	{
+		lenient().when(playerInventoryState.hasItem(PHARAOHS_SCEPTRE_5)).thenReturn(false);
+		lenient().when(playerInventoryState.hasItem(PHARAOHS_SCEPTRE_4)).thenReturn(true);
+
+		List<ConditionalAlternative> alts = Arrays.asList(
+			altWithReq("Fast: Pharaoh sceptre any tier",
+				new SourceRequirements(null, null, null, null, null, null,
+					Arrays.asList(PHARAOHS_SCEPTRE_5, PHARAOHS_SCEPTRE_4))),
+			altWithReq("Slow: walk", null));
+
+		assertEquals("Fast: Pharaoh sceptre any tier", selectFirstMatching(alts));
+	}
+
+	@Test
+	public void alternativeSelection_fallsBackWhenNoChargeTierHeld()
+	{
+		lenient().when(playerInventoryState.hasItem(PHARAOHS_SCEPTRE_5)).thenReturn(false);
+		lenient().when(playerInventoryState.hasItem(PHARAOHS_SCEPTRE_4)).thenReturn(false);
+		lenient().when(playerInventoryState.hasItem(QUETZAL_WHISTLE)).thenReturn(true);
+
+		List<ConditionalAlternative> alts = Arrays.asList(
+			altWithReq("Fast: Pharaoh sceptre any tier",
+				new SourceRequirements(null, null, null, null, null, null,
+					Arrays.asList(PHARAOHS_SCEPTRE_5, PHARAOHS_SCEPTRE_4))),
+			altWithReq("Fallback: Quetzal whistle inventory",
+				new SourceRequirements(null, null, null, null, null,
+					Collections.singletonList(QUETZAL_WHISTLE), null)));
+
+		assertEquals("Fallback: Quetzal whistle inventory", selectFirstMatching(alts));
+	}
+
+	// -- Helpers ----------------------------------------------------------------
+
+	private static SourceRequirements anyReq(int itemId)
+	{
+		return new SourceRequirements(
+			null, null, null, null, null, null,
+			Collections.singletonList(itemId));
+	}
+
+	private static ConditionalAlternative altWithReq(String description, SourceRequirements requirements)
+	{
+		return new ConditionalAlternative(
+			requirements,
+			description,
+			null, null, null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			null
+		);
+	}
+
+	private String selectFirstMatching(List<ConditionalAlternative> alts)
+	{
+		for (ConditionalAlternative alt : alts)
+		{
+			if (alt.getRequirements() != null && checker.meetsRequirements(alt.getRequirements()))
+			{
+				return alt.getDescription();
+			}
+		}
+		return null;
+	}
+}

--- a/src/test/java/com/collectionloghelper/data/RequirementsCheckerInventoryItemsTest.java
+++ b/src/test/java/com/collectionloghelper/data/RequirementsCheckerInventoryItemsTest.java
@@ -111,7 +111,7 @@ public class RequirementsCheckerInventoryItemsTest
 	{
 		SourceRequirements req = new SourceRequirements(
 			null, null, null, null, null,
-			Collections.emptyList());
+			Collections.emptyList(), null);
 		assertTrue(checker.meetsRequirements(req));
 	}
 
@@ -142,7 +142,7 @@ public class RequirementsCheckerInventoryItemsTest
 		lenient().when(playerInventoryState.hasItem(QUETZAL_WHISTLE)).thenReturn(true);
 		SourceRequirements req = new SourceRequirements(
 			null, null, null, null, null,
-			Arrays.asList(PHARAOHS_SCEPTRE_5, QUETZAL_WHISTLE));
+			Arrays.asList(PHARAOHS_SCEPTRE_5, QUETZAL_WHISTLE), null);
 		assertTrue(checker.meetsRequirements(req));
 	}
 
@@ -153,7 +153,7 @@ public class RequirementsCheckerInventoryItemsTest
 		lenient().when(playerInventoryState.hasItem(QUETZAL_WHISTLE)).thenReturn(false);
 		SourceRequirements req = new SourceRequirements(
 			null, null, null, null, null,
-			Arrays.asList(PHARAOHS_SCEPTRE_5, QUETZAL_WHISTLE));
+			Arrays.asList(PHARAOHS_SCEPTRE_5, QUETZAL_WHISTLE), null);
 		assertFalse(checker.meetsRequirements(req));
 	}
 
@@ -165,7 +165,7 @@ public class RequirementsCheckerInventoryItemsTest
 		lenient().when(playerInventoryState.hasItem(PHARAOHS_SCEPTRE_5)).thenReturn(true);
 		List<Integer> ids = Arrays.asList(null, PHARAOHS_SCEPTRE_5);
 		SourceRequirements req = new SourceRequirements(
-			null, null, null, null, null, ids);
+			null, null, null, null, null, ids, null);
 		assertTrue(checker.meetsRequirements(req));
 	}
 
@@ -181,7 +181,7 @@ public class RequirementsCheckerInventoryItemsTest
 			null, null, null,
 			Collections.singletonList("JEWELLERY_BOX_FANCY"),
 			Collections.singletonList(RING_OF_SHADOWS),
-			Collections.singletonList(PHARAOHS_SCEPTRE_5));
+			Collections.singletonList(PHARAOHS_SCEPTRE_5), null);
 		assertTrue(checker.meetsRequirements(req));
 	}
 
@@ -195,7 +195,7 @@ public class RequirementsCheckerInventoryItemsTest
 			null, null, null,
 			Collections.singletonList("JEWELLERY_BOX_FANCY"),
 			Collections.singletonList(RING_OF_SHADOWS),
-			Collections.singletonList(PHARAOHS_SCEPTRE_5));
+			Collections.singletonList(PHARAOHS_SCEPTRE_5), null);
 		assertFalse(checker.meetsRequirements(req));
 	}
 
@@ -208,7 +208,7 @@ public class RequirementsCheckerInventoryItemsTest
 			null, null, null,
 			Collections.singletonList("JEWELLERY_BOX_FANCY"),
 			null,
-			Collections.singletonList(PHARAOHS_SCEPTRE_5));
+			Collections.singletonList(PHARAOHS_SCEPTRE_5), null);
 		assertFalse(checker.meetsRequirements(req));
 	}
 
@@ -245,7 +245,7 @@ public class RequirementsCheckerInventoryItemsTest
 	{
 		return new SourceRequirements(
 			null, null, null, null, null,
-			Collections.singletonList(itemId));
+			Collections.singletonList(itemId), null);
 	}
 
 	private static ConditionalAlternative altWithReq(String description, SourceRequirements requirements)

--- a/src/test/java/com/collectionloghelper/data/SourceRequirementsB0Test.java
+++ b/src/test/java/com/collectionloghelper/data/SourceRequirementsB0Test.java
@@ -155,11 +155,11 @@ public class SourceRequirementsB0Test
 		SourceRequirements a = new SourceRequirements(
 			null, null, null,
 			Collections.singletonList("MOUNTED_GLORY"),
-			Collections.singletonList(22557), null);
+			Collections.singletonList(22557), null, null);
 		SourceRequirements b = new SourceRequirements(
 			null, null, null,
 			Collections.singletonList("MOUNTED_GLORY"),
-			Collections.singletonList(22557), null);
+			Collections.singletonList(22557), null, null);
 		assertEquals(a, b);
 		assertEquals(a.hashCode(), b.hashCode());
 	}
@@ -170,11 +170,11 @@ public class SourceRequirementsB0Test
 		SourceRequirements a = new SourceRequirements(
 			null, null, null,
 			Collections.singletonList("MOUNTED_GLORY"),
-			null, null);
+			null, null, null);
 		SourceRequirements b = new SourceRequirements(
 			null, null, null,
 			Collections.singletonList("JEWELLERY_BOX_FANCY"),
-			null, null);
+			null, null, null);
 		assertTrue(!a.equals(b));
 	}
 
@@ -188,7 +188,7 @@ public class SourceRequirementsB0Test
 			null,
 			Collections.singletonList("FREMENNIK_HARD"),
 			Arrays.asList("JEWELLERY_BOX_FANCY", "MOUNTED_GLORY"),
-			Arrays.asList(22557, 28266), null);
+			Arrays.asList(22557, 28266), null, null);
 		String json = GSON.toJson(original);
 		SourceRequirements restored = GSON.fromJson(json, SourceRequirements.class);
 		assertEquals(original, restored);

--- a/src/test/java/com/collectionloghelper/data/SourceRequirementsInventoryItemsAnyGsonTest.java
+++ b/src/test/java/com/collectionloghelper/data/SourceRequirementsInventoryItemsAnyGsonTest.java
@@ -38,44 +38,48 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Gson deserialisation tests for the {@code inventoryItemIds} field on
- * {@link SourceRequirements}.
+ * Gson deserialisation tests for the {@code inventoryItemIdsAny} OR-semantic
+ * field on {@link SourceRequirements}.
  *
  * <p>Covers absent / null / empty / single-element / multi-element JSON shapes,
- * legacy backwards compatibility, and Gson behaviour on malformed input. The
- * field is purely additive: existing drop_rates.json sources that omit it must
- * continue to deserialise with {@code getInventoryItemIds() == null}.
+ * backwards compatibility with the existing six-field schema, and Gson
+ * behaviour on malformed input. The field is purely additive: existing
+ * drop_rates.json sources that omit it must continue to deserialise with
+ * {@code getInventoryItemIdsAny() == null}.
  *
- * <p>Pairs with {@link SourceRequirementsB0Test} which covers the same matrix
- * for {@code pohTeleports} and {@code equippedItemIds} introduced by Tier B0
- * (PR #623). This class adds the same coverage for the inventory-item field
- * that closes the wieldable-but-used-from-inventory teleport gap left by B0.
+ * <p>Pairs with {@link SourceRequirementsInventoryItemsGsonTest} which covers
+ * the AND-semantic sibling {@code inventoryItemIds}. This class adds the same
+ * coverage for the OR-semantic field that closes the multi-charge-tier
+ * teleport gap (Pharaoh's sceptre 1-5 + Jeweled, Quetzal whistle tiers,
+ * Crystal teleport charge tiers).
  */
-public class SourceRequirementsInventoryItemsGsonTest
+public class SourceRequirementsInventoryItemsAnyGsonTest
 {
 	private static final Gson GSON = new GsonBuilder().create();
 
 	// -- Backwards compatibility -------------------------------------------------
 
 	@Test
-	public void deserialise_legacyJsonWithoutField_inventoryItemIdsIsNull()
+	public void deserialise_legacyJsonWithoutField_inventoryItemIdsAnyIsNull()
 	{
 		String json = "{\"quests\":[\"DESERT_TREASURE_II\"]}";
 		SourceRequirements req = GSON.fromJson(json, SourceRequirements.class);
-		assertNull(req.getInventoryItemIds());
+		assertNull(req.getInventoryItemIdsAny());
 	}
 
 	@Test
-	public void deserialise_legacyJsonWithAllPriorFields_inventoryItemIdsIsNull()
+	public void deserialise_legacyJsonWithAllPriorFields_inventoryItemIdsAnyIsNull()
 	{
-		// Sanity guard: legacy JSON that exercises every pre-existing field must
-		// still produce a parsed object with inventoryItemIds == null.
+		// Sanity guard: legacy JSON that exercises every pre-existing field,
+		// including the AND-semantic inventoryItemIds, must still produce a
+		// parsed object with inventoryItemIdsAny == null.
 		String json = "{"
 			+ "\"quests\":[\"DESERT_TREASURE_II\"],"
 			+ "\"skills\":[{\"skill\":\"SLAYER\",\"level\":95}],"
 			+ "\"diaries\":[\"FREMENNIK_HARD\"],"
 			+ "\"pohTeleports\":[\"JEWELLERY_BOX_FANCY\"],"
-			+ "\"equippedItemIds\":[22557]"
+			+ "\"equippedItemIds\":[22557],"
+			+ "\"inventoryItemIds\":[12938]"
 			+ "}";
 		SourceRequirements req = GSON.fromJson(json, SourceRequirements.class);
 		assertEquals(Collections.singletonList("DESERT_TREASURE_II"), req.getQuests());
@@ -83,82 +87,85 @@ public class SourceRequirementsInventoryItemsGsonTest
 		assertEquals(Collections.singletonList("FREMENNIK_HARD"), req.getDiaries());
 		assertEquals(Collections.singletonList("JEWELLERY_BOX_FANCY"), req.getPohTeleports());
 		assertEquals(Collections.singletonList(22557), req.getEquippedItemIds());
-		assertNull(req.getInventoryItemIds());
+		assertEquals(Collections.singletonList(12938), req.getInventoryItemIds());
+		assertNull(req.getInventoryItemIdsAny());
 	}
 
 	// -- Field-only shapes -------------------------------------------------------
 
 	@Test
-	public void deserialise_inventoryItemIdsNull_isNull()
+	public void deserialise_inventoryItemIdsAnyNull_isNull()
 	{
-		String json = "{\"inventoryItemIds\":null}";
+		String json = "{\"inventoryItemIdsAny\":null}";
 		SourceRequirements req = GSON.fromJson(json, SourceRequirements.class);
-		assertNull(req.getInventoryItemIds());
+		assertNull(req.getInventoryItemIdsAny());
 	}
 
 	@Test
-	public void deserialise_inventoryItemIdsEmpty_isEmptyNotNull()
+	public void deserialise_inventoryItemIdsAnyEmpty_isEmptyNotNull()
 	{
-		String json = "{\"inventoryItemIds\":[]}";
+		String json = "{\"inventoryItemIdsAny\":[]}";
 		SourceRequirements req = GSON.fromJson(json, SourceRequirements.class);
-		assertNotNull(req.getInventoryItemIds());
-		assertTrue(req.getInventoryItemIds().isEmpty());
+		assertNotNull(req.getInventoryItemIdsAny());
+		assertTrue(req.getInventoryItemIdsAny().isEmpty());
 	}
 
 	@Test
-	public void deserialise_inventoryItemIdsSingle_oneItem()
+	public void deserialise_inventoryItemIdsAnySingle_oneItem()
 	{
 		// Pharaoh's sceptre charges-5 placeholder ID; value chosen for shape, not lookup.
-		String json = "{\"inventoryItemIds\":[26945]}";
+		String json = "{\"inventoryItemIdsAny\":[26945]}";
 		SourceRequirements req = GSON.fromJson(json, SourceRequirements.class);
-		assertEquals(Collections.singletonList(26945), req.getInventoryItemIds());
+		assertEquals(Collections.singletonList(26945), req.getInventoryItemIdsAny());
 	}
 
 	@Test
-	public void deserialise_inventoryItemIdsMultiple_preservesOrder()
+	public void deserialise_inventoryItemIdsAnyMultiple_preservesOrder()
 	{
-		// Zul-andra teleport scroll + Quetzal whistle + Crystal teleport seed placeholders.
-		String json = "{\"inventoryItemIds\":[12938,29782,23959]}";
+		// Pharaoh's sceptre charges 1-5 plus Jeweled: 6-tier multi-charge variant
+		// set, exactly the shape this field exists to express.
+		String json = "{\"inventoryItemIdsAny\":[26945,26946,26947,26948,26949,26950]}";
 		SourceRequirements req = GSON.fromJson(json, SourceRequirements.class);
-		assertEquals(Arrays.asList(12938, 29782, 23959), req.getInventoryItemIds());
+		assertEquals(Arrays.asList(26945, 26946, 26947, 26948, 26949, 26950),
+			req.getInventoryItemIdsAny());
 	}
 
 	@Test
-	public void deserialise_inventoryItemIdsNegativeId_parsed()
+	public void deserialise_inventoryItemIdsAnyNegativeId_parsed()
 	{
 		// Gson does not validate item-ID positivity at parse time; that contract
 		// lives in the evaluator (RequirementsChecker) and the lint layer above.
-		// This test pins current behaviour so a future evaluator-side guard is
-		// an explicit decision rather than an accidental break.
-		String json = "{\"inventoryItemIds\":[-1]}";
+		// Mirrors the AND-semantic sibling so the malformed-input contract is
+		// uniform across both inventory fields.
+		String json = "{\"inventoryItemIdsAny\":[-1]}";
 		SourceRequirements req = GSON.fromJson(json, SourceRequirements.class);
-		assertEquals(Collections.singletonList(-1), req.getInventoryItemIds());
+		assertEquals(Collections.singletonList(-1), req.getInventoryItemIdsAny());
 	}
 
 	@Test
-	public void deserialise_inventoryItemIdsContainingString_throws()
+	public void deserialise_inventoryItemIdsAnyContainingString_throws()
 	{
 		// Mirrors Gson's default strict number-parsing for typed list elements.
-		String json = "{\"inventoryItemIds\":[\"not-an-int\"]}";
+		String json = "{\"inventoryItemIdsAny\":[\"not-an-int\"]}";
 		assertThrows(JsonSyntaxException.class,
 			() -> GSON.fromJson(json, SourceRequirements.class));
 	}
 
 	@Test
-	public void deserialise_inventoryItemIdsContainingFloat_throws()
+	public void deserialise_inventoryItemIdsAnyContainingFloat_throws()
 	{
 		// Gson rejects non-integer JSON numbers for the declared Integer element
-		// type. This pins current behaviour so the malformed-input contract is
+		// type. Pins current behaviour so the malformed-input contract is
 		// explicit rather than implicit.
-		String json = "{\"inventoryItemIds\":[26945.7]}";
+		String json = "{\"inventoryItemIdsAny\":[26945.7]}";
 		assertThrows(JsonSyntaxException.class,
 			() -> GSON.fromJson(json, SourceRequirements.class));
 	}
 
-	// -- All six fields populated -----------------------------------------------
+	// -- All seven fields populated ---------------------------------------------
 
 	@Test
-	public void deserialise_allSixFieldsPopulated_parsesAll()
+	public void deserialise_allSevenFieldsPopulated_parsesAll()
 	{
 		String json = "{"
 			+ "\"quests\":[\"TROLL_STRONGHOLD\"],"
@@ -166,7 +173,8 @@ public class SourceRequirementsInventoryItemsGsonTest
 			+ "\"diaries\":[\"FREMENNIK_HARD\"],"
 			+ "\"pohTeleports\":[\"JEWELLERY_BOX_FANCY\"],"
 			+ "\"equippedItemIds\":[22557],"
-			+ "\"inventoryItemIds\":[26945,23959]"
+			+ "\"inventoryItemIds\":[12938],"
+			+ "\"inventoryItemIdsAny\":[26945,26946,26947]"
 			+ "}";
 		SourceRequirements req = GSON.fromJson(json, SourceRequirements.class);
 		assertEquals(Collections.singletonList("TROLL_STRONGHOLD"), req.getQuests());
@@ -174,40 +182,56 @@ public class SourceRequirementsInventoryItemsGsonTest
 		assertEquals(Collections.singletonList("FREMENNIK_HARD"), req.getDiaries());
 		assertEquals(Collections.singletonList("JEWELLERY_BOX_FANCY"), req.getPohTeleports());
 		assertEquals(Collections.singletonList(22557), req.getEquippedItemIds());
-		assertEquals(Arrays.asList(26945, 23959), req.getInventoryItemIds());
+		assertEquals(Collections.singletonList(12938), req.getInventoryItemIds());
+		assertEquals(Arrays.asList(26945, 26946, 26947), req.getInventoryItemIdsAny());
 	}
 
 	// -- equals / hashCode -------------------------------------------------------
 
 	@Test
-	public void equals_sameInventoryItemIds_areEqual()
+	public void equals_sameInventoryItemIdsAny_areEqual()
 	{
 		SourceRequirements a = new SourceRequirements(
-			null, null, null, null, null,
-			Arrays.asList(26945, 23959), null);
+			null, null, null, null, null, null,
+			Arrays.asList(26945, 26946));
 		SourceRequirements b = new SourceRequirements(
-			null, null, null, null, null,
-			Arrays.asList(26945, 23959), null);
+			null, null, null, null, null, null,
+			Arrays.asList(26945, 26946));
 		assertEquals(a, b);
 		assertEquals(a.hashCode(), b.hashCode());
 	}
 
 	@Test
-	public void equals_differingInventoryItemIds_notEqual()
+	public void equals_differingInventoryItemIdsAny_notEqual()
 	{
 		SourceRequirements a = new SourceRequirements(
+			null, null, null, null, null, null,
+			Collections.singletonList(26945));
+		SourceRequirements b = new SourceRequirements(
+			null, null, null, null, null, null,
+			Collections.singletonList(26946));
+		assertTrue(!a.equals(b));
+	}
+
+	@Test
+	public void equals_inventoryItemIdsAnyVsInventoryItemIds_notEqual()
+	{
+		// The two list fields are distinct positional slots even when populated
+		// with identical IDs. equals/hashCode must distinguish them, otherwise
+		// the evaluator would not be able to choose AND vs OR semantics.
+		SourceRequirements andOnly = new SourceRequirements(
 			null, null, null, null, null,
 			Collections.singletonList(26945), null);
-		SourceRequirements b = new SourceRequirements(
-			null, null, null, null, null,
-			Collections.singletonList(23959), null);
-		assertTrue(!a.equals(b));
+		SourceRequirements anyOnly = new SourceRequirements(
+			null, null, null, null, null, null,
+			Collections.singletonList(26945));
+		assertTrue(!andOnly.equals(anyOnly));
 	}
 
 	// -- Round-trip --------------------------------------------------------------
 
 	@Test
-	public void gsonRoundTrip_withInventoryItemIds_preservesStructure()
+	public void gsonRoundTrip_withInventoryItemIdsAny_preservesStructure()
 	{
 		SourceRequirements original = new SourceRequirements(
 			Collections.singletonList("DESERT_TREASURE_II"),
@@ -215,7 +239,8 @@ public class SourceRequirementsInventoryItemsGsonTest
 			Collections.singletonList("FREMENNIK_HARD"),
 			Arrays.asList("JEWELLERY_BOX_FANCY"),
 			Arrays.asList(22557),
-			Arrays.asList(26945, 23959), null);
+			Arrays.asList(12938),
+			Arrays.asList(26945, 26946, 26947, 26948, 26949, 26950));
 		String json = GSON.toJson(original);
 		SourceRequirements restored = GSON.fromJson(json, SourceRequirements.class);
 		assertEquals(original, restored);

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerNestedConditionalTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerNestedConditionalTest.java
@@ -431,12 +431,12 @@ public class GuidanceSequencerNestedConditionalTest
 
 	private SourceRequirements makeQuestReq(String questName)
 	{
-		return new SourceRequirements(Arrays.asList(questName), null, null, null, null, null);
+		return new SourceRequirements(Arrays.asList(questName), null, null, null, null, null, null);
 	}
 
 	private SourceRequirements makeSkillReq(String skill, int level)
 	{
-		return new SourceRequirements(null, Arrays.asList(new SkillRequirement(skill, level)), null, null, null, null);
+		return new SourceRequirements(null, Arrays.asList(new SkillRequirement(skill, level)), null, null, null, null, null);
 	}
 
 	/**

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
@@ -1431,12 +1431,12 @@ public class GuidanceSequencerTest
 
 	private SourceRequirements makeQuestRequirement(String questName)
 	{
-		return new SourceRequirements(Arrays.asList(questName), null, null, null, null, null);
+		return new SourceRequirements(Arrays.asList(questName), null, null, null, null, null, null);
 	}
 
 	private SourceRequirements makeSkillRequirement(String skill, int level)
 	{
-		return new SourceRequirements(null, Arrays.asList(new SkillRequirement(skill, level)), null, null, null, null);
+		return new SourceRequirements(null, Arrays.asList(new SkillRequirement(skill, level)), null, null, null, null, null);
 	}
 
 	private GuidanceStep makeStepWithAlternatives(String description, int worldX, int worldY,

--- a/src/test/java/com/collectionloghelper/ui/widget/SourceRequirementsHeaderTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/SourceRequirementsHeaderTest.java
@@ -150,7 +150,7 @@ public class SourceRequirementsHeaderTest
 		when(client.getIntStack()).thenReturn(new int[]{2});
 
 		SourceRequirements req = new SourceRequirements(
-			Collections.singletonList("DRAGON_SLAYER_II"), null, null, null, null, null);
+			Collections.singletonList("DRAGON_SLAYER_II"), null, null, null, null, null, null);
 		CollectionLogSource source = makeSourceWithRequirements("Vorkath", req);
 
 		List<RequirementRow> rows = checker.buildRequirementRows(source);
@@ -172,7 +172,7 @@ public class SourceRequirementsHeaderTest
 		when(client.getIntStack()).thenReturn(new int[]{1});
 
 		SourceRequirements req = new SourceRequirements(
-			Collections.singletonList("DRAGON_SLAYER_II"), null, null, null, null, null);
+			Collections.singletonList("DRAGON_SLAYER_II"), null, null, null, null, null, null);
 		CollectionLogSource source = makeSourceWithRequirements("Vorkath", req);
 
 		List<RequirementRow> rows = checker.buildRequirementRows(source);
@@ -191,7 +191,7 @@ public class SourceRequirementsHeaderTest
 		when(client.getIntStack()).thenReturn(new int[]{0});
 
 		SourceRequirements req = new SourceRequirements(
-			Collections.singletonList("DRAGON_SLAYER_II"), null, null, null, null, null);
+			Collections.singletonList("DRAGON_SLAYER_II"), null, null, null, null, null, null);
 		CollectionLogSource source = makeSourceWithRequirements("Vorkath", req);
 
 		List<RequirementRow> rows = checker.buildRequirementRows(source);
@@ -213,7 +213,7 @@ public class SourceRequirementsHeaderTest
 		when(client.getRealSkillLevel(Skill.SLAYER)).thenReturn(95);
 
 		SourceRequirements req = new SourceRequirements(
-			null, Collections.singletonList(new SkillRequirement("SLAYER", 91)), null, null, null, null);
+			null, Collections.singletonList(new SkillRequirement("SLAYER", 91)), null, null, null, null, null);
 		CollectionLogSource source = makeSourceWithRequirements("Cerberus", req);
 
 		List<RequirementRow> rows = checker.buildRequirementRows(source);
@@ -235,7 +235,7 @@ public class SourceRequirementsHeaderTest
 		when(client.getRealSkillLevel(Skill.SLAYER)).thenReturn(80);
 
 		SourceRequirements req = new SourceRequirements(
-			null, Collections.singletonList(new SkillRequirement("SLAYER", 91)), null, null, null, null);
+			null, Collections.singletonList(new SkillRequirement("SLAYER", 91)), null, null, null, null, null);
 		CollectionLogSource source = makeSourceWithRequirements("Cerberus", req);
 
 		List<RequirementRow> rows = checker.buildRequirementRows(source);
@@ -257,7 +257,7 @@ public class SourceRequirementsHeaderTest
 		when(client.getVarbitValue(ArgumentMatchers.anyInt())).thenReturn(1);
 
 		SourceRequirements req = new SourceRequirements(
-			null, null, Collections.singletonList("ARDOUGNE_ELITE"), null, null, null);
+			null, null, Collections.singletonList("ARDOUGNE_ELITE"), null, null, null, null);
 		CollectionLogSource source = makeSourceWithRequirements("Zulrah", req);
 
 		List<RequirementRow> rows = checker.buildRequirementRows(source);
@@ -278,7 +278,7 @@ public class SourceRequirementsHeaderTest
 		when(client.getVarbitValue(ArgumentMatchers.anyInt())).thenReturn(0);
 
 		SourceRequirements req = new SourceRequirements(
-			null, null, Collections.singletonList("ARDOUGNE_ELITE"), null, null, null);
+			null, null, Collections.singletonList("ARDOUGNE_ELITE"), null, null, null, null);
 		CollectionLogSource source = makeSourceWithRequirements("Zulrah", req);
 
 		List<RequirementRow> rows = checker.buildRequirementRows(source);
@@ -304,7 +304,7 @@ public class SourceRequirementsHeaderTest
 		SourceRequirements req = new SourceRequirements(
 			Collections.singletonList("TROLL_STRONGHOLD"),
 			Collections.singletonList(new SkillRequirement("STRENGTH", 70)),
-			null, null, null, null);
+			null, null, null, null, null);
 		CollectionLogSource source = makeSourceWithRequirements("General Graardor", req);
 
 		List<RequirementRow> rows = checker.buildRequirementRows(source);
@@ -332,7 +332,7 @@ public class SourceRequirementsHeaderTest
 		SourceRequirements req = new SourceRequirements(
 			Collections.singletonList("TROLL_STRONGHOLD"),
 			Collections.singletonList(new SkillRequirement("STRENGTH", 70)),
-			null, null, null, null);
+			null, null, null, null, null);
 		CollectionLogSource source = makeSourceWithRequirements("General Graardor", req);
 
 		List<RequirementRow> rows = checker.buildRequirementRows(source);


### PR DESCRIPTION
## Summary

Adds an additive `requirements.inventoryItemIdsAny` field on `SourceRequirements`, evaluated against `PlayerInventoryState.hasItem(int)` as an **any-match**: the requirement is met when the player's regular inventory contains AT LEAST ONE of the listed item IDs. The new clause AND-combines with every other field on `SourceRequirements`, including the AND-semantic `inventoryItemIds` sibling added in #640.

Closes the schema gap flagged in PR #628's deferral note. The four wave-8-pending sources all use multi-tier inventory-teleport items, where the player can hold any one of several charge-tier or revision variants:

| Source | Item set | Need |
|---|---|---|
| Tombs of Amascut | Pharaoh's sceptre charges 1-5 + Jeweled (6 IDs) | OR across 6 variants |
| Phantom Muspah | Quetzal whistle basic / enhanced / perfected / perfected-infinite | OR across 4 variants |
| The Gauntlet | Teleport crystal charge tiers | OR across charge tiers |
| Corrupted Gauntlet | Teleport crystal charge tiers | OR across charge tiers |

Authoring these as AND with `inventoryItemIds` would assert the player holds every charge tier simultaneously, which never matches in practice. This PR is schema + tests only; pilot wiring of all four sources lands in a follow-up data PR.

Mirrors PR #640's structure exactly: same `@Nullable` Lombok annotation style, same Gson + evaluator integration, same test class shape (Gson + checker + migration guard). The difference is the evaluator clause uses `anyMatch` semantics instead of `allMatch`.

## Precedent

- PR **#640** added the AND-semantic `inventoryItemIds` field. This PR is the OR-semantic sibling using the same field-and-test pattern.
- PR **#628** explicitly flagged both AND and OR inventory schema work as the path to unblock the five sources deferred from the B1 batch closure.

## Files

**Modified (2):**
- `src/main/java/com/collectionloghelper/data/SourceRequirements.java` - new `@Nullable List<Integer> inventoryItemIdsAny;` field with full javadoc covering use cases and semantics.
- `src/main/java/com/collectionloghelper/data/RequirementsChecker.java` - new evaluator clause in `checkRequirementsDetail` that any-matches against `playerInventoryState.hasItem(int)` and short-circuits on first hit. Empty list and all-null list both collapse to vacuous-true, matching the AND-semantic siblings.

**Added (3):**
- `src/test/java/com/collectionloghelper/data/SourceRequirementsInventoryItemsAnyGsonTest.java` - 14 Gson tests (absent / null / empty / single / multi / negative ID / malformed string / malformed float / all-seven-fields populated / equals + hashCode parity / equals distinguishes inventoryItemIds vs inventoryItemIdsAny / round-trip).
- `src/test/java/com/collectionloghelper/data/RequirementsCheckerInventoryItemsAnyTest.java` - 15 evaluator tests (empty vacuous pass, single-item present / absent, multi-item one-present pass, none-present fail, all-present pass, null-entry skip, all-null vacuous pass, AND with equipped / POH / quest clauses, AND with the inventoryItemIds sibling in both directions, plus two alternative-selection tests mirroring `GuidanceStep.resolveAlternative`).
- `src/test/java/com/collectionloghelper/data/InventoryItemsAnyMigrationTest.java` - 2 migration-guard tests (database loads, every production `SourceRequirements` has null `inventoryItemIdsAny`). Mirrors `InventoryItemsMigrationTest` and walks top-level requirements, waypoints, flat conditional alternatives, and nested conditional alternatives.

**Test-callsite churn (8 files, 47 callsites):**

Recurring `@Value` positional-constructor migration tax, same shape as #623 and #640: every existing `new SourceRequirements(...)` call gets a trailing `null` for the new 7th positional slot. Files touched: `CollectionLogSourceTest`, `RequirementsCheckerB0Test`, `RequirementsCheckerInventoryItemsTest`, `SourceRequirementsB0Test`, `SourceRequirementsInventoryItemsGsonTest`, `GuidanceSequencerNestedConditionalTest`, `GuidanceSequencerTest`, `SourceRequirementsHeaderTest`.

## Zero data changes

`drop_rates.json` is untouched. The `InventoryItemsAnyMigrationTest` enforces this: it walks every source in the production database and asserts `getInventoryItemIdsAny() == null` at every requirement-bearing position.

## Build

`./gradlew build` passes locally - full unit suite + `lintDropRates` + Jacoco coverage gate all green.

## Test plan

- [x] `./gradlew build` green on local
- [ ] CI green on the PR
- [ ] Manual review of evaluator short-circuit logic against the AND-semantic sibling for parity
- [ ] Confirm the migration-guard test fails as expected when a future wave-8 PR wires the first source