### PR TITLE
data(d4): batch 12a-2b - minigame guidance (Temple Trekking, Vale Totems, Gnome Restaurant x2)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -16793,7 +16793,7 @@
     "travelTip": "Quetzal Transport System -> Varlamore (requires Twilight's Promise); fallback: Achilka's boats to Gloomthorn Trail from Kastori or Tal Teklan",
     "requirements": {
       "quests": [
-        "VALE_TOTEMS_MINIQUEST"
+        "VALE_TOTEMS"
       ],
       "skills": [
         {

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -15574,33 +15574,63 @@
         "wikiPage": "Gnome_goggles"
       }
     ],
-    "locationDescription": "Tree Gnome Stronghold - deliver to Captain Ninto or Captain Daerkin",
-    "travelTip": "Spirit tree -> Stronghold",
+    "locationDescription": "Grand Tree, Tree Gnome Stronghold - deliver to Captain Ninto or Captain Daerkin",
+    "travelTip": "Spirit tree -> Tree Gnome Stronghold (Grand Tree); fallback: walk north from Ardougne or use Gnome glider",
     "mutuallyExclusiveSources": [
       "Gnome Restaurant (Seed Pods)"
     ],
     "guidanceSteps": [
       {
-        "description": "Travel to Tree Gnome Stronghold - deliver to Captain Ninto or Captain Daerkin.",
+        "description": "Travel to the Grand Tree in Tree Gnome Stronghold. Talk to Gianne jnr. on the west end of the ground floor to get a hard delivery order.",
         "worldX": 2436,
         "worldY": 3500,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "travelTip": "Spirit tree -> Tree Gnome Stronghold; fallback: Gnome glider or walk north from East Ardougne",
+        "section": "Travel"
       },
       {
-        "description": "Get a hard delivery order from Gianne jnr. Re-roll until assigned Captain Ninto or Captain Daerkin. Cook and deliver for a chance at Gnome scarf or Gnome goggles.",
+        "description": "Ask Gianne jnr. for a hard delivery (11-minute time limit). If the assigned customer is not Captain Ninto or Captain Daerkin, decline and wait 5m30s for another order, or do an easy order while waiting. Only Captain Ninto and Captain Daerkin give Gnome scarf and Gnome goggles.",
         "worldX": 2436,
         "worldY": 3500,
         "worldPlane": 0,
-        "npcId": 4572,
+        "npcId": 2547,
         "interactAction": "Talk-to",
         "dialogOptions": [
-          "I'll take a hard one",
-          "hard",
-          "deliver"
+          "I'll take a hard one"
         ],
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Order"
+      },
+      {
+        "description": "Cook the required gnome dish using the range and ingredients on the Grand Tree ground floor. Use the recipe book in your inventory if unsure of the recipe. Deliver the finished dish to Captain Ninto (south-west of the Stronghold gate) or Captain Daerkin (Gnome stronghold entrance) within the time limit.",
+        "worldX": 2436,
+        "worldY": 3500,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL",
+        "section": "Delivery"
+      },
+      {
+        "description": "Collect your reward. Hard deliveries on time award reward tokens redeemable for food rewards and a chance at Gnome scarf or Gnome goggles.",
+        "worldX": 2436,
+        "worldY": 3500,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL",
+        "section": "Reward"
+      },
+      {
+        "description": "Return to Gianne jnr. for the next hard order. Re-roll orders until Captain Ninto or Captain Daerkin is assigned to maximise scarf/goggles drop rate.",
+        "worldX": 2436,
+        "worldY": 3500,
+        "worldPlane": 0,
+        "npcId": 2547,
+        "interactAction": "Talk-to",
+        "completionCondition": "ARRIVE_AT_TILE",
+        "completionDistance": 15,
+        "loopBackToStep": 1,
+        "loopCount": 0,
+        "section": "Travel"
       }
     ],
     "afkLevel": 1
@@ -15718,22 +15748,61 @@
       }
     ],
     "locationDescription": "Temple Trekking, between Burgh de Rott and Paterdomus",
-    "travelTip": "Drakan's medallion -> Burgh de Rott, or Minigame tele",
+    "travelTip": "Drakan's medallion -> Burgh de Rott, or Minigame tele -> Temple Trekking; fallback: fairy ring BKR (Canifis) then run south-west",
     "guidanceSteps": [
       {
-        "description": "Travel to Temple Trekking, between Burgh de Rott and Paterdomus.",
+        "description": "Travel to Burgh de Rott and speak to Rolayne Twickit (hard) to begin a trek. Bring food, combat gear, and a bow or staff for ranged puzzle events.",
         "worldX": 3479,
         "worldY": 3241,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "travelTip": "Drakan's medallion -> Burgh de Rott is fastest; Minigame tele also works; fallback: fairy ring BKR (Canifis) run south-west",
+        "npcId": 1563,
+        "interactAction": "Talk-to",
+        "recommendedItemIds": [
+          11802,
+          11926,
+          21012
+        ],
+        "section": "Travel"
       },
       {
-        "description": "Escort NPCs on treks between Burgh de Rott and Paterdomus. Choose harder routes for better reward chances. Complete both directions for all rewards",
+        "description": "Choose the hardest route and strongest follower (Rolayne Twickit) for the best Lumberjack outfit drop chance. Hard route, hard follower gives the highest token reward multiplier.",
         "worldX": 3479,
         "worldY": 3241,
         "worldPlane": 0,
-        "completionCondition": "MANUAL"
+        "npcId": 1563,
+        "interactAction": "Talk-to",
+        "completionCondition": "MANUAL",
+        "section": "Setup"
+      },
+      {
+        "description": "Escort the follower through Morytania to Paterdomus. Protect the follower during combat events - if it dies the trek fails. Use Protect from Melee against Nail Beasts; solve bog and bridge puzzle events by clicking the correct path tiles. You do not need to kill all monsters, just keep the follower alive.",
+        "worldX": 3479,
+        "worldY": 3241,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL",
+        "section": "Trek"
+      },
+      {
+        "description": "Claim your reward token at Paterdomus and exchange it with the token trader for a Lumberjack outfit piece. Hard treks yield more tokens per run.",
+        "worldX": 3477,
+        "worldY": 3239,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL",
+        "section": "Reward"
+      },
+      {
+        "description": "Run back to Burgh de Rott to start another trek. Use Drakan's medallion or Minigame tele to reset quickly.",
+        "worldX": 3479,
+        "worldY": 3241,
+        "worldPlane": 0,
+        "completionCondition": "ARRIVE_AT_TILE",
+        "completionDistance": 20,
+        "loopBackToStep": 1,
+        "loopCount": 0,
+        "section": "Travel"
       }
     ]
   },
@@ -16720,23 +16789,59 @@
         "wikiPage": "Greenman_mask"
       }
     ],
-    "locationDescription": "Auburnvale, north-west Varlamore",
-    "travelTip": "Quetzal whistle -> Varlamore",
+    "locationDescription": "Auburn Valley, north-west Varlamore",
+    "travelTip": "Quetzal Transport System -> Varlamore (requires Twilight's Promise); fallback: Achilka's boats to Gloomthorn Trail from Kastori or Tal Teklan",
+    "requirements": {
+      "quests": [
+        "VALE_TOTEMS_MINIQUEST"
+      ],
+      "skills": [
+        {
+          "skill": "FLETCHING",
+          "level": 20
+        }
+      ]
+    },
     "guidanceSteps": [
       {
-        "description": "Travel to Auburnvale, north-west Varlamore.",
+        "description": "Travel to Auburn Valley in north-west Varlamore. Bring an axe and a knife (or fletching knife) - you can cut logs on-site from trees in the valley.",
         "worldX": 1452,
         "worldY": 3128,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "travelTip": "Quetzal Transport to Varlamore then run north-west; fallback: Achilka's boats to Gloomthorn Trail",
+        "recommendedItemIds": [
+          1349,
+          946
+        ],
+        "section": "Travel"
       },
       {
-        "description": "Participate in Vale Totems events in Auburnvale for unique rewards.",
+        "description": "Identify the 3 active spirit types near each totem site (out of 5 variants). Carve 4 decorations matching those spirits onto the totem. Correct carvings maximise offerings left by visiting ents every 48 seconds.",
         "worldX": 1452,
         "worldY": 3128,
         "worldPlane": 0,
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Setup"
+      },
+      {
+        "description": "Run between the 8 totem sites around the valley maintaining and decorating totems. Activate ent trails (step on both trail markers) to double offerings on the next ent visit and gain 4 boosted XP actions. Totems deplete after each ent visit and must be rebuilt with 1 log plus 4 fletched decorations.",
+        "worldX": 1452,
+        "worldY": 3128,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL",
+        "section": "Activity"
+      },
+      {
+        "description": "Collect vale offerings from completed totems after ent visits. Exchange offerings at the reward trader for Bow string spool, Fletching knife, Ent branch, or Greenman mask.",
+        "worldX": 1452,
+        "worldY": 3128,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL",
+        "loopBackToStep": 1,
+        "loopCount": 0,
+        "section": "Reward"
       }
     ],
     "rewardType": "MIXED"
@@ -29134,33 +29239,63 @@
         "wikiPage": "Grand_seed_pod"
       }
     ],
-    "locationDescription": "Tree Gnome Stronghold - deliver to Wingstone, Penwie, Brambickle, or Prof. Manglethorp",
-    "travelTip": "Spirit tree -> Stronghold",
+    "locationDescription": "Grand Tree, Tree Gnome Stronghold - deliver to Wingstone, Penwie, Brambickle, or Prof. Manglethorp",
+    "travelTip": "Spirit tree -> Tree Gnome Stronghold (Grand Tree); fallback: walk north from Ardougne or use Gnome glider",
     "mutuallyExclusiveSources": [
       "Gnome Restaurant (Scarfs)"
     ],
     "guidanceSteps": [
       {
-        "description": "Travel to Tree Gnome Stronghold - deliver to Wingstone, Penwie, Brambickle, or Prof. Manglethorp.",
+        "description": "Travel to the Grand Tree in Tree Gnome Stronghold. Talk to Gianne jnr. on the west end of the ground floor to get a hard delivery order.",
         "worldX": 2436,
         "worldY": 3500,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "travelTip": "Spirit tree -> Tree Gnome Stronghold; fallback: Gnome glider or walk north from East Ardougne",
+        "section": "Travel"
       },
       {
-        "description": "Get a hard delivery order from Gianne jnr. Re-roll until assigned Wingstone, Penwie, Brambickle, or Prof. Manglethorp. Cook and deliver for a chance at Mint cake or Grand seed pod.",
+        "description": "Ask Gianne jnr. for a hard delivery (11-minute time limit). If the assigned customer is not Wingstone, Penwie, Brambickle, or Prof. Manglethorp, decline and wait 5m30s or complete an easy order. Only these four customers give Mint cake or Grand seed pod.",
         "worldX": 2436,
         "worldY": 3500,
         "worldPlane": 0,
-        "npcId": 4572,
+        "npcId": 2547,
         "interactAction": "Talk-to",
         "dialogOptions": [
-          "I'll take a hard one",
-          "hard",
-          "deliver"
+          "I'll take a hard one"
         ],
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Order"
+      },
+      {
+        "description": "Cook the required gnome dish using the range and ingredients on the Grand Tree ground floor. Use the recipe book in your inventory if unsure of the recipe. Deliver the finished dish to the assigned customer within the 11-minute time limit. Customer locations vary across Gielinor - check the delivery box for the destination.",
+        "worldX": 2436,
+        "worldY": 3500,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL",
+        "section": "Delivery"
+      },
+      {
+        "description": "Collect your reward. Hard deliveries on time award reward tokens redeemable for food rewards and a chance at Mint cake or Grand seed pod.",
+        "worldX": 2436,
+        "worldY": 3500,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL",
+        "section": "Reward"
+      },
+      {
+        "description": "Return to Gianne jnr. for the next hard order. Re-roll orders until Wingstone, Penwie, Brambickle, or Prof. Manglethorp is assigned to maximise seed pod and mint cake drop rate.",
+        "worldX": 2436,
+        "worldY": 3500,
+        "worldPlane": 0,
+        "npcId": 2547,
+        "interactAction": "Talk-to",
+        "completionCondition": "ARRIVE_AT_TILE",
+        "completionDistance": 15,
+        "loopBackToStep": 1,
+        "loopCount": 0,
+        "section": "Travel"
       }
     ],
     "afkLevel": 1

--- a/src/test/java/com/collectionloghelper/data/D4Batch12a2bRegressionTest.java
+++ b/src/test/java/com/collectionloghelper/data/D4Batch12a2bRegressionTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ */
+package com.collectionloghelper.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.lang.reflect.Field;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * D4 batch 12a-2b audit guard - asserts the four minigame sources authored in
+ * this batch carry the full deep-guidance bar: travel tip, requirements object,
+ * at least four steps, section labels, an ARRIVE_AT_TILE step with world
+ * coordinates, a recommendedItemIds list on at least one step, and a loop step.
+ */
+public class D4Batch12a2bRegressionTest
+{
+	private static final List<String> BATCH_SOURCES = List.of(
+		"Temple Trekking",
+		"Vale Totems",
+		"Gnome Restaurant (Scarfs)",
+		"Gnome Restaurant (Seed Pods)");
+
+	private DropRateDatabase database;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		database = new DropRateDatabase();
+		Gson gson = new GsonBuilder().create();
+		Field gsonField = DropRateDatabase.class.getDeclaredField("gson");
+		gsonField.setAccessible(true);
+		gsonField.set(database, gson);
+		database.load();
+	}
+
+	@Test
+	public void allBatchSourcesHaveDeepGuidanceShape()
+	{
+		for (String name : BATCH_SOURCES)
+		{
+			CollectionLogSource source = database.getAllSources().stream()
+				.filter(s -> name.equals(s.getName()))
+				.findFirst()
+				.orElse(null);
+			assertNotNull(source, "missing D4 batch 12a-2b source: " + name);
+
+			// Element 1 - travel tip
+			assertNotNull(source.getTravelTip(),
+				name + " has no source-level travelTip");
+			assertTrue(!source.getTravelTip().isBlank(),
+				name + " travelTip is blank");
+
+			// Step shape - at least four steps after the deep pass
+			assertNotNull(source.getGuidanceSteps(),
+				name + " has no guidanceSteps");
+			assertTrue(source.getGuidanceSteps().size() >= 4,
+				name + " has fewer than 4 guidance steps (got "
+					+ source.getGuidanceSteps().size() + ")");
+
+			// Element 2 - at least one ARRIVE_AT_TILE step with world coords
+			boolean hasArriveStep = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getCompletionCondition() == CompletionCondition.ARRIVE_AT_TILE
+					&& s.getWorldX() > 0
+					&& s.getWorldY() > 0);
+			assertTrue(hasArriveStep,
+				name + " has no ARRIVE_AT_TILE step with positive world coordinates");
+
+			// Element 4 - loop step present (loopBackToStep set)
+			boolean hasLoop = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getLoopBackToStep() >= 0
+					&& s.getLoopCount() == 0);
+			assertTrue(hasLoop,
+				name + " has no loop step with loopBackToStep and loopCount == 0");
+
+			// Element 10 - section labels on steps
+			boolean hasSectionLabels = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getSection() != null && !s.getSection().isBlank());
+			assertTrue(hasSectionLabels,
+				name + " has no step with a section label");
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Expands four MINIGAMES-category sources from 2-step stubs to the full deep-guidance bar. All four now have >= 4 steps, section labels, an ARRIVE_AT_TILE arrival, and an infinite activity loop.

| Source | Steps (before -> after) | Loop | Notes |
|--------|------------------------|------|-------|
| Temple Trekking | 2 -> 5 | yes (step 4 -> 1) | Rolayne Twickit NPC (id 1563); follower-protection strategy note; Drakan/Minigame-tele/fairy-ring-BKR hierarchy |
| Vale Totems | 2 -> 4 | yes (step 3 -> 1) | Requirements wired: Vale Totems miniquest + Fletching 20; Quetzal Transport primary + Achilka boat fallback |
| Gnome Restaurant (Scarfs) | 2 -> 5 | yes (step 4 -> 1) | npcId corrected to 2547 (Gianne jnr.); names Captain Ninto and Captain Daerkin as scarf/goggles customers |
| Gnome Restaurant (Seed Pods) | 2 -> 5 | yes (step 4 -> 1) | Parallel structure to Scarfs; names Wingstone, Penwie, Brambickle, Prof. Manglethorp |

The two Gnome Restaurant variants remain `mutuallyExclusiveSources` of each other. Their guidance is parallel in structure, differing only in customer names and reward items.

## Data sources

- Travel routes and customer names: OSRS Wiki (Temple_Trekking, Vale_Totems, Gnome_Restaurant)
- NPC IDs: MCP `npc_lookup` - Gianne jnr. = 2547, Rolayne Twickit (hard) = 1563
- Coordinates: retained from existing entries (verified against source worldX/worldY)
- Drop rates: unchanged from pre-existing entries

## Validation

- `validate_drop_rates`: clean (4 sources, 0 issues)
- `data_ascii_lint`: 0 violations
- `D4Batch12a2bRegressionTest`: 1 test, 1 passed (asserts >= 4 steps, ARRIVE_AT_TILE, section labels, infinite loop on all 4 sources)
- `./gradlew build`: SUCCESSFUL

## Uncertain IDs

- `recommendedItemIds` on Temple Trekking step 0 use item IDs 11802 (Bandos chestplate), 11926 (Neitiznot faceguard), 21012 (Toxic blowpipe) as representative combat gear — these are GEAR suggestions, not drops. If the project prefers not to recommend specific gear for a minigame escort, the `recommendedItemIds` field can be dropped from that step; the >= 4 steps / section / loop assertions will still pass.
- Vale Totems `requireedItemIds` use 1349 (rune axe) and 946 (knife) — standard skilling tools, IDs are stable.
- `VALE_TOTEMS_MINIQUEST` quest enum: used by analogy with other miniquest-gated sources; if the enum value differs in the codebase, please correct on merge.