### PR TITLE
data(d4): batch 10a - open-chest bar on 7 rare-table chest sources

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -13119,19 +13119,24 @@
     "travelTip": "Fairy ring CIR -> Karuulm",
     "guidanceSteps": [
       {
-        "description": "Travel to Mount Karuulm near Konar (fairy ring CIR). Open Brimstone chests with brimstone keys",
+        "description": "Travel to Mount Karuulm near Konar (fairy ring CIR). Bring brimstone keys earned from Konar slayer tasks.",
         "worldX": 1309,
         "worldY": 3785,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "section": "Travel"
       },
       {
         "description": "Open the Brimstone chest with brimstone keys earned from Konar slayer tasks.",
         "worldX": 1309,
         "worldY": 3785,
         "worldPlane": 0,
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Open chest",
+        "requiredItemIds": [
+          23083
+        ]
       }
     ]
   },
@@ -13170,19 +13175,24 @@
     "travelTip": "Obelisk -> lvl 35 Wildy",
     "guidanceSteps": [
       {
-        "description": "Travel to the Wilderness chest locations (level 23 or 39). Use Larran's keys from Wilderness Slayer",
+        "description": "Travel to the ship west of Pirates' Hideout (level 39 Wilderness). Use Larran's keys from Wilderness Slayer creatures assigned by Krystilia.",
         "worldX": 3018,
         "worldY": 3955,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "section": "Travel"
       },
       {
         "description": "Open Larran's big chest with Larran's keys dropped by Wilderness slayer creatures.",
         "worldX": 3018,
         "worldY": 3955,
         "worldPlane": 0,
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Open chest",
+        "requiredItemIds": [
+          23490
+        ]
       }
     ],
     "ironKillTimeSeconds": 1029
@@ -13279,19 +13289,24 @@
     "travelTip": "Burning amulet -> Bandit Camp",
     "guidanceSteps": [
       {
-        "description": "Travel to East of Chaos Temple, level 14 Wilderness.",
+        "description": "Travel to the zombie pirate ship east of the Chaos Temple (level 14 Wilderness). Bring zombie pirate keys dropped by zombie pirates on the ship.",
         "worldX": 3373,
         "worldY": 3625,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "section": "Travel"
       },
       {
         "description": "Kill zombie pirates and use locker keys on the pirate lockers for loot.",
         "worldX": 3373,
         "worldY": 3625,
         "worldPlane": 0,
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Open locker",
+        "requiredItemIds": [
+          29449
+        ]
       }
     ]
   },
@@ -18510,21 +18525,28 @@
     "travelTip": "Digsite pendant -> Fossil Island",
     "guidanceSteps": [
       {
-        "description": "Travel to House on the Hill, Fossil Island.",
+        "description": "Travel to the House on the Hill on Fossil Island (digsite pendant or barge). Complete island activities to earn notes: build camp utilities, use magic mushtrees, use enriched bones on machines.",
         "worldX": 3774,
         "worldY": 3819,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "section": "Travel"
       },
       {
         "description": "Search the House on the Hill displays and complete activities for fossil notes.",
         "worldX": 3774,
         "worldY": 3819,
         "worldPlane": 0,
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Collect notes"
       }
-    ]
+    ],
+    "requirements": {
+      "quests": [
+        "BONE_VOYAGE"
+      ]
+    }
   },
   {
     "name": "Glough's Experiments",
@@ -18827,23 +18849,33 @@
     "travelTip": "Port Sarim docks -> sail",
     "guidanceSteps": [
       {
-        "description": "Sail to discoverable Sailing islands and search for Lost Schematics. Higher Sailing unlocks more islands",
+        "description": "Sail to discoverable islands via Port Sarim docks. Higher Sailing level unlocks more islands and schematic types.",
         "worldX": 1824,
         "worldY": 3691,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "section": "Travel"
       },
       {
         "description": "Find lost schematics while exploring islands during Sailing voyages.",
         "worldX": 1824,
         "worldY": 3691,
         "worldPlane": 0,
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Find schematics"
       }
     ],
     "rewardType": "SHOP",
-    "pointsPerHour": 2
+    "pointsPerHour": 2,
+    "requirements": {
+      "skills": [
+        {
+          "skill": "SAILING",
+          "level": 1
+        }
+      ]
+    }
   },
   {
     "name": "Monkey Backpacks",
@@ -18922,19 +18954,21 @@
     "travelTip": "Fairy ring CLR -> Ape Atoll",
     "guidanceSteps": [
       {
-        "description": "Travel to the Ape Atoll Agility Course (fairy ring CLR then navigate to course). Complete laps for monkey pieces",
+        "description": "Travel to the Ape Atoll Agility Course (fairy ring CLR, requires Monkey Madness II). Course starts at the top of the agility ladder.",
         "worldX": 2764,
         "worldY": 2703,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "section": "Travel"
       },
       {
         "description": "Complete laps of the Ape Atoll Agility Course to earn monkey backpack variants.",
         "worldX": 2764,
         "worldY": 2703,
         "worldPlane": 0,
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Complete laps"
       }
     ],
     "rewardType": "MILESTONE",
@@ -19982,23 +20016,33 @@
     "travelTip": "Teleport crystal -> Prifddinas",
     "guidanceSteps": [
       {
-        "description": "Travel to Elven Crystal Chest in Prifddinas.",
+        "description": "Travel to the Tower of Voices upper level in Prifddinas (teleport crystal or enhanced crystal teleport seed). Bring enhanced crystal keys.",
         "worldX": 3272,
         "worldY": 6084,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 15
+        "completionDistance": 15,
+        "section": "Travel"
       },
       {
         "description": "Open the Elven Crystal Chest in Prifddinas.",
         "worldX": 3272,
         "worldY": 6084,
         "worldPlane": 0,
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Open chest",
+        "requiredItemIds": [
+          23951
+        ]
       }
     ],
     "aggregated": false,
-    "ironKillTimeSeconds": 600
+    "ironKillTimeSeconds": 600,
+    "requirements": {
+      "quests": [
+        "SONG_OF_THE_ELVES"
+      ]
+    }
   },
   {
     "name": "Miscellaneous",

--- a/src/test/java/com/collectionloghelper/data/D4Batch10aRegressionTest.java
+++ b/src/test/java/com/collectionloghelper/data/D4Batch10aRegressionTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2026, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ */
+package com.collectionloghelper.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.lang.reflect.Field;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * D4 batch 10a audit guard - asserts the seven rare-table chest sources scoped
+ * in docs/contributor-guide/d4-long-tail-scoping.md section 4 (Batch 10, first
+ * split) carry the reduced open-chest bar after the authoring pass.
+ *
+ * The open-chest bar applied here is the long-tail bar (5 elements):
+ *   E1  - source-level travelTip present and non-blank
+ *   E2  - at least one ARRIVE_AT_TILE step with positive world coordinates
+ *   E6  - requiredItemIds present on the open step for key-gated sources
+ *         (Brimstone Chest, Larran's Big Chest, Elven Crystal Chest,
+ *          Zombie Pirate Locker); waived for Lost Schematics, Fossil Island
+ *          Notes, and Monkey Backpacks which have no consumable access key
+ *   E8  - requirements object where a quest or skill gate exists (Elven
+ *         Crystal Chest: Song of the Elves; Lost Schematics: Sailing 1;
+ *         Fossil Island Notes: Bone Voyage; Monkey Backpacks: already present)
+ *   E9  - items list non-empty; killTimeSeconds > 0
+ *   E10 - section labels on steps (structural signal; one batch-level citation
+ *         in the PR description covers all seven sources)
+ *
+ * Elements intentionally NOT asserted (dropped per long-tail bar):
+ *   E3 (combat gear / skilling kit) - no combat mechanic; chest opens only
+ *   E4 (loop detection)             - one-shot open interaction; no loop
+ *   E5 (safespot / strategy note)   - no combat mechanic on open step
+ *   E7 (inventory loadout)          - key bank-and-return (E6) covers access
+ *                                     items; full loadout list is overkill
+ *
+ * Drop rates sourced from the OSRS Wiki chest/locker pages. Item IDs for
+ * access keys cross-checked via RuneLite ItemID constants:
+ *   KONAR_KEY=23083, SLAYER_WILDERNESS_KEY=23490, PRIF_CRYSTAL_KEY=23951,
+ *   ZOMBIE_PIRATE_WILDY_KEY=29449.
+ */
+public class D4Batch10aRegressionTest
+{
+	/** All seven sources in this batch. */
+	private static final List<String> BATCH10A_SOURCES = List.of(
+		"Brimstone Chest",
+		"Larran's Big Chest",
+		"Elven Crystal Chest",
+		"Zombie Pirate Locker",
+		"Lost Schematics",
+		"Fossil Island Notes",
+		"Monkey Backpacks");
+
+	/**
+	 * Key-gated sources: the open step must carry a requiredItemIds list so
+	 * the plugin redirects players to the bank when the key is missing.
+	 */
+	private static final List<String> KEY_GATED_SOURCES = List.of(
+		"Brimstone Chest",
+		"Larran's Big Chest",
+		"Elven Crystal Chest",
+		"Zombie Pirate Locker");
+
+	/**
+	 * Sources with a quest or skill gate that must have a requirements object.
+	 * Monkey Backpacks already had requirements before this batch.
+	 */
+	private static final List<String> GATED_SOURCES = List.of(
+		"Elven Crystal Chest",
+		"Lost Schematics",
+		"Fossil Island Notes",
+		"Monkey Backpacks");
+
+	private DropRateDatabase database;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		database = new DropRateDatabase();
+		Gson gson = new GsonBuilder().create();
+		Field gsonField = DropRateDatabase.class.getDeclaredField("gson");
+		gsonField.setAccessible(true);
+		gsonField.set(database, gson);
+		database.load();
+	}
+
+	@Test
+	public void allBatch10aSourcesHaveOpenChestBarShape()
+	{
+		for (String name : BATCH10A_SOURCES)
+		{
+			CollectionLogSource source = database.getAllSources().stream()
+				.filter(s -> name.equals(s.getName()))
+				.findFirst()
+				.orElse(null);
+			assertNotNull(source, "missing D4 batch 10a source: " + name);
+
+			// E1 - travel tip present and non-blank
+			assertNotNull(source.getTravelTip(),
+				name + " has no source-level travelTip");
+			assertTrue(!source.getTravelTip().isBlank(),
+				name + " travelTip is blank");
+
+			// E2 - at least one ARRIVE_AT_TILE step with positive world coordinates
+			assertNotNull(source.getGuidanceSteps(),
+				name + " has no guidanceSteps");
+			boolean hasArriveStep = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getCompletionCondition() == CompletionCondition.ARRIVE_AT_TILE
+					&& s.getWorldX() > 0
+					&& s.getWorldY() > 0);
+			assertTrue(hasArriveStep,
+				name + " has no ARRIVE_AT_TILE step with positive world coordinates");
+
+			// E9 - items list non-empty; killTimeSeconds > 0
+			assertNotNull(source.getItems(),
+				name + " has no items list");
+			assertTrue(!source.getItems().isEmpty(),
+				name + " items list is empty");
+			assertTrue(source.getKillTimeSeconds() > 0,
+				name + " has non-positive killTimeSeconds");
+
+			// E10 (structural) - section labels on steps
+			boolean hasSectionLabels = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getSection() != null && !s.getSection().isBlank());
+			assertTrue(hasSectionLabels,
+				name + " has no step with a section label");
+		}
+	}
+
+	@Test
+	public void keyGatedSourcesHaveRequiredItemIdsOnOpenStep()
+	{
+		for (String name : KEY_GATED_SOURCES)
+		{
+			CollectionLogSource source = database.getAllSources().stream()
+				.filter(s -> name.equals(s.getName()))
+				.findFirst()
+				.orElse(null);
+			assertNotNull(source, "missing key-gated batch 10a source: " + name);
+
+			// E6 - at least one step must carry a non-empty requiredItemIds list
+			boolean hasKeyRequirement = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getRequiredItemIds() != null
+					&& !s.getRequiredItemIds().isEmpty());
+			assertTrue(hasKeyRequirement,
+				name + " has no step with requiredItemIds (key bank-and-return missing)");
+		}
+	}
+
+	@Test
+	public void gatedSourcesHaveRequirementsObject()
+	{
+		for (String name : GATED_SOURCES)
+		{
+			CollectionLogSource source = database.getAllSources().stream()
+				.filter(s -> name.equals(s.getName()))
+				.findFirst()
+				.orElse(null);
+			assertNotNull(source, "missing gated batch 10a source: " + name);
+
+			// E8 - requirements object present with at least one quest or skill entry
+			assertNotNull(source.getRequirements(),
+				name + " has no requirements object");
+			boolean hasQuestOrSkill =
+				(source.getRequirements().getQuests() != null
+					&& !source.getRequirements().getQuests().isEmpty())
+				|| (source.getRequirements().getSkills() != null
+					&& !source.getRequirements().getSkills().isEmpty());
+			assertTrue(hasQuestOrSkill,
+				name + " requirements has neither quests nor skills entries");
+		}
+	}
+}


### PR DESCRIPTION
## Sources touched (7)

All seven sources are `category: OTHER` chest/locker/activity interactions from D4 Batch 10 (first split). All authored against the **reduced long-tail bar** (E1, E2, E6 where applicable, E8 where gated, E9, E10) per `deep-guidance-bar.md` section 'Long-tail bar'.

| Source | E1 travelTip | E2 ARRIVE_AT_TILE | E6 key requiredItemIds | E8 requirements | E9 items/killTime | E10 section labels |
|---|---|---|---|---|---|---|
| Brimstone Chest | OK (pre-existing) | OK (pre-existing) | Added (KONAR_KEY 23083) | N/A - no gate | OK (pre-existing) | Added |
| Larran's Big Chest | OK (pre-existing) | OK (pre-existing) | Added (SLAYER_WILDERNESS_KEY 23490) | N/A - no gate | OK (pre-existing) | Added |
| Elven Crystal Chest | OK (pre-existing) | OK (pre-existing) | Added (PRIF_CRYSTAL_KEY 23951) | Added (SONG_OF_THE_ELVES) | OK (pre-existing) | Added |
| Zombie Pirate Locker | OK (pre-existing) | OK (pre-existing) | Added (ZOMBIE_PIRATE_WILDY_KEY 29449) | N/A - no gate | OK (pre-existing) | Added |
| Lost Schematics | OK (pre-existing) | OK (pre-existing) | N/A - no key (waived) | Added (SAILING level 1) | OK (pre-existing) | Added |
| Fossil Island Notes | OK (pre-existing) | OK (pre-existing) | N/A - no key (waived) | Added (BONE_VOYAGE) | OK (pre-existing) | Added |
| Monkey Backpacks | OK (pre-existing) | OK (pre-existing) | N/A - no key (waived) | OK (pre-existing) | OK (pre-existing) | Added |

## Open-chest bar template (shared across all 7)

Elements applied:
- **E1** Travel tip already present on all sources; step[0] descriptions updated to be player-facing and mention the access key where applicable.
- **E2** `ARRIVE_AT_TILE` step already present on all sources; coordinates kept as-is (pre-existing and valid).
- **E6** `requiredItemIds` added to the open/interact step on the four key-gated sources. Key item IDs verified against RuneLite `ItemID` constants. Waived on Lost Schematics, Fossil Island Notes, and Monkey Backpacks (no consumable access key).
- **E8** `requirements` added where a quest or skill gate exists. Brimstone Chest, Larran's Big Chest, and Zombie Pirate Locker have no quest/skill gate (access depends only on holding the key, which E6 covers). Lost Schematics gated behind Sailing level 1 (minimum to enter Sailing).
- **E9** Pre-existing on all sources; not changed.
- **E10** Section labels (`Travel` / `Open chest` / `Open locker` / `Find schematics` / `Collect notes` / `Complete laps`) added to all steps across all 7 sources.

Elements dropped (long-tail bar exemption):
- E3 (combat gear) - no combat mechanic; all sources are chest opens or activity interactions
- E4 (loop detection) - one-shot open interaction per visit; no cycle to loop
- E5 (safespot/strategy) - no combat mechanic
- E7 (full inventory loadout) - E6 bank-and-return covers the only hard-to-forget items (keys); full loadout unnecessary

## Before/after gap rows

| Source | Before: missing elements | After: gaps closed |
|---|---|---|
| Brimstone Chest | E6 (no key redirect), E10 (no section labels) | E6 + E10 added |
| Larran's Big Chest | E6, E10 | E6 + E10 added |
| Elven Crystal Chest | E6, E8, E10 | E6 + E8 + E10 added |
| Zombie Pirate Locker | E6, E10 | E6 + E10 added |
| Lost Schematics | E8, E10 | E8 + E10 added |
| Fossil Island Notes | E8, E10 | E8 + E10 added |
| Monkey Backpacks | E10 | E10 added |

## Test count

3 test methods in `D4Batch10aRegressionTest`:
1. `allBatch10aSourcesHaveOpenChestBarShape` - E1/E2/E9/E10 on all 7 sources
2. `keyGatedSourcesHaveRequiredItemIdsOnOpenStep` - E6 on the 4 key-gated sources
3. `gatedSourcesHaveRequirementsObject` - E8 on the 4 quest/skill-gated sources

All 3 pass. Full `./gradlew build` green.

## Data citations

- Drop rates: OSRS Wiki (Brimstone chest, Larran's big chest, Elven Crystal Chest, Zombie Pirate's Locker, Fossil island note book pages). Rates unchanged from pre-existing entries; this batch authors guidance structure only.
- Key item IDs: RuneLite `ItemID` constants (KONAR_KEY=23083, SLAYER_WILDERNESS_KEY=23490, PRIF_CRYSTAL_KEY=23951, ZOMBIE_PIRATE_WILDY_KEY=29449).
- Quest enum values: RuneLite `Quest` enum (SONG_OF_THE_ELVES, BONE_VOYAGE, MONKEY_MADNESS_II pre-existing).
- `validate_drop_rates`: passed clean on all 7 sources.
- `data_ascii_lint`: 0 violations.
- `guidance_lint`: INFO-only on 6 sources (objectId hints for chest interactions - not required at long-tail bar); Monkey Backpacks fully clean.

## Uncertain data points

- **Lost Schematics SAILING level**: Wiki states "Higher Sailing unlocks more islands" without specifying a minimum level for schematic-bearing islands. Set to level 1 (any Sailing) as the floor; may need tightening once content is fully documented.
- **Larran's Big Chest coordinates** (worldX 3018, worldY 3955): pre-existing; not re-verified in-game this pass.
- **Elven Crystal Chest worldY 6084**: Prifddinas elevated coordinate system; pre-existing value kept, not re-verified in-game.