### PR TITLE
feat(schema): B4.3.4 Phase 1+2 - additive perItemStepPriority schema + evaluator (no pilot)

### DIFF
--- a/src/main/java/com/collectionloghelper/data/GuidanceStep.java
+++ b/src/main/java/com/collectionloghelper/data/GuidanceStep.java
@@ -289,6 +289,27 @@ public class GuidanceStep
 	@JsonAdapter(ConditionNodeDeserializer.class)
 	ConditionNode conditionTree;
 
+	/**
+	 * Optional per-item step priority map (B4.3.4 Phase 1+2).  Maps a clog item
+	 * ID to a numeric priority that the sequencer's step-selection logic can
+	 * consult when an active target item is set.  Steps not present in the map
+	 * resolve to priority 0 (the default).  Higher numeric values indicate
+	 * higher priority for the indicated item.
+	 *
+	 * <p>Intended use: multi-step sources where each step "owns" a subset of
+	 * the source's clog items (e.g. Barrows' six per-brother kill steps, each
+	 * owning that brother's four set pieces).  When the player picks a target
+	 * item, the sequencer can prefer the step that owns it without changing
+	 * the underlying trip mechanics or completion detection.
+	 *
+	 * <p>Null by default. Existing JSON without this field deserialises
+	 * unchanged. Phase 1+2 lands the schema and the {@link #resolvePriority}
+	 * helper; no production source sets this field. Phase 3 (separate later
+	 * PR) introduces the first pilot wiring (Barrows per-brother).
+	 */
+	@Nullable
+	Map<Integer, Integer> perItemStepPriority;
+
 	public int getCompletionDistance()
 	{
 		return completionDistance > 0 ? completionDistance : 5;
@@ -341,6 +362,33 @@ public class GuidanceStep
 			}
 		}
 		return npcId;
+	}
+
+	/**
+	 * Resolves the per-item step priority for this step given the active
+	 * guidance target item (B4.3.4 Phase 1+2). When {@link #perItemStepPriority}
+	 * has an entry for {@code targetItemId}, that priority is returned.
+	 * Returns 0 (the default priority) when the map is null, {@code targetItemId}
+	 * is null, or no entry exists for the target.
+	 *
+	 * <p>Phase 1+2 ships only the resolver. No production source sets
+	 * {@code perItemStepPriority}, so this method always returns 0 in the
+	 * current data set. Sequencer integration (Phase 3+) is a later PR.
+	 *
+	 * @param targetItemId the clog item ID the player is hunting, or {@code null}
+	 * @return the resolved priority (0 when no override applies)
+	 */
+	public int resolvePriority(@Nullable Integer targetItemId)
+	{
+		if (targetItemId != null && perItemStepPriority != null)
+		{
+			Integer override = perItemStepPriority.get(targetItemId);
+			if (override != null)
+			{
+				return override;
+			}
+		}
+		return 0;
 	}
 
 	/**
@@ -516,7 +564,8 @@ public class GuidanceStep
 			this.section,
 			null, // waypoints: merged steps inherit null; authors set waypoints on the base step
 			this.dynamicTargetEvaluator,
-			this.conditionTree // tree is inherited from base; alternatives do not override it in B1
+			this.conditionTree, // tree is inherited from base; alternatives do not override it in B1
+			this.perItemStepPriority // priority map inherited from base; alternatives do not override it in B4.3.4
 		);
 	}
 }

--- a/src/main/java/com/collectionloghelper/guidance/bosses/CerberusGuidance.java
+++ b/src/main/java/com/collectionloghelper/guidance/bosses/CerberusGuidance.java
@@ -99,7 +99,8 @@ public class CerberusGuidance implements BossGuidance
 			"Travel",          // section
 			null,              // waypoints
 			null,              // dynamicTargetEvaluator
-			null               // conditionTree
+			null,              // conditionTree
+			null               // perItemStepPriority
 		);
 
 		GuidanceStep gateStep = new GuidanceStep(
@@ -135,7 +136,8 @@ public class CerberusGuidance implements BossGuidance
 			"Travel",          // section
 			null,              // waypoints
 			null,              // dynamicTargetEvaluator
-			null               // conditionTree
+			null,              // conditionTree
+			null               // perItemStepPriority
 		);
 
 		GuidanceStep killStep = new GuidanceStep(
@@ -170,7 +172,8 @@ public class CerberusGuidance implements BossGuidance
 			"Combat",          // section
 			null,              // waypoints
 			null,              // dynamicTargetEvaluator
-			null               // conditionTree
+			null,              // conditionTree
+			null               // perItemStepPriority
 		);
 
 		return Arrays.asList(travelStep, gateStep, killStep);

--- a/src/test/java/com/collectionloghelper/data/B4_3_4_MigrationTest.java
+++ b/src/test/java/com/collectionloghelper/data/B4_3_4_MigrationTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * B4.3.4 Phase 1+2 migration guard.
+ *
+ * <p>The Phase 1+2 schema landing is strictly additive: a new
+ * {@code perItemStepPriority} slot on {@link GuidanceStep}. No production
+ * source opts in during this PR. Phase 3 will wire the first pilot (Barrows
+ * per-brother kill steps); when that lands, each pilot source must be added
+ * to {@link #PHASE_3_PILOT_SOURCES} so this guard distinguishes intentional
+ * pilots from accidental opt-ins.
+ *
+ * <p>Mirrors the B1 / B2 / B3 / B5 regression-guard pattern: walk the database,
+ * accumulate violations, fail with one readable message.
+ */
+public class B4_3_4_MigrationTest
+{
+	/**
+	 * Sources that have intentionally opted into {@code perItemStepPriority}
+	 * via a Phase 3+ pilot. Empty until Phase 3 lands (Barrows per-brother).
+	 * Any new entry here must come in the same PR as the {@code drop_rates.json}
+	 * edit that adds the priority map.
+	 */
+	private static final java.util.Set<String> PHASE_3_PILOT_SOURCES = java.util.Collections.emptySet();
+
+	private DropRateDatabase database;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		database = new DropRateDatabase();
+
+		Gson gson = new GsonBuilder().create();
+		Field gsonField = DropRateDatabase.class.getDeclaredField("gson");
+		gsonField.setAccessible(true);
+		gsonField.set(database, gson);
+
+		database.load();
+	}
+
+	@Test
+	public void onlyAllowlistedPilotsCarryPerItemStepPriority()
+	{
+		List<String> violations = new ArrayList<>();
+
+		for (CollectionLogSource source : database.getAllSources())
+		{
+			List<GuidanceStep> steps = source.getGuidanceSteps();
+			if (steps == null)
+			{
+				continue;
+			}
+			boolean isPilot = PHASE_3_PILOT_SOURCES.contains(source.getName());
+			for (int i = 0; i < steps.size(); i++)
+			{
+				GuidanceStep step = steps.get(i);
+				if (step == null)
+				{
+					continue;
+				}
+				if (step.getPerItemStepPriority() != null && !isPilot)
+				{
+					violations.add(source.getName() + " step " + (i + 1)
+						+ " has non-null perItemStepPriority but is not in PHASE_3_PILOT_SOURCES; "
+						+ "add the source name to the allowlist and ship a structural test alongside the JSON edit");
+				}
+			}
+		}
+
+		assertTrue(violations.isEmpty(),
+			"B4.3.4 perItemStepPriority opt-in invariant violated. Only allowlisted Phase 3+ pilots may set "
+				+ "perItemStepPriority. Violations:\n" + String.join("\n", violations));
+	}
+
+	@Test
+	public void databaseLoadsAndProducesSources()
+	{
+		assertNotNull(database.getAllSources());
+		assertTrue(database.getAllSources().size() > 0,
+			"Production drop_rates.json must load at least one source");
+	}
+}

--- a/src/test/java/com/collectionloghelper/data/CollectionLogSourceTest.java
+++ b/src/test/java/com/collectionloghelper/data/CollectionLogSourceTest.java
@@ -384,7 +384,8 @@ public class CollectionLogSourceTest
 			null,           // section
 			null,           // waypoints
 			null,            // dynamicTargetEvaluator
-			null            // conditionTree
+			null,            // conditionTree
+			null            // perItemStepPriority
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/data/GuidanceStepPerItemStepPriorityIntegrationTest.java
+++ b/src/test/java/com/collectionloghelper/data/GuidanceStepPerItemStepPriorityIntegrationTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Integration test asserting that the new {@code perItemStepPriority} schema
+ * field on {@link GuidanceStep} (B4.3.4 Phase 1+2) does not alter the behaviour
+ * of any other resolver method when the field is null.
+ *
+ * <p>Mirrors the {@code B1GuidanceStepIntegrationTest} pattern: a synthetic
+ * step with the new field set is exercised end-to-end via Gson serialisation
+ * + the existing resolver helpers, confirming the new field is orthogonal to
+ * description / npc / required-items / conditional alternatives / condition tree.
+ */
+public class GuidanceStepPerItemStepPriorityIntegrationTest
+{
+	private final Gson gson = new GsonBuilder().create();
+
+	// -- fall-through: null field changes nothing ------------------------------
+
+	@Test
+	public void nullField_doesNotChangeAnyOtherResolver()
+	{
+		Map<Integer, String> descOverrides = new HashMap<>();
+		descOverrides.put(4708, "Hunt Ahrim's hood");
+
+		Map<Integer, Integer> npcOverrides = new HashMap<>();
+		npcOverrides.put(4708, 1672);
+
+		GuidanceStep step = stepWith(
+			"Generic kill step",
+			descOverrides,
+			999,
+			npcOverrides,
+			null /* perItemStepPriority */);
+
+		// All sibling resolvers still work as before.
+		assertEquals("Hunt Ahrim's hood", step.resolveDescription(4708));
+		assertEquals("Generic kill step", step.resolveDescription(null));
+		assertEquals(1672, step.resolveNpcId(4708));
+		assertEquals(999, step.resolveNpcId(null));
+
+		// And the new resolver returns the default for any input when the map is null.
+		assertEquals(0, step.resolvePriority(4708));
+		assertEquals(0, step.resolvePriority(null));
+		assertNull(step.getPerItemStepPriority(),
+			"null perItemStepPriority must remain null after construction");
+	}
+
+	// -- populated field works independently of siblings ----------------------
+
+	@Test
+	public void populatedField_returnsOverrideWithoutDisturbingSiblings()
+	{
+		Map<Integer, String> descOverrides = new HashMap<>();
+		descOverrides.put(4708, "Hunt Ahrim's hood");
+
+		Map<Integer, Integer> npcOverrides = new HashMap<>();
+		npcOverrides.put(4708, 1672);
+
+		Map<Integer, Integer> priorityMap = new HashMap<>();
+		priorityMap.put(4708, 100);
+		priorityMap.put(4712, 100);
+
+		GuidanceStep step = stepWith(
+			"Generic kill step",
+			descOverrides,
+			999,
+			npcOverrides,
+			priorityMap);
+
+		assertEquals("Hunt Ahrim's hood", step.resolveDescription(4708));
+		assertEquals(1672, step.resolveNpcId(4708));
+		assertEquals(100, step.resolvePriority(4708));
+		assertEquals(100, step.resolvePriority(4712));
+		assertEquals(0, step.resolvePriority(4716),
+			"Dharok helm is not in this Ahrim-kill step's priority map; resolver must return 0");
+	}
+
+	// -- Gson round-trip with the new field populated -------------------------
+
+	@Test
+	public void gsonRoundTrip_preservesPerItemStepPriority()
+	{
+		String json = "{"
+			+ "\"description\":\"Kill Ahrim\","
+			+ "\"perItemStepPriority\":{\"4708\":100,\"4712\":100,\"4714\":100,\"4710\":100},"
+			+ "\"completionCondition\":\"VARBIT_AT_LEAST\""
+			+ "}";
+
+		GuidanceStep step = gson.fromJson(json, GuidanceStep.class);
+
+		assertNotNull(step.getPerItemStepPriority());
+		assertEquals(4, step.getPerItemStepPriority().size());
+		assertEquals(100, step.resolvePriority(4708));
+		assertEquals(100, step.resolvePriority(4712));
+		assertEquals(100, step.resolvePriority(4714));
+		assertEquals(100, step.resolvePriority(4710));
+		assertEquals(0, step.resolvePriority(4716),
+			"a key absent from the deserialised map must resolve to default 0");
+	}
+
+	// -- helper -----------------------------------------------------------------
+
+	private static GuidanceStep stepWith(
+		String description,
+		Map<Integer, String> perItemStepDescription,
+		int npcId,
+		Map<Integer, Integer> perItemNpcId,
+		Map<Integer, Integer> perItemStepPriority)
+	{
+		return new GuidanceStep(
+			description,
+			perItemStepDescription,
+			0, 0, 0,                    // worldX, worldY, worldPlane
+			npcId, perItemNpcId, null, null,
+			null, null,                 // travelTip, requiredItemIds
+			null,                       // perItemRequiredItemIds
+			null,                       // recommendedItemIds
+			null,                       // perItemRecommendedItemIds
+			CompletionCondition.MANUAL,
+			0, 0, 0, 0,                 // completionItemId, completionItemCount, completionDistance, completionNpcId
+			null,                       // completionNpcIds
+			null,                       // worldMessage
+			0, null, null,              // objectId, objectIds, objectInteractAction
+			null, null,                 // highlightItemIds, groundItemIds
+			null,                       // completionChatPattern
+			0, 0,                       // completionVarbitId, completionVarbitValue
+			false,                      // useItemOnObject
+			0,                          // objectMaxDistance
+			null,                       // objectFilterTiles
+			null,                       // highlightWidgetIds
+			0, 0,                       // loopBackToStep, loopCount
+			null,                       // skipIfHasAnyItemIds
+			null,                       // dynamicItemObjectTiers
+			null,                       // completionZone
+			null,                       // conditionalAlternatives
+			null,                       // section
+			null,                       // waypoints
+			null,                       // dynamicTargetEvaluator
+			null,                       // conditionTree
+			perItemStepPriority         // perItemStepPriority
+		);
+	}
+}

--- a/src/test/java/com/collectionloghelper/data/GuidanceStepSectionTest.java
+++ b/src/test/java/com/collectionloghelper/data/GuidanceStepSectionTest.java
@@ -154,7 +154,8 @@ public class GuidanceStepSectionTest
 			section,
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
-			null  // conditionTree
+			null,  // conditionTree
+			null  // perItemStepPriority
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/data/GuidanceStepTest.java
+++ b/src/test/java/com/collectionloghelper/data/GuidanceStepTest.java
@@ -334,7 +334,8 @@ public class GuidanceStepTest
 			null, // section
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
-			null  // conditionTree
+			null,  // conditionTree
+			null  // perItemStepPriority
 		);
 	}
 
@@ -370,7 +371,8 @@ public class GuidanceStepTest
 			null, // section
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
-			null  // conditionTree
+			null,  // conditionTree
+			null  // perItemStepPriority
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/data/PerItemStepPriorityDeserializerTest.java
+++ b/src/test/java/com/collectionloghelper/data/PerItemStepPriorityDeserializerTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Gson deserialisation cases for the new {@code perItemStepPriority} schema
+ * field on {@link GuidanceStep} (B4.3.4 Phase 1+2).
+ *
+ * <p>Covers: absent, explicit null, empty object, single entry, multiple
+ * entries, and malformed values. The malformed cases verify that Gson surfaces
+ * a {@link JsonSyntaxException} rather than silently accepting bad data --
+ * the regression suite and the {@code B4_3_4_MigrationTest} both rely on
+ * authoring-time failures, not silent map corruption.
+ */
+public class PerItemStepPriorityDeserializerTest
+{
+	private final Gson gson = new GsonBuilder().create();
+
+	// -- absent -----------------------------------------------------------------
+
+	@Test
+	public void absentField_deserialisesToNullMap()
+	{
+		String json = "{"
+			+ "\"description\":\"Kill brother\","
+			+ "\"completionCondition\":\"MANUAL\""
+			+ "}";
+
+		GuidanceStep step = gson.fromJson(json, GuidanceStep.class);
+
+		assertNotNull(step);
+		assertNull(step.getPerItemStepPriority(),
+			"perItemStepPriority must be null when absent from JSON (additive-field invariant)");
+	}
+
+	// -- explicit null ----------------------------------------------------------
+
+	@Test
+	public void explicitNull_deserialisesToNullMap()
+	{
+		String json = "{"
+			+ "\"description\":\"Kill brother\","
+			+ "\"perItemStepPriority\":null,"
+			+ "\"completionCondition\":\"MANUAL\""
+			+ "}";
+
+		GuidanceStep step = gson.fromJson(json, GuidanceStep.class);
+
+		assertNull(step.getPerItemStepPriority());
+	}
+
+	// -- empty object -----------------------------------------------------------
+
+	@Test
+	public void emptyObject_deserialisesToEmptyMap()
+	{
+		String json = "{"
+			+ "\"description\":\"Kill brother\","
+			+ "\"perItemStepPriority\":{},"
+			+ "\"completionCondition\":\"MANUAL\""
+			+ "}";
+
+		GuidanceStep step = gson.fromJson(json, GuidanceStep.class);
+
+		Map<Integer, Integer> map = step.getPerItemStepPriority();
+		assertNotNull(map, "empty JSON object should deserialise to an empty (non-null) map");
+		assertTrue(map.isEmpty(), "empty JSON object must yield an empty map");
+	}
+
+	// -- single entry -----------------------------------------------------------
+
+	@Test
+	public void singleEntry_deserialisesIntoMap()
+	{
+		String json = "{"
+			+ "\"description\":\"Kill Ahrim\","
+			+ "\"perItemStepPriority\":{\"4708\":100},"
+			+ "\"completionCondition\":\"VARBIT_AT_LEAST\""
+			+ "}";
+
+		GuidanceStep step = gson.fromJson(json, GuidanceStep.class);
+
+		Map<Integer, Integer> map = step.getPerItemStepPriority();
+		assertNotNull(map);
+		assertEquals(1, map.size());
+		assertEquals(Integer.valueOf(100), map.get(4708));
+	}
+
+	// -- multiple entries (Ahrim's four set pieces) ----------------------------
+
+	@Test
+	public void multipleEntries_allKeysAndValuesPreserved()
+	{
+		// Ahrim's hood / robetop / robeskirt / staff per the B4.3.4 design table.
+		String json = "{"
+			+ "\"description\":\"Kill Ahrim\","
+			+ "\"perItemStepPriority\":{"
+			+ "  \"4708\":100,"
+			+ "  \"4712\":100,"
+			+ "  \"4714\":100,"
+			+ "  \"4710\":100"
+			+ "},"
+			+ "\"completionCondition\":\"VARBIT_AT_LEAST\""
+			+ "}";
+
+		GuidanceStep step = gson.fromJson(json, GuidanceStep.class);
+
+		Map<Integer, Integer> map = step.getPerItemStepPriority();
+		assertNotNull(map);
+		assertEquals(4, map.size());
+		assertEquals(Integer.valueOf(100), map.get(4708));
+		assertEquals(Integer.valueOf(100), map.get(4712));
+		assertEquals(Integer.valueOf(100), map.get(4714));
+		assertEquals(Integer.valueOf(100), map.get(4710));
+	}
+
+	// -- distinct priority values per item -------------------------------------
+
+	@Test
+	public void distinctValues_preservedPerKey()
+	{
+		String json = "{"
+			+ "\"description\":\"Kill mixed minions\","
+			+ "\"perItemStepPriority\":{\"100\":1,\"200\":50,\"300\":999},"
+			+ "\"completionCondition\":\"MANUAL\""
+			+ "}";
+
+		GuidanceStep step = gson.fromJson(json, GuidanceStep.class);
+
+		Map<Integer, Integer> map = step.getPerItemStepPriority();
+		assertEquals(Integer.valueOf(1), map.get(100));
+		assertEquals(Integer.valueOf(50), map.get(200));
+		assertEquals(Integer.valueOf(999), map.get(300));
+	}
+
+	// -- malformed: non-numeric value ------------------------------------------
+
+	@Test
+	public void malformedValue_nonNumeric_throws()
+	{
+		String json = "{"
+			+ "\"description\":\"Kill brother\","
+			+ "\"perItemStepPriority\":{\"4708\":\"high\"},"
+			+ "\"completionCondition\":\"MANUAL\""
+			+ "}";
+
+		assertThrows(JsonSyntaxException.class,
+			() -> gson.fromJson(json, GuidanceStep.class),
+			"non-numeric priority value must fail at deserialisation time");
+	}
+
+	// -- malformed: array instead of object ------------------------------------
+
+	@Test
+	public void malformedShape_arrayInsteadOfObject_throws()
+	{
+		String json = "{"
+			+ "\"description\":\"Kill brother\","
+			+ "\"perItemStepPriority\":[1,2,3],"
+			+ "\"completionCondition\":\"MANUAL\""
+			+ "}";
+
+		assertThrows(JsonSyntaxException.class,
+			() -> gson.fromJson(json, GuidanceStep.class),
+			"array value for perItemStepPriority must fail at deserialisation time");
+	}
+}

--- a/src/test/java/com/collectionloghelper/data/PerItemStepPriorityEvaluatorTest.java
+++ b/src/test/java/com/collectionloghelper/data/PerItemStepPriorityEvaluatorTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Unit tests for {@link GuidanceStep#resolvePriority(Integer)} -- the
+ * single-branch evaluator that backs the B4.3.4 Phase 1+2 schema field
+ * {@code perItemStepPriority}.
+ *
+ * <p>The contract mirrors {@code resolveNpcId} / {@code resolveDescription}:
+ * an override is returned when the map has an entry for the active target
+ * item id; otherwise the default (0) is returned. There is no production
+ * sequencer integration in Phase 1+2 -- the helper is the entire surface.
+ */
+public class PerItemStepPriorityEvaluatorTest
+{
+	// Synthetic Ahrim-kill-step fixture mirroring the B4.3.4 design table.
+	private static final int AHRIM_HOOD = 4708;
+	private static final int AHRIM_ROBETOP = 4712;
+	private static final int AHRIM_ROBESKIRT = 4714;
+	private static final int AHRIM_STAFF = 4710;
+
+	private static final int DHAROK_HELM = 4716;
+	private static final int BOLT_RACK = 4740; // not owned by any per-brother step
+
+	private static final int PRIORITY = 100;
+
+	// -- null target ------------------------------------------------------------
+
+	@Test
+	public void resolvePriority_nullTarget_returnsZero()
+	{
+		Map<Integer, Integer> map = new HashMap<>();
+		map.put(AHRIM_HOOD, PRIORITY);
+
+		GuidanceStep step = stepWithPriority(map);
+
+		assertEquals(0, step.resolvePriority(null),
+			"null target id must always resolve to default priority 0");
+	}
+
+	// -- null map ---------------------------------------------------------------
+
+	@Test
+	public void resolvePriority_nullMap_returnsZero()
+	{
+		GuidanceStep step = stepWithPriority(null);
+
+		assertEquals(0, step.resolvePriority(AHRIM_HOOD),
+			"null perItemStepPriority map must always resolve to default priority 0");
+	}
+
+	// -- empty map --------------------------------------------------------------
+
+	@Test
+	public void resolvePriority_emptyMap_returnsZero()
+	{
+		GuidanceStep step = stepWithPriority(Collections.emptyMap());
+
+		assertEquals(0, step.resolvePriority(AHRIM_HOOD),
+			"empty perItemStepPriority map must always resolve to default priority 0");
+	}
+
+	// -- matching entry returns override ----------------------------------------
+
+	@Test
+	public void resolvePriority_matchingEntry_returnsOverride()
+	{
+		Map<Integer, Integer> map = new HashMap<>();
+		map.put(AHRIM_HOOD, PRIORITY);
+		map.put(AHRIM_ROBETOP, PRIORITY);
+		map.put(AHRIM_ROBESKIRT, PRIORITY);
+		map.put(AHRIM_STAFF, PRIORITY);
+
+		GuidanceStep step = stepWithPriority(map);
+
+		assertEquals(PRIORITY, step.resolvePriority(AHRIM_HOOD));
+		assertEquals(PRIORITY, step.resolvePriority(AHRIM_ROBETOP));
+		assertEquals(PRIORITY, step.resolvePriority(AHRIM_ROBESKIRT));
+		assertEquals(PRIORITY, step.resolvePriority(AHRIM_STAFF));
+	}
+
+	// -- non-matching entry falls back to 0 ------------------------------------
+
+	@Test
+	public void resolvePriority_targetNotInMap_returnsZero()
+	{
+		// Ahrim-kill step: owns only Ahrim set pieces.
+		Map<Integer, Integer> map = new HashMap<>();
+		map.put(AHRIM_HOOD, PRIORITY);
+		map.put(AHRIM_ROBETOP, PRIORITY);
+
+		GuidanceStep step = stepWithPriority(map);
+
+		assertEquals(0, step.resolvePriority(DHAROK_HELM),
+			"a Dharok-helm hunt against the Ahrim-kill step must resolve to 0 (not Ahrim's owner)");
+		assertEquals(0, step.resolvePriority(BOLT_RACK),
+			"Bolt rack has no per-brother entry on any step and must resolve to 0 everywhere");
+	}
+
+	// -- distinct priority values per item are preserved ---------------------
+
+	@Test
+	public void resolvePriority_distinctValues_preservedPerKey()
+	{
+		Map<Integer, Integer> map = new HashMap<>();
+		map.put(100, 1);
+		map.put(200, 50);
+		map.put(300, 999);
+
+		GuidanceStep step = stepWithPriority(map);
+
+		assertEquals(1, step.resolvePriority(100));
+		assertEquals(50, step.resolvePriority(200));
+		assertEquals(999, step.resolvePriority(300));
+		assertEquals(0, step.resolvePriority(400));
+	}
+
+	// -- negative priorities are passed through (sequencer may interpret) -----
+
+	@Test
+	public void resolvePriority_negativeValue_returnedVerbatim()
+	{
+		Map<Integer, Integer> map = new HashMap<>();
+		map.put(AHRIM_HOOD, -7);
+
+		GuidanceStep step = stepWithPriority(map);
+
+		assertEquals(-7, step.resolvePriority(AHRIM_HOOD),
+			"resolver must return the mapped value verbatim; semantic interpretation belongs to the sequencer");
+	}
+
+	// -- helper -----------------------------------------------------------------
+
+	private static GuidanceStep stepWithPriority(Map<Integer, Integer> perItemStepPriority)
+	{
+		return new GuidanceStep(
+			"Kill the brother",
+			null,                       // perItemStepDescription
+			0, 0, 0,                    // worldX, worldY, worldPlane
+			0, null, null, null,        // npcId, perItemNpcId, interactAction, dialogOptions
+			null, null,                 // travelTip, requiredItemIds
+			null,                       // perItemRequiredItemIds
+			null,                       // recommendedItemIds
+			null,                       // perItemRecommendedItemIds
+			CompletionCondition.MANUAL,
+			0, 0, 0, 0,                 // completionItemId, completionItemCount, completionDistance, completionNpcId
+			null,                       // completionNpcIds
+			null,                       // worldMessage
+			0, null, null,              // objectId, objectIds, objectInteractAction
+			null, null,                 // highlightItemIds, groundItemIds
+			null,                       // completionChatPattern
+			0, 0,                       // completionVarbitId, completionVarbitValue
+			false,                      // useItemOnObject
+			0,                          // objectMaxDistance
+			null,                       // objectFilterTiles
+			null,                       // highlightWidgetIds
+			0, 0,                       // loopBackToStep, loopCount
+			null,                       // skipIfHasAnyItemIds
+			null,                       // dynamicItemObjectTiers
+			null,                       // completionZone
+			null,                       // conditionalAlternatives
+			null,                       // section
+			null,                       // waypoints
+			null,                       // dynamicTargetEvaluator
+			null,                       // conditionTree
+			perItemStepPriority         // perItemStepPriority (under test)
+		);
+	}
+}

--- a/src/test/java/com/collectionloghelper/data/condition/B1GuidanceStepIntegrationTest.java
+++ b/src/test/java/com/collectionloghelper/data/condition/B1GuidanceStepIntegrationTest.java
@@ -177,7 +177,8 @@ public class B1GuidanceStepIntegrationTest
 			0, null, null, null, null, null,
 			0, 0, false, 0, null, null, 0, 0, null, null, null, null, null,
 			null /* waypoints */, null /* dynamicTargetEvaluator */,
-			tree
+			tree,
+			null /* perItemStepPriority */
 		);
 	}
 

--- a/src/test/java/com/collectionloghelper/guidance/DynamicItemObjectTierResolverTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/DynamicItemObjectTierResolverTest.java
@@ -298,7 +298,8 @@ public class DynamicItemObjectTierResolverTest
 			null,           // section
 			null,           // waypoints
 			null,            // dynamicTargetEvaluator
-			null            // conditionTree
+			null,            // conditionTree
+			null            // perItemStepPriority
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/guidance/DynamicTargetEvaluatorDispatchTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/DynamicTargetEvaluatorDispatchTest.java
@@ -420,7 +420,8 @@ public class DynamicTargetEvaluatorDispatchTest
 			null,  // section
 			null,  // waypoints
 			evaluatorKey,  // dynamicTargetEvaluator
-			null  // conditionTree
+			null,  // conditionTree
+			null  // perItemStepPriority
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/guidance/DynamicTargetManagerTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/DynamicTargetManagerTest.java
@@ -253,7 +253,8 @@ public class DynamicTargetManagerTest
 			null,  // section
 			null,  // waypoints
 			evaluatorKey,  // dynamicTargetEvaluator
-			null  // conditionTree
+			null,  // conditionTree
+			null  // perItemStepPriority
 		);
 	}
 

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorDescriptionTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorDescriptionTest.java
@@ -303,7 +303,8 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 			null, // section
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
-			null  // conditionTree
+			null,  // conditionTree
+			null  // perItemStepPriority
 		);
 	}
 

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorNpcIdTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorNpcIdTest.java
@@ -310,7 +310,8 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 			null, // section
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
-			null  // conditionTree
+			null,  // conditionTree
+			null  // perItemStepPriority
 		);
 	}
 

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerNestedConditionalTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerNestedConditionalTest.java
@@ -493,7 +493,8 @@ public class GuidanceSequencerNestedConditionalTest
 			null, // section
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
-			null  // conditionTree
+			null,  // conditionTree
+			null  // perItemStepPriority
 		);
 	}
 
@@ -529,7 +530,8 @@ public class GuidanceSequencerNestedConditionalTest
 			null, // section
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
-			null  // conditionTree
+			null,  // conditionTree
+			null  // perItemStepPriority
 		);
 	}
 

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
@@ -121,7 +121,8 @@ public class GuidanceSequencerTest
 			null, // section
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
-			null  // conditionTree
+			null,  // conditionTree
+			null  // perItemStepPriority
 		);
 	}
 
@@ -156,7 +157,8 @@ public class GuidanceSequencerTest
 			null, // section
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
-			null  // conditionTree
+			null,  // conditionTree
+			null  // perItemStepPriority
 		);
 	}
 
@@ -191,7 +193,8 @@ public class GuidanceSequencerTest
 			null, // section
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
-			null  // conditionTree
+			null,  // conditionTree
+			null  // perItemStepPriority
 		);
 	}
 
@@ -226,7 +229,8 @@ public class GuidanceSequencerTest
 			null, // section
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
-			null  // conditionTree
+			null,  // conditionTree
+			null  // perItemStepPriority
 		);
 	}
 
@@ -261,7 +265,8 @@ public class GuidanceSequencerTest
 			null, // section
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
-			null  // conditionTree
+			null,  // conditionTree
+			null  // perItemStepPriority
 		);
 	}
 
@@ -296,7 +301,8 @@ public class GuidanceSequencerTest
 			null, // section
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
-			null  // conditionTree
+			null,  // conditionTree
+			null  // perItemStepPriority
 		);
 	}
 
@@ -331,7 +337,8 @@ public class GuidanceSequencerTest
 			null, // section
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
-			null  // conditionTree
+			null,  // conditionTree
+			null  // perItemStepPriority
 		);
 	}
 
@@ -366,7 +373,8 @@ public class GuidanceSequencerTest
 			null, // section
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
-			null  // conditionTree
+			null,  // conditionTree
+			null  // perItemStepPriority
 		);
 	}
 
@@ -402,7 +410,8 @@ public class GuidanceSequencerTest
 			null, // section
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
-			null  // conditionTree
+			null,  // conditionTree
+			null  // perItemStepPriority
 		);
 	}
 
@@ -437,7 +446,8 @@ public class GuidanceSequencerTest
 			null, // section
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
-			null  // conditionTree
+			null,  // conditionTree
+			null  // perItemStepPriority
 		);
 	}
 
@@ -472,7 +482,8 @@ public class GuidanceSequencerTest
 			null, // section
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
-			null  // conditionTree
+			null,  // conditionTree
+			null  // perItemStepPriority
 		);
 	}
 
@@ -507,7 +518,8 @@ public class GuidanceSequencerTest
 			null, // section
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
-			null  // conditionTree
+			null,  // conditionTree
+			null  // perItemStepPriority
 		);
 	}
 
@@ -996,7 +1008,8 @@ public class GuidanceSequencerTest
 			null, // section
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
-			null  // conditionTree
+			null,  // conditionTree
+			null  // perItemStepPriority
 		);
 
 		List<GuidanceStep> steps = Arrays.asList(
@@ -1471,7 +1484,8 @@ public class GuidanceSequencerTest
 			null, // section
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
-			null  // conditionTree
+			null,  // conditionTree
+			null  // perItemStepPriority
 		);
 	}
 
@@ -1708,7 +1722,8 @@ public class GuidanceSequencerTest
 			null, // section
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
-			null  // conditionTree
+			null,  // conditionTree
+			null  // perItemStepPriority
 		);
 
 		List<GuidanceStep> steps = Arrays.asList(step);

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerWaypointTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerWaypointTest.java
@@ -133,7 +133,8 @@ public class GuidanceSequencerWaypointTest
 			null, // section
 			waypoints,
 			null,  // dynamicTargetEvaluator
-			null  // conditionTree
+			null,  // conditionTree
+			null  // perItemStepPriority
 		);
 	}
 
@@ -171,7 +172,8 @@ public class GuidanceSequencerWaypointTest
 			null,
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
-			null  // conditionTree
+			null,  // conditionTree
+			null  // perItemStepPriority
 		);
 	}
 
@@ -285,7 +287,8 @@ public class GuidanceSequencerWaypointTest
 			null,
 			null, // waypoints = null
 			null,  // dynamicTargetEvaluator
-			null  // conditionTree
+			null,  // conditionTree
+			null  // perItemStepPriority
 		);
 
 		AtomicBoolean stepAdvanced = new AtomicBoolean(false);
@@ -336,7 +339,8 @@ public class GuidanceSequencerWaypointTest
 			null,
 			Collections.emptyList(), // waypoints = empty list
 			null,  // dynamicTargetEvaluator
-			null  // conditionTree
+			null,  // conditionTree
+			null  // perItemStepPriority
 		);
 
 		AtomicBoolean stepAdvanced = new AtomicBoolean(false);

--- a/src/test/java/com/collectionloghelper/guidance/RequiredItemResolverTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/RequiredItemResolverTest.java
@@ -654,7 +654,8 @@ public class RequiredItemResolverTest
 			null, // section
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
-			null  // conditionTree
+			null,  // conditionTree
+			null  // perItemStepPriority
 		);
 	}
 
@@ -695,7 +696,8 @@ public class RequiredItemResolverTest
 			null,  // section
 			null,  // waypoints
 			null,   // dynamicTargetEvaluator
-			null   // conditionTree
+			null,   // conditionTree
+			null   // perItemStepPriority
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/guidance/bosses/BossGuidanceDispatchTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/bosses/BossGuidanceDispatchTest.java
@@ -104,7 +104,8 @@ public class BossGuidanceDispatchTest
 			0, null, null, null, null, null,
 			0, 0, false, 0, null, null, 0, 0, null, null, null, null, null,
 			null /* waypoints */, null /* dynamicTargetEvaluator */,
-			null /* conditionTree */
+			null /* conditionTree */,
+			null /* perItemStepPriority */
 		);
 	}
 

--- a/src/test/java/com/collectionloghelper/guidance/dynamic/WintertodtBrazierEvaluatorTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/dynamic/WintertodtBrazierEvaluatorTest.java
@@ -233,7 +233,8 @@ public class WintertodtBrazierEvaluatorTest
 			null,  // section
 			null,  // waypoints
 			DynamicTargetEvaluatorRegistry.WINTERTODT_ACTIVE_BRAZIER,  // dynamicTargetEvaluator
-			null  // conditionTree
+			null,  // conditionTree
+			null  // perItemStepPriority
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/lifecycle/GuidanceEventRouterTest.java
+++ b/src/test/java/com/collectionloghelper/lifecycle/GuidanceEventRouterTest.java
@@ -144,7 +144,8 @@ public class GuidanceEventRouterTest
 			null, // section
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
-			null  // conditionTree
+			null,  // conditionTree
+			null  // perItemStepPriority
 		);
 	}
 

--- a/src/test/java/com/collectionloghelper/ui/widget/BankScanIntegrationTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/BankScanIntegrationTest.java
@@ -346,7 +346,8 @@ public class BankScanIntegrationTest
 			null, // section
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
-			null  // conditionTree
+			null,  // conditionTree
+			null  // perItemStepPriority
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/ui/widget/StepProgressViewTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/StepProgressViewTest.java
@@ -1186,7 +1186,8 @@ public class StepProgressViewTest
 			section,
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
-			null  // conditionTree
+			null,  // conditionTree
+			null  // perItemStepPriority
 		);
 	}
 
@@ -1216,7 +1217,8 @@ public class StepProgressViewTest
 			null, // section
 			null, // waypoints
 			null,   // dynamicTargetEvaluator
-			null   // conditionTree
+			null,   // conditionTree
+			null   // perItemStepPriority
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/ui/widget/StepSectionGrouperTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/StepSectionGrouperTest.java
@@ -77,7 +77,8 @@ public class StepSectionGrouperTest
 			section,
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
-			null  // conditionTree
+			null,  // conditionTree
+			null  // perItemStepPriority
 		);
 	}
 


### PR DESCRIPTION
## Summary

Lands the schema field + single-branch evaluator for **per-item step priority** routing per the design merged in **#652**. Strictly additive: a single `@Nullable Map<Integer, Integer> perItemStepPriority` slot on `GuidanceStep`, zero production sources opt in. Phase 3 (Barrows per-brother pilot wiring) is a separate later PR.

Mirrors the B1 Phase 1+2 (**#637**) additive-field landing pattern and follows the activation-chain shape established by the B4.3 per-item override series (**#421** `perItemStepDescription`, **#423** `perItemNpcId`).

## Schema change

```java
/**
 * Optional per-item step priority map (B4.3.4 Phase 1+2).  Maps a clog item
 * ID to a numeric priority that the sequencer's step-selection logic can
 * consult when an active target item is set. ...
 */
@Nullable
Map<Integer, Integer> perItemStepPriority;

public int resolvePriority(@Nullable Integer targetItemId)
{
    if (targetItemId != null && perItemStepPriority != null)
    {
        Integer override = perItemStepPriority.get(targetItemId);
        if (override != null)
        {
            return override;
        }
    }
    return 0;
}
```

Field placement: appended after `conditionTree` to keep the @Value positional-constructor migration purely additive (mirrors how #637 appended `conditionTree`). `mergeAlternative` inherits the map from the base step; conditional alternatives do not override it in Phase 1+2.

## Files added

**Tests (`src/test/java/com/collectionloghelper/data/`):**

- `PerItemStepPriorityDeserializerTest` -- **8 Gson cases**: absent, explicit null, empty object, single entry, multiple entries (Ahrim's 4 set pieces from the design table), distinct values per key, malformed non-numeric value, malformed array shape
- `PerItemStepPriorityEvaluatorTest` -- **7 cases**: null target, null map, empty map, matching entries (4 Ahrim set pieces), target-not-in-map (Dharok helm + Bolt rack), distinct values per key, negative value passthrough
- `B4_3_4_MigrationTest` -- **2 cases**: every step on every source has null `perItemStepPriority` (Phase 1+2 invariant guard, allowlist starts empty for Phase 3+ to extend), database load smoke
- `GuidanceStepPerItemStepPriorityIntegrationTest` -- **3 cases**: null field changes nothing for sibling resolvers, populated field is independent of siblings, Gson round-trip preserves the map

**20 new test cases total. All pass.**

## Files modified

- `GuidanceStep.java` -- single new `@Nullable Map<Integer, Integer> perItemStepPriority` field appended to the positional constructor, plus `resolvePriority(Integer)` helper; `mergeAlternative` inherits the map from the base step
- `CerberusGuidance.java` -- three `new GuidanceStep(...)` callsites updated with the trailing `null` slot
- **20 test classes** updated for the `@Value` positional-constructor migration (the recurring tax flagged in #637 / #623 / #640 / #645 reviews). Sites total: 39 (one extra in `B1GuidanceStepIntegrationTest` and `BossGuidanceDispatchTest` whose helpers use inline-comment style and were patched by hand)

## Zero production data changes

`drop_rates.json` is untouched. `B4_3_4_MigrationTest.onlyAllowlistedPilotsCarryPerItemStepPriority` enforces this as a regression guard until Phase 3 adds the first source (Barrows) to `PHASE_3_PILOT_SOURCES`.

## Build status

- `./gradlew build` -- **PASS** (`compileJava`, `compileTestJava`, `test`, `lintDropRates`, `jar`, `jacocoTestReport`, `jacocoTestCoverageVerification`)
- 20/20 new B4.3.4 tests pass
- No pre-existing tests regressed

## Phase 3 (separate PR)

The first pilot will wire `perItemStepPriority` maps on the six Barrows kill steps (24 entries: 4 set pieces x 6 brothers per the design table in #652 section 5), add a `BarrowsPerBrotherTest` structural guard, and add `"Barrows"` to `B4_3_4_MigrationTest.PHASE_3_PILOT_SOURCES`. Sequencer integration (teaching `GuidanceSequencer` to honour the priority pass on activate + on `activeTargetItemId` change) lands alongside the pilot.

## Test plan

- [x] Unit: 8 deserialiser + 7 evaluator cases pass
- [x] Regression: `B4_3_4_MigrationTest` confirms no production source sets `perItemStepPriority`
- [x] Integration: synthetic step + Gson round-trip pass; sibling resolvers unaffected
- [x] Build: `./gradlew build` green
- [x] No `drop_rates.json` diff
- [x] ASCII-only across all new and modified files

Refs cha-ndler/collection-log-helper#652 (design), cha-ndler/collection-log-helper#637 (additive Phase 1+2 precedent), cha-ndler/collection-log-helper#421 / cha-ndler/collection-log-helper#423 (perItem* activation-chain pattern).