### PR TITLE
data(d4): batch 5 - long-tail bar on 14 low-level slayer sources

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -6325,7 +6325,13 @@
         "objectInteractAction": "Enter",
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
-        "recommendedItemIds": [20997, 13652, 6685, 3024, 11804],
+        "recommendedItemIds": [
+          20997,
+          13652,
+          6685,
+          3024,
+          11804
+        ],
         "section": "Travel"
       },
       {
@@ -7413,7 +7419,13 @@
             "travelTip": "Inventory Pharaoh's sceptre -> Jaltevas -> Necropolis"
           }
         ],
-        "recommendedItemIds": [26219, 27275, 20997, 6685, 3024],
+        "recommendedItemIds": [
+          26219,
+          27275,
+          20997,
+          6685,
+          3024
+        ],
         "section": "Travel"
       },
       {
@@ -7734,7 +7746,13 @@
             "travelTip": "Inventory Pharaoh's sceptre -> Jaltevas -> Necropolis"
           }
         ],
-        "recommendedItemIds": [26219, 27275, 20997, 6685, 3024],
+        "recommendedItemIds": [
+          26219,
+          27275,
+          20997,
+          6685,
+          3024
+        ],
         "section": "Travel"
       },
       {
@@ -9923,7 +9941,8 @@
         "worldY": 3543,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "section": "Travel"
       },
       {
         "description": "Kill Crawling Hands in the Slayer Tower basement. Very low combat - good for early slayer tasks",
@@ -9933,7 +9952,8 @@
         "npcId": 448,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 448
+        "completionNpcId": 448,
+        "section": "Combat"
       }
     ]
   },
@@ -9979,7 +9999,8 @@
           2810,
           10050,
           0
-        ]
+        ],
+        "section": "Travel"
       },
       {
         "description": "Enter the Fremennik Slayer Dungeon (fairy ring AJR) or Lumbridge Swamp caves",
@@ -9988,7 +10009,8 @@
         "worldPlane": 0,
         "objectId": 2123,
         "objectInteractAction": "Enter",
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Travel"
       },
       {
         "description": "Kill Cave Crawlers in the Fremennik Slayer Dungeon or Lumbridge Swamp caves. Low Slayer requirement (10). Can poison you",
@@ -9998,7 +10020,8 @@
         "npcId": 406,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 406
+        "completionNpcId": 406,
+        "section": "Combat"
       }
     ]
   },
@@ -10044,7 +10067,8 @@
           2810,
           10050,
           0
-        ]
+        ],
+        "section": "Travel"
       },
       {
         "description": "Enter the Fremennik Slayer Dungeon (fairy ring AJR). Bring a bag of salt to finish them",
@@ -10053,7 +10077,8 @@
         "worldPlane": 0,
         "objectId": 2123,
         "objectInteractAction": "Enter",
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Travel"
       },
       {
         "description": "Kill Rockslugs in the Fremennik Slayer Dungeon. Finish them with a bag of salt when low HP (requires 20 Slayer)",
@@ -10063,7 +10088,11 @@
         "npcId": 421,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 421
+        "completionNpcId": 421,
+        "section": "Combat",
+        "requiredItemIds": [
+          4161
+        ]
       }
     ]
   },
@@ -10123,7 +10152,8 @@
           2810,
           10050,
           0
-        ]
+        ],
+        "section": "Travel"
       },
       {
         "description": "Enter the Fremennik Slayer Dungeon (fairy ring AJR). Mirror shield required",
@@ -10132,7 +10162,8 @@
         "worldPlane": 0,
         "objectId": 2123,
         "objectInteractAction": "Enter",
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Travel"
       },
       {
         "description": "Kill Cockatrices in the Fremennik Slayer Dungeon. Requires mirror shield equipped (25 Slayer)",
@@ -10142,7 +10173,8 @@
         "npcId": 419,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 419
+        "completionNpcId": 419,
+        "section": "Combat"
       }
     ]
   },
@@ -10188,7 +10220,8 @@
           2810,
           10050,
           0
-        ]
+        ],
+        "section": "Travel"
       },
       {
         "description": "Enter the Fremennik Slayer Dungeon (fairy ring AJR) or use Catacombs of Kourend",
@@ -10197,7 +10230,8 @@
         "worldPlane": 0,
         "objectId": 2123,
         "objectInteractAction": "Enter",
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Travel"
       },
       {
         "description": "Kill Pyrefiends in the Fremennik Slayer Dungeon or Catacombs of Kourend (30 Slayer). Use Protect from Magic",
@@ -10207,7 +10241,8 @@
         "npcId": 433,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 433
+        "completionNpcId": 433,
+        "section": "Combat"
       }
     ]
   },
@@ -10254,7 +10289,8 @@
         "worldY": 3110,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "section": "Travel"
       },
       {
         "description": "Kill Mogres at Mudskipper Point. Throw fishing explosives into the flooded area to spawn them (requires Skippy and the Mogres miniquest)",
@@ -10264,7 +10300,11 @@
         "npcId": 2592,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 2592
+        "completionNpcId": 2592,
+        "section": "Combat",
+        "requiredItemIds": [
+          6664
+        ]
       }
     ]
   },
@@ -10429,7 +10469,8 @@
         "worldY": 3535,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "section": "Travel"
       },
       {
         "description": "Climb the stairs to the first or second floor of the Slayer Tower",
@@ -10438,7 +10479,8 @@
         "worldPlane": 1,
         "objectId": 2114,
         "objectInteractAction": "Climb-up",
-        "completionCondition": "PLAYER_ON_PLANE"
+        "completionCondition": "PLAYER_ON_PLANE",
+        "section": "Travel"
       },
       {
         "description": "Kill Infernal Mages in the Slayer Tower. Use Protect from Magic (45 Slayer)",
@@ -10448,7 +10490,8 @@
         "npcId": 443,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 443
+        "completionNpcId": 443,
+        "section": "Combat"
       }
     ]
   },
@@ -10491,7 +10534,8 @@
         "worldY": 10132,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15
+        "completionDistance": 15,
+        "section": "Travel"
       },
       {
         "description": "Kill Brine Rats in the Brine Rat Cavern. Dig with a spade south of the Windswept Tree near Rellekka lighthouse to enter",
@@ -10501,7 +10545,8 @@
         "npcId": 4501,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 4501
+        "completionNpcId": 4501,
+        "section": "Combat"
       }
     ]
   },
@@ -10705,7 +10750,8 @@
         "worldY": 3535,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "section": "Travel"
       },
       {
         "description": "Climb the stairs to the Bloodveld area. Catacombs offers burst/barrage spots",
@@ -10714,7 +10760,8 @@
         "worldPlane": 1,
         "objectId": 2114,
         "objectInteractAction": "Climb-up",
-        "completionCondition": "PLAYER_ON_PLANE"
+        "completionCondition": "PLAYER_ON_PLANE",
+        "section": "Travel"
       },
       {
         "description": "Kill Bloodvelds in the Slayer Tower or Catacombs of Kourend. Use Protect from Melee, weak to ranged (50 Slayer)",
@@ -10724,7 +10771,8 @@
         "npcId": 484,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 484
+        "completionNpcId": 484,
+        "section": "Combat"
       }
     ]
   },
@@ -10831,7 +10879,8 @@
           2810,
           10050,
           0
-        ]
+        ],
+        "section": "Travel"
       },
       {
         "description": "Enter the Fremennik Slayer Dungeon (fairy ring AJR) or Catacombs of Kourend for burst tasks",
@@ -10840,7 +10889,8 @@
         "worldPlane": 0,
         "objectId": 2123,
         "objectInteractAction": "Enter",
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Travel"
       },
       {
         "description": "Kill Jellies in the Fremennik Slayer Dungeon or Catacombs of Kourend. Use Protect from Melee (52 Slayer)",
@@ -10850,7 +10900,8 @@
         "npcId": 437,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 437
+        "completionNpcId": 437,
+        "section": "Combat"
       }
     ]
   },
@@ -10903,7 +10954,8 @@
           2810,
           10050,
           0
-        ]
+        ],
+        "section": "Travel"
       },
       {
         "description": "Enter the Fremennik Slayer Dungeon (fairy ring AJR). Leaf-bladed weapons required",
@@ -10912,7 +10964,8 @@
         "worldPlane": 0,
         "objectId": 2123,
         "objectInteractAction": "Enter",
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Travel"
       },
       {
         "description": "Kill Turoths in the Fremennik Slayer Dungeon. Must use leaf-bladed weapons, broad bolts, or magic dart (55 Slayer)",
@@ -10922,7 +10975,8 @@
         "npcId": 430,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 430
+        "completionNpcId": 430,
+        "section": "Combat"
       }
     ]
   },
@@ -11077,7 +11131,8 @@
         "worldY": 3535,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "section": "Travel"
       },
       {
         "description": "Climb the stairs to the Aberrant Spectre floor. Nosepeg/slayer helm required",
@@ -11086,7 +11141,8 @@
         "worldPlane": 1,
         "objectId": 2114,
         "objectInteractAction": "Climb-up",
-        "completionCondition": "PLAYER_ON_PLANE"
+        "completionCondition": "PLAYER_ON_PLANE",
+        "section": "Travel"
       },
       {
         "description": "Kill Aberrant Spectres in the Slayer Tower or Catacombs. Requires nosepeg or slayer helm. Use Protect from Magic (60 Slayer)",
@@ -11096,7 +11152,8 @@
         "npcId": 2,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 2
+        "completionNpcId": 2,
+        "section": "Combat"
       }
     ]
   },
@@ -11372,7 +11429,8 @@
         "worldY": 2962,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "section": "Travel"
       },
       {
         "description": "Kill Dust Devils in the Smoke Dungeon or Catacombs of Kourend. Requires face protection (slayer helm works). Burst/barrage in Catacombs for fast tasks",
@@ -11382,7 +11440,8 @@
         "npcId": 423,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 423
+        "completionNpcId": 423,
+        "section": "Combat"
       }
     ]
   },
@@ -11531,7 +11590,8 @@
           2810,
           10050,
           0
-        ]
+        ],
+        "section": "Travel"
       },
       {
         "description": "Enter the Fremennik Slayer Dungeon (fairy ring AJR). Leaf-bladed weapons required",
@@ -11540,7 +11600,8 @@
         "worldPlane": 0,
         "objectId": 2123,
         "objectInteractAction": "Enter",
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Travel"
       },
       {
         "description": "Kill Kuraskes in the Fremennik Slayer Dungeon. Must use leaf-bladed weapons, broad bolts, or magic dart (70 Slayer)",
@@ -11550,7 +11611,8 @@
         "npcId": 410,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 410
+        "completionNpcId": 410,
+        "section": "Combat"
       }
     ]
   },

--- a/src/test/java/com/collectionloghelper/data/D4Batch5RegressionTest.java
+++ b/src/test/java/com/collectionloghelper/data/D4Batch5RegressionTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2026, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ */
+package com.collectionloghelper.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.lang.reflect.Field;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * D4 batch 5 audit guard - asserts the fourteen low-level slayer sources scoped
+ * in docs/contributor-guide/d4-long-tail-scoping.md section 4 carry the
+ * long-tail bar after the batch 5 authoring pass.
+ *
+ * Long-tail bar elements checked here:
+ *   E1  - travelTip present and non-blank
+ *   E2  - at least one auto-arrival step (ARRIVE_AT_TILE, ARRIVE_AT_ZONE, or
+ *          PLAYER_ON_PLANE) with positive world coordinates
+ *   E6  - requiredItemIds on the kill step for Mogre (fishing explosive) and
+ *          Rockslug (bag of salt); waived with reason for the other twelve
+ *          sources which need no consumable access item
+ *   E8  - requirements block present with at least one skill or quest entry
+ *   E9  - at least one item with a positive dropRate
+ *
+ * Section labels (Travel / Combat) are also asserted on every source since they
+ * drive the panel UI grouping for all authored sources regardless of bar level.
+ *
+ * Elements E3, E4, E5, E7, E10 are waived for this batch per the long-tail bar
+ * definition: these low-level slayer monsters have no phase mechanics, no
+ * multi-cycle loop, and require no hard-to-replace inventory loadout beyond the
+ * two cases covered by E6 above.
+ */
+public class D4Batch5RegressionTest
+{
+	/** All fourteen batch-5 sources in the order they appear in the scoping doc. */
+	private static final List<String> BATCH5_SOURCES = List.of(
+		"Crawling Hand",
+		"Cave Crawler",
+		"Cockatrice",
+		"Pyrefiend",
+		"Mogre",
+		"Rockslug",
+		"Jelly",
+		"Brine Rat",
+		"Turoth",
+		"Bloodveld",
+		"Infernal Mage",
+		"Dust Devil",
+		"Aberrant Spectre",
+		"Kurask");
+
+	/**
+	 * Sources with a quest prerequisite for access.
+	 * Brine Rat requires Olaf's Quest to enter Brine Rat Cavern.
+	 */
+	private static final List<String> QUEST_GATED_SOURCES = List.of(
+		"Brine Rat");
+
+	/**
+	 * Sources where E6 (bank-and-return) is wired because the kill step
+	 * requires a consumable item that must be in inventory:
+	 *   Mogre    - fishing explosive (item 6664) to spawn the NPC
+	 *   Rockslug - bag of salt (item 4161) to finish the kill
+	 */
+	private static final List<String> E6_WIRED_SOURCES = List.of(
+		"Mogre",
+		"Rockslug");
+
+	private DropRateDatabase database;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		database = new DropRateDatabase();
+		Gson gson = new GsonBuilder().create();
+		Field gsonField = DropRateDatabase.class.getDeclaredField("gson");
+		gsonField.setAccessible(true);
+		gsonField.set(database, gson);
+		database.load();
+	}
+
+	/** All fourteen sources must exist in the database. */
+	@Test
+	public void allBatch5SourcesExistInDatabase()
+	{
+		for (String name : BATCH5_SOURCES)
+		{
+			CollectionLogSource source = findSource(name);
+			assertNotNull(source, "missing D4 batch 5 source: " + name);
+		}
+	}
+
+	/** E1 - travelTip must be set and non-blank on every source. */
+	@Test
+	public void allBatch5SourcesHaveTravelTip()
+	{
+		for (String name : BATCH5_SOURCES)
+		{
+			CollectionLogSource source = findSource(name);
+			assertNotNull(source, "missing D4 batch 5 source: " + name);
+			assertNotNull(source.getTravelTip(),
+				name + " has no source-level travelTip (E1)");
+			assertTrue(!source.getTravelTip().isBlank(),
+				name + " travelTip is blank (E1)");
+		}
+	}
+
+	/** E2 - at least one auto-arrival step with positive world coordinates. */
+	@Test
+	public void allBatch5SourcesHaveAutoArrivalStep()
+	{
+		for (String name : BATCH5_SOURCES)
+		{
+			CollectionLogSource source = findSource(name);
+			assertNotNull(source, "missing D4 batch 5 source: " + name);
+			assertNotNull(source.getGuidanceSteps(),
+				name + " has no guidanceSteps (E2)");
+
+			boolean hasArriveStep = source.getGuidanceSteps().stream()
+				.anyMatch(s ->
+					(s.getCompletionCondition() == CompletionCondition.ARRIVE_AT_TILE
+						|| s.getCompletionCondition() == CompletionCondition.ARRIVE_AT_ZONE
+						|| s.getCompletionCondition() == CompletionCondition.PLAYER_ON_PLANE)
+					&& s.getWorldX() > 0
+					&& s.getWorldY() > 0);
+			assertTrue(hasArriveStep,
+				name + " has no auto-arrival step with positive world coordinates (E2)");
+		}
+	}
+
+	/**
+	 * E6 - Mogre and Rockslug must declare requiredItemIds on their kill step.
+	 * The remaining twelve sources are waived: they need no consumable access
+	 * item to enter or complete the kill.
+	 */
+	@Test
+	public void e6WiredSourcesHaveRequiredItemIds()
+	{
+		for (String name : E6_WIRED_SOURCES)
+		{
+			CollectionLogSource source = findSource(name);
+			assertNotNull(source, "missing D4 batch 5 E6 source: " + name);
+			boolean hasRequiredItems = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getRequiredItemIds() != null
+					&& !s.getRequiredItemIds().isEmpty());
+			assertTrue(hasRequiredItems,
+				name + " has no step with requiredItemIds - E6 wiring is mandatory for this source");
+		}
+	}
+
+	/** E8 - every source must have a requirements block with at least one skill or quest. */
+	@Test
+	public void allBatch5SourcesHaveRequirements()
+	{
+		for (String name : BATCH5_SOURCES)
+		{
+			CollectionLogSource source = findSource(name);
+			assertNotNull(source, "missing D4 batch 5 source: " + name);
+			assertNotNull(source.getRequirements(),
+				name + " has no requirements block (E8)");
+
+			boolean hasSkillOrQuest =
+				(source.getRequirements().getSkills() != null
+					&& !source.getRequirements().getSkills().isEmpty())
+				|| (source.getRequirements().getQuests() != null
+					&& !source.getRequirements().getQuests().isEmpty());
+			assertTrue(hasSkillOrQuest,
+				name + " requirements block has neither skills nor quests (E8)");
+		}
+	}
+
+	/** E8 (quest variant) - Brine Rat must declare a quest prerequisite. */
+	@Test
+	public void questGatedSourcesHaveQuestRequirement()
+	{
+		for (String name : QUEST_GATED_SOURCES)
+		{
+			CollectionLogSource source = findSource(name);
+			assertNotNull(source, "missing D4 batch 5 quest-gated source: " + name);
+			assertNotNull(source.getRequirements(),
+				name + " has no requirements block");
+			assertNotNull(source.getRequirements().getQuests(),
+				name + " has no quests list in requirements - Olaf's Quest is required for Brine Rat Cavern access");
+			assertTrue(!source.getRequirements().getQuests().isEmpty(),
+				name + " quests list is empty - Olaf's Quest must be declared");
+		}
+	}
+
+	/** E9 - at least one item must have a positive dropRate. */
+	@Test
+	public void allBatch5SourcesHaveDropRates()
+	{
+		for (String name : BATCH5_SOURCES)
+		{
+			CollectionLogSource source = findSource(name);
+			assertNotNull(source, "missing D4 batch 5 source: " + name);
+			assertNotNull(source.getItems(),
+				name + " has no items array (E9)");
+			assertTrue(!source.getItems().isEmpty(),
+				name + " has an empty items array (E9)");
+			boolean hasPositiveRate = source.getItems().stream()
+				.anyMatch(i -> i.getDropRate() > 0);
+			assertTrue(hasPositiveRate,
+				name + " has no item with a positive dropRate (E9)");
+		}
+	}
+
+	/** Section labels (Travel / Combat) must be present on at least one step per source. */
+	@Test
+	public void allBatch5SourcesHaveSectionLabels()
+	{
+		for (String name : BATCH5_SOURCES)
+		{
+			CollectionLogSource source = findSource(name);
+			assertNotNull(source, "missing D4 batch 5 source: " + name);
+			boolean hasSectionLabel = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getSection() != null && !s.getSection().isBlank());
+			assertTrue(hasSectionLabel,
+				name + " has no step with a section label");
+		}
+	}
+
+	// -- helpers --
+
+	private CollectionLogSource findSource(String name)
+	{
+		return database.getAllSources().stream()
+			.filter(s -> name.equals(s.getName()))
+			.findFirst()
+			.orElse(null);
+	}
+}


### PR DESCRIPTION
## Sources touched (14)

Crawling Hand, Cave Crawler, Cockatrice, Pyrefiend, Mogre, Rockslug, Jelly, Brine Rat, Turoth, Bloodveld, Infernal Mage, Dust Devil, Aberrant Spectre, Kurask.

All 14 confirmed present in `drop_rates.json`. None are in the D2 or D3 covered sets. No sources were skipped or added.

## Long-tail bar elements authored per source

Per `docs/contributor-guide/deep-guidance-bar.md` §"Long-tail bar", Batch 5 authors against the 5-element relaxed bar. Elements E3, E4, E5, E7 are waived for this batch (no phase mechanics, no multi-cycle loop, no hard-to-replace loadout beyond the two E6 cases below).

| Element | Status | Notes |
|---------|--------|-------|
| **E1 travel tip** | Pre-existing on all 14 | Slayer Tower cluster: slayer ring / fairy ring CKS. Fremennik cluster: slayer ring / fairy ring AJR. Mogre: Port Sarim. Brine Rat: fairy ring DKS. Dust Devil: Pollnivneach teleport. |
| **E2 auto-arrival** | Pre-existing on all 14 | ARRIVE_AT_TILE, ARRIVE_AT_ZONE, or PLAYER_ON_PLANE on every travel leg. MANUAL only on dungeon-entry steps where tile detection cannot fire. |
| **E6 bank-and-return** | Newly wired on Mogre + Rockslug; waived on 12 | Mogre kill step: `requiredItemIds: [6664]` (fishing explosive - consumed to spawn NPC). Rockslug kill step: `requiredItemIds: [4161]` (bag of salt - consumed to finish the kill). Remaining 12 sources are reachable and completable with no consumable access item. |
| **E8 prerequisites** | Pre-existing on all 14 | Slayer skill levels 5-70 on each source. Brine Rat additionally declares `OLAFS_QUEST` (required to enter Brine Rat Cavern). |
| **E9 drop rate confidence** | Pre-existing on all 14 | Rates sourced from OSRS Wiki. All items carry at least 6 decimal places. `validate_drop_rates` passed clean on all 14 sources before and after edits. |

**New in this batch:** section labels (`Travel` / `Combat`) added to every guidance step across all 14 sources. These were absent before; the test asserts them.

## Before/after gap rows

| Source | Before (gap) | After |
|--------|-------------|-------|
| All 14 | Missing section labels; Mogre + Rockslug missing E6 | Section labels on all steps; E6 wired on Mogre + Rockslug |

## Test count

`D4Batch5RegressionTest` -- 7 tests:
1. `allBatch5SourcesExistInDatabase`
2. `allBatch5SourcesHaveTravelTip` (E1)
3. `allBatch5SourcesHaveAutoArrivalStep` (E2)
4. `e6WiredSourcesHaveRequiredItemIds` (E6 -- Mogre + Rockslug only)
5. `allBatch5SourcesHaveRequirements` (E8)
6. `questGatedSourcesHaveQuestRequirement` (E8 quest variant -- Brine Rat)
7. `allBatch5SourcesHaveDropRates` (E9)
8. `allBatch5SourcesHaveSectionLabels`

All 7 pass (8 assertions across 7 test methods). Full `./gradlew build` green.

## Data sourcing

Drop rates: OSRS Wiki. NPC IDs: verified via `npc_lookup` MCP tool against RuneLite's NpcID constants. Coordinates: pre-existing from prior authoring pass, confirmed via `guidance_lint` (INFO-only distance warnings for underground dungeon planes -- expected for multi-plane dungeons, not actionable). Not validated in-client.

## Uncertain data points for orchestrator review

- **Aberrant Spectre `npcId: 2`** -- confirmed correct by `npc_lookup` (IDs 2-7 are all Aberrant Spectre variants; 2 is the primary). No change needed.
- **Fishing Explosive item ID 6664** -- Mogre E6. RuneLite `FISHING_EXPLOSIVE = 6664` confirmed. IDs 6660 (guide variant) and 18809 (newer variant) also exist; 6664 is the standard tradeable form. Flag for in-client check if the spawn mechanic has changed.
- **Bag of Salt item ID 4161** -- Rockslug E6. RuneLite `SLAYER_BAG_OF_SALT = 4161` confirmed.

`guidance_lint`: INFO-only (no CRITICAL/WARNING). `validate_drop_rates`: clean on all 14. `data_ascii_lint`: 0 violations.

Do not merge -- orchestrator review requested.