### PR TITLE
fix(data): correct Frost Nagua npcId to the killable monster

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -10628,7 +10628,7 @@
     ],
     "locationDescription": "Ruins of Tapoyauik, beneath Twilight Temple, Varlamore",
     "travelTip": "Pendant of ates -> Ruins of Tapoyauik (requires The Heart of Darkness), or quetzal whistle -> Civitas illa Fortis -> walk south",
-    "npcId": 13728,
+    "npcId": 13788,
     "interactAction": "Attack",
     "guidanceSteps": [
       {
@@ -10664,10 +10664,10 @@
         "worldX": 1362,
         "worldY": 4511,
         "worldPlane": 0,
-        "npcId": 13728,
+        "npcId": 13788,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
-        "completionNpcId": 13728,
+        "completionNpcId": 13788,
         "section": "Combat",
         "recommendedItemIds": [
           8010,


### PR DESCRIPTION
## Problem
The Frost Nagua source used `npcId 13728` at source level, on the combat step, and as `completionNpcId`. Per the RuneLite `NpcID` constants, `13728` is `FROST_NAGUA_CUTSCENE` — the killable slayer monster is `FROST_NAGUA` = `13788`. The combat-step outline and `ACTOR_DEATH` completion would target an NPC that is not present during normal kills.

Surfaced during the wave-12 review of #664 (D4 batch 7); the ID was pre-existing data, not introduced by that batch.

## Fix
Retarget all three references (`13728` → `13788`), consistent with the Earthen Nagua entry using the plain monster ID `14420`.

## Validation
Full `./gradlew test` green; JSON parses; ASCII-clean. Note: quest resolution (`Quest.valueOf`) and npc highlighting fail silently when an ID is wrong, so this class of defect is not caught by CI — verified against the RuneLite ID registry instead.