### PR TITLE
docs(c-extension): close milestone in ROADMAP (5 deferred sources wired via #650)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -587,6 +587,7 @@ Focus: god-object decomposition, build hardening, test expansion. Resulted in th
 - [x] C4 — Skill-cape perk state                        status: done          owner: cha-ndler  updated: 2026-05-14  pr: #471
 - [x] C5 — Partial-quest state                          status: done          owner: cha-ndler  updated: 2026-05-14  pr: #462
 - [x] C6 — Wire into top-20 sources                     status: done          owner: cha-ndler  updated: 2026-05-23  note: All in-scope batches landed per #621 scoping. B0 schema #623 -> B1 C2-equipped-items #625 + #626 + #627 + #628 -> B2 C1-POH-teleports #630 -> B3 C3-diaries non-overlap #631 + overlap (stacked on B2) #632. C4 deferred (zero top-20 applications per scoping sec. 2); C5 covered by existing `requirements.quests` field.
+  - 2026-05-24: C-extension closed — 5 deferred inventory-teleport sources wired via #650 using #640 (inventoryItemIds AND) + #645 (inventoryItemIdsAny OR). #628 deferral resolved.
 - [x] C7 — Player-capability debug overlay              status: done          owner: cha-ndler  updated: 2026-05-14  pr: #459
 
 **Tier D — Coverage breadth**


### PR DESCRIPTION
## Summary

Records C-extension milestone closure under Tier C6 in `docs/ROADMAP.md`. Mirrors the closure-note pattern used by #633 (C6) and #647 (D3).

The C-extension batch (deferred from B1 closure per #628) shipped end-to-end this session:

- **Schema** — landed via #640 (`inventoryItemIds` AND-semantics) + #645 (`inventoryItemIdsAny` OR-semantics).
- **Data wiring** — landed via #650, applying the new fields to the 5 deferred inventory-teleport sources.

With #650 merged, the #628 deferral is resolved. All in-scope C6 wiring batches plus the C-extension follow-up are now complete.

## Scope

- Adds one sub-bullet under the C6 row noting the closure, with citations to #628 / #640 / #645 / #650.
- Does NOT change the C6 row's primary `[x] done` status (already set by #633).
- No other rows touched. `Last reviewed:` already at 2026-05-24.

## Test plan

- [x] `git diff --stat` shows exactly 1 file (`docs/ROADMAP.md`), 1 insertion
- [x] C6 row primary status unchanged
- [x] Sub-bullet formatted consistently with adjacent rows