### PR TITLE
docs(b4-3-4): scope Barrows per-brother targeting design

### DIFF
--- a/docs/contributor-guide/b4.3.4-barrows-per-brother-design.md
+++ b/docs/contributor-guide/b4.3.4-barrows-per-brother-design.md
@@ -1,0 +1,169 @@
+# B4.3.4 Barrows per-brother targeting — design
+
+> Implements [Tier B4.3.4](../ROADMAP.md#tier-b--guidance-depth-parity-with-quest-helper). Deferred from the B4.3 backfills for design review per [#420](https://github.com/cha-ndler/collection-log-helper/issues/420); this doc proposes the design before any implementation PR is opened.
+
+---
+
+## 1. Problem
+
+The Barrows source in `drop_rates.json` (lines 7717-8040) has **25 collection-log items**: 24 brother-set pieces (4 per brother × 6 brothers) plus the Bolt rack. Each set piece can drop **only** from the chest when the player has killed the matching brother that trip. Bolt rack drops independent of which brothers were killed.
+
+The current `guidanceSteps` array already issues six per-brother kill steps (1672 Ahrim, 1673 Dharok, 1674 Guthan, 1675 Karil, 1676 Torag, 1677 Verac), each closed by a `VARBIT_AT_LEAST` check against the corresponding `BARROWS_KILLED_*` varbit (457-462). A trip is "complete" when all six varbits read 1, the player enters the central tunnel, and opens the chest.
+
+The B4.3 per-item override family (`perItemStepDescription` #421, `perItemNpcId` #423, `perItemRequiredItemIds` from B4.1) is **not enough** to express "for hunters of Ahrim's hood, skip past the other five brother kill steps and only require the Ahrim kill." The reasons:
+
+1. **Skip semantics, not retarget semantics.** The existing per-item fields override *content* (text, NPC ID, required inventory) of a step the sequencer was already going to run. Barrows needs to *skip* steps entirely — a Dharok-helm hunter still has to kill all six brothers for the chest to open with set-piece eligibility, but the *route guidance* should highlight Dharok first and treat the other five as background work.
+2. **Multi-step ownership.** The mismatch sits across steps 2-7, not inside one step. `perItemStepDescription` rewrites one step; it cannot reorder a six-element sub-sequence.
+3. **VARBIT-completion is already perfect for sequencer advancement.** The 6 `BARROWS_KILLED_*` varbits already auto-advance each kill step. The missing piece is *targeting* (which brother to render first / loudest in the overlay), not *completion detection*.
+
+So the design question is: how do we tell the overlay, "for this active target item, prioritise *that* brother's kill step"?
+
+---
+
+## 2. Schema proposal
+
+Two viable options.
+
+### Option A — `perItemStepPriority` on `GuidanceStep`
+
+Add `@Nullable Map<Integer, Integer>` mapping clog item ID -> a numeric priority for the *containing step*. The sequencer's step-selection logic gains a per-item priority lookup: when an active target item has an entry for any of the active source's steps, the highest-priority matching step is rendered first; lower-priority steps are still tracked (varbit completion still fires) but de-emphasised in the panel and overlay.
+
+- **Schema cost.** One new `@Nullable` field, parallel to the existing `perItem*` family.
+- **Authoring shape.** Each of the six Barrows kill steps gets a four-entry map (its brother's set pieces -> priority 100; the other 20 set pieces unset, treated as default priority 0).
+- **Activation chain.** Reuses `activeTargetItemId` propagation that B4.1 already wired through `GuidanceOverlayCoordinator`. New `GuidanceStep.resolvePriority(Integer targetItemId)` helper mirrors `resolveDescription` / `resolveNpcId`.
+- **Pros.** Minimal additive schema; zero impact on the 225 existing sources (default priority is 0 everywhere); composes cleanly with `perItemNpcId` (Barrows already has correct NPC IDs per-step; no need to override them).
+- **Cons.** Introduces "priority" as a new sequencer concept. The sequencer today is a strict 1..N counter, not a priority heap. Implementing it requires teaching `GuidanceSequencer` to *reorder* the active step pointer when `activeTargetItemId` changes mid-source.
+
+### Option B — `perItemStepRoute` on the source root
+
+Add `@Nullable Map<Integer, List<Integer>>` at the source level (not on `GuidanceStep`) mapping clog item ID -> ordered list of step indices to walk for that item. The default route is `[1, 2, 3, ..., N]`; a per-item override replaces it with a custom permutation/subset.
+
+- **Schema cost.** One new field on the source-level model (not `GuidanceStep`).
+- **Authoring shape.** Barrows would get 24 entries — one per set piece — each saying "kill the relevant brother first, then the other five, then loot the chest." Bolt rack uses the default.
+- **Pros.** Fully general; can re-order, skip, or insert steps based on active target. Useful for any future source where step *order* depends on which item the player is hunting.
+- **Cons.** Heavier schema. Risks duplicating `conditionalAlternatives` (#637 condition trees) since both can branch step content. A 24-entry route table per source becomes a maintenance burden — every authoring change to Barrows' step list requires re-checking all 24 routes. Also makes the activation chain harder to reason about (the route resolution happens at a different layer than the per-step `perItem*` overrides).
+
+### Comparison
+
+| Concern | Option A (per-step priority) | Option B (per-item route) |
+|---|---|---|
+| Backwards compat with 225 existing sources | Zero impact (null default) | Zero impact (null default) |
+| Authoring friction (Barrows case) | 6 four-entry maps on existing kill steps | 24 list entries on the source root |
+| Overlap with `conditionTree` (#637) | None — orthogonal (completion vs prioritisation) | Partial — both can branch step content |
+| Overlap with B5 dynamic-target evaluator (#473) | None — B5 retargets a single step's `WorldPoint`; A retargets the sequencer's *current step* | None — same |
+| Sequencer impact | Need step-reorder hook | Need step-route lookup at source-load |
+| Generalises beyond Barrows | Yes — any multi-step source where each step "owns" a subset of items (e.g. Slayer dungeon multi-NPC) | Yes — but the cost-benefit only beats A when steps need true reordering rather than just prioritisation |
+
+### Recommendation — Option A
+
+Pick **Option A (`perItemStepPriority`)**. Rationale:
+
+- Barrows specifically does not need *reordering* in the strict sense. The trip mechanics force all six brothers to die before the chest opens; the player can kill them in any order. What we need is "tell the player which one matters first." A priority field expresses that without lying about the trip flow.
+- Option A's authoring shape (a small map on each kill step) is naturally co-located with the step it affects. Option B's source-root route table puts the data far from the step definitions it references by index — high risk of index-drift bugs when steps are inserted/removed.
+- Option A reuses the established `perItem*` activation chain (B4.1's `activeTargetItemId`). Option B forces a second activation pathway through the source loader.
+- Future sources with multi-target kill steps (Slayer dungeons with mixed NPC types, GWD anteroom packs, eventual Nightmare totem variants) will benefit from priority semantics in the same shape.
+
+If a future source ever needs *true reordering* (not just prioritisation), Option B can be added on top of A without conflict — A handles the 80% case; B is a later escape hatch.
+
+---
+
+## 3. Java API + activation chain
+
+For Option A:
+
+```java
+// GuidanceStep.java — new field next to perItemNpcId
+/**
+ * Optional per-item priority for this step.  When the active guidance target
+ * has an entry in this map, the sequencer treats this step as the highest-priority
+ * step for that item: panel + overlay render this step first, even if it sits
+ * later in the source's step array.  Steps with no entry resolve to priority 0.
+ *
+ * <p>Null by default — existing JSON without this field deserialises unchanged.
+ */
+@Nullable
+Map<Integer, Integer> perItemStepPriority;
+
+public int resolvePriority(@Nullable Integer targetItemId)
+{
+    if (targetItemId != null && perItemStepPriority != null)
+    {
+        Integer p = perItemStepPriority.get(targetItemId);
+        if (p != null) return p;
+    }
+    return 0;
+}
+```
+
+Sequencer wiring sketch (in `GuidanceSequencer`):
+
+1. On `activateGuidance(sourceId, activeTargetItemId)`, after the existing skip-chain pass, compute `priorityIndex = argmax_i(steps[i].resolvePriority(activeTargetItemId))`. If `priorityIndex > 0` and the priority is positive and the step is not already complete, set the current step pointer to `priorityIndex` (skip-chain still gates whether that step actually fires).
+2. On `activeTargetItemId` changes mid-source (panel item-pick), re-run the priority pass.
+3. Normal step completion (VARBIT, ACTOR_DEATH, etc.) advances 1..N as today; once the prioritised step completes, the sequencer falls through to the next-highest priority *un-complete* step until all priority entries are exhausted, then resumes default sequential order.
+
+Activation-chain propagation reuses the `activeTargetItemId` plumbing that B4.1 fixed in PR #421 (set after `deactivateGuidance`, not before). No new field on `GuidanceOverlayCoordinator`.
+
+### Test surface
+
+- `GuidanceStepTest` — 4 new cases: `resolvePriority(null)` returns 0; entry returns mapped value; missing entry returns 0; null map returns 0.
+- `GuidanceSequencerPriorityTest` (new file) — 6 cases: priority pass picks correct step on activate; mid-source target-change re-runs priority pass; completed priority step falls through to next-highest; priority 0 entries treated as default; multiple equal priorities pick lowest index (deterministic); B1 conditionTree completion still wins over the static enum in priority-selected steps.
+- `B4MigrationTest` — regression guard: load `drop_rates.json`, assert every step has `perItemStepPriority == null` until B4.3.4 wiring lands; tighten to "only Barrows steps may set it" after the pilot.
+
+---
+
+## 4. Migration plan
+
+Strictly additive. Zero risk to 225 existing sources at each phase boundary.
+
+- **Phase 1 — Schema landing.** Add `@Nullable Map<Integer, Integer> perItemStepPriority` to `GuidanceStep`. Add `resolvePriority` helper. Add the 4 unit tests. No sequencer changes; field is parsed but unused. Constructor-arity migration: 19 `GuidanceStep` callsites in tests gain a trailing `, null` (same pattern as #423 / #637).
+- **Phase 2 — Sequencer wiring.** Teach `GuidanceSequencer` to honour the priority pass on activate + on `activeTargetItemId` change. Add `GuidanceSequencerPriorityTest`. Still zero production data uses the field; regression test enforces.
+- **Phase 3 — Barrows pilot.** Wire `perItemStepPriority` maps on the six Barrows kill steps. 24 entries total (4 set pieces × 6 brothers). Add a `BarrowsPerBrotherTest` that asserts: for each set-piece item ID, the sequencer's first chosen step has the matching brother's NPC ID; for Bolt rack (no entry), the sequencer follows the default 1..N order.
+- **Phase 4 (optional).** Audit `drop_rates.json` for other multi-target-kill sources. From the current data: GWD anterooms (mixed minion drops), Tombs of Amascut path-puzzle rooms, and any future Nightmare totem mechanic are candidates. Each one is its own data-only PR.
+
+Each phase is independently shippable. Phase 1 + Phase 2 land together if the sequencer change is small enough; Phase 3 is a separate data PR after the schema settles.
+
+---
+
+## 5. Mapping table — Barrows per-brother authoring entries
+
+All 6 brother NPC IDs and 6 kill varbits verified via `runelite_id_lookup` and `varbit_lookup` against `runelite-api/src/main/java/net/runelite/api/gameval/VarbitID.java` / `NpcID.java` on master.
+
+| Brother | NPC name | NPC ID | Kill varbit name | Varbit ID | Threshold | Set-piece item IDs (priority 100) |
+|---|---|---|---|---|---|---|
+| Ahrim | Ahrim the Blighted | 1672 | `BARROWS_KILLED_AHRIM` | 457 | >= 1 | 4708 hood, 4712 robetop, 4714 robeskirt, 4710 staff |
+| Dharok | Dharok the Wretched | 1673 | `BARROWS_KILLED_DHAROK` | 458 | >= 1 | 4716 helm, 4720 platebody, 4722 platelegs, 4718 greataxe |
+| Guthan | Guthan the Infested | 1674 | `BARROWS_KILLED_GUTHAN` | 459 | >= 1 | 4724 helm, 4728 platebody, 4730 chainskirt, 4726 warspear |
+| Karil | Karil the Tainted | 1675 | `BARROWS_KILLED_KARIL` | 460 | >= 1 | 4732 coif, 4736 leathertop, 4738 leatherskirt, 4734 crossbow |
+| Torag | Torag the Corrupted | 1676 | `BARROWS_KILLED_TORAG` | 461 | >= 1 | 4745 helm, 4749 platebody, 4751 platelegs, 4747 hammers |
+| Verac | Verac the Defiled | 1677 | `BARROWS_KILLED_VERAC` | 462 | >= 1 | 4753 helm, 4757 brassard, 4759 plateskirt, 4755 flail |
+| _n/a_ | (no brother)       | _n/a_ | _n/a_                  | _n/a_     | _n/a_     | 4740 Bolt rack — drops from any brother, no override |
+
+All 7 rows populated. Threshold is `>= 1` (any kill in the current trip) — this matches what the existing `completionVarbitValue: 1` on the live Barrows steps already uses.
+
+---
+
+## 6. Open questions
+
+1. **Akrisae's robes** — the original B4.3.4 issue text mentioned an Akrisae set as a 7th Barrows clog item. **This is not the case in OSRS**: Akrisae is from Temple Trekking, not the Barrows reward chest. The Barrows clog has 25 entries: 24 set pieces + Bolt rack. No per-brother chain for Akrisae is needed in this source. Confirm before authoring.
+2. **Bolt rack** — drops from any brother's pile and from the chest. Default sequential order (no `perItemStepPriority` entry) is correct: any kill produces eligibility. No override needed.
+3. **B5 dynamic-target evaluator (#473) conflict.** None expected. B5 retargets a single step's `WorldPoint` per tick; A4.3.4 picks *which step* the sequencer points at on activate. The two layers compose: a B5-marked step still gets per-tick `WorldPoint` evaluation once the sequencer has selected it via the priority pass.
+4. **`conditionTree` (#637) overlap.** None. `conditionTree` describes when a step *completes*; `perItemStepPriority` describes which step to point at on activate. Both can coexist on the same step.
+5. **Tunnel + chest steps (8 and 9).** No priority entry needed — they apply identically to every item. Default sequential order after the six kill steps remains correct.
+6. **Mid-trip target switch.** If the player picks a different active target item mid-trip (e.g. switches from Ahrim's hood to Dharok's helm after killing Ahrim), the priority pass re-runs and the sequencer jumps to the Dharok step. The Ahrim varbit is already at 1, so the Ahrim step (if revisited) auto-skips via the existing completion check. Confirm `GuidanceSequencer` handles the jump-to-completed-step case gracefully — likely already true per the skip-chain, but add a test.
+
+---
+
+## 7. References
+
+- ROADMAP entry: [Tier B4.3.4](../ROADMAP.md#tier-b--guidance-depth-parity-with-quest-helper) (line 564).
+- Survey: [#420](https://github.com/cha-ndler/collection-log-helper/issues/420) — B4.2 per-item method-differentiation candidate survey.
+- B4.3 schema chain:
+  - [#421](https://github.com/cha-ndler/collection-log-helper/pull/421) — `perItemStepDescription`.
+  - [#423](https://github.com/cha-ndler/collection-log-helper/pull/423) — `perItemNpcId`.
+  - [#422](https://github.com/cha-ndler/collection-log-helper/pull/422) — Shayzien backfill.
+  - [#425](https://github.com/cha-ndler/collection-log-helper/pull/425) + [#436](https://github.com/cha-ndler/collection-log-helper/pull/436) — Perilous Moons backfill + travel-step fix.
+  - [#444](https://github.com/cha-ndler/collection-log-helper/pull/444) — Cyclopes Defenders backfill.
+- B1 composable conditions: [#637](https://github.com/cha-ndler/collection-log-helper/pull/637) — `conditionTree` evaluator.
+- B5 dynamic targets: [#473](https://github.com/cha-ndler/collection-log-helper/pull/473) — `dynamicTargetEvaluator` per-step key.
+- Existing Barrows data: `src/main/resources/com/collectionloghelper/drop_rates.json` lines 7717-8040.
+- Existing schema: `src/main/java/com/collectionloghelper/data/GuidanceStep.java`.


### PR DESCRIPTION
## Summary

Scoping doc for **B4.3.4 Barrows per-brother targeting**, deferred from the B4.3 per-item backfill chain per #420 for design review. No code, no `drop_rates.json` changes — design only.

## Chosen option

**Option A — `perItemStepPriority` on `GuidanceStep`**: an additive `@Nullable Map<Integer, Integer>` on each step that maps clog item ID -> numeric priority. The sequencer's priority pass picks the highest-priority un-complete step on activate and on active-target-item change.

Rejected: Option B (source-root `perItemStepRoute` permutation table) — heavier schema, index-drift risk, partially overlaps `conditionTree` (#637). Option A reuses the established `perItem*` activation chain and composes cleanly with B5 dynamic targets (#473) and B1 condition trees (#637).

## Key facts verified

- All 6 brother NPC IDs (1672-1677) confirmed via `runelite_id_lookup` against `gameval/NpcID.java`.
- All 6 `BARROWS_KILLED_*` varbits (457-462) confirmed via `varbit_lookup` against `gameval/VarbitID.java`.
- Barrows clog has **25 items** (24 set pieces + Bolt rack), not 7 — the issue text mentioned Akrisae's robes, but Akrisae is from Temple Trekking, not Barrows. Flagged as open question Q1.

## Open questions

- Akrisae confirmation (Q1).
- Mid-trip target switch handling — sequencer must gracefully jump to/past completed priority steps (Q6).
- `conditionTree` / B5 / `perItemNpcId` composition — verified orthogonal, no overlap.

## Recommended pilot ordering

1. **Phase 1** — schema landing (one PR, 19 test-callsite arity migrations, zero data).
2. **Phase 2** — sequencer priority pass + tests (separate PR or folded into Phase 1).
3. **Phase 3** — Barrows data wiring + per-brother regression test.
4. **Phase 4 (optional)** — audit other multi-target-kill sources (GWD anterooms, ToA path puzzles, future Nightmare totems).

Refs #420.