### PR TITLE
fix(data): correct Underwater Crabs dive step trigger

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -28644,13 +28644,12 @@
         "section": "Travel"
       },
       {
-        "description": "Dive into the underwater entrance at Mudskipper Point. Equip your fishbowl helmet and diving apparatus before diving. The entrance is on the south side of the point.",
-        "worldX": 2987,
-        "worldY": 3033,
+        "description": "Equip your fishbowl helmet and diving apparatus, then dive into the underwater entrance on the south side of Mudskipper Point to descend to the Mogre Camp underwater area.",
+        "worldX": 2978,
+        "worldY": 9181,
         "worldPlane": 0,
-        "objectId": 10905,
-        "objectInteractAction": "Dive-into",
-        "completionCondition": "PLAYER_ON_PLANE",
+        "completionCondition": "ARRIVE_AT_TILE",
+        "completionDistance": 10,
         "section": "Travel"
       },
       {


### PR DESCRIPTION
## Problem
D4 batch 3 (#661) authored the Underwater Crabs dive step (step 2) with `objectId: 10905` + `objectInteractAction: "Dive-into"` and `completionCondition: PLAYER_ON_PLANE`. Two defects:

- **`10905` is an unnamed cache object** whose known spawns are at (3050,4687)/(3370,2831)/... — none at Mudskipper Point (~2987,3033). The in-client outline/arrow would not resolve.
- **`PLAYER_ON_PLANE` cannot fire here** — the Mogre Camp underwater area sits on the same plane (0) as the surface, just a shifted region (y ~9181). The step would never auto-advance.

## Fix
Strip the bogus object interaction; retarget step 2 to an `ARRIVE_AT_TILE` trigger at the underwater arrival tile (2978, 9181, plane 0), so the step completes when the player actually descends to the Mogre Camp. Description updated to guide the dive without claiming a clickable object.

## Validation
- Retains the 5-step shape and every D4 batch 3 long-tail-bar element (travelTip, >=4 steps, ARRIVE_AT_TILE steps with coords, recommended gear, activity loop) — `D4Batch3RegressionTest` still green.
- Full `./gradlew test` passes; JSON parses; ASCII-clean.

Note: the surface dive interaction has no reliably-named scenery object in the cache; if in-client validation later identifies the correct dive object/NPC, the step can be upgraded to an object interaction.