### PR TITLE
data(d4): batch 12a-1 - long-tail minigame guidance (set 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -14161,7 +14161,8 @@
     "travelTip": "Minigame tele -> Pest Control",
     "guidanceSteps": [
       {
-        "description": "Travel to Void Knights' Outpost, south of Port Sarim.",
+        "section": "Travel",
+        "description": "Travel to Void Knights' Outpost south of Port Sarim. Use the Minigame teleport (Pest Control) for the fastest route.",
         "worldX": 2659,
         "worldY": 2676,
         "worldPlane": 0,
@@ -14169,7 +14170,8 @@
         "completionDistance": 20
       },
       {
-        "description": "Board a lander to play Pest Control. Defend the Void Knight by destroying all 4 portals. Earn commendation points for the Void Knight set pieces",
+        "section": "Queue",
+        "description": "Board the lander matching your combat level (Novice <100, Intermediate 100-150, Veteran 150+). Wait for the lander to fill and depart to the island.",
         "worldX": 2659,
         "worldY": 2676,
         "worldPlane": 0,
@@ -14178,8 +14180,32 @@
           "Intermediate",
           "Veteran"
         ],
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionDistance": 5
+      },
+      {
+        "section": "Round",
+        "description": "Destroy all 4 portals while defending the Void Knight. Use Protect from Melee when swarmed by spinners near the Void Knight. Prioritise portals over kills - the game ends instantly if the Void Knight falls.",
+        "worldX": 2659,
+        "worldY": 2676,
+        "worldPlane": 0,
+        "recommendedItemIds": [
+          8839,
+          8840,
+          11665
+        ],
         "completionCondition": "CHAT_MESSAGE_RECEIVED",
-        "completionChatPattern": "You have successfully defended the island!"
+        "completionChatPattern": "You have successfully defended the island!",
+        "loopBackToStep": 1,
+        "loopCount": 0
+      },
+      {
+        "section": "Reward",
+        "description": "Commendation points are awarded automatically after each won round. Spend at the Void Knight Commendations shop for Void armour pieces (150-650 pts each).",
+        "worldX": 2659,
+        "worldY": 2676,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL"
       }
     ],
     "rewardType": "SHOP",
@@ -15532,7 +15558,8 @@
     "travelTip": "Xeric's talisman -> Hosidius",
     "guidanceSteps": [
       {
-        "description": "Travel to the Tithe Farm in Hosidius (Xeric talisman Xeric Heart or fairy ring CIR then south)",
+        "section": "Travel",
+        "description": "Travel to Tithe Farm in Hosidius via Xeric's talisman (Xeric's Heart) or fairy ring CIR then walk south. Requires 34% Hosidius favour and 34 Farming.",
         "worldX": 1791,
         "worldY": 3504,
         "worldPlane": 0,
@@ -15540,10 +15567,35 @@
         "completionDistance": 20
       },
       {
-        "description": "Plant and harvest Golovanova fruit to earn Tithe Farm points for rewards.",
+        "section": "Setup",
+        "description": "Bring seeds scaled to your Farming level (Golovanova at 34+, Logavano at 54+, Bologano at 74+), a watering can or Gricoller's can, and stamina potions for long sessions.",
         "worldX": 1791,
         "worldY": 3504,
         "worldPlane": 0,
+        "recommendedItemIds": [
+          13353,
+          13639
+        ],
+        "completionCondition": "MANUAL"
+      },
+      {
+        "section": "Skilling",
+        "description": "Plant seeds in patches, water them before the timer expires (watch the plant stage indicator above each patch), and harvest when fully grown. Higher-tier seeds give more points per hour; aim for 74+ Tithe Farm points per round to trigger bonus rewards.",
+        "worldX": 1791,
+        "worldY": 3504,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL",
+        "loopBackToStep": 2,
+        "loopCount": 0
+      },
+      {
+        "section": "Reward",
+        "description": "Spend Tithe Farm points at Gricoller's exchange for the Farmer's outfit (400 pts total), Seed box (250 pts), Herb sack (250 pts), or Gricoller's can (200 pts).",
+        "worldX": 1791,
+        "worldY": 3504,
+        "worldPlane": 0,
+        "npcId": 7638,
+        "interactAction": "Trade",
         "completionCondition": "MANUAL"
       }
     ],
@@ -16274,7 +16326,8 @@
     "travelTip": "Minigame tele -> Castle Wars",
     "guidanceSteps": [
       {
-        "description": "Travel to Castle Wars arena, south of Observatory.",
+        "section": "Travel",
+        "description": "Travel to Castle Wars via the Minigame teleport. The arena entrance is south of the Observatory.",
         "worldX": 2440,
         "worldY": 3089,
         "worldPlane": 0,
@@ -16282,7 +16335,8 @@
         "completionDistance": 20
       },
       {
-        "description": "Play Castle Wars by capturing the enemy flag and defending your own. Earn tickets to buy gold decorative armour from Lanthus",
+        "section": "Queue",
+        "description": "Enter a team portal (Saradomin, Zamorak, or Guthix for a balanced game). Wait in the lobby until the 20-minute game begins.",
         "worldX": 2440,
         "worldY": 3089,
         "worldPlane": 0,
@@ -16293,6 +16347,33 @@
           "Zamorak",
           "Guthix"
         ],
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionDistance": 5
+      },
+      {
+        "section": "Round",
+        "description": "Capture the enemy flag from their castle and return it to your own base to score tickets. Bring explosives to destroy barricades or use a catapult to slow attackers. Each successful capture earns 1 Castle Wars ticket.",
+        "worldX": 2440,
+        "worldY": 3089,
+        "worldPlane": 0,
+        "recommendedItemIds": [
+          4071,
+          4069,
+          4068
+        ],
+        "completionCondition": "CHAT_MESSAGE_RECEIVED",
+        "completionChatPattern": "The game has ended",
+        "loopBackToStep": 1,
+        "loopCount": 0
+      },
+      {
+        "section": "Reward",
+        "description": "Spend Castle Wars tickets at Lanthus's shop for decorative armour. Gold armour sets are the most expensive (500-800 pts per piece) and require many games.",
+        "worldX": 2440,
+        "worldY": 3089,
+        "worldPlane": 0,
+        "npcId": 1295,
+        "interactAction": "Trade",
         "completionCondition": "MANUAL"
       }
     ],
@@ -16339,7 +16420,8 @@
     "travelTip": "Minigame tele -> Soul Wars",
     "guidanceSteps": [
       {
-        "description": "Travel to Isle of Souls, west of Edgeville.",
+        "section": "Travel",
+        "description": "Travel to Isle of Souls via the Minigame teleport (Soul Wars) or the portal west of Edgeville.",
         "worldX": 2210,
         "worldY": 2858,
         "worldPlane": 0,
@@ -16347,7 +16429,8 @@
         "completionDistance": 20
       },
       {
-        "description": "Talk to Nomad or enter the Soul Wars Portal to join a game.",
+        "section": "Queue",
+        "description": "Talk to Nomad or enter the Soul Wars portal to join a team (blue or red). Wait in the lobby until the game starts.",
         "worldX": 2210,
         "worldY": 2858,
         "worldPlane": 0,
@@ -16357,6 +16440,32 @@
           "Join",
           "Yes"
         ],
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionDistance": 5
+      },
+      {
+        "section": "Round",
+        "description": "Kill enemies to collect soul fragments, then offer them at the Soul obelisk to weaken the opposing Avatar. When the Avatar reaches 0 soul fragments, attack and kill it. Use Protect from Magic when fighting the Avatar directly.",
+        "worldX": 2210,
+        "worldY": 2858,
+        "worldPlane": 0,
+        "recommendedItemIds": [
+          25340,
+          25346
+        ],
+        "completionCondition": "CHAT_MESSAGE_RECEIVED",
+        "completionChatPattern": "The game has ended",
+        "loopBackToStep": 1,
+        "loopCount": 0
+      },
+      {
+        "section": "Reward",
+        "description": "Collect Zeal tokens from Nomad after each game. Spend on the Ectoplasmator (2500), Soul cape (2500), or Unsired shards. The Lil' creator pet has a 1/400 drop rate from the reward chest.",
+        "worldX": 2210,
+        "worldY": 2858,
+        "worldPlane": 0,
+        "npcId": 8521,
+        "interactAction": "Trade",
         "completionCondition": "MANUAL"
       }
     ],
@@ -16663,7 +16772,8 @@
     "travelTip": "Minigame tele -> LMS",
     "guidanceSteps": [
       {
-        "description": "Travel to Ferox Enclave, north of Varrock in the Wilderness.",
+        "section": "Travel",
+        "description": "Travel to Ferox Enclave via the Minigame teleport (Last Man Standing). The LMS lobby is on the island east of the enclave.",
         "worldX": 3151,
         "worldY": 3634,
         "worldPlane": 0,
@@ -16671,7 +16781,32 @@
         "completionDistance": 20
       },
       {
-        "description": "Play Last Man Standing - a battle royale minigame on the island east of Ferox Enclave. Earn points to buy the Halos and Dragon Claws ornament kit",
+        "section": "Queue",
+        "description": "Enter the LMS lobby building and choose Competitive or Casual mode. Competitive earns more points per match but requires staking coins to enter.",
+        "worldX": 3151,
+        "worldY": 3634,
+        "worldPlane": 0,
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionDistance": 5
+      },
+      {
+        "section": "Round",
+        "description": "Scavenge weapons, armour, and food from supply crates on the island. Fight other players; the last player standing wins. Prioritise securing food and a weapon early; loot defeated players mid-game.",
+        "worldX": 3151,
+        "worldY": 3634,
+        "worldPlane": 0,
+        "recommendedItemIds": [
+          24219,
+          24192
+        ],
+        "completionCondition": "CHAT_MESSAGE_RECEIVED",
+        "completionChatPattern": "The game has ended",
+        "loopBackToStep": 1,
+        "loopCount": 0
+      },
+      {
+        "section": "Reward",
+        "description": "Earn points per match (more for placements and kills). Spend at the LMS shop on Halos (450 pts), Ornate maul handle (15 pts), cosmetic paints, or the Guthixian icon (500 pts).",
         "worldX": 3151,
         "worldY": 3634,
         "worldPlane": 0,
@@ -17056,7 +17191,8 @@
         "objectInteractAction": null,
         "highlightItemIds": null,
         "useItemOnObject": false,
-        "completionChatPattern": null
+        "completionChatPattern": null,
+        "section": "Travel"
       },
       {
         "description": "Play Trouble Brewing on Mos Le'Harmless. Brew 'rum' by collecting ingredients and operating the distillery. Earn Pieces of Eight",
@@ -17082,7 +17218,8 @@
         "objectInteractAction": null,
         "highlightItemIds": null,
         "useItemOnObject": false,
-        "completionChatPattern": null
+        "completionChatPattern": null,
+        "section": "Queue"
       },
       {
         "description": "Take 25 buckets from the workbench using Take-5 to fill with water for brewing",
@@ -17105,7 +17242,8 @@
         "objectInteractAction": "Take-Tool",
         "highlightItemIds": null,
         "useItemOnObject": false,
-        "completionChatPattern": null
+        "completionChatPattern": null,
+        "section": "Brewing"
       },
       {
         "description": "Fill buckets at the water pumps and use them in the brewing process",
@@ -17130,7 +17268,8 @@
           1925
         ],
         "useItemOnObject": true,
-        "completionChatPattern": null
+        "completionChatPattern": null,
+        "section": "Brewing"
       },
       {
         "description": "Climb ladder to upper floor",
@@ -17156,7 +17295,8 @@
         "objectInteractAction": "Climb-up",
         "highlightItemIds": null,
         "useItemOnObject": false,
-        "completionChatPattern": null
+        "completionChatPattern": null,
+        "section": "Brewing"
       },
       {
         "description": "Empty buckets of water into the hopper",
@@ -17196,7 +17336,8 @@
             2
           ]
         ],
-        "completionChatPattern": null
+        "completionChatPattern": null,
+        "section": "Brewing"
       },
       {
         "description": "Climb ladder back to ground floor",
@@ -17224,7 +17365,8 @@
         "useItemOnObject": false,
         "completionChatPattern": null,
         "loopBackToStep": 4,
-        "loopCount": 3
+        "loopCount": 3,
+        "section": "Brewing"
       },
       {
         "description": "AFK until the game ends, then spend Pieces of Eight on rewards",
@@ -17265,7 +17407,8 @@
               }
             }
           ]
-        }
+        },
+        "section": "Reward"
       }
     ],
     "cumulativeTrackItemId": 1929,
@@ -17392,7 +17535,8 @@
     ],
     "guidanceSteps": [
       {
-        "description": "Travel to the Barbarian Assault outpost (games necklace or fairy ring CLQ)",
+        "section": "Travel",
+        "description": "Travel to Barbarian Outpost north of Baxtorian Falls via the Minigame teleport (Barbarian Assault) or a games necklace.",
         "worldX": 2519,
         "worldY": 3571,
         "worldPlane": 0,
@@ -17401,20 +17545,41 @@
         "completionDistance": 15
       },
       {
-        "description": "Play rounds to earn honour points. Buy gambles from Commander Connad for rare pet chance",
+        "section": "Queue",
+        "description": "Talk to Captain Cain to join a team of 5. Choose your role: Attacker, Collector, Defender, or Healer. Each role uses a different mechanic and earns role-specific honour points per wave.",
         "worldX": 2519,
         "worldY": 3571,
         "worldPlane": 0,
+        "npcId": 5257,
+        "interactAction": "Talk-to",
         "dialogOptions": [
           "Attacker",
           "Defender",
           "Collector",
           "Healer"
         ],
-        "completionCondition": "MANUAL"
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionDistance": 5
       },
       {
-        "description": "Buy rewards from Commander Connad",
+        "section": "Round",
+        "description": "Complete all 10 waves and defeat the Penance Queen. Always use the egg or bait type announced on your role's call panel - using the wrong type wastes points. On wave 10, Collectors must power the Egg launcher by depositing eggs into it to damage the Queen.",
+        "worldX": 2519,
+        "worldY": 3571,
+        "worldPlane": 0,
+        "recommendedItemIds": [
+          10551,
+          10553,
+          10555
+        ],
+        "completionCondition": "CHAT_MESSAGE_RECEIVED",
+        "completionChatPattern": "Congratulations, you've beaten the Penance Queen",
+        "loopBackToStep": 1,
+        "loopCount": 0
+      },
+      {
+        "section": "Reward",
+        "description": "Spend honour points at Commander Connad's shop: Fighter torso (1500 pts), Penance skirt (1500 pts), role hats (1100 pts each). Buy Gambles (500 pts) for a chance at the Pet penance queen (1/1000 per gamble).",
         "worldX": 2519,
         "worldY": 3571,
         "worldPlane": 0,

--- a/src/test/java/com/collectionloghelper/data/D4Batch12a1RegressionTest.java
+++ b/src/test/java/com/collectionloghelper/data/D4Batch12a1RegressionTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2026, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ */
+package com.collectionloghelper.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.lang.reflect.Field;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * D4 batch 12a-1 audit guard - asserts the seven long-tail minigame sources
+ * (Pest Control, Soul Wars, Last Man Standing, Castle Wars, Tithe Farm,
+ * Trouble Brewing, Barbarian Assault) carry the full deep-guidance bar after
+ * the batch 12a-1 authoring pass: travel tip, at least four guidance steps,
+ * section labels on steps, an ARRIVE_AT_TILE step with world coordinates,
+ * an activity-loop declaration (loopBackToStep), and a recommendedItemIds
+ * list on the activity step.
+ *
+ * Trouble Brewing is asserted separately - it has 8 steps including a
+ * multi-sub-loop brewing cycle, so its section and loop assertions use a
+ * broader shape check rather than the 4-step minimum.
+ */
+public class D4Batch12a1RegressionTest
+{
+	private static final List<String> STANDARD_MINIGAME_SOURCES = List.of(
+		"Pest Control",
+		"Soul Wars",
+		"Last Man Standing",
+		"Castle Wars",
+		"Tithe Farm",
+		"Barbarian Assault");
+
+	private DropRateDatabase database;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		database = new DropRateDatabase();
+		Gson gson = new GsonBuilder().create();
+		Field gsonField = DropRateDatabase.class.getDeclaredField("gson");
+		gsonField.setAccessible(true);
+		gsonField.set(database, gson);
+		database.load();
+	}
+
+	/**
+	 * Standard minigame sources: full deep-guidance bar with travel, queue,
+	 * activity-loop, and reward sections.
+	 */
+	@Test
+	public void allStandardMinigameSourcesHaveDeepGuidanceShape()
+	{
+		for (String name : STANDARD_MINIGAME_SOURCES)
+		{
+			CollectionLogSource source = database.getAllSources().stream()
+				.filter(s -> name.equals(s.getName()))
+				.findFirst()
+				.orElse(null);
+			assertNotNull(source, "missing D4 batch 12a-1 source: " + name);
+
+			// E1 - travel tip
+			assertNotNull(source.getTravelTip(),
+				name + " has no source-level travelTip");
+			assertTrue(!source.getTravelTip().isBlank(),
+				name + " travelTip is blank");
+
+			// Step count - at least four steps (Travel, Queue, Round, Reward)
+			assertNotNull(source.getGuidanceSteps(),
+				name + " has no guidanceSteps");
+			assertTrue(source.getGuidanceSteps().size() >= 4,
+				name + " has fewer than 4 guidance steps (got "
+					+ source.getGuidanceSteps().size() + ")");
+
+			// E2 - at least one ARRIVE_AT_TILE step with world coords
+			boolean hasArriveStep = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getCompletionCondition() == CompletionCondition.ARRIVE_AT_TILE
+					&& s.getWorldX() > 0
+					&& s.getWorldY() > 0);
+			assertTrue(hasArriveStep,
+				name + " has no ARRIVE_AT_TILE step with positive world coordinates");
+
+			// E4 - activity-loop declared (minigame round loops back to queue step >= 1)
+			boolean hasLoop = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getLoopBackToStep() > 0);
+			assertTrue(hasLoop,
+				name + " has no step with loopBackToStep > 0");
+
+			// E3 - recommendedItemIds on at least one step
+			boolean hasRecommendedGear = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getRecommendedItemIds() != null
+					&& !s.getRecommendedItemIds().isEmpty());
+			assertTrue(hasRecommendedGear,
+				name + " has no step with a populated recommendedItemIds list");
+
+			// E10 proxy - section labels on steps
+			boolean hasSectionLabels = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getSection() != null && !s.getSection().isBlank());
+			assertTrue(hasSectionLabels,
+				name + " has no step with a section label");
+		}
+	}
+
+	/**
+	 * Trouble Brewing: 8-step brewing loop. Asserts section labels, loop
+	 * presence, ARRIVE_AT_TILE, and minimum step count separately because its
+	 * structure differs from the 4-section standard minigame shape.
+	 */
+	@Test
+	public void troubleBrewingHasDeepGuidanceShape()
+	{
+		CollectionLogSource source = database.getAllSources().stream()
+			.filter(s -> "Trouble Brewing".equals(s.getName()))
+			.findFirst()
+			.orElse(null);
+		assertNotNull(source, "Trouble Brewing source missing from drop_rates.json");
+
+		// E1 - travel tip
+		assertNotNull(source.getTravelTip(), "Trouble Brewing has no travelTip");
+		assertTrue(!source.getTravelTip().isBlank(), "Trouble Brewing travelTip is blank");
+
+		// Step count - multi-step brewing loop retains at least 6 steps
+		assertNotNull(source.getGuidanceSteps(), "Trouble Brewing has no guidanceSteps");
+		assertTrue(source.getGuidanceSteps().size() >= 6,
+			"Trouble Brewing has fewer than 6 guidance steps (got "
+				+ source.getGuidanceSteps().size() + ")");
+
+		// E2 - at least one ARRIVE_AT_TILE step with world coords
+		boolean hasArriveStep = source.getGuidanceSteps().stream()
+			.anyMatch(s -> s.getCompletionCondition() == CompletionCondition.ARRIVE_AT_TILE
+				&& s.getWorldX() > 0
+				&& s.getWorldY() > 0);
+		assertTrue(hasArriveStep,
+			"Trouble Brewing has no ARRIVE_AT_TILE step with positive world coordinates");
+
+		// E4 - brewing sub-loop present (loops to step >= 1)
+		boolean hasLoop = source.getGuidanceSteps().stream()
+			.anyMatch(s -> s.getLoopBackToStep() > 0);
+		assertTrue(hasLoop, "Trouble Brewing has no loopBackToStep > 0 declaration");
+
+		// E10 proxy - section labels on steps
+		boolean hasSectionLabels = source.getGuidanceSteps().stream()
+			.anyMatch(s -> s.getSection() != null && !s.getSection().isBlank());
+		assertTrue(hasSectionLabels, "Trouble Brewing has no step with a section label");
+
+		// E8 - requirements present (Cabin Fever quest + 40 Cooking)
+		assertNotNull(source.getRequirements(), "Trouble Brewing has no requirements object");
+	}
+}

--- a/src/test/java/com/collectionloghelper/data/DropRateDatabaseTest.java
+++ b/src/test/java/com/collectionloghelper/data/DropRateDatabaseTest.java
@@ -527,30 +527,35 @@ public class DropRateDatabaseTest
 	}
 
 	/**
-	 * Pest Control final step must use CHAT_MESSAGE_RECEIVED with the confirmed
-	 * game-win message (OSRS Wiki: Pest_Control).
+	 * Pest Control round step must use CHAT_MESSAGE_RECEIVED with the confirmed
+	 * game-win message (OSRS Wiki: Pest_Control). The deep-guidance pass added a
+	 * Travel, Queue, Round, and Reward step; the round step (index 2) carries the
+	 * win detection and loop-back, while the final step is a MANUAL reward step.
 	 */
 	@Test
 	public void spotCheck_pestControl_finalStep_isChatMessageReceived()
 	{
 		CollectionLogSource source = database.getSourceByName("Pest Control");
-		assertNotNull( source,"Pest Control source must exist");
+		assertNotNull(source, "Pest Control source must exist");
 
 		List<GuidanceStep> steps = source.getGuidanceSteps();
-		assertNotNull( steps,"Pest Control must have guidance steps");
-		assertFalse( steps.isEmpty(),"Pest Control must have at least one step");
+		assertNotNull(steps, "Pest Control must have guidance steps");
+		assertTrue(steps.size() >= 3,
+			"Pest Control must have at least 3 steps after the deep-guidance pass");
 
-		GuidanceStep finalStep = steps.get(steps.size() - 1);
-		assertEquals(
-			CompletionCondition.CHAT_MESSAGE_RECEIVED,
-			finalStep.getCompletionCondition(),
-			"Pest Control final step must use CHAT_MESSAGE_RECEIVED");
+		// Round step is the one with CHAT_MESSAGE_RECEIVED and loopBackToStep
+		GuidanceStep roundStep = steps.stream()
+			.filter(s -> s.getCompletionCondition() == CompletionCondition.CHAT_MESSAGE_RECEIVED)
+			.findFirst()
+			.orElse(null);
+		assertNotNull(roundStep,
+			"Pest Control must have a CHAT_MESSAGE_RECEIVED step (round completion)");
 		assertNotNull(
-			finalStep.getCompletionChatPattern(),
-			"Pest Control final step must have a completionChatPattern");
+			roundStep.getCompletionChatPattern(),
+			"Pest Control round step must have a completionChatPattern");
 		assertEquals(
 			"You have successfully defended the island!",
-			finalStep.getCompletionChatPattern(),
+			roundStep.getCompletionChatPattern(),
 			"Pest Control chat pattern must match game-win message exactly");
 	}
 


### PR DESCRIPTION
## Sources authored (7 of 7)

All 7 sources raised to the full deep-guidance bar (Travel / Queue / Round / Reward sections, ARRIVE_AT_ZONE queue step, CHAT_MESSAGE_RECEIVED activity-loop with loopBackToStep + loopCount: 0, recommendedItemIds on round step).

| Source | Steps before | Steps after | Notes |
|---|---|---|---|
| Pest Control | 2 | 4 | Loop to Queue step (1); Void armour gear hint |
| Soul Wars | 2 | 4 | Loop to Queue step (1); Avatar strategy note |
| Last Man Standing | 2 | 4 | Loop to Queue step (1); scavenging strategy note |
| Castle Wars | 2 | 4 | Loop to Queue step (1); flag-capture strategy note |
| Tithe Farm | 2 | 4 | Skilling loop (step 2); Gricoller's can + Seed box gear hint |
| Trouble Brewing | 8 | 8 | Section labels only; existing 8-step brewing sub-loop preserved |
| Barbarian Assault | 3 | 4 | Loop to Queue step (1); role-call strategy note; Penance Queen tip |

## Sources skipped / deferred

None — all 7 in scope were below bar and are now authored.

## Test changes

- Added `D4Batch12a1RegressionTest.java` (2 tests, 7 sources asserted)
- Updated `DropRateDatabaseTest#spotCheck_pestControl_finalStep_isChatMessageReceived` to match the new 4-step shape (CHAT_MESSAGE_RECEIVED is now the Round step at index 2, not the final step)

## Data sources

- Drop rates / item IDs: OSRS Wiki (all items are shop-purchased; dropRate: 1.0 with pointCost)
- Coordinates: existing entries retained (verified via prior authoring passes)
- NPC IDs (Nomad 8521, Gricoller 7638, Lanthus 1295, Connad 5258, Cain 5257): OSRS Wiki
- `guidance_lint` (warning+): 7/7 clean
- `validate_drop_rates`: 7/7 clean
- `data_ascii_lint`: 0 violations
- `./gradlew build`: BUILD SUCCESSFUL (1655 tests, 0 failures)

## Uncertain data points

- Soul Wars NPC ID 8521 (Nomad reward trade): inferred from wiki; not verified in-game. If wrong, the interactAction on the Reward step will silently not highlight — step still advances MANUAL.
- Tithe Farm NPC ID 7638 (Gricoller): inferred from wiki. Same caveat.
- Castle Wars NPC ID 1295 (Lanthus): from wiki; same caveat.
- `ARRIVE_AT_ZONE` on Queue steps uses `completionDistance: 5` — no zone coordinates were added (that requires in-game verification). These steps will behave as proximity checks only.