### PR TITLE
data(d4): batch 4 - full-bar deep guidance on 9 non-gathering-skill sources

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -19878,22 +19878,27 @@
       }
     ],
     "locationDescription": "Colossal Wyrm Agility Course in Avium Savannah, Varlamore",
-    "travelTip": "Quetzal whistle -> Varlamore",
+    "travelTip": "Quetzal transport whistle -> Civitas illa Fortis, run south-west to Avium Savannah; or Colossal wyrm teleport scroll (purchased from Telia)",
     "guidanceSteps": [
       {
-        "description": "Travel to Colossal Wyrm Agility Course in Avium Savannah, Varlamore.",
+        "description": "Travel to the Colossal Wyrm Agility Course in Avium Savannah, Varlamore. Requires Children of the Sun and 50 Agility. Use the quetzal transport whistle to Civitas illa Fortis then run south-west, or use a Colossal wyrm teleport scroll.",
         "worldX": 1652,
         "worldY": 2931,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "travelTip": "Quetzal whistle -> Civitas illa Fortis -> run south-west; or Colossal wyrm teleport scroll",
+        "section": "Travel"
       },
       {
-        "description": "Run the Colossal Wyrm Agility Course for marks of grace and termite rewards.",
+        "description": "Complete laps of the Colossal Wyrm Agility Course for Varlamore marks of grace and termite currency. Collect marks when they appear on obstacles - they despawn after 10 minutes. Spend marks at Telia for Varlamore graceful pieces and Calcified acorns. Higher Agility level increases lap speed and mark rate.",
         "worldX": 1652,
         "worldY": 2931,
         "worldPlane": 0,
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Skilling",
+        "loopBackToStep": 1,
+        "loopCount": 20
       }
     ],
     "rewardType": "SHOP",
@@ -19979,22 +19984,35 @@
       }
     ],
     "locationDescription": "Rooftop Agility Courses, starting at Varrock",
-    "travelTip": "Varrock teleport -> course start",
+    "travelTip": "Camelot teleport -> Seers' Village rooftop (best marks/hr at 60+); Varrock teleport for lower-level courses",
+    "requirements": {
+      "skills": [
+        {
+          "skill": "AGILITY",
+          "level": 10
+        }
+      ]
+    },
     "guidanceSteps": [
       {
-        "description": "Travel to Rooftop Agility Courses, starting at Varrock.",
+        "description": "Travel to your best rooftop course. Seers' Village (60+ Agility, Camelot teleport) gives the most marks per hour. Use Varrock (10+), Canifis (40+), Falador (50+), or Pollnivneach (70+) depending on your level.",
         "worldX": 3214,
         "worldY": 3414,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 25,
+        "travelTip": "Camelot teleport -> Seers' Village rooftop (60+ Agility); Varrock teleport for Varrock rooftop (10+)",
+        "section": "Travel"
       },
       {
-        "description": "Complete rooftop agility courses for marks of grace (Graceful set, recolours).",
+        "description": "Complete rooftop agility laps. Collect marks of grace when they appear on the course - they despawn after 10 minutes. Equipping graceful reduces run drain by 30% per piece. Aim for the highest-level course available to maximise marks per hour.",
         "worldX": 3214,
         "worldY": 3414,
         "worldPlane": 0,
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Skilling",
+        "loopBackToStep": 1,
+        "loopCount": 20
       }
     ],
     "rewardType": "SHOP",
@@ -20676,23 +20694,36 @@
         "independent": true
       }
     ],
-    "locationDescription": "Crashed shooting stars found throughout Gielinor",
-    "travelTip": "POH telescope -> nearest teleport",
+    "locationDescription": "Crashed shooting stars found throughout Gielinor (spawn every ~90 minutes per world)",
+    "travelTip": "POH mahogany telescope -> pinpoints star landing within 2 minutes; use the nearest teleport for that region; or join the Shooting Stars grouping channel for crowd-sourced locations",
+    "requirements": {
+      "skills": [
+        {
+          "skill": "MINING",
+          "level": 10
+        }
+      ]
+    },
     "guidanceSteps": [
       {
-        "description": "Look for crashed shooting stars using a telescope in your POH, or check the star tracker on the mining guild notice board.",
+        "description": "Locate the next crashed star. Use a telescope in your player-owned house Study (mahogany telescope gives a 2-minute window). Alternatively join the Shooting Stars grouping chat or use a community star-tracker site. Stars fall every 85-95 minutes and vary in size (tier 1-9). Teleport to the region the telescope indicates.",
         "worldX": 3214,
         "worldY": 3414,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 25,
+        "travelTip": "Use POH telescope to identify region, then teleport there; or Shooting Stars grouping channel",
+        "section": "Scout"
       },
       {
-        "description": "Mine crashed shooting stars found throughout Gielinor for star dust.",
+        "description": "Mine the crashed star. Stars degrade through tiers as miners chip away at them - being the first miner awards double stardust for 300 dust mined. Talk to the Star Sprite that emerges from the core (visible when star reaches tier 1) to receive bonus stardust. Collect stardust and exchange at Dusuri's Star Shop (Mining Guild, Falador) for Celestial ring and Star fragments.",
         "worldX": 3214,
         "worldY": 3414,
         "worldPlane": 0,
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Mine",
+        "loopBackToStep": 0,
+        "loopCount": 20
       }
     ],
     "rewardType": "SHOP",
@@ -27506,23 +27537,36 @@
         "wikiPage": "Rocky"
       }
     ],
-    "locationDescription": "Draynor Village seed market",
-    "travelTip": "Draynor Village teleport or Lumbridge Home teleport -> walk west",
+    "locationDescription": "Draynor Village seed market, or Hosidius seed stall (no guard aggression)",
+    "travelTip": "Amulet of glory -> Draynor Village; or Tithe Farm teleport -> Hosidius seed stall for safer thieving",
+    "requirements": {
+      "skills": [
+        {
+          "skill": "THIEVING",
+          "level": 27
+        }
+      ]
+    },
     "guidanceSteps": [
       {
-        "description": "Travel to the Draynor Village seed market stall (Amulet of glory to Draynor or Lumbridge teleport)",
+        "description": "Travel to a seed stall. Draynor Village (Amulet of glory) is accessible early; Hosidius seed stall (Kourend) has no market guard and is preferred at higher levels. The Rocky pet is the only collection log drop from seed stalls.",
         "worldX": 3080,
         "worldY": 3252,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "travelTip": "Amulet of glory -> Draynor Village; or Tithe Farm teleport -> Hosidius seed stall",
+        "section": "Travel"
       },
       {
-        "description": "Steal from seed stalls in Draynor Village for the Master Farmer outfit pieces.",
+        "description": "Steal from seed stalls (27 Thieving required). At Draynor, dodge the market guard to avoid being stunned - click an adjacent stall or move away when the guard faces you. At Hosidius there is no guard. Rocky pet chance is approximately 1/34,000 per steal at base rate.",
         "worldX": 3080,
         "worldY": 3252,
         "worldPlane": 0,
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Skilling",
+        "loopBackToStep": 1,
+        "loopCount": 50
       }
     ],
     "afkLevel": 2
@@ -27543,23 +27587,36 @@
         "wikiPage": "Baby_chinchompa"
       }
     ],
-    "locationDescription": "Wilderness black chinchompa hunting area",
-    "travelTip": "Wilderness Obelisk to level 35 -> run east",
+    "locationDescription": "Wilderness black chinchompa hunting area (level 32 Wilderness)",
+    "travelTip": "Edgeville lever -> Wilderness Volcano -> run south-east to level 32-36; or Wilderness Obelisk level 35 teleport",
+    "requirements": {
+      "skills": [
+        {
+          "skill": "HUNTER",
+          "level": 73
+        }
+      ]
+    },
     "guidanceSteps": [
       {
-        "description": "Travel to Wilderness black chinchompa hunting area.",
+        "description": "Travel to the black chinchompa hunting area in level 32-36 Wilderness. Bring only what you can afford to lose - PKers actively target this area. Use the Edgeville lever to reach the Wilderness quickly. A spring trap or box trap and emergency teleport are recommended.",
         "worldX": 3143,
         "worldY": 3771,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "travelTip": "Edgeville lever -> Wilderness Volcano -> run south-east; or Wilderness Obelisk level 35",
+        "section": "Travel"
       },
       {
-        "description": "Catch black chinchompas in the Wilderness (level 32-36). Bring minimal risk - PKers frequent this area. Best caught with box traps at 80+ Hunter",
+        "description": "Set box traps to catch black chinchompas (73 Hunter required). Stay alert for PKers approaching from any direction - keep a teleport ready. Always check the mini-map for nearby players. Inventory fills quickly so bank or drop when full.",
         "worldX": 3143,
         "worldY": 3771,
         "worldPlane": 0,
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Skilling",
+        "loopBackToStep": 1,
+        "loopCount": 10
       }
     ],
     "afkLevel": 0
@@ -27698,23 +27755,39 @@
         "wikiPage": "Rift_guardian"
       }
     ],
-    "locationDescription": "Fire altar",
-    "travelTip": "Ring of dueling to Duel Arena -> enter fire altar ruins with fire talisman/tiara",
+    "locationDescription": "Fire Altar, north-east of Al Kharid",
+    "travelTip": "Ring of dueling -> Duel Arena (Al Kharid) -> run north-east to fire altar ruins; or Abyss (requires Enter the Abyss miniquest, omit glory/prayer for PvP danger)",
+    "requirements": {
+      "skills": [
+        {
+          "skill": "RUNECRAFTING",
+          "level": 14
+        }
+      ]
+    },
     "guidanceSteps": [
       {
-        "description": "Travel to the Fire Altar via the Abyss or duel ring to Al Kharid then run north",
+        "description": "Travel to the Fire Altar north-east of Al Kharid. Bring a fire tiara (wear it to enter freely) or a fire talisman. Equip a large pouch and medium pouch to carry more essence per trip. Ring of dueling to Duel Arena is the standard banking method - use it to teleport to Castle Wars bank between trips.",
         "worldX": 2583,
         "worldY": 4838,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15
+        "completionDistance": 15,
+        "travelTip": "Ring of dueling -> Duel Arena -> run north-east to fire altar ruins",
+        "requiredItemIds": [
+          6527
+        ],
+        "section": "Travel"
       },
       {
-        "description": "Travel to the Fire altar and craft fire runes.",
+        "description": "Craft fire runes at the altar (14 Runecrafting required). Click the altar to craft all essence in inventory and pouches. Use Ring of dueling to teleport to Castle Wars bank, refill essence, then repeat. Rift guardian pet chance applies each time you craft runes. Lava rune crafting (via combo rune method) is faster XP but requires Earth runes.",
         "worldX": 2583,
         "worldY": 4838,
         "worldPlane": 0,
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Skilling",
+        "loopBackToStep": 0,
+        "loopCount": 50
       }
     ],
     "afkLevel": 1
@@ -27735,23 +27808,36 @@
         "wikiPage": "Tangleroot"
       }
     ],
-    "locationDescription": "Farming Guild",
-    "travelTip": "Fairy ring CIR -> Farming Guild",
+    "locationDescription": "Fruit tree patches: Gnome Stronghold, Lleyta, Brimhaven, Catherby, Tree Gnome Village, Farming Guild (75+)",
+    "travelTip": "Spirit tree -> Gnome Stronghold (patch 1); Gnome glider to Lleyta; Brimhaven via boat; Skills necklace -> Catherby; fairy ring CIR -> Farming Guild (75+ Farming)",
+    "requirements": {
+      "skills": [
+        {
+          "skill": "FARMING",
+          "level": 27
+        }
+      ]
+    },
     "guidanceSteps": [
       {
-        "description": "Travel to the Farming Guild (fairy ring CIR) or any fruit tree patch for farming runs",
+        "description": "Start a fruit tree run. Plant saplings at all available patches: Gnome Stronghold (spirit tree), Lleyta (gnome glider), Brimhaven (Charter ship or Ardougne cloak 2+), Catherby (skills necklace or Camelot teleport), Tree Gnome Village (fairy ring CLR), and Farming Guild (75+ Farming, fairy ring CIR). Pay the nearby gardener to protect each tree from disease.",
         "worldX": 1249,
         "worldY": 3719,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 30,
+        "travelTip": "Fairy ring CIR -> Farming Guild; spirit tree -> Gnome Stronghold; gnome glider to Lleyta",
+        "section": "Plant"
       },
       {
-        "description": "Travel to the Farming Guild and check health of fruit trees.",
+        "description": "Wait approximately 16 hours for fruit trees to fully grow (each tree takes 8 growth cycles at ~2 hours each). Tangleroot pet chance applies each time you check health of any fully grown tree. Return to all patches and check health to claim XP and log progress. Re-plant immediately to maximise pet attempts over time.",
         "worldX": 1249,
         "worldY": 3719,
         "worldPlane": 0,
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Harvest",
+        "loopBackToStep": 0,
+        "loopCount": 50
       }
     ],
     "afkLevel": 3
@@ -29643,8 +29729,8 @@
         "milestoneKills": 1
       }
     ],
-    "locationDescription": "Prifddinas, south-east corner",
-    "travelTip": "Teleport crystal -> Prifddinas",
+    "locationDescription": "Prifddinas, south-east corner (Ithell district)",
+    "travelTip": "Teleport crystal or Moonclan teleport -> Prifddinas; or fairy ring AJS -> run north",
     "requirements": {
       "quests": [
         "SONG_OF_THE_ELVES"
@@ -29654,22 +29740,25 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to the south-east corner of Prifddinas (crystal seed teleport). Requires Song of the Elves",
+        "description": "Travel to Prifddinas (requires Song of the Elves). Use a teleport crystal, Moonclan teleport, or fairy ring AJS. The rabbit spawns in the south-east corner of the city (Ithell district).",
         "worldX": 3267,
         "worldY": 6082,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15
+        "completionDistance": 15,
+        "travelTip": "Teleport crystal -> Prifddinas; or fairy ring AJS -> run north",
+        "section": "Travel"
       },
       {
-        "description": "Find and kill the Prifddinas rabbit for the crystal grail.",
+        "description": "Locate and kill the Prifddinas Rabbit in the south-east corner of the city. The rabbit has very low combat level (level 2) so any attack style works. This is a one-off guaranteed drop - only one Crystal grail exists.",
         "worldX": 3267,
         "worldY": 6082,
         "worldPlane": 0,
         "npcId": 9118,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 9118
+        "completionNpcId": 9118,
+        "section": "Kill"
       }
     ],
     "mutuallyExclusiveSources": [
@@ -29694,27 +29783,43 @@
       }
     ],
     "locationDescription": "Darkmeyer, Morytania",
-    "travelTip": "Drakan's medallion -> Darkmeyer",
+    "travelTip": "Drakan's medallion -> Darkmeyer; or Kharyrll teleport (Ancient Magicks) -> run north",
     "requirements": {
       "quests": [
         "SINS_OF_THE_FATHER"
+      ],
+      "skills": [
+        {
+          "skill": "THIEVING",
+          "level": 82
+        }
       ]
     },
     "guidanceSteps": [
       {
-        "description": "Travel to Darkmeyer via Drakan medallion. Pickpocket Vyrewatch Sentinels for blood shards",
+        "description": "Travel to Darkmeyer via Drakan's medallion (Sins of the Father required). Equip vyre noble clothing (top, legs, shoes) before entering - without it Vyrewatch Sentinels will attack rather than let you pickpocket them.",
         "worldX": 3631,
         "worldY": 3325,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "travelTip": "Drakan's medallion -> Darkmeyer; or Kharyrll teleport -> run north",
+        "requiredItemIds": [
+          24774,
+          24775,
+          24776
+        ],
+        "section": "Travel"
       },
       {
-        "description": "Travel to Darkmeyer and pickpocket vyres for blood shards.",
+        "description": "Pickpocket Vyrewatch Sentinels (82 Thieving required). Wear vyre noble robes to avoid aggression. Blood shards drop at approximately 1/5000 per pickpocket. Rogue's outfit doubles pickpocket loot. Use Dodgy necklace to avoid stun/damage on failure.",
         "worldX": 3631,
         "worldY": 3325,
         "worldPlane": 0,
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Skilling",
+        "loopBackToStep": 1,
+        "loopCount": 50
       }
     ],
     "mutuallyExclusiveSources": [

--- a/src/test/java/com/collectionloghelper/data/D4Batch4RegressionTest.java
+++ b/src/test/java/com/collectionloghelper/data/D4Batch4RegressionTest.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2026, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ */
+package com.collectionloghelper.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.lang.reflect.Field;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * D4 batch 4 audit guard - asserts the nine non-gathering skilling and timed-event
+ * sources scoped in docs/contributor-guide/d4-long-tail-scoping.md section 4 carry
+ * the full deep-guidance bar after the batch 4 authoring pass:
+ * travel tip, at least one ARRIVE_AT_TILE step with world coordinates, section
+ * labels on steps, and (for repeatable sources) a loop step.  Prifddinas Rabbit
+ * is a one-kill source and is exempt from the loop assertion.
+ * Requirements (E8) are asserted for sources that have a meaningful skill or quest
+ * gate per the OSRS Wiki.
+ */
+public class D4Batch4RegressionTest
+{
+	/** All nine batch-4 sources. */
+	private static final List<String> BATCH4_SOURCES = List.of(
+		"Rooftop Agility",
+		"Colossal Wyrm Agility",
+		"Black Chinchompas",
+		"Prifddinas Rabbit",
+		"Pickpocketing Darkmeyer Vyre",
+		"Thieving (Seed Stalls)",
+		"Farming (Fruit Trees)",
+		"Runecrafting (Fire Runes)",
+		"Shooting Stars");
+
+	/**
+	 * Repeatable sources that must declare a loop step (loopBackToStep set).
+	 * Prifddinas Rabbit is a one-kill drop and is intentionally excluded.
+	 */
+	private static final List<String> LOOP_SOURCES = List.of(
+		"Rooftop Agility",
+		"Colossal Wyrm Agility",
+		"Black Chinchompas",
+		"Pickpocketing Darkmeyer Vyre",
+		"Thieving (Seed Stalls)",
+		"Farming (Fruit Trees)",
+		"Runecrafting (Fire Runes)",
+		"Shooting Stars");
+
+	/**
+	 * Sources that must declare a requirements block (skill or quest gate).
+	 */
+	private static final List<String> GATED_SOURCES = List.of(
+		"Rooftop Agility",
+		"Colossal Wyrm Agility",
+		"Black Chinchompas",
+		"Prifddinas Rabbit",
+		"Pickpocketing Darkmeyer Vyre",
+		"Thieving (Seed Stalls)",
+		"Farming (Fruit Trees)",
+		"Runecrafting (Fire Runes)",
+		"Shooting Stars");
+
+	private DropRateDatabase database;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		database = new DropRateDatabase();
+		Gson gson = new GsonBuilder().create();
+		Field gsonField = DropRateDatabase.class.getDeclaredField("gson");
+		gsonField.setAccessible(true);
+		gsonField.set(database, gson);
+		database.load();
+	}
+
+	@Test
+	public void allBatch4SourcesExistInDatabase()
+	{
+		for (String name : BATCH4_SOURCES)
+		{
+			CollectionLogSource source = findSource(name);
+			assertNotNull(source, "missing D4 batch 4 source: " + name);
+		}
+	}
+
+	@Test
+	public void allBatch4SourcesHaveTravelTip()
+	{
+		for (String name : BATCH4_SOURCES)
+		{
+			CollectionLogSource source = findSource(name);
+			assertNotNull(source, "missing D4 batch 4 source: " + name);
+
+			// Element 1 - travel tip
+			assertNotNull(source.getTravelTip(),
+				name + " has no source-level travelTip");
+			assertTrue(!source.getTravelTip().isBlank(),
+				name + " travelTip is blank");
+		}
+	}
+
+	@Test
+	public void allBatch4SourcesHaveAtLeastTwoGuidanceSteps()
+	{
+		for (String name : BATCH4_SOURCES)
+		{
+			CollectionLogSource source = findSource(name);
+			assertNotNull(source, "missing D4 batch 4 source: " + name);
+
+			assertNotNull(source.getGuidanceSteps(),
+				name + " has no guidanceSteps");
+			assertTrue(source.getGuidanceSteps().size() >= 2,
+				name + " has fewer than 2 guidance steps after the deep-guidance pass (got "
+					+ source.getGuidanceSteps().size() + ")");
+		}
+	}
+
+	@Test
+	public void allBatch4SourcesHaveArriveAtTileStep()
+	{
+		for (String name : BATCH4_SOURCES)
+		{
+			CollectionLogSource source = findSource(name);
+			assertNotNull(source, "missing D4 batch 4 source: " + name);
+
+			// Element 2 - at least one ARRIVE_AT_TILE step with world coords
+			boolean hasArriveStep = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getCompletionCondition() == CompletionCondition.ARRIVE_AT_TILE
+					&& s.getWorldX() > 0
+					&& s.getWorldY() > 0);
+			assertTrue(hasArriveStep,
+				name + " has no ARRIVE_AT_TILE step with positive world coordinates");
+		}
+	}
+
+	@Test
+	public void allBatch4SourcesHaveSectionLabels()
+	{
+		for (String name : BATCH4_SOURCES)
+		{
+			CollectionLogSource source = findSource(name);
+			assertNotNull(source, "missing D4 batch 4 source: " + name);
+
+			// Steps must carry section labels for multi-step sources
+			boolean hasSectionLabels = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getSection() != null && !s.getSection().isBlank());
+			assertTrue(hasSectionLabels,
+				name + " has no step with a section label");
+		}
+	}
+
+	@Test
+	public void repeatableSourcesHaveLoopStep()
+	{
+		for (String name : LOOP_SOURCES)
+		{
+			CollectionLogSource source = findSource(name);
+			assertNotNull(source, "missing D4 batch 4 loop source: " + name);
+
+			// Element 4 - at least one step declares a loop (loopCount > 0 is the discriminator;
+			// loopBackToStep may be 0 for "return to first step", so only loopCount is checked)
+			boolean hasLoop = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getLoopCount() > 0);
+			assertTrue(hasLoop,
+				name + " has no loop step (loopCount > 0) after the deep-guidance pass");
+		}
+	}
+
+	@Test
+	public void gatedSourcesHaveRequirements()
+	{
+		for (String name : GATED_SOURCES)
+		{
+			CollectionLogSource source = findSource(name);
+			assertNotNull(source, "missing D4 batch 4 gated source: " + name);
+
+			// Element 8 - requirements block present
+			assertNotNull(source.getRequirements(),
+				name + " has no requirements block; a skill or quest gate is expected");
+		}
+	}
+
+	@Test
+	public void allBatch4SourcesHaveDropRates()
+	{
+		for (String name : BATCH4_SOURCES)
+		{
+			CollectionLogSource source = findSource(name);
+			assertNotNull(source, "missing D4 batch 4 source: " + name);
+
+			// Element 9 - at least one item has a positive drop rate
+			assertNotNull(source.getItems(),
+				name + " has no items array");
+			assertTrue(!source.getItems().isEmpty(),
+				name + " has an empty items array");
+			boolean hasRate = source.getItems().stream()
+				.anyMatch(i -> i.getDropRate() > 0);
+			assertTrue(hasRate,
+				name + " has no item with a positive dropRate");
+		}
+	}
+
+	// -- helpers --
+
+	private CollectionLogSource findSource(String name)
+	{
+		return database.getAllSources().stream()
+			.filter(s -> name.equals(s.getName()))
+			.findFirst()
+			.orElse(null);
+	}
+}


### PR DESCRIPTION
## Summary

D4 Batch 4 — non-gathering skilling + timed events. Authors the full deep-guidance bar on all 9 sources scoped in `docs/contributor-guide/d4-long-tail-scoping.md` §4 Batch 4.

## Sources touched (9 / 9 — all present, none skipped)

| Source | Before (elements present) | After |
|--------|--------------------------|-------|
| Rooftop Agility | E1 E2 E9 | E1 E2 E4 E5 E8 E9 + sections |
| Colossal Wyrm Agility | E1 E2 E8 E9 | E1 E2 E4 E5 E8 E9 + sections |
| Black Chinchompas | E1 E2 E5 E9 | E1 E2 E4 E5 E8 E9 + sections |
| Prifddinas Rabbit | E1 E2 E8 E9 | E1 E2 E8 E9 + sections (one-kill, no loop) |
| Pickpocketing Darkmeyer Vyre | E1 E2 E8 E9 | E1 E2 E4 E5 E6 E8 E9 + sections |
| Thieving (Seed Stalls) | E1 E2 E9 | E1 E2 E4 E5 E8 E9 + sections |
| Farming (Fruit Trees) | E1 E2 E9 | E1 E2 E4 E5 E8 E9 + sections (multi-day loop) |
| Runecrafting (Fire Runes) | E1 E2 E9 | E1 E2 E4 E5 E6 E8 E9 + sections |
| Shooting Stars | E1 E2 E9 | E1 E2 E4 E5 E8 E9 + sections |

**Notable per-source notes:**
- **Farming (Fruit Trees):** E4 uses the multi-day loop pattern per scoping doc — plant step loops back to itself with a 16-hour growth cycle note; covers all 6 fruit tree patch locations in step description.
- **Shooting Stars:** E5 includes the Star Sprite minigame loop note per scoping doc (talk to Star Sprite for bonus stardust). Guidance lint INFO on step 1 (objectId not set on mine step) is expected — crashed stars are roaming events with variable object IDs.
- **Pickpocketing Darkmeyer Vyre / Runecrafting (Fire Runes):** E6 wired — required items on travel step (vyre noble robes / fire tiara).
- **Prifddinas Rabbit:** one-kill guaranteed drop; loop intentionally omitted. Sections added (Travel / Kill).

## Test count added

`D4Batch4RegressionTest.java` — **7 test methods** covering all 9 sources:
1. `allBatch4SourcesExistInDatabase`
2. `allBatch4SourcesHaveTravelTip`
3. `allBatch4SourcesHaveAtLeastTwoGuidanceSteps`
4. `allBatch4SourcesHaveArriveAtTileStep`
5. `allBatch4SourcesHaveSectionLabels`
6. `repeatableSourcesHaveLoopStep` (8 sources; Prifddinas Rabbit exempt)
7. `gatedSourcesHaveRequirements` (all 9)
8. `allBatch4SourcesHaveDropRates`

(8 methods total — miscounted above; test file has 8 `@Test` methods)

## Validation results

- `validate_drop_rates`: all 9 sources pass clean
- `guidance_lint`: 8 of 9 pass clean; Shooting Stars has 1 INFO (objectId not set on mine step — expected for variable-location roaming event)
- `data_ascii_lint`: 0 violations
- `./gradlew build`: BUILD SUCCESSFUL

## Data sources (E10)

- **Drop rates:** OSRS Wiki primary (all rates pre-existing in drop_rates.json, not changed)
- **Item IDs:** verified against existing drop_rates.json entries
- **Coordinates:** confirmed via `coordinate_helper` MCP tool
- **NPC IDs:** confirmed via `npc_lookup` MCP tool (Prifddinas Rabbit NPC ID 9118, Vyrewatch Sentinel IDs 9756-9763)
- **Activity details:** OSRS Wiki (Rooftop Agility Courses, Shooting Stars, Farming, Runecrafting, Thieving pages)
- **Game version:** authored against current OSRS build (May 2026)

## In-game validation

- [ ] Rooftop Agility: not yet validated in-client
- [ ] Colossal Wyrm Agility: not yet validated in-client
- [ ] Black Chinchompas: not yet validated in-client
- [ ] Prifddinas Rabbit: not yet validated in-client
- [ ] Pickpocketing Darkmeyer Vyre: not yet validated in-client
- [ ] Thieving (Seed Stalls): not yet validated in-client
- [ ] Farming (Fruit Trees): not yet validated in-client
- [ ] Runecrafting (Fire Runes): not yet validated in-client
- [ ] Shooting Stars: not yet validated in-client

Data is wiki-sourced, not in-client validated. Checklist items above should be ticked by a contributor with game access before or shortly after merge.