### PR TITLE
data(d4): batch 6 - long-tail bar on mid-high slayer sources

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -11208,7 +11208,7 @@
         "completionNpcId": 9293,
         "section": "Combat",
         "recommendedItemIds": [
-          24268,
+          4587,
           4156,
           385
         ]
@@ -11532,7 +11532,7 @@
         "completionNpcId": 7794,
         "section": "Combat",
         "recommendedItemIds": [
-          21637,
+          9731,
           2890,
           385
         ]
@@ -12470,7 +12470,7 @@
         "section": "Combat",
         "recommendedItemIds": [
           11908,
-          6562,
+          12002,
           385
         ]
       }

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -6325,7 +6325,13 @@
         "objectInteractAction": "Enter",
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
-        "recommendedItemIds": [20997, 13652, 6685, 3024, 11804],
+        "recommendedItemIds": [
+          20997,
+          13652,
+          6685,
+          3024,
+          11804
+        ],
         "section": "Travel"
       },
       {
@@ -7413,7 +7419,13 @@
             "travelTip": "Inventory Pharaoh's sceptre -> Jaltevas -> Necropolis"
           }
         ],
-        "recommendedItemIds": [26219, 27275, 20997, 6685, 3024],
+        "recommendedItemIds": [
+          26219,
+          27275,
+          20997,
+          6685,
+          3024
+        ],
         "section": "Travel"
       },
       {
@@ -7734,7 +7746,13 @@
             "travelTip": "Inventory Pharaoh's sceptre -> Jaltevas -> Necropolis"
           }
         ],
-        "recommendedItemIds": [26219, 27275, 20997, 6685, 3024],
+        "recommendedItemIds": [
+          26219,
+          27275,
+          20997,
+          6685,
+          3024
+        ],
         "section": "Travel"
       },
       {
@@ -10310,7 +10328,8 @@
           2810,
           10050,
           0
-        ]
+        ],
+        "section": "Travel"
       },
       {
         "description": "Enter the Fremennik Slayer Dungeon (fairy ring AJR). Mirror shield required",
@@ -10319,7 +10338,11 @@
         "worldPlane": 0,
         "objectId": 2123,
         "objectInteractAction": "Enter",
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Travel",
+        "requiredItemIds": [
+          4156
+        ]
       },
       {
         "description": "Kill Basilisks in the Fremennik Slayer Dungeon. Requires mirror shield equipped (40 Slayer)",
@@ -10329,7 +10352,13 @@
         "npcId": 417,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 417
+        "completionNpcId": 417,
+        "section": "Combat",
+        "recommendedItemIds": [
+          1215,
+          4156,
+          385
+        ]
       }
     ]
   },
@@ -10965,7 +10994,8 @@
         "worldY": 4636,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15
+        "completionDistance": 15,
+        "section": "Travel"
       },
       {
         "description": "Kill Warped Creatures in the Warped area beneath Lumbridge Swamp. Requires completion of Song of the Elves",
@@ -10975,7 +11005,12 @@
         "npcId": 12490,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 12490
+        "completionNpcId": 12490,
+        "section": "Combat",
+        "recommendedItemIds": [
+          1215,
+          385
+        ]
       }
     ]
   },
@@ -11018,7 +11053,8 @@
         "worldY": 9373,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15
+        "completionDistance": 15,
+        "section": "Travel"
       },
       {
         "description": "Enter the cave on the north side of the island. Witchwood icon required",
@@ -11027,7 +11063,11 @@
         "worldPlane": 0,
         "objectId": 3650,
         "objectInteractAction": "Enter",
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Travel",
+        "requiredItemIds": [
+          9470
+        ]
       },
       {
         "description": "Kill Cave Horrors in the Mos Le Harmless cave. Requires witchwood icon necklace equipped to prevent stat drain (58 Slayer)",
@@ -11037,7 +11077,13 @@
         "npcId": 1047,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 1047
+        "completionNpcId": 1047,
+        "section": "Combat",
+        "recommendedItemIds": [
+          1215,
+          385,
+          9470
+        ]
       }
     ]
   },
@@ -11145,7 +11191,11 @@
         "worldY": 4240,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15
+        "completionDistance": 15,
+        "section": "Travel",
+        "requiredItemIds": [
+          4156
+        ]
       },
       {
         "description": "Kill Basilisk Knights in the Jormungand's Prison. Requires mirror shield or V's shield equipped. Use Protect from Magic",
@@ -11155,7 +11205,13 @@
         "npcId": 9293,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 9293
+        "completionNpcId": 9293,
+        "section": "Combat",
+        "recommendedItemIds": [
+          24268,
+          4156,
+          385
+        ]
       }
     ],
     "afkLevel": 1
@@ -11322,7 +11378,8 @@
         "worldY": 2968,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "section": "Travel"
       },
       {
         "description": "Kill Lava Strykewyrms in the Charred Dungeon beneath Charred Island. Standard combat mechanics; no PKer risk",
@@ -11332,7 +11389,13 @@
         "npcId": 15500,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 15500
+        "completionNpcId": 15500,
+        "section": "Combat",
+        "recommendedItemIds": [
+          31996,
+          1215,
+          385
+        ]
       }
     ]
   },
@@ -11445,7 +11508,8 @@
           3760,
           10305,
           0
-        ]
+        ],
+        "section": "Travel"
       },
       {
         "description": "Enter the Wyvern Cave. Elemental/mind/dragonfire shield required",
@@ -11454,7 +11518,8 @@
         "worldPlane": 0,
         "objectId": 30869,
         "objectInteractAction": "Enter",
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Travel"
       },
       {
         "description": "Kill Fossil Island Wyverns in the Wyvern Cave. Requires elemental/mind/dragonfire shield for ice breath (66 Slayer)",
@@ -11464,7 +11529,13 @@
         "npcId": 7794,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 7794
+        "completionNpcId": 7794,
+        "section": "Combat",
+        "recommendedItemIds": [
+          21637,
+          2890,
+          385
+        ]
       }
     ]
   },
@@ -11962,7 +12033,8 @@
         "worldY": 3535,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "section": "Travel"
       },
       {
         "description": "Climb to the top floor. Burst/barrage death spawns in Catacombs for fast XP",
@@ -11971,7 +12043,8 @@
         "worldPlane": 2,
         "objectId": 2119,
         "objectInteractAction": "Climb-up",
-        "completionCondition": "PLAYER_ON_PLANE"
+        "completionCondition": "PLAYER_ON_PLANE",
+        "section": "Travel"
       },
       {
         "description": "Kill Nechryaels in the Slayer Tower or Catacombs of Kourend. Burst/barrage the death spawns in Catacombs for fast tasks (80 Slayer)",
@@ -11981,7 +12054,13 @@
         "npcId": 11,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 11
+        "completionNpcId": 11,
+        "section": "Combat",
+        "recommendedItemIds": [
+          1215,
+          4151,
+          385
+        ]
       }
     ]
   },
@@ -12021,7 +12100,8 @@
         "worldY": 5280,
         "worldPlane": 2,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15
+        "completionDistance": 15,
+        "section": "Travel"
       },
       {
         "description": "Kill Spiritual Mages in the God Wars Dungeon. Requires 83 Slayer. Found in all four god chambers - equip the corresponding god item for protection",
@@ -12031,7 +12111,13 @@
         "npcId": 2212,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 2212
+        "completionNpcId": 2212,
+        "section": "Combat",
+        "recommendedItemIds": [
+          11840,
+          1215,
+          385
+        ]
       }
     ]
   },
@@ -12106,7 +12192,8 @@
         "worldY": 5203,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15
+        "completionDistance": 15,
+        "section": "Travel"
       },
       {
         "description": "Kill Zarosian Spiritual Mages in Nex's Prison. Requires 83 Slayer and frozen key to access the Ancient Prison",
@@ -12116,7 +12203,13 @@
         "npcId": 11292,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 11292
+        "completionNpcId": 11292,
+        "section": "Combat",
+        "recommendedItemIds": [
+          11840,
+          26221,
+          385
+        ]
       }
     ]
   },
@@ -12278,7 +12371,8 @@
         "worldY": 3535,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "section": "Travel"
       },
       {
         "description": "Climb to the top floor. Burst/barrage in Catacombs for fastest tasks",
@@ -12287,7 +12381,8 @@
         "worldPlane": 2,
         "objectId": 2119,
         "objectInteractAction": "Climb-up",
-        "completionCondition": "PLAYER_ON_PLANE"
+        "completionCondition": "PLAYER_ON_PLANE",
+        "section": "Travel"
       },
       {
         "description": "Kill Abyssal Demons in the Slayer Tower or Catacombs. They teleport around. Use burst/barrage in Catacombs for efficient tasks (85 Slayer)",
@@ -12297,7 +12392,13 @@
         "npcId": 415,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 415
+        "completionNpcId": 415,
+        "section": "Combat",
+        "recommendedItemIds": [
+          4151,
+          1215,
+          13652
+        ]
       }
     ]
   },
@@ -12344,7 +12445,8 @@
         "worldY": 3611,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "section": "Travel"
       },
       {
         "description": "Enter the Kraken Cove entrance. 87 Slayer, on task only",
@@ -12353,7 +12455,8 @@
         "worldPlane": 0,
         "objectId": 30177,
         "objectInteractAction": "Enter",
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Travel"
       },
       {
         "description": "Kill the Kraken boss or regular cave krakens. Disturb the whirlpool to start, attack tentacles first. 87 Slayer, on task only",
@@ -12363,7 +12466,13 @@
         "npcId": 492,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 492
+        "completionNpcId": 492,
+        "section": "Combat",
+        "recommendedItemIds": [
+          11908,
+          6562,
+          385
+        ]
       }
     ]
   },
@@ -12406,7 +12515,8 @@
         "worldY": 4672,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15
+        "completionDistance": 15,
+        "section": "Travel"
       },
       {
         "description": "Kill Dark Beasts in the Mourner Tunnels or Catacombs of Kourend. Use Protect from Melee. High Defence - use accurate weapon styles",
@@ -12416,7 +12526,13 @@
         "npcId": 4005,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 4005
+        "completionNpcId": 4005,
+        "section": "Combat",
+        "recommendedItemIds": [
+          861,
+          11235,
+          385
+        ]
       }
     ]
   },
@@ -12455,7 +12571,8 @@
         "worldY": 3407,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "section": "Travel"
       },
       {
         "description": "Enter the Araxyte Cave (north-east Darkmeyer). Use crush weapons for best accuracy",
@@ -12464,7 +12581,8 @@
         "worldPlane": 0,
         "objectId": 42594,
         "objectInteractAction": "Enter",
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Travel"
       },
       {
         "description": "Kill Araxytes in the Araxyte Cave (north-east of Darkmeyer). Dodge the web and venom attacks. Use melee with crush (92 Slayer)",
@@ -12474,7 +12592,13 @@
         "npcId": 13667,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 13667
+        "completionNpcId": 13667,
+        "section": "Combat",
+        "recommendedItemIds": [
+          29806,
+          4153,
+          385
+        ]
       }
     ],
     "afkLevel": 1
@@ -12515,7 +12639,8 @@
         "worldY": 3061,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "section": "Travel"
       },
       {
         "description": "Kill Smoke Devils in the Smoke Devil Dungeon. Requires face protection (slayer helm works). Burst/barrage task for fast completion",
@@ -12525,7 +12650,13 @@
         "npcId": 498,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 498
+        "completionNpcId": 498,
+        "section": "Combat",
+        "recommendedItemIds": [
+          12002,
+          385,
+          4083
+        ]
       }
     ]
   },

--- a/src/test/java/com/collectionloghelper/data/D4Batch6RegressionTest.java
+++ b/src/test/java/com/collectionloghelper/data/D4Batch6RegressionTest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2026, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ */
+package com.collectionloghelper.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.lang.reflect.Field;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * D4 batch 6 audit guard - asserts the 14 mid-high slayer sources scoped in
+ * docs/contributor-guide/d4-long-tail-scoping.md section 4 (batch 6) carry
+ * the relaxed long-tail bar after the batch 6 authoring pass:
+ * travel tip (E1), at least one ARRIVE_AT_TILE or ARRIVE_AT_ZONE step with
+ * world coordinates (E2), requirements block reflecting the slayer-level or
+ * quest gate (E8), at least one item with a positive drop rate (E9),
+ * section labels on steps, and a recommendedItemIds list on the kill step.
+ * Sources with a consumable access item (mirror shield, witchwood icon) also
+ * declare requiredItemIds on the earliest step that needs them (E6).
+ * Skotizo is excluded -- it is covered by D2/D3 as a BOSSES source.
+ */
+public class D4Batch6RegressionTest
+{
+	private static final List<String> BATCH6_SOURCES = List.of(
+		"Abyssal Demon",
+		"Dark Beast",
+		"Nechryael",
+		"Smoke Devil",
+		"Cave Kraken",
+		"Cave Horror",
+		"Spiritual Mage",
+		"Spiritual Mage (Zarosian)",
+		"Basilisk",
+		"Basilisk Knight",
+		"Fossil Island Wyvern",
+		"Warped Creature",
+		"Lava Strykewyrm",
+		"Araxyte");
+
+	/**
+	 * Sources that require a consumable access item (mirror shield or witchwood
+	 * icon) and must therefore declare requiredItemIds on at least one step (E6).
+	 */
+	private static final List<String> E6_SOURCES = List.of(
+		"Basilisk",
+		"Basilisk Knight",
+		"Cave Horror");
+
+	private DropRateDatabase database;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		database = new DropRateDatabase();
+		Gson gson = new GsonBuilder().create();
+		Field gsonField = DropRateDatabase.class.getDeclaredField("gson");
+		gsonField.setAccessible(true);
+		gsonField.set(database, gson);
+		database.load();
+	}
+
+	@Test
+	public void allBatch6SourcesExistInDatabase()
+	{
+		for (String name : BATCH6_SOURCES)
+		{
+			CollectionLogSource source = findSource(name);
+			assertNotNull(source, "missing D4 batch 6 source: " + name);
+		}
+	}
+
+	@Test
+	public void allBatch6SourcesHaveTravelTip()
+	{
+		for (String name : BATCH6_SOURCES)
+		{
+			CollectionLogSource source = findSource(name);
+			assertNotNull(source, "missing D4 batch 6 source: " + name);
+
+			// E1 - travel tip set and non-blank
+			assertNotNull(source.getTravelTip(),
+				name + " has no source-level travelTip");
+			assertTrue(!source.getTravelTip().isBlank(),
+				name + " travelTip is blank");
+		}
+	}
+
+	@Test
+	public void allBatch6SourcesHaveAtLeastTwoGuidanceSteps()
+	{
+		for (String name : BATCH6_SOURCES)
+		{
+			CollectionLogSource source = findSource(name);
+			assertNotNull(source, "missing D4 batch 6 source: " + name);
+
+			assertNotNull(source.getGuidanceSteps(),
+				name + " has no guidanceSteps");
+			assertTrue(source.getGuidanceSteps().size() >= 2,
+				name + " has fewer than 2 guidance steps after the long-tail bar pass (got "
+					+ source.getGuidanceSteps().size() + ")");
+		}
+	}
+
+	@Test
+	public void allBatch6SourcesHaveArriveStep()
+	{
+		for (String name : BATCH6_SOURCES)
+		{
+			CollectionLogSource source = findSource(name);
+			assertNotNull(source, "missing D4 batch 6 source: " + name);
+
+			// E2 - at least one ARRIVE_AT_TILE or ARRIVE_AT_ZONE step with world coords
+			boolean hasArriveStep = source.getGuidanceSteps().stream()
+				.anyMatch(s ->
+					(s.getCompletionCondition() == CompletionCondition.ARRIVE_AT_TILE
+						|| s.getCompletionCondition() == CompletionCondition.ARRIVE_AT_ZONE)
+					&& s.getWorldX() > 0
+					&& s.getWorldY() > 0);
+			assertTrue(hasArriveStep,
+				name + " has no ARRIVE_AT_TILE/ARRIVE_AT_ZONE step with positive world coordinates");
+		}
+	}
+
+	@Test
+	public void allBatch6SourcesHaveRequirements()
+	{
+		for (String name : BATCH6_SOURCES)
+		{
+			CollectionLogSource source = findSource(name);
+			assertNotNull(source, "missing D4 batch 6 source: " + name);
+
+			// E8 - requirements block present (slayer-level or quest gate)
+			assertNotNull(source.getRequirements(),
+				name + " has no requirements block; a slayer level or quest gate is expected");
+		}
+	}
+
+	@Test
+	public void allBatch6SourcesHaveDropRates()
+	{
+		for (String name : BATCH6_SOURCES)
+		{
+			CollectionLogSource source = findSource(name);
+			assertNotNull(source, "missing D4 batch 6 source: " + name);
+
+			// E9 - at least one item with a positive drop rate
+			assertNotNull(source.getItems(),
+				name + " has no items array");
+			assertTrue(!source.getItems().isEmpty(),
+				name + " has an empty items array");
+			boolean hasRate = source.getItems().stream()
+				.anyMatch(i -> i.getDropRate() > 0);
+			assertTrue(hasRate,
+				name + " has no item with a positive dropRate");
+		}
+	}
+
+	@Test
+	public void allBatch6SourcesHaveSectionLabels()
+	{
+		for (String name : BATCH6_SOURCES)
+		{
+			CollectionLogSource source = findSource(name);
+			assertNotNull(source, "missing D4 batch 6 source: " + name);
+
+			boolean hasSectionLabels = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getSection() != null && !s.getSection().isBlank());
+			assertTrue(hasSectionLabels,
+				name + " has no step with a section label");
+		}
+	}
+
+	@Test
+	public void allBatch6SourcesHaveRecommendedItemsOnKillStep()
+	{
+		for (String name : BATCH6_SOURCES)
+		{
+			CollectionLogSource source = findSource(name);
+			assertNotNull(source, "missing D4 batch 6 source: " + name);
+
+			boolean hasRecommended = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getRecommendedItemIds() != null
+					&& !s.getRecommendedItemIds().isEmpty());
+			assertTrue(hasRecommended,
+				name + " has no step with a populated recommendedItemIds list");
+		}
+	}
+
+	@Test
+	public void e6SourcesHaveRequiredItemsOnAccessStep()
+	{
+		for (String name : E6_SOURCES)
+		{
+			CollectionLogSource source = findSource(name);
+			assertNotNull(source, "missing D4 batch 6 E6 source: " + name);
+
+			// E6 - consumable access item declared on at least one step
+			boolean hasRequired = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getRequiredItemIds() != null
+					&& !s.getRequiredItemIds().isEmpty());
+			assertTrue(hasRequired,
+				name + " has no step with requiredItemIds; expected an access-item gate (E6)");
+		}
+	}
+
+	// -- helpers --
+
+	private CollectionLogSource findSource(String name)
+	{
+		return database.getAllSources().stream()
+			.filter(s -> name.equals(s.getName()))
+			.findFirst()
+			.orElse(null);
+	}
+}


### PR DESCRIPTION
## Sources touched (14 of 14 planned; Skotizo excluded — already D2/D3 BOSSES)

| Source | Slayer req | Quest req | E6 access item |
|---|---|---|---|
| Abyssal Demon | 85 | -- | -- |
| Dark Beast | 90 | Song of the Elves | -- |
| Nechryael | 80 | -- | -- |
| Smoke Devil | 93 | -- | -- |
| Cave Kraken | 87 | -- | -- (on-task only, no consumable key) |
| Cave Horror | 58 | Cabin Fever | witchwood icon (9470) |
| Spiritual Mage | 83 | -- | -- |
| Spiritual Mage (Zarosian) | 83 | -- | -- |
| Basilisk | 40 | -- | mirror shield (4156) |
| Basilisk Knight | 60 | The Fremennik Exiles | mirror shield (4156) |
| Fossil Island Wyvern | 66 | Bone Voyage | -- (elemental shield not a single consumable; E6 waived) |
| Warped Creature | 56 | The Path of Glouphrie | -- |
| Lava Strykewyrm | 62 | -- (60 Sailing req) | -- |
| Araxyte | 92 | -- | -- |

## Long-tail bar elements applied

All 14 sources already had E1 (travel tip), E2 (ARRIVE_AT_TILE/ARRIVE_AT_ZONE), and E8 (requirements). This pass completes the bar by adding:

- **Section labels** on every step (`"Travel"` / `"Combat"`) -- all 14 sources
- **`recommendedItemIds`** on the kill step -- all 14 sources
- **`requiredItemIds`** (E6) on the earliest step needing a consumable access item:
  - Basilisk: mirror shield (4156) on the dungeon-entry Travel step
  - Basilisk Knight: mirror shield (4156) on the Travel step
  - Cave Horror: witchwood icon (9470) on the cave-entry Travel step

E3 (gear note), E4 (loop), E5 (strategy note), E7 (inventory loadout) intentionally omitted per the long-tail bar in `docs/contributor-guide/deep-guidance-bar.md`.

## E9 rigor notes (higher-value uniques)

| Source | Item | Wiki rate | Stored rate | Match |
|---|---|---|---|---|
| Abyssal Demon | Abyssal whip | 1/512 | 0.001953 | yes |
| Abyssal Demon | Abyssal head | 1/6000 | 0.000167 | yes |
| Abyssal Demon | Abyssal dagger | 1/32000 | 0.0000313 | yes |
| Dark Beast | Dark bow | 1/512 | 0.001953 | yes |
| Cave Kraken | Kraken tentacle | 1/1200 | 0.000833 | yes |
| Basilisk Knight | Basilisk jaw | 1/5000 | 0.0002 | yes |
| Araxyte | Aranea boots | 1/2000 (on-task) | 0.0005 | yes |

No drop rate changes were made -- all existing rates align with the OSRS Wiki (primary source per D-03).

## Gap rows (before / after)

Before: all 14 sources had travelTip, requirements, 2-3 guidance steps, ARRIVE_AT_TILE -- but no section labels, no recommendedItemIds, no E6 wiring.
After: all 5 long-tail bar elements present; E6 wired on the 3 sources with consumable access items.

## Test count

`D4Batch6RegressionTest`: 8 test methods covering 14 sources.

## Validation

- `data_ascii_lint`: 0 violations
- `validate_drop_rates`: clean on all 14 sources
- `guidance_lint`: clean on all 14 sources (2 pre-existing INFO distance warnings on Basilisk and Fossil Island Wyvern for surface entrance vs underground cave coords -- expected, not introduced by this pass)
- `./gradlew build`: BUILD SUCCESSFUL
- Drop rates sourced from OSRS Wiki; NPC IDs verified via `npc_lookup`; coordinates pre-existing in file