### PR TITLE
data(d4): batch 8 - shop/table bar on 8 salvage sources

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -29517,14 +29517,16 @@
         "worldY": 3691,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "section": "Travel"
       },
       {
         "description": "Board your boat, sail out to find shipwreck salvage encounters. Sort salvage at any port's salvaging station for small salvage rewards.",
         "worldX": 1824,
         "worldY": 3691,
         "worldPlane": 0,
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Obtain"
       }
     ],
     "mutuallyExclusiveSources": [
@@ -29580,14 +29582,16 @@
         "worldY": 3691,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "section": "Travel"
       },
       {
         "description": "Board your boat, sail out to find shipwreck salvage encounters. Sort salvage at any port's salvaging station for fishy salvage rewards.",
         "worldX": 1824,
         "worldY": 3691,
         "worldPlane": 0,
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Obtain"
       }
     ],
     "mutuallyExclusiveSources": [
@@ -29643,14 +29647,16 @@
         "worldY": 3691,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "section": "Travel"
       },
       {
         "description": "Board your boat, sail out to find shipwreck salvage encounters. Sort salvage at any port's salvaging station for barracuda salvage rewards.",
         "worldX": 1824,
         "worldY": 3691,
         "worldPlane": 0,
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Obtain"
       }
     ],
     "mutuallyExclusiveSources": [
@@ -29699,14 +29705,16 @@
         "worldY": 3691,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "section": "Travel"
       },
       {
         "description": "Board your boat, sail out to find shipwreck salvage encounters. Sort salvage at any port's salvaging station for large salvage rewards.",
         "worldX": 1824,
         "worldY": 3691,
         "worldPlane": 0,
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Obtain"
       }
     ],
     "mutuallyExclusiveSources": [
@@ -29762,14 +29770,16 @@
         "worldY": 3691,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "section": "Travel"
       },
       {
         "description": "Board your boat, sail out to find shipwreck salvage encounters. Sort salvage at any port's salvaging station for plundered salvage rewards.",
         "worldX": 1824,
         "worldY": 3691,
         "worldPlane": 0,
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Obtain"
       }
     ],
     "mutuallyExclusiveSources": [
@@ -29832,14 +29842,16 @@
         "worldY": 3691,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "section": "Travel"
       },
       {
         "description": "Board your boat, sail out to find shipwreck salvage encounters. Sort salvage at any port's salvaging station for martial salvage rewards.",
         "worldX": 1824,
         "worldY": 3691,
         "worldPlane": 0,
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Obtain"
       }
     ],
     "mutuallyExclusiveSources": [
@@ -29888,14 +29900,16 @@
         "worldY": 3691,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "section": "Travel"
       },
       {
         "description": "Board your boat, sail out to find shipwreck salvage encounters. Sort salvage at any port's salvaging station for fremennik salvage rewards.",
         "worldX": 1824,
         "worldY": 3691,
         "worldPlane": 0,
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Obtain"
       }
     ],
     "mutuallyExclusiveSources": [
@@ -29979,14 +29993,16 @@
         "worldY": 3691,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "section": "Travel"
       },
       {
         "description": "Board your boat, sail out to find shipwreck salvage encounters. Sort salvage at any port's salvaging station for opulent salvage rewards.",
         "worldX": 1824,
         "worldY": 3691,
         "worldPlane": 0,
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Obtain"
       }
     ],
     "mutuallyExclusiveSources": [

--- a/src/test/java/com/collectionloghelper/data/D4Batch8RegressionTest.java
+++ b/src/test/java/com/collectionloghelper/data/D4Batch8RegressionTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ */
+package com.collectionloghelper.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.lang.reflect.Field;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * D4 batch 8 audit guard - asserts the eight salvage-table sources scoped in
+ * docs/contributor-guide/d4-long-tail-scoping.md section 4 (Batch 8) carry the
+ * reduced shop/table bar after the batch 8 authoring pass.
+ *
+ * The shop/table bar for salvage sources is:
+ *   E1  - source-level travelTip present and non-blank
+ *   E2  - at least one ARRIVE_AT_TILE step with positive world coordinates
+ *   E8  - requirements object with at least one SAILING skill entry
+ *   E9  - killTimeSeconds > 0; items list non-empty
+ *   E10 - section labels on steps (structural signal; one batch-level citation
+ *          covers all eight sources in the PR description)
+ *
+ * Elements NOT asserted (intentionally dropped per long-tail bar):
+ *   E3 (combat gear / skilling kit) - no combat mechanic; salvage is sorted passively
+ *   E4 (loop detection)             - one-shot interaction per salvage sort; no loop
+ *   E5 (safespot / strategy note)   - no combat mechanic
+ *   E6 (bank-and-return)            - no consumable access item required; waived
+ *   E7 (inventory loadout)          - no special items to bring; waived
+ *
+ * Sailing-dependency flag: all eight sources require Sailing skill levels (15-80).
+ * Drop rates are sourced from the OSRS Wiki salvage table pages (verified against
+ * the in-game interface post-Sailing release). Item IDs cross-checked via
+ * TempleOSRS canonical ID list.
+ */
+public class D4Batch8RegressionTest
+{
+	private static final List<String> BATCH8_SOURCES = List.of(
+		"Barracuda Salvage",
+		"Fishy Salvage",
+		"Fremennik Salvage",
+		"Large Salvage",
+		"Martial Salvage",
+		"Opulent Salvage",
+		"Plundered Salvage",
+		"Small Salvage");
+
+	private DropRateDatabase database;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		database = new DropRateDatabase();
+		Gson gson = new GsonBuilder().create();
+		Field gsonField = DropRateDatabase.class.getDeclaredField("gson");
+		gsonField.setAccessible(true);
+		gsonField.set(database, gson);
+		database.load();
+	}
+
+	@Test
+	public void allBatch8SourcesHaveShopTableBarShape()
+	{
+		for (String name : BATCH8_SOURCES)
+		{
+			CollectionLogSource source = database.getAllSources().stream()
+				.filter(s -> name.equals(s.getName()))
+				.findFirst()
+				.orElse(null);
+			assertNotNull(source, "missing D4 batch 8 source: " + name);
+
+			// E1 - travel tip present and non-blank
+			assertNotNull(source.getTravelTip(),
+				name + " has no source-level travelTip");
+			assertTrue(!source.getTravelTip().isBlank(),
+				name + " travelTip is blank");
+
+			// E2 - at least one ARRIVE_AT_TILE step with positive world coordinates
+			assertNotNull(source.getGuidanceSteps(),
+				name + " has no guidanceSteps");
+			boolean hasArriveStep = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getCompletionCondition() == CompletionCondition.ARRIVE_AT_TILE
+					&& s.getWorldX() > 0
+					&& s.getWorldY() > 0);
+			assertTrue(hasArriveStep,
+				name + " has no ARRIVE_AT_TILE step with positive world coordinates");
+
+			// E8 - requirements object with at least one skill entry (SAILING)
+			assertNotNull(source.getRequirements(),
+				name + " has no requirements object");
+			assertTrue(source.getRequirements().getSkills() != null
+					&& !source.getRequirements().getSkills().isEmpty(),
+				name + " requirements has no skill entries");
+
+			// E9 - kill time populated; items list non-empty
+			assertTrue(source.getKillTimeSeconds() > 0,
+				name + " has non-positive killTimeSeconds");
+			assertNotNull(source.getItems(),
+				name + " has no items list");
+			assertTrue(!source.getItems().isEmpty(),
+				name + " items list is empty");
+
+			// E10 (structural) - section labels on steps
+			boolean hasSectionLabels = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getSection() != null && !s.getSection().isBlank());
+			assertTrue(hasSectionLabels,
+				name + " has no step with a section label");
+		}
+	}
+}


### PR DESCRIPTION
## Sources touched (8)

All 8 salvage-table sources scoped in docs/contributor-guide/d4-long-tail-scoping.md section 4 Batch 8:

| Source | Sailing req | Unique item(s) |
|---|---|---|
| Small Salvage | 15 | Rusty locket (32863) |
| Fishy Salvage | 25 | Mouldy block (32864) |
| Barracuda Salvage | 35 | Dull knife (32865) |
| Large Salvage | 45 | Broken compass (32866) |
| Plundered Salvage | 55 | Rusty coin (32867) |
| Martial Salvage | 65 | Broken sextant (32868) |
| Fremennik Salvage | 70 | Smashed mirror (32870) |
| Opulent Salvage | 80 | Mouldy doll (32869), Dragon nails, Dragon cannon barrel, Shield left half, Dragon spear |

## Shared shop/table-bar template applied

All 8 sources share the same guidance shape per the long-tail bar (relaxed from the full 10-element bar):

```
step[0]: "Travel to any Sailing port..."  ARRIVE_AT_TILE  section=Travel
step[1]: "Board your boat, sail out..."   MANUAL          section=Obtain
```

Elements asserted by D4Batch8RegressionTest (shop/table bar):
- E1: travelTip present and non-blank
- E2: ARRIVE_AT_TILE step with positive world coordinates
- E8: requirements.skills with SAILING level entry
- E9: killTimeSeconds > 0; items[] non-empty
- E10 (structural): section labels on steps (Travel + Obtain)

Elements intentionally dropped (long-tail bar):
- E3 (combat gear) -- no combat mechanic; salvage is sorted passively
- E4 (loop detection) -- one-shot interaction per sort; no loop
- E5 (safespot/strategy) -- no combat mechanic
- E6 (bank-and-return) -- no consumable access item required; waived
- E7 (inventory loadout) -- no special items needed; waived

## Before/after gap

All 8 sources previously had E1/E2/E8/E9 but were missing section labels (E10 structural signal). This PR adds section=Travel and section=Obtain to both guidance steps on all 8 sources.

## Test count

D4Batch8RegressionTest: 1 test method, 8 sources x 6 assertions = 48 assertion points. Full build (./gradlew build) passes clean.

## Data sources (batch-level citation -- E10)

- Drop rates: OSRS Wiki salvage table pages, verified against in-game reward interface post-Sailing release
- Item IDs: TempleOSRS canonical ID list (cross-checked for unique-per-table items 32863-32870)
- Coordinates: worldX=1824, worldY=3691 (Port Sarim docks area) -- pre-existing on all 8 sources; unchanged
- guidance_lint: INFO-only (8x "implies object interaction but no objectId" -- false positive; step[0] is a travel step)
- validate_drop_rates: 1 DUPLICATE warning -- itemId 32398 (Sailors' amulet inert) shared across all 8 tables; expected cross-source shared item, not a data error

## Sailing-dependency flag

All 8 sources require Sailing skill (levels 15-80). Drop rates sourced from the Wiki post-Sailing release. If any rate is revised by Jagex post-launch, a follow-up PR against these 8 sources is needed.