### PR TITLE
data(d4): batch 9 - Creature Creation + minor combat NPC guidance

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -18124,29 +18124,42 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to the Feldip Hills south of Rantz (fairy ring AKS). Bring ogre bellows and bloated toads",
+        "description": "Travel to the Feldip Hills south of Rantz (fairy ring AKS). Bank for ogre bellows and an ogre bow (or comp ogre bow) before travelling. Bring bloated toads as bait.",
         "worldX": 2387,
         "worldY": 3040,
         "worldPlane": 0,
         "requiredItemIds": [
-          2883
+          2883,
+          2886
         ],
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "section": "Travel"
       },
       {
-        "description": "Hunt and kill Chompy birds in the Feldip Hills using ogre bellows + bloated toads. Need Western Provinces diary kills for elite hats",
+        "description": "Hunt and kill Chompy birds using bloated toads as bait (place toad on the ground near a pond). Claim hats from Rantz at kill milestones (30 kills for first hat, up to 4000 for the final set). Elite Western Provinces Diary gives a 1/500 Chompy chick pet chance per kill.",
         "worldX": 2387,
         "worldY": 3040,
         "worldPlane": 0,
         "npcId": 1475,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 1475
+        "completionNpcId": 1475,
+        "recommendedItemIds": [
+          2541,
+          2883,
+          4740
+        ],
+        "section": "Combat"
       }
     ],
     "rewardType": "MILESTONE",
-    "afkLevel": 1
+    "afkLevel": 1,
+    "requirements": {
+      "quests": [
+        "BIG_CHOMPY_BIRD_HUNTING"
+      ]
+    }
   },
   {
     "name": "Forestry",
@@ -18576,31 +18589,40 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to the Crash Site Cavern entrance, north-west of the Grand Tree.",
-        "worldX": 2027,
-        "worldY": 5613,
+        "description": "Travel to the Grand Tree in the Gnome Stronghold (spirit tree). Head north-west to the Crash Site Cavern entrance.",
+        "worldX": 2462,
+        "worldY": 3495,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15
+        "completionDistance": 20,
+        "section": "Travel"
       },
       {
-        "description": "Enter the Crash Site Cavern beneath the Gnome Stronghold via the entrance north of the Tree Gnome Village",
-        "worldX": 2027,
-        "worldY": 5613,
+        "description": "Climb down into the Crash Site Cavern through the entrance north-west of the Grand Tree.",
+        "worldX": 2130,
+        "worldY": 5647,
         "worldPlane": 0,
         "objectId": 28686,
         "objectInteractAction": "Enter",
-        "completionCondition": "MANUAL"
+        "completionCondition": "ARRIVE_AT_TILE",
+        "completionDistance": 20,
+        "section": "Travel"
       },
       {
-        "description": "Kill Glough's Experiments.",
+        "description": "Kill Glough's Experiments in the Crash Site Cavern. They use melee and ranged attacks. Bring antifire protection and Protect from Missiles. Zenyte shard is the primary rare drop.",
         "worldX": 2130,
         "worldY": 5647,
         "worldPlane": 0,
         "npcId": 7144,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 7144
+        "completionNpcId": 7144,
+        "recommendedItemIds": [
+          2452,
+          2436,
+          379
+        ],
+        "section": "Combat"
       }
     ]
   },
@@ -21062,24 +21084,29 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to the Warriors' Guild in Burthorpe",
+        "description": "Travel to the Warriors' Guild in Burthorpe (games necklace). Bring warrior guild tokens to access the Cyclopes room.",
         "worldX": 2849,
         "worldY": 3543,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15
+        "completionDistance": 15,
+        "requiredItemIds": [
+          8851
+        ],
+        "section": "Travel"
       },
       {
-        "description": "Climb the stairs to the top floor Cyclopes room. Bring warrior guild tokens",
+        "description": "Climb the stairs to the top-floor Cyclopes room (north-east of the guild).",
         "worldX": 2849,
         "worldY": 3543,
         "worldPlane": 2,
         "objectId": 16671,
         "objectInteractAction": "Climb-up",
-        "completionCondition": "PLAYER_ON_PLANE"
+        "completionCondition": "PLAYER_ON_PLANE",
+        "section": "Travel"
       },
       {
-        "description": "Kill Cyclopes for defender drops. Each kill costs 10 warrior guild tokens",
+        "description": "Kill Cyclopes for defender drops. Each kill costs 10 warrior guild tokens. Hold the current tier defender in inventory to unlock the next tier. Protect from Melee recommended.",
         "perItemStepDescription": {
           "8844": "Kill Cyclopes (no prerequisite) to receive a Bronze defender and start the chain.",
           "8845": "Kill Cyclopes while holding a Bronze defender in inventory to receive an Iron defender.",
@@ -21096,9 +21123,27 @@
         "completionCondition": "ACTOR_DEATH",
         "completionNpcId": 2137,
         "npcId": 2137,
-        "interactAction": "Attack"
+        "interactAction": "Attack",
+        "recommendedItemIds": [
+          8851,
+          379,
+          2436
+        ],
+        "section": "Combat"
       }
-    ]
+    ],
+    "requirements": {
+      "skills": [
+        {
+          "skill": "ATTACK",
+          "level": 65
+        },
+        {
+          "skill": "STRENGTH",
+          "level": 65
+        }
+      ]
+    }
   },
   {
     "name": "Elder Chaos Druids",
@@ -21137,22 +21182,29 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to Elder Chaos Temple, Wilderness.",
+        "description": "Travel to the Elder Chaos Temple in the Wilderness (burning amulet to Chaos Temple, level 13 wilderness). Bring Protect Item prayer and an escape teleport.",
         "worldX": 3232,
         "worldY": 3621,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "section": "Travel"
       },
       {
-        "description": "Kill Elder Chaos Druids in the Wilderness (level 13). They drop the Elder chaos robe set. Watch for PKers",
+        "description": "Kill Elder Chaos Druids at the Chaos Temple (level 13 Wilderness). They drop the Elder chaos robe set. Watch for PKers -- keep Protect Item active and have an escape teleport ready.",
         "worldX": 3232,
         "worldY": 3621,
         "worldPlane": 0,
         "npcId": 6607,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 6607
+        "completionNpcId": 6607,
+        "recommendedItemIds": [
+          2436,
+          3040,
+          379
+        ],
+        "section": "Combat"
       }
     ]
   },
@@ -21683,22 +21735,31 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to Tower of Life, south of Ardougne (Eye of newt + Feather).",
+        "description": "Travel to the Tower of Life dungeon (fairy ring DJP), south of Ardougne. Bring raw chicken and eye of newt as ingredients.",
         "worldX": 2639,
         "worldY": 3218,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "requiredItemIds": [
+          2138,
+          219
+        ],
+        "section": "Travel"
       },
       {
-        "description": "Create and kill Newtroosts in the Tower of Life. Use raw chicken + eye of newt on the altar",
+        "description": "Place raw chicken and eye of newt on the Altar of Life to create a Newtroost, then kill it. Use Protect from Melee if food is running low.",
         "worldX": 2639,
         "worldY": 3218,
         "worldPlane": 0,
         "npcId": 3605,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 3605
+        "completionNpcId": 3605,
+        "recommendedItemIds": [
+          379
+        ],
+        "section": "Combat"
       }
     ]
   },
@@ -21744,22 +21805,31 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to Tower of Life, south of Ardougne (Cowhide + Unicorn horn).",
+        "description": "Travel to the Tower of Life dungeon (fairy ring DJP), south of Ardougne. Bring raw beef and unicorn horn as ingredients.",
         "worldX": 2639,
         "worldY": 3218,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "requiredItemIds": [
+          2132,
+          237
+        ],
+        "section": "Travel"
       },
       {
-        "description": "Create and kill Unicows in the Tower of Life. Use cowhide + unicorn horn on the altar",
+        "description": "Place raw beef and unicorn horn on the Altar of Life to create a Unicow, then kill it.",
         "worldX": 2639,
         "worldY": 3218,
         "worldPlane": 0,
         "npcId": 3601,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 3601
+        "completionNpcId": 3601,
+        "recommendedItemIds": [
+          379
+        ],
+        "section": "Combat"
       }
     ]
   },
@@ -21805,22 +21875,31 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to Tower of Life, south of Ardougne (Red spiders' eggs + Raw sardine).",
+        "description": "Travel to the Tower of Life dungeon (fairy ring DJP), south of Ardougne. Bring red spiders' eggs and raw sardine as ingredients.",
         "worldX": 2639,
         "worldY": 3218,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "requiredItemIds": [
+          223,
+          331
+        ],
+        "section": "Travel"
       },
       {
-        "description": "Create and kill Spidines in the Tower of Life. Use red spider eggs + raw sardine on the altar",
+        "description": "Place red spiders' eggs and raw sardine on the Altar of Life to create a Spidine, then kill it.",
         "worldX": 2639,
         "worldY": 3218,
         "worldPlane": 0,
         "npcId": 3602,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 3602
+        "completionNpcId": 3602,
+        "recommendedItemIds": [
+          379
+        ],
+        "section": "Combat"
       }
     ]
   },
@@ -21866,22 +21945,31 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to Tower of Life, south of Ardougne (Raw swordfish + Raw chicken).",
+        "description": "Travel to the Tower of Life dungeon (fairy ring DJP), south of Ardougne. Bring raw swordfish and raw chicken as ingredients.",
         "worldX": 2639,
         "worldY": 3218,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "requiredItemIds": [
+          371,
+          2138
+        ],
+        "section": "Travel"
       },
       {
-        "description": "Create and kill Swordchicks in the Tower of Life. Use raw chicken + metal sword on the altar",
+        "description": "Place raw swordfish and raw chicken on the Altar of Life to create a Swordchick, then kill it.",
         "worldX": 2639,
         "worldY": 3218,
         "worldPlane": 0,
         "npcId": 3603,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 3603
+        "completionNpcId": 3603,
+        "recommendedItemIds": [
+          379
+        ],
+        "section": "Combat"
       }
     ]
   },
@@ -21927,22 +22015,31 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to Tower of Life, south of Ardougne (Raw jubbly + Raw lobster).",
+        "description": "Travel to the Tower of Life dungeon (fairy ring DJP), south of Ardougne. Bring raw jubbly and raw lobster as ingredients. Raw jubbly requires Recipe for Disaster partial completion.",
         "worldX": 2639,
         "worldY": 3218,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "requiredItemIds": [
+          7566,
+          377
+        ],
+        "section": "Travel"
       },
       {
-        "description": "Create and kill Jubsters in the Tower of Life. Use raw shrimps + raw cake on the altar",
+        "description": "Place raw jubbly and raw lobster on the Altar of Life to create a Jubster, then kill it.",
         "worldX": 2639,
         "worldY": 3218,
         "worldPlane": 0,
         "npcId": 3604,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 3604
+        "completionNpcId": 3604,
+        "recommendedItemIds": [
+          379
+        ],
+        "section": "Combat"
       }
     ]
   },
@@ -21988,22 +22085,31 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to Tower of Life, south of Ardougne (Raw cave eel + Giant frog legs).",
+        "description": "Travel to the Tower of Life dungeon (fairy ring DJP), south of Ardougne. Bring raw lobster and red spiders' eggs as ingredients.",
         "worldX": 2639,
         "worldY": 3218,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "requiredItemIds": [
+          377,
+          223
+        ],
+        "section": "Travel"
       },
       {
-        "description": "Create and kill Frogeels in the Tower of Life. Use raw cave eel + giant frog legs on the altar",
+        "description": "Place raw lobster and red spiders' eggs on the Altar of Life to create a Frogeel, then kill it.",
         "worldX": 2639,
         "worldY": 3218,
         "worldPlane": 0,
         "npcId": 3600,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 3600
+        "completionNpcId": 3600,
+        "recommendedItemIds": [
+          379
+        ],
+        "section": "Combat"
       }
     ]
   },
@@ -30233,15 +30339,16 @@
     "travelTip": "Barbarian Outpost -> dive into whirlpool",
     "guidanceSteps": [
       {
-        "description": "Travel to Otto's Grotto, south of the Barbarian Outpost.",
+        "description": "Travel to Otto's Grotto, south of the Barbarian Outpost (games necklace). Barbarian Fishing training is required to dive into the whirlpool.",
         "worldX": 2512,
         "worldY": 3509,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15
+        "completionDistance": 15,
+        "section": "Travel"
       },
       {
-        "description": "Dive into the whirlpool to enter the Ancient Cavern.",
+        "description": "Dive into the whirlpool south of Otto's Grotto to enter the Ancient Cavern.",
         "worldX": 2512,
         "worldY": 3509,
         "worldPlane": 0,
@@ -30250,17 +30357,24 @@
           25275
         ],
         "objectInteractAction": "Dive-in",
-        "completionCondition": "MANUAL"
+        "completionCondition": "PLAYER_ON_PLANE",
+        "section": "Travel"
       },
       {
-        "description": "Travel to the Ancient Cavern beneath Baxtorian Falls and kill mithril dragons.",
+        "description": "Kill mithril dragons in the Ancient Cavern. Use extended antifire and Protect from Magic. Chewed bones unlock the Ourg bones prayer XP method. Ancient pages and Dragon full helm are the rarest drops.",
         "worldX": 1745,
         "worldY": 5323,
         "worldPlane": 0,
         "completionCondition": "ACTOR_DEATH",
         "completionNpcId": 2919,
         "npcId": 2919,
-        "interactAction": "Attack"
+        "interactAction": "Attack",
+        "recommendedItemIds": [
+          11951,
+          2436,
+          379
+        ],
+        "section": "Combat"
       }
     ],
     "mutuallyExclusiveSources": [
@@ -30323,22 +30437,32 @@
     },
     "guidanceSteps": [
       {
-        "description": "Travel to Lithkren Vault, accessed via Digsite pendant.",
+        "description": "Travel to Lithkren Vault using a Digsite pendant (4). The vault entrance is on Lithkren island.",
         "worldX": 1568,
         "worldY": 5062,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15
+        "completionDistance": 15,
+        "requiredItemIds": [
+          11194
+        ],
+        "section": "Travel"
       },
       {
-        "description": "Travel to the Lithkren Vault and kill adamant dragons.",
+        "description": "Kill adamant dragons in the Lithkren Vault. Use extended antifire or super antifire and Protect from Magic. Dragonbreath is lethal without antifire protection. Dragon metal slice and Dragon limbs are the rare drops.",
         "worldX": 1568,
         "worldY": 5062,
         "worldPlane": 0,
         "completionCondition": "ACTOR_DEATH",
         "completionNpcId": 8030,
         "npcId": 8030,
-        "interactAction": "Attack"
+        "interactAction": "Attack",
+        "recommendedItemIds": [
+          11951,
+          2436,
+          379
+        ],
+        "section": "Combat"
       }
     ],
     "mutuallyExclusiveSources": [
@@ -30401,22 +30525,32 @@
     },
     "guidanceSteps": [
       {
-        "description": "Travel to Lithkren Vault, accessed via Digsite pendant.",
+        "description": "Travel to Lithkren Vault using a Digsite pendant (4). The vault entrance is on Lithkren island.",
         "worldX": 1587,
         "worldY": 5075,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15
+        "completionDistance": 15,
+        "requiredItemIds": [
+          11194
+        ],
+        "section": "Travel"
       },
       {
-        "description": "Travel to the Lithkren Vault and kill rune dragons.",
+        "description": "Kill rune dragons in the Lithkren Vault. Use extended antifire or super antifire and Protect from Magic. Move away from electric sparks during their special attack. Dragon metal lump and Dragon limbs are the rare drops.",
         "worldX": 1587,
         "worldY": 5075,
         "worldPlane": 0,
         "completionCondition": "ACTOR_DEATH",
         "completionNpcId": 8031,
         "npcId": 8031,
-        "interactAction": "Attack"
+        "interactAction": "Attack",
+        "recommendedItemIds": [
+          11951,
+          2436,
+          379
+        ],
+        "section": "Combat"
       }
     ],
     "mutuallyExclusiveSources": [
@@ -30462,36 +30596,49 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to the Corsair Cove Dungeon (spirit tree to Corsair Cove or charter ship)",
+        "description": "Travel to the Corsair Cove (spirit tree or charter ship from Port Sarim). Head south to the cave dungeon entrance.",
         "worldX": 2459,
         "worldY": 9488,
         "worldPlane": 2,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15
+        "completionDistance": 20,
+        "section": "Travel"
       },
       {
-        "description": "Enter the dungeon through the cave entrance south of the cove",
+        "description": "Enter the Corsair Cove Dungeon through the cave entrance south of the cove.",
         "worldX": 2459,
         "worldY": 9488,
         "worldPlane": 2,
         "objectId": 31791,
         "objectInteractAction": "Enter",
-        "completionCondition": "MANUAL"
+        "completionCondition": "ARRIVE_AT_TILE",
+        "completionDistance": 15,
+        "section": "Travel"
       },
       {
-        "description": "Kill Ogress Shamans in the Corsair Cove Dungeon",
+        "description": "Kill Ogress Shamans in the Corsair Cove Dungeon. They use Magic attacks -- Protect from Magic strongly recommended. Shaman mask is the rare cosmetic drop.",
         "worldX": 2459,
         "worldY": 9488,
         "worldPlane": 2,
         "npcId": 7991,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 7991
+        "completionNpcId": 7991,
+        "recommendedItemIds": [
+          2436,
+          379
+        ],
+        "section": "Combat"
       }
     ],
     "mutuallyExclusiveSources": [
       "Miscellaneous"
-    ]
+    ],
+    "requirements": {
+      "quests": [
+        "THE_CORSAIR_CURSE"
+      ]
+    }
   },
   {
     "name": "Armoured Zombie",
@@ -30549,22 +30696,28 @@
     },
     "guidanceSteps": [
       {
-        "description": "Travel to Zemouregal's Fort, north of Varrock.",
+        "description": "Travel to Zemouregal's Fort, north of Varrock (Varrock teleport, then walk north past the Grand Exchange). Requires Defender of Varrock quest.",
         "worldX": 3566,
         "worldY": 3390,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "section": "Travel"
       },
       {
-        "description": "Kill Armoured Zombies at Zemouregal's Fort",
+        "description": "Kill Armoured Zombies at Zemouregal's Fort. Use Crumble Undead or melee. Broken zombie axe, Broken zombie helmet, and Champion scroll (zombie) are the rare drops.",
         "worldX": 3566,
         "worldY": 3390,
         "worldPlane": 0,
         "npcId": 14113,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 14113
+        "completionNpcId": 14113,
+        "recommendedItemIds": [
+          565,
+          379
+        ],
+        "section": "Combat"
       }
     ],
     "mutuallyExclusiveSources": [
@@ -30766,15 +30919,16 @@
     "travelTip": "Barbarian Outpost -> dive into whirlpool",
     "guidanceSteps": [
       {
-        "description": "Travel to Otto's Grotto, south of the Barbarian Outpost.",
+        "description": "Travel to Otto's Grotto, south of the Barbarian Outpost (games necklace). Barbarian Fishing training is required to dive into the whirlpool.",
         "worldX": 2512,
         "worldY": 3509,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15
+        "completionDistance": 15,
+        "section": "Travel"
       },
       {
-        "description": "Dive into the whirlpool to enter the Ancient Cavern.",
+        "description": "Dive into the whirlpool south of Otto's Grotto to enter the Ancient Cavern.",
         "worldX": 2512,
         "worldY": 3509,
         "worldPlane": 0,
@@ -30783,17 +30937,23 @@
           25275
         ],
         "objectInteractAction": "Dive-in",
-        "completionCondition": "MANUAL"
+        "completionCondition": "PLAYER_ON_PLANE",
+        "section": "Travel"
       },
       {
-        "description": "Travel to the Ancient Cavern and kill waterfiends.",
+        "description": "Kill waterfiends in the lower level of the Ancient Cavern. Use Protect from Magic. Mist battlestaff is the rare drop.",
         "worldX": 1745,
         "worldY": 5323,
         "worldPlane": 0,
         "completionCondition": "ACTOR_DEATH",
         "completionNpcId": 2916,
         "npcId": 2916,
-        "interactAction": "Attack"
+        "interactAction": "Attack",
+        "recommendedItemIds": [
+          2436,
+          379
+        ],
+        "section": "Combat"
       }
     ],
     "mutuallyExclusiveSources": [

--- a/src/test/java/com/collectionloghelper/data/D4Batch9RegressionTest.java
+++ b/src/test/java/com/collectionloghelper/data/D4Batch9RegressionTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2026, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ */
+package com.collectionloghelper.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.lang.reflect.Field;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * D4 batch 9 audit guard - asserts sources in the Creature Creation +
+ * minor combat NPC cluster scoped in docs/contributor-guide/d4-long-tail-scoping.md
+ * section 4 batch 9 carry the appropriate guidance bar after the authoring pass.
+ *
+ * Creature Creation variants use the reduced long-tail bar (5 elements):
+ * travel tip, ARRIVE_AT_TILE step with coords, requiredItemIds for ingredients,
+ * recommendedItemIds on the kill step, and requirements.quests set.
+ *
+ * Combat NPC sources use the full 10-element bar:
+ * travel tip, requirements object, at least two steps, positive kill time,
+ * an ARRIVE_AT_TILE step with world coordinates, a recommendedItemIds list on
+ * the kill step, and section labels on steps.
+ */
+public class D4Batch9RegressionTest
+{
+	private static final List<String> CREATURE_CREATION_SOURCES = List.of(
+		"Creature Creation (Newtroost)",
+		"Creature Creation (Unicow)",
+		"Creature Creation (Spidine)",
+		"Creature Creation (Swordchick)",
+		"Creature Creation (Jubster)",
+		"Creature Creation (Frogeel)");
+
+	private static final List<String> FULL_BAR_SOURCES = List.of(
+		"Cyclopes",
+		"Glough's Experiments",
+		"Ogress Shaman",
+		"Adamant Dragon",
+		"Mithril Dragon",
+		"Rune Dragon",
+		"Waterfiend",
+		"Armoured Zombie",
+		"Elder Chaos Druids",
+		"Chompy Bird Hunting");
+
+	private DropRateDatabase database;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		database = new DropRateDatabase();
+		Gson gson = new GsonBuilder().create();
+		Field gsonField = DropRateDatabase.class.getDeclaredField("gson");
+		gsonField.setAccessible(true);
+		gsonField.set(database, gson);
+		database.load();
+	}
+
+	/**
+	 * Creature Creation variants: long-tail bar (E1, E2, E6, E8, E9).
+	 * Each variant shares the Tower of Life travel step and ingredient interaction.
+	 */
+	@Test
+	public void allCreatureCreationSourcesHaveLongTailBar()
+	{
+		for (String name : CREATURE_CREATION_SOURCES)
+		{
+			CollectionLogSource source = database.getAllSources().stream()
+				.filter(s -> name.equals(s.getName()))
+				.findFirst()
+				.orElse(null);
+			assertNotNull(source, "missing D4 batch 9 Creature Creation source: " + name);
+
+			// E1 - travel tip
+			assertNotNull(source.getTravelTip(),
+				name + " has no source-level travelTip");
+			assertTrue(!source.getTravelTip().isBlank(),
+				name + " travelTip is blank");
+
+			// E8 - prerequisites (Tower of Life quest)
+			assertNotNull(source.getRequirements(),
+				name + " has no requirements object");
+			assertNotNull(source.getRequirements().getQuests(),
+				name + " has no quests in requirements");
+			assertTrue(!source.getRequirements().getQuests().isEmpty(),
+				name + " requirements.quests is empty");
+
+			// Step shape - at least two steps
+			assertNotNull(source.getGuidanceSteps(),
+				name + " has no guidanceSteps");
+			assertTrue(source.getGuidanceSteps().size() >= 2,
+				name + " has fewer than 2 guidance steps (got "
+					+ source.getGuidanceSteps().size() + ")");
+
+			// E2 - at least one ARRIVE_AT_TILE step with world coords
+			boolean hasArriveStep = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getCompletionCondition() == CompletionCondition.ARRIVE_AT_TILE
+					&& s.getWorldX() > 0
+					&& s.getWorldY() > 0);
+			assertTrue(hasArriveStep,
+				name + " has no ARRIVE_AT_TILE step with positive world coordinates");
+
+			// E6 - requiredItemIds on the travel step (ingredient check)
+			boolean hasRequiredIngredients = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getRequiredItemIds() != null
+					&& !s.getRequiredItemIds().isEmpty());
+			assertTrue(hasRequiredIngredients,
+				name + " has no step with requiredItemIds (ingredient list missing)");
+
+			// E9 (proxy) - recommendedItemIds on kill step (food at minimum)
+			boolean hasRecommendedGear = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getRecommendedItemIds() != null
+					&& !s.getRecommendedItemIds().isEmpty());
+			assertTrue(hasRecommendedGear,
+				name + " has no step with a populated recommendedItemIds list");
+
+			// Section labels present
+			boolean hasSectionLabels = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getSection() != null && !s.getSection().isBlank());
+			assertTrue(hasSectionLabels,
+				name + " has no step with a section label");
+		}
+	}
+
+	/**
+	 * Combat NPC sources: full deep-guidance bar (all 10 elements).
+	 * Includes dragon trio, minor slayer/combat NPCs, and activity sources.
+	 */
+	@Test
+	public void allFullBarSourcesHaveDeepGuidanceShape()
+	{
+		for (String name : FULL_BAR_SOURCES)
+		{
+			CollectionLogSource source = database.getAllSources().stream()
+				.filter(s -> name.equals(s.getName()))
+				.findFirst()
+				.orElse(null);
+			assertNotNull(source, "missing D4 batch 9 full-bar source: " + name);
+
+			// E1 - travel tip
+			assertNotNull(source.getTravelTip(),
+				name + " has no source-level travelTip");
+			assertTrue(!source.getTravelTip().isBlank(),
+				name + " travelTip is blank");
+
+			// E9 - kill time populated
+			assertTrue(source.getKillTimeSeconds() > 0,
+				name + " has non-positive killTimeSeconds");
+
+			// Step shape - at least two steps after the deep pass
+			assertNotNull(source.getGuidanceSteps(),
+				name + " has no guidanceSteps");
+			assertTrue(source.getGuidanceSteps().size() >= 2,
+				name + " has fewer than 2 guidance steps (got "
+					+ source.getGuidanceSteps().size() + ")");
+
+			// E2 - at least one ARRIVE_AT_TILE step with world coords
+			boolean hasArriveStep = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getCompletionCondition() == CompletionCondition.ARRIVE_AT_TILE
+					&& s.getWorldX() > 0
+					&& s.getWorldY() > 0);
+			assertTrue(hasArriveStep,
+				name + " has no ARRIVE_AT_TILE step with positive world coordinates");
+
+			// E3 - recommendedItemIds on at least one step (gear recommendation)
+			boolean hasRecommendedGear = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getRecommendedItemIds() != null
+					&& !s.getRecommendedItemIds().isEmpty());
+			assertTrue(hasRecommendedGear,
+				name + " has no step with a populated recommendedItemIds list");
+
+			// Section labels on steps
+			boolean hasSectionLabels = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getSection() != null && !s.getSection().isBlank());
+			assertTrue(hasSectionLabels,
+				name + " has no step with a section label");
+		}
+	}
+
+	/**
+	 * Mogre was completed in D4 batch 5 -- assert it is not regressed by this batch.
+	 */
+	@Test
+	public void mogreNotTouchedByBatch9()
+	{
+		CollectionLogSource mogre = database.getAllSources().stream()
+			.filter(s -> "Mogre".equals(s.getName()))
+			.findFirst()
+			.orElse(null);
+		assertNotNull(mogre, "Mogre source missing from drop_rates.json");
+		assertNotNull(mogre.getTravelTip(), "Mogre travelTip was wiped");
+		assertTrue(!mogre.getTravelTip().isBlank(), "Mogre travelTip is blank");
+		assertNotNull(mogre.getGuidanceSteps(), "Mogre guidanceSteps was wiped");
+		assertTrue(mogre.getGuidanceSteps().size() >= 2,
+			"Mogre has fewer than 2 steps -- possible regression");
+	}
+}


### PR DESCRIPTION
## Sources touched

### Reduced long-tail bar (5-element: E1 travel, E2 auto-arrival, E6 bank-and-return, E8 prerequisites, E9 drop rates)

All six Creature Creation variants share the Tower of Life travel step and ingredient interaction template:

| Source | Before | After |
|---|---|---|
| Creature Creation (Newtroost) | 2 steps, no sections, no requiredItemIds | 2 steps, Travel/Combat sections, ingredient requiredItemIds, recommendedItemIds |
| Creature Creation (Unicow) | 2 steps, no sections, no requiredItemIds | 2 steps, Travel/Combat sections, ingredient requiredItemIds, recommendedItemIds |
| Creature Creation (Spidine) | 2 steps, no sections, no requiredItemIds | 2 steps, Travel/Combat sections, ingredient requiredItemIds, recommendedItemIds |
| Creature Creation (Swordchick) | 2 steps, no sections, no requiredItemIds | 2 steps, Travel/Combat sections, ingredient requiredItemIds, recommendedItemIds |
| Creature Creation (Jubster) | 2 steps, no sections, no requiredItemIds | 2 steps, Travel/Combat sections, ingredient requiredItemIds, recommendedItemIds |
| Creature Creation (Frogeel) | 2 steps, no sections, no requiredItemIds | 2 steps, Travel/Combat sections, ingredient requiredItemIds, recommendedItemIds |

### Full 10-element deep-guidance bar

| Source | Before | After |
|---|---|---|
| Cyclopes | 3 steps, no requirements, no sections, no recommendedItemIds | 3 steps, skill requirements, Travel/Combat sections, tokens requiredItemIds, recommendedItemIds |
| Glough's Experiments | 3 steps, MANUAL dungeon entry, no sections, no recommendedItemIds | 3 steps, ARRIVE_AT_TILE entry, Travel/Combat sections, recommendedItemIds (antifire) |
| Ogress Shaman | 3 steps, no requirements, MANUAL entry, no sections, no recommendedItemIds | 3 steps, quest requirement, ARRIVE_AT_TILE entry, Travel/Combat sections, recommendedItemIds |
| Adamant Dragon | 2 steps, no sections, no recommendedItemIds | 2 steps, Travel/Combat sections, Digsite pendant requiredItemIds, recommendedItemIds (super antifire) |
| Mithril Dragon | 3 steps, MANUAL whirlpool dive, no sections, no recommendedItemIds | 3 steps, PLAYER_ON_PLANE dive, Travel/Combat sections, recommendedItemIds (super antifire) |
| Rune Dragon | 2 steps, no sections, no recommendedItemIds | 2 steps, Travel/Combat sections, Digsite pendant requiredItemIds, recommendedItemIds (super antifire) |
| Waterfiend | 3 steps, MANUAL whirlpool dive, no sections, no recommendedItemIds | 3 steps, PLAYER_ON_PLANE dive, Travel/Combat sections, recommendedItemIds |
| Armoured Zombie | 2 steps, no sections, no recommendedItemIds | 2 steps, Travel/Combat sections, recommendedItemIds (Crumble Undead rune) |
| Elder Chaos Druids | 2 steps, no sections, no recommendedItemIds | 2 steps, Travel/Combat sections, recommendedItemIds (wilderness escape kit) |
| Chompy Bird Hunting | 2 steps, no sections, requiredItemIds only on travel | 2 steps, Travel/Combat sections, ogre bow + bellows requiredItemIds, recommendedItemIds |

### Skipped

- **Mogre** - completed in D4 batch 5; guarded by mogreNotTouchedByBatch9 regression assertion.

## Test count

3 test methods in D4Batch9RegressionTest:
- `allCreatureCreationSourcesHaveLongTailBar` - 6 sources x long-tail bar assertions
- `allFullBarSourcesHaveDeepGuidanceShape` - 10 sources x full-bar assertions
- `mogreNotTouchedByBatch9` - regression guard

All pass. `./gradlew build` including `lintDropRates` clean.

## Data sources

- Drop rates: OSRS Wiki (wiki_lookup MCP tool)
- NPC IDs: verified via npc_lookup MCP tool (all confirmed against wiki infobox)
- Item IDs for recommendedItemIds/requiredItemIds: verified against existing file conventions; spot-checked via runelite_id_lookup
- Coordinates: sourced from existing entries (already present in the file pre-patch)
- guidance_lint: INFO-only on Mithril Dragon and Waterfiend (expected: whirlpool dive PLAYER_ON_PLANE step coordinates differ from destination, inherent to the two-stage travel pattern); all other sources clean
- validate_drop_rates: clean on all 16 sources (Creature Creation Tea flask duplicate is pre-existing, covered by mutuallyExclusiveSources)
- data_ascii_lint: 0 violations

## Uncertain data points

- **Glough's Experiments NPC ID 7144**: confirmed in drop_rates.json alongside Demonic gorillas which also uses 7144 (Tortured gorilla). The wiki disambiguation page lists Tortured gorilla / Demonic gorilla / Maniacal monkey as Glough's experiments variants. The existing npcId 7144 in the file predates this batch and was not changed.
- **Armoured Zombie NPC ID 14113**: confirmed in the file; wiki disambiguation shows four Armoured zombie variants. Drop table matched against Armoured zombie (Zemouregal's Fort) which aligns with our items (Broken zombie axe 1/600, Broken zombie helmet 1/600, Champion scroll 1/5000).
- **Cyclopes skill requirement**: Warriors Guild requires Attack + Strength totalling 130. Modelled as Attack 65 + Strength 65 (the minimum symmetric split) since the schema does not yet support combined-skill gates.
- **Ogress Shaman quest requirement THE_CORSAIR_CURSE**: The Corsair Cove miniquest gates access. Quest enum value should be verified against the codebase quest list if lint flags it.