### PR TITLE
data(c-extension): wire inventoryItemIds(Any) on 5 deferred inventory-teleport sources

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -786,6 +786,13 @@
             },
             "description": "Use the POH superior garden fairy ring (dramen/lunar staff equipped) to dial AKQ, then run east to Zul-Andra",
             "travelTip": "POH superior garden fairy ring -> AKQ -> run east to Zul-Andra"
+          },
+          {
+            "requirements": {
+              "inventoryItemIds": [12938]
+            },
+            "description": "Right-click the Zul-andra teleport scroll in your inventory to land directly at Zul-Andra, then board the Sacrificial boat",
+            "travelTip": "Inventory Zul-andra teleport scroll -> Zul-Andra"
           }
         ],
         "section": "Travel"
@@ -1540,7 +1547,16 @@
         "worldY": 3940,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "conditionalAlternatives": [
+          {
+            "requirements": {
+              "inventoryItemIdsAny": [29271, 29273, 29275, 33120]
+            },
+            "description": "Right-click your Quetzal whistle (basic / enhanced / perfected / perfected-infinite) in the inventory and pick the Phantom Muspah destination to land directly at the Ancient Prison entrance, skipping the Weiss -> Ghorrock overland route",
+            "travelTip": "Inventory Quetzal whistle -> Phantom Muspah"
+          }
+        ]
       },
       {
         "description": "Run south through Ghorrock Dungeon and step onto the Ancient Prison entrance tile",
@@ -6794,6 +6810,13 @@
             },
             "description": "Pharaoh's sceptre to the Necropolis (Desert Hard diary makes the sceptre unlimited-charge, so you can spam-teleport without recharging at the desert lectern). Bring Tbow or Bow of faerdhinen, Osmumten's fang for stab phases, Tumeken's shadow if owned, full brews/restores and prayer potions; set invocations under 150 raid level for entry-mode loot",
             "travelTip": "Pharaoh's sceptre -> Necropolis (unlimited charges via Desert Hard diary)"
+          },
+          {
+            "requirements": {
+              "inventoryItemIdsAny": [26945, 26946, 26947, 26948, 26949, 26950, 26951]
+            },
+            "description": "Right-click any tier of Pharaoh's sceptre in your inventory (uncharged tiers 1-3 / charged / jeweled) and pick Jaltevas to land at the Necropolis entrance. Bring Tbow or Bow of faerdhinen, Osmumten's fang for stab phases, Tumeken's shadow if owned, full brews/restores and prayer potions; set invocations under 150 raid level for entry-mode loot",
+            "travelTip": "Inventory Pharaoh's sceptre -> Jaltevas -> Necropolis"
           }
         ],
         "section": "Travel"
@@ -7097,6 +7120,13 @@
             },
             "description": "Pharaoh's sceptre to the Necropolis (Desert Hard diary makes the sceptre unlimited-charge, so you can spam-teleport without recharging at the desert lectern). Bring Tbow or Bow of faerdhinen, Osmumten's fang, Tumeken's shadow if owned, full brews/restores; aim for invocations totalling raid level 300-450 for solid loot efficiency before entering",
             "travelTip": "Pharaoh's sceptre -> Necropolis (unlimited charges via Desert Hard diary)"
+          },
+          {
+            "requirements": {
+              "inventoryItemIdsAny": [26945, 26946, 26947, 26948, 26949, 26950, 26951]
+            },
+            "description": "Right-click any tier of Pharaoh's sceptre in your inventory (uncharged tiers 1-3 / charged / jeweled) and pick Jaltevas to land at the Necropolis entrance. Bring Tbow or Bow of faerdhinen, Osmumten's fang, Tumeken's shadow if owned, full brews/restores; aim for invocations totalling raid level 300-450 for solid loot efficiency before entering",
+            "travelTip": "Inventory Pharaoh's sceptre -> Jaltevas -> Necropolis"
           }
         ],
         "section": "Travel"
@@ -7400,6 +7430,13 @@
             },
             "description": "Pharaoh's sceptre to the Necropolis (Desert Hard diary makes the sceptre unlimited-charge, so you can spam-teleport without recharging at the desert lectern). At raid level 500 bring Tumeken's shadow or Tbow, Osmumten's fang, full brews/restores, extra prayer potions and a Soulreaper axe spec; gear must be top-tier or kill times balloon",
             "travelTip": "Pharaoh's sceptre -> Necropolis (unlimited charges via Desert Hard diary)"
+          },
+          {
+            "requirements": {
+              "inventoryItemIdsAny": [26945, 26946, 26947, 26948, 26949, 26950, 26951]
+            },
+            "description": "Right-click any tier of Pharaoh's sceptre in your inventory (uncharged tiers 1-3 / charged / jeweled) and pick Jaltevas to land at the Necropolis entrance. At raid level 500 bring Tumeken's shadow or Tbow, Osmumten's fang, full brews/restores, extra prayer potions and a Soulreaper axe spec; gear must be top-tier or kill times balloon",
+            "travelTip": "Inventory Pharaoh's sceptre -> Jaltevas -> Necropolis"
           }
         ],
         "section": "Travel"
@@ -7518,6 +7555,13 @@
             },
             "description": "Operate the Crystal teleport seed for the rub-on-cape variant (Western Provinces Elite diary attaches the Prifddinas teleport to your max / quest / achievement cape, so you can teleport from anywhere without dedicating an inventory slot to the seed). Then run north-west to the Gauntlet portal in Lletya district",
             "travelTip": "Cape Crystal teleport -> Prifddinas (Western Provinces Elite diary unlock)"
+          },
+          {
+            "requirements": {
+              "inventoryItemIdsAny": [23904, 23858]
+            },
+            "description": "Right-click your Teleport crystal (regular or HM-charged) in the inventory and pick Prifddinas, then run north-west to the Gauntlet portal in Lletya district",
+            "travelTip": "Inventory Teleport crystal -> Prifddinas"
           }
         ]
       },
@@ -7628,6 +7672,13 @@
             },
             "description": "Operate the Crystal teleport seed for the rub-on-cape variant (Western Provinces Elite diary attaches the Prifddinas teleport to your max / quest / achievement cape, so you can teleport from anywhere without dedicating an inventory slot to the seed). Then run north-west to the Gauntlet portal in Lletya district",
             "travelTip": "Cape Crystal teleport -> Prifddinas (Western Provinces Elite diary unlock)"
+          },
+          {
+            "requirements": {
+              "inventoryItemIdsAny": [23904, 23858]
+            },
+            "description": "Right-click your Teleport crystal (regular or HM-charged) in the inventory and pick Prifddinas, then run north-west to the Gauntlet portal in Lletya district",
+            "travelTip": "Inventory Teleport crystal -> Prifddinas"
           }
         ]
       },

--- a/src/test/java/com/collectionloghelper/data/CExtensionInventoryTeleportRegressionTest.java
+++ b/src/test/java/com/collectionloghelper/data/CExtensionInventoryTeleportRegressionTest.java
@@ -1,0 +1,311 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.lang.reflect.Field;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * C-extension regression guard - locks the inventory-teleport conditional
+ * alternatives wired on the five sources that were deferred from B1 closure
+ * (PR #628) until the {@code inventoryItemIds} (PR #640) and
+ * {@code inventoryItemIdsAny} (PR #645) schema fields landed.
+ *
+ * <p>Per-source insertions, ordered behind any pre-existing diary / POH
+ * alternative (sequencer priority: diary &gt; POH &gt; equipped &gt;
+ * inventory &gt; base):
+ *
+ * <ul>
+ *   <li>Tombs of Amascut / 300 / 500 Invocation: existing diary alternative
+ *       at [0], new inventory-any alternative at [1] listing all 7
+ *       {@code PHARAOHS_SCEPTRE*} ItemID variants (26945-26951).</li>
+ *   <li>Zulrah: existing POH (FAIRY_RING) alternative at [0], new
+ *       inventory alternative at [1] listing
+ *       {@code TELEPORTSCROLL_ZULANDRA} (12938).</li>
+ *   <li>Phantom Muspah: no prior alternatives, new inventory-any
+ *       alternative at [0] listing the 4 {@code HG_QUETZALWHISTLE_*}
+ *       ItemID variants (29271, 29273, 29275, 33120).</li>
+ *   <li>Corrupted Gauntlet / The Gauntlet: existing diary
+ *       (WESTERN_ELITE) alternative at [0], new inventory-any
+ *       alternative at [1] listing {@code GAUNTLET_TELEPORT_CRYSTAL}
+ *       (23904) and {@code GAUNTLET_TELEPORT_CRYSTAL_HM} (23858).</li>
+ * </ul>
+ *
+ * <p>Mirrors {@code C6B3OverlapRegressionTest} (stacked-alternative shape)
+ * for ToA/Zulrah/Gauntlets, and the unstacked first-alternative shape used
+ * by {@code C6B2RegressionTest} for the Muspah insertion.
+ */
+public class CExtensionInventoryTeleportRegressionTest
+{
+	/** Pharaoh's sceptre variants: uncharged tiers 1-3, charged, charged_initial (jeweled). */
+	private static final List<Integer> PHARAOHS_SCEPTRE_VARIANTS = List.of(
+		26945, 26946, 26947, 26948, 26949, 26950, 26951);
+
+	/** Quetzal whistle variants: basic, enhanced, perfected, perfected-infinite. */
+	private static final List<Integer> QUETZAL_WHISTLE_VARIANTS = List.of(
+		29271, 29273, 29275, 33120);
+
+	/** Teleport crystal variants for Prifddinas: regular + Hard-Mode-charged. */
+	private static final List<Integer> GAUNTLET_TELEPORT_CRYSTAL_VARIANTS = List.of(
+		23904, 23858);
+
+	/** Zul-andra teleport scroll, single-ID inventory item. */
+	private static final List<Integer> ZULANDRA_SCROLL = List.of(12938);
+
+	/**
+	 * Per-source spec: index where the inventory alternative is expected,
+	 * whether the alternative is OR-semantic ({@code inventoryItemIdsAny}) or
+	 * AND-semantic ({@code inventoryItemIds}), and the expected ID list.
+	 */
+	private static final Map<String, InventorySpec> SPECS = buildSpecs();
+
+	private static Map<String, InventorySpec> buildSpecs()
+	{
+		Map<String, InventorySpec> map = new LinkedHashMap<>();
+		map.put("Tombs of Amascut",
+			new InventorySpec(1, true, PHARAOHS_SCEPTRE_VARIANTS, 2));
+		map.put("Tombs of Amascut (300 Invocation)",
+			new InventorySpec(1, true, PHARAOHS_SCEPTRE_VARIANTS, 2));
+		map.put("Tombs of Amascut (500 Invocation)",
+			new InventorySpec(1, true, PHARAOHS_SCEPTRE_VARIANTS, 2));
+		map.put("Zulrah",
+			new InventorySpec(1, false, ZULANDRA_SCROLL, 2));
+		map.put("Phantom Muspah",
+			new InventorySpec(0, true, QUETZAL_WHISTLE_VARIANTS, 1));
+		map.put("Corrupted Gauntlet",
+			new InventorySpec(1, true, GAUNTLET_TELEPORT_CRYSTAL_VARIANTS, 2));
+		map.put("The Gauntlet",
+			new InventorySpec(1, true, GAUNTLET_TELEPORT_CRYSTAL_VARIANTS, 2));
+		return map;
+	}
+
+	/**
+	 * Per-source base-step description tokens that MUST still appear in the
+	 * unmodified first guidance step, proving the inventory-teleport edit
+	 * only touched {@code conditionalAlternatives} and left the base route
+	 * intact.
+	 */
+	private static final Map<String, String> EXPECTED_BASE_DESCRIPTION_MARKER = buildBaseMarkers();
+
+	private static Map<String, String> buildBaseMarkers()
+	{
+		Map<String, String> map = new LinkedHashMap<>();
+		map.put("Tombs of Amascut", "Pharaoh's sceptre to teleport to the Necropolis");
+		map.put("Tombs of Amascut (300 Invocation)", "Pharaoh's sceptre to teleport to the Necropolis");
+		map.put("Tombs of Amascut (500 Invocation)", "Pharaoh's sceptre to teleport to the Necropolis");
+		map.put("Zulrah", "using a Zul-andra teleport scroll");
+		map.put("Phantom Muspah", "icy basalt to teleport to Weiss");
+		map.put("Corrupted Gauntlet", "Teleport to Prifddinas via teleport crystal");
+		map.put("The Gauntlet", "Teleport to Prifddinas via teleport crystal");
+		return map;
+	}
+
+	private DropRateDatabase database;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		database = new DropRateDatabase();
+
+		Gson gson = new GsonBuilder().create();
+		Field gsonField = DropRateDatabase.class.getDeclaredField("gson");
+		gsonField.setAccessible(true);
+		gsonField.set(database, gson);
+
+		database.load();
+	}
+
+	@Test
+	public void inventoryAlternativeIsAtExpectedIndexWithExpectedIds()
+	{
+		for (Map.Entry<String, InventorySpec> entry : SPECS.entrySet())
+		{
+			String name = entry.getKey();
+			InventorySpec spec = entry.getValue();
+
+			CollectionLogSource source = findSource(name);
+			assertNotNull(source, "Expected source: " + name);
+			assertNotNull(source.getGuidanceSteps(), name + ": guidanceSteps must not be null");
+			assertFalse(source.getGuidanceSteps().isEmpty(),
+				name + ": guidanceSteps must not be empty");
+
+			GuidanceStep firstStep = source.getGuidanceSteps().get(0);
+			List<ConditionalAlternative> alternatives = firstStep.getConditionalAlternatives();
+			assertNotNull(alternatives,
+				name + ": first step must declare conditionalAlternatives");
+			assertEquals(spec.expectedTotalAlternatives, alternatives.size(),
+				name + ": expected " + spec.expectedTotalAlternatives
+					+ " conditionalAlternatives entries, found " + alternatives.size());
+
+			ConditionalAlternative alt = alternatives.get(spec.index);
+			assertNotNull(alt,
+				name + ": conditional alternative missing at index " + spec.index);
+
+			SourceRequirements reqs = alt.getRequirements();
+			assertNotNull(reqs,
+				name + ": inventory alternative must declare requirements");
+
+			if (spec.anySemantic)
+			{
+				assertNull(reqs.getInventoryItemIds(),
+					name + ": inventoryItemIds should be null on an OR-semantic alternative");
+				assertEquals(spec.expectedIds, reqs.getInventoryItemIdsAny(),
+					name + ": inventoryItemIdsAny mismatch at index " + spec.index);
+			}
+			else
+			{
+				assertNull(reqs.getInventoryItemIdsAny(),
+					name + ": inventoryItemIdsAny should be null on an AND-semantic alternative");
+				assertEquals(spec.expectedIds, reqs.getInventoryItemIds(),
+					name + ": inventoryItemIds mismatch at index " + spec.index);
+			}
+
+			assertNotNull(alt.getDescription(),
+				name + ": inventory alternative must override description");
+			assertTrue(
+				alt.getDescription().toLowerCase().contains("inventory")
+					|| alt.getDescription().toLowerCase().contains("right-click"),
+				name + ": inventory alternative description should mention inventory/right-click; got: "
+					+ alt.getDescription());
+
+			assertNotNull(alt.getTravelTip(),
+				name + ": inventory alternative must override travelTip");
+			assertTrue(alt.getTravelTip().toLowerCase().contains("inventory"),
+				name + ": inventory alternative travelTip should mention inventory; got: "
+					+ alt.getTravelTip());
+		}
+	}
+
+	@Test
+	public void priorAlternativesArePreserved()
+	{
+		// Zulrah: existing POH (FAIRY_RING) at [0] must survive the insertion at [1].
+		ConditionalAlternative zulrahPoh =
+			findSource("Zulrah").getGuidanceSteps().get(0).getConditionalAlternatives().get(0);
+		assertNotNull(zulrahPoh.getRequirements());
+		assertEquals(List.of("FAIRY_RING"), zulrahPoh.getRequirements().getPohTeleports(),
+			"Zulrah: pre-existing FAIRY_RING POH alternative must remain at index 0");
+
+		// ToA x3: existing DESERT_HARD diary at [0] must survive.
+		for (String name : List.of(
+			"Tombs of Amascut",
+			"Tombs of Amascut (300 Invocation)",
+			"Tombs of Amascut (500 Invocation)"))
+		{
+			ConditionalAlternative diary =
+				findSource(name).getGuidanceSteps().get(0).getConditionalAlternatives().get(0);
+			assertNotNull(diary.getRequirements());
+			assertEquals(List.of("DESERT_HARD"), diary.getRequirements().getDiaries(),
+				name + ": pre-existing DESERT_HARD diary alternative must remain at index 0");
+		}
+
+		// Gauntlets: existing WESTERN_ELITE diary at [0] must survive.
+		for (String name : List.of("Corrupted Gauntlet", "The Gauntlet"))
+		{
+			ConditionalAlternative diary =
+				findSource(name).getGuidanceSteps().get(0).getConditionalAlternatives().get(0);
+			assertNotNull(diary.getRequirements());
+			assertEquals(List.of("WESTERN_ELITE"), diary.getRequirements().getDiaries(),
+				name + ": pre-existing WESTERN_ELITE diary alternative must remain at index 0");
+		}
+	}
+
+	@Test
+	public void baseStepDescriptionIsUntouched()
+	{
+		for (Map.Entry<String, String> entry : EXPECTED_BASE_DESCRIPTION_MARKER.entrySet())
+		{
+			String name = entry.getKey();
+			String expectedMarker = entry.getValue();
+
+			CollectionLogSource source = findSource(name);
+			assertNotNull(source, "Expected source: " + name);
+
+			GuidanceStep firstStep = source.getGuidanceSteps().get(0);
+			String baseDescription = firstStep.getDescription();
+			assertNotNull(baseDescription,
+				name + ": base step description must not be null");
+			assertTrue(
+				baseDescription.contains(expectedMarker),
+				name + ": base step description must still contain the original fallback wording '"
+					+ expectedMarker + "'. Got: " + baseDescription);
+		}
+	}
+
+	@Test
+	public void allFiveSourceFamiliesArePresentInDatabase()
+	{
+		// Cardinality lock: 7 JSON entries across the 5 deferred-source families.
+		assertEquals(7, SPECS.size(),
+			"C-extension wave-8a covers exactly 7 source entries (ToA x 3 + Zulrah + Muspah + Gauntlet x 2)");
+		for (String name : SPECS.keySet())
+		{
+			assertNotNull(findSource(name),
+				"Expected source missing from drop_rates.json: " + name);
+		}
+	}
+
+	private CollectionLogSource findSource(String name)
+	{
+		for (CollectionLogSource source : database.getAllSources())
+		{
+			if (name.equals(source.getName()))
+			{
+				return source;
+			}
+		}
+		return null;
+	}
+
+	/** Per-source expectation envelope. */
+	private static final class InventorySpec
+	{
+		final int index;
+		final boolean anySemantic;
+		final List<Integer> expectedIds;
+		final int expectedTotalAlternatives;
+
+		InventorySpec(int index, boolean anySemantic, List<Integer> expectedIds,
+			int expectedTotalAlternatives)
+		{
+			this.index = index;
+			this.anySemantic = anySemantic;
+			this.expectedIds = expectedIds;
+			this.expectedTotalAlternatives = expectedTotalAlternatives;
+		}
+	}
+}

--- a/src/test/java/com/collectionloghelper/data/InventoryItemsAnyMigrationTest.java
+++ b/src/test/java/com/collectionloghelper/data/InventoryItemsAnyMigrationTest.java
@@ -29,6 +29,7 @@ import com.google.gson.GsonBuilder;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -39,23 +40,38 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Migration guard for the additive {@code inventoryItemIdsAny} field on
  * {@link SourceRequirements}.
  *
- * <p>This PR adds the field, evaluator wiring, and Gson coverage but performs
- * zero pilot wiring in production data. This test walks the full production
- * {@code drop_rates.json} and asserts that every {@link SourceRequirements}
- * instance reached via top-level source requirements, conditional-alternative
- * requirements (flat and nested), and waypoint requirements has a null
- * {@code inventoryItemIdsAny}. The first opportunity to flip a single source
- * is a separate later data PR that wires the 4 deferred multi-tier teleport
- * sources (Tombs of Amascut, Phantom Muspah, The Gauntlet, Corrupted
- * Gauntlet).
+ * <p>The schema-addition PR (#645) shipped the field, evaluator wiring, and
+ * Gson coverage with zero production data using it. The C-extension data
+ * wiring PR then wires a small allowlist of sources whose teleport vector
+ * has multiple charge-tier variants: Tombs of Amascut (base / 300 / 500
+ * Invocation, Pharaoh's sceptre tiers), Phantom Muspah (Quetzal whistle
+ * tiers), and The Gauntlet / Corrupted Gauntlet (Teleport crystal regular
+ * + HM). Every other {@link SourceRequirements} instance reached via
+ * top-level source requirements, conditional-alternative requirements
+ * (flat and nested), and waypoint requirements must still leave the field
+ * null.
  *
  * <p>Mirrors {@link InventoryItemsMigrationTest} and the earlier
  * {@code B1MigrationTest} / {@code B1aRegressionTest} / {@code B1bRegressionTest}
  * pattern: walk the database, accumulate violations, fail with one readable
- * message.
+ * message. Positive coverage of the wired sources lives in
+ * {@link CExtensionInventoryTeleportRegressionTest}.
  */
 public class InventoryItemsAnyMigrationTest
 {
+	/**
+	 * Sources allowed to set {@code inventoryItemIdsAny} per the C-extension
+	 * data wiring PR. Any other source that flips this field will trip the
+	 * migration guard and force an explicit allowlist update.
+	 */
+	private static final Set<String> ALLOWED_SOURCES = Set.of(
+		"Tombs of Amascut",
+		"Tombs of Amascut (300 Invocation)",
+		"Tombs of Amascut (500 Invocation)",
+		"Phantom Muspah",
+		"The Gauntlet",
+		"Corrupted Gauntlet");
+
 	private DropRateDatabase database;
 
 	@BeforeEach
@@ -90,13 +106,19 @@ public class InventoryItemsAnyMigrationTest
 		}
 
 		assertTrue(violations.isEmpty(),
-			"inventoryItemIdsAny invariant violated. No production source may set inventoryItemIdsAny in this PR; pilot wiring lands in a follow-up data PR (Tombs of Amascut, Phantom Muspah, The Gauntlet, Corrupted Gauntlet). Violations:\n"
+			"inventoryItemIdsAny invariant violated. Only sources in the C-extension allowlist "
+				+ ALLOWED_SOURCES + " may set inventoryItemIdsAny; new entries require an explicit "
+				+ "ALLOWED_SOURCES update plus matching CExtensionInventoryTeleportRegressionTest coverage. Violations:\n"
 				+ String.join("\n", violations));
 	}
 
 	private static void checkSource(CollectionLogSource source, List<String> violations)
 	{
 		String sourceName = source.getName();
+		if (ALLOWED_SOURCES.contains(sourceName))
+		{
+			return;
+		}
 		checkRequirements(sourceName + " (top-level requirements)", source.getRequirements(), violations);
 
 		// CollectionLogSource owns the requirement-bearing Waypoint list. GuidanceStep

--- a/src/test/java/com/collectionloghelper/data/InventoryItemsMigrationTest.java
+++ b/src/test/java/com/collectionloghelper/data/InventoryItemsMigrationTest.java
@@ -29,6 +29,7 @@ import com.google.gson.GsonBuilder;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -39,20 +40,29 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Migration guard for the additive {@code inventoryItemIds} field on
  * {@link SourceRequirements}.
  *
- * <p>This PR adds the field, evaluator wiring, and Gson coverage but performs
- * zero pilot wiring in production data. This test walks the full production
- * {@code drop_rates.json} and asserts that every {@link SourceRequirements}
- * instance reached via top-level source requirements, conditional-alternative
- * requirements (flat and nested), and waypoint requirements has a null
- * {@code inventoryItemIds}. The first opportunity to flip a single source is a
- * separate later data PR.
+ * <p>The schema-addition PR (#640) shipped the field, evaluator wiring, and
+ * Gson coverage with zero production data using it. The C-extension data
+ * wiring PR then wires a small allowlist of sources via the AND-semantic
+ * {@code inventoryItemIds}: today only Zulrah's inventory scroll alternative
+ * is in this set. Every other {@link SourceRequirements} instance reached
+ * via top-level source requirements, conditional-alternative requirements
+ * (flat and nested), and waypoint requirements must still leave the field
+ * null.
  *
  * <p>Mirrors {@code B1MigrationTest}, {@code B1aRegressionTest}, and
  * {@code B1bRegressionTest}: walk the database, accumulate violations, fail
- * with one readable message.
+ * with one readable message. Positive coverage of the wired sources lives in
+ * {@link CExtensionInventoryTeleportRegressionTest}.
  */
 public class InventoryItemsMigrationTest
 {
+	/**
+	 * Sources allowed to set {@code inventoryItemIds} per the C-extension data
+	 * wiring PR. Any other source that flips this field will trip the
+	 * migration guard and force an explicit allowlist update.
+	 */
+	private static final Set<String> ALLOWED_SOURCES = Set.of("Zulrah");
+
 	private DropRateDatabase database;
 
 	@BeforeEach
@@ -87,13 +97,19 @@ public class InventoryItemsMigrationTest
 		}
 
 		assertTrue(violations.isEmpty(),
-			"inventoryItemIds invariant violated. No production source may set inventoryItemIds in this PR; pilot wiring lands in a follow-up data PR. Violations:\n"
+			"inventoryItemIds invariant violated. Only sources in the C-extension allowlist "
+				+ ALLOWED_SOURCES + " may set inventoryItemIds; new entries require an explicit "
+				+ "ALLOWED_SOURCES update plus matching CExtensionInventoryTeleportRegressionTest coverage. Violations:\n"
 				+ String.join("\n", violations));
 	}
 
 	private static void checkSource(CollectionLogSource source, List<String> violations)
 	{
 		String sourceName = source.getName();
+		if (ALLOWED_SOURCES.contains(sourceName))
+		{
+			return;
+		}
 		checkRequirements(sourceName + " (top-level requirements)", source.getRequirements(), violations);
 
 		// CollectionLogSource owns the requirement-bearing Waypoint list. GuidanceStep


### PR DESCRIPTION
## Summary

Closes the 5-source deferral noted in PR #628 by wiring the inventory-teleport conditional alternatives that were waiting on the schema fields shipped in PR #640 (`inventoryItemIds`, AND-semantic) and PR #645 (`inventoryItemIdsAny`, OR-semantic).

Authoring style mirrors PR #630 (B2 POH-teleport template) and PR #632 (B3-overlap stacking). Pre-existing diary / POH alternatives are preserved unchanged; the new inventory alternative is inserted after them per the sequencer priority `diary > POH > equipped > inventory > base`. Base step descriptions are untouched, so the no-inventory fallback still works.

## Sources, fields, and item IDs

| Source | Field | Item IDs | Pre-existing alt at [0] |
|---|---|---|---|
| Tombs of Amascut | `inventoryItemIdsAny` | 26945, 26946, 26947, 26948, 26949, 26950, 26951 (all `PHARAOHS_SCEPTRE*` ItemID variants) | `DESERT_HARD` diary |
| Tombs of Amascut (300 Invocation) | `inventoryItemIdsAny` | same as above | `DESERT_HARD` diary |
| Tombs of Amascut (500 Invocation) | `inventoryItemIdsAny` | same as above | `DESERT_HARD` diary |
| Zulrah | `inventoryItemIds` | 12938 (`TELEPORTSCROLL_ZULANDRA`) | `FAIRY_RING` POH (from PR #630) |
| Phantom Muspah | `inventoryItemIdsAny` | 29271, 29273, 29275, 33120 (`HG_QUETZALWHISTLE_BASIC` / `_ENHANCED` / `_PERFECTED` / `_PERFECTED_INFINITE`) | (no prior alternatives — new alt is at [0]) |
| The Gauntlet | `inventoryItemIdsAny` | 23904 (`GAUNTLET_TELEPORT_CRYSTAL`), 23858 (`GAUNTLET_TELEPORT_CRYSTAL_HM`) | `WESTERN_ELITE` diary |
| Corrupted Gauntlet | `inventoryItemIdsAny` | same as above | `WESTERN_ELITE` diary |

All item IDs resolved via `runelite_id_lookup` against the master `ItemID` constants. The Pharaoh's sceptre family has 7 ItemID variants (uncharged tiers 1-3 at 26945/26946/26947, charged at 26948/26949, charged-initial / jeweled at 26950/26951) — all 7 are wired so any sceptre tier satisfies the OR clause.

## Migration-guard updates

`InventoryItemsMigrationTest` and `InventoryItemsAnyMigrationTest` originally asserted a blanket "no production source sets this field" invariant against the post-#640 / post-#645 state. They are flipped to per-source allowlists: any future source flipping `inventoryItemIds(Any)` must update `ALLOWED_SOURCES` plus add positive coverage in `CExtensionInventoryTeleportRegressionTest`.

## Test plan

- [x] `./gradlew build` green (full JUnit suite + `lintDropRates`).
- [x] New `CExtensionInventoryTeleportRegressionTest` covers:
  - Inventory alternative at expected index with expected ID list, correct AND vs OR semantic, and inventory-flavoured description / travelTip.
  - Pre-existing diary (ToA x 3, Gauntlets) and POH (Zulrah) alternatives still at index [0].
  - Base step descriptions untouched.
  - Cardinality lock: exactly 7 JSON entries across the 5 deferred-source families.
- [x] Pre-existing migration tests (`InventoryItemsMigrationTest`, `InventoryItemsAnyMigrationTest`) still pass with the updated allowlists.
- [x] Forbid-list grep on diff and commit message: clean.
- [x] ASCII-only check on the diff: clean.

## References

- PR #628 — original 5-source deferral note.
- PR #640 — `inventoryItemIds` (AND) schema + evaluator.
- PR #645 — `inventoryItemIdsAny` (OR) schema + evaluator.
- PR #630 — B2 POH-teleport conditional-alternative authoring template.
- PR #632 — B3-overlap stacking pattern.