### PR TITLE
data(d4): batch 12a-2a - minigame guidance (Fishing Trawler, MTA, Brimhaven, Rogues' Den)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -13858,23 +13858,60 @@
       }
     ],
     "locationDescription": "Brimhaven Agility Arena, east of Brimhaven",
-    "travelTip": "Fairy ring CKR -> Brimhaven",
+    "travelTip": "Fairy ring CKR -> Brimhaven, or charter ship to Brimhaven",
+    "requirements": {
+      "skills": [
+        {
+          "skill": "AGILITY",
+          "level": 40
+        }
+      ]
+    },
     "guidanceSteps": [
       {
-        "description": "Travel to Brimhaven Agility Arena, east of Brimhaven.",
+        "description": "Travel to Brimhaven Agility Arena east of Brimhaven. Fairy ring CKR is fastest; alternatively charter ship to Brimhaven from any coastal port. Pay 200gp entrance fee to Cap'n Izzy No-Beard at the door",
         "worldX": 2809,
         "worldY": 3194,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "travelTip": "Fairy ring CKR -> run east to arena entrance",
+        "section": "Travel"
       },
       {
-        "description": "Complete laps in the Brimhaven Agility Arena to earn agility tickets for rewards.",
+        "description": "Navigate the obstacle course inside the arena. Follow the blinking yellow arrow to the marked obstacle - only the highlighted obstacle awards a ticket. Tag it, then follow the next arrow. Avoid traps (spinning blades, dart traps) that deal damage",
+        "worldX": 2809,
+        "worldY": 3194,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL",
+        "recommendedItemIds": [
+          13237,
+          13238,
+          13239,
+          13240,
+          13241,
+          13242
+        ],
+        "section": "Activity"
+      },
+      {
+        "description": "Continue tagging highlighted obstacles to accumulate tickets. Prioritise the marked obstacle each time the arrow changes - missing it resets the ticket timer",
+        "worldX": 2809,
+        "worldY": 3194,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL",
+        "section": "Activity",
+        "loopBackToStep": 1,
+        "loopCount": 0
+      },
+      {
+        "description": "Exchange agility tickets with Cap'n Izzy No-Beard for Brimhaven Graceful recolours (250 tickets each piece) or the Pirate's hook (800 tickets). The full Graceful set takes 1500 tickets total",
         "worldX": 2809,
         "worldY": 3194,
         "worldPlane": 0,
         "completionCondition": "CHAT_MESSAGE_RECEIVED",
-        "completionChatPattern": "You have received an Agility Arena Ticket"
+        "completionChatPattern": "You have received an Agility Arena Ticket",
+        "section": "Reward"
       }
     ],
     "rewardType": "SHOP",
@@ -14297,22 +14334,56 @@
       }
     ],
     "locationDescription": "Mage Training Arena, north-east of Al Kharid",
-    "travelTip": "Ring of dueling -> Emir's Arena",
+    "travelTip": "Ring of dueling -> Emir's Arena, then run north-east",
+    "requirements": {
+      "skills": [
+        {
+          "skill": "MAGIC",
+          "level": 7
+        }
+      ]
+    },
     "guidanceSteps": [
       {
-        "description": "Travel to Mage Training Arena, north-east of Al Kharid.",
+        "description": "Travel to the Mage Training Arena north-east of Al Kharid. Ring of dueling to Emir's Arena is fastest; alternatively teleport to Al Kharid and run north-east past the Duel Arena ruins",
         "worldX": 3363,
         "worldY": 3316,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "travelTip": "Ring of dueling -> Emir's Arena, run north-east",
+        "section": "Travel"
       },
       {
-        "description": "Earn pizazz points from the four training rooms to buy rewards from the shop.",
+        "description": "Enter one of the four training rooms. Telekinetic: move statues with Telekinetic Grab. Alchemy: High Alch the correct items. Enchanting: Lvl-1 Enchant jewelry. Graveyard (needs Bones to Peaches unlocked): convert bones. Each room awards its own coloured pizazz points",
+        "worldX": 3374,
+        "worldY": 3316,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL",
+        "recommendedItemIds": [
+          564,
+          558,
+          562
+        ],
+        "section": "Activity"
+      },
+      {
+        "description": "Bank to restock runes and repeat training rooms until you have enough pizazz points for your target reward. Aim for the Graveyard room once Bones to Peaches is unlocked - it is the fastest pizazz per hour",
         "worldX": 3363,
         "worldY": 3316,
         "worldPlane": 0,
-        "completionCondition": "MANUAL"
+        "completionCondition": "MANUAL",
+        "section": "Activity",
+        "loopBackToStep": 1,
+        "loopCount": 0
+      },
+      {
+        "description": "When you have enough pizazz points, visit the reward shop inside the arena to purchase Infinity armour pieces, wands, Mage's book, or Bones to Peaches. The Master wand (17 pizazz of each type) and Mage's book are the primary targets",
+        "worldX": 3363,
+        "worldY": 3316,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL",
+        "section": "Reward"
       }
     ],
     "rewardType": "SHOP",
@@ -15648,22 +15719,61 @@
       }
     ],
     "locationDescription": "Fishing Trawler, Port Khazard",
-    "travelTip": "Minigame tele -> Trawler",
+    "travelTip": "Minigame tele -> Fishing Trawler, or fairy ring BKP -> Port Khazard",
+    "requirements": {
+      "skills": [
+        {
+          "skill": "FISHING",
+          "level": 15
+        }
+      ]
+    },
     "guidanceSteps": [
       {
-        "description": "Travel to Port Khazard (fairy ring BKP or Ardougne teleport). Board Murphy's trawler",
+        "description": "Travel to Port Khazard. Use the Minigame Grouping teleport (Fishing Trawler) for the fastest route, or fairy ring BKP then run south. Bring bailing buckets and rope for repairs",
         "worldX": 2661,
         "worldY": 3164,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "travelTip": "Minigame tele -> Fishing Trawler, or fairy ring BKP -> run south",
+        "requiredItemIds": [
+          1925,
+          954
+        ],
+        "section": "Travel"
       },
       {
-        "description": "Board Murphy's trawler at Port Khazard. Bail water and repair nets during the 5-minute voyage. Angler's outfit pieces are 1/8 per trawler reward",
+        "description": "Talk to Murphy and board the trawler when the game is ready to depart",
         "worldX": 2661,
         "worldY": 3164,
         "worldPlane": 0,
-        "completionCondition": "MANUAL"
+        "completionCondition": "PLAYER_ON_PLANE",
+        "targetPlane": 1,
+        "section": "Activity"
+      },
+      {
+        "description": "During the 10-minute voyage, bail water from flooded sections (use bucket on water) and repair damaged nets with rope. Bailing continuously maximises your loot share. Two or more unrepaired nets will end the trip early",
+        "worldX": 2661,
+        "worldY": 3164,
+        "worldPlane": 1,
+        "completionCondition": "MANUAL",
+        "recommendedItemIds": [
+          1925,
+          954
+        ],
+        "section": "Activity",
+        "loopBackToStep": 2,
+        "loopCount": 0
+      },
+      {
+        "description": "When the trawler returns to Port Khazard, collect your fish haul from Murphy. Each Angler outfit piece has approximately a 1-in-12 chance per completed voyage. Bank and board again for the next run",
+        "worldX": 2661,
+        "worldY": 3164,
+        "worldPlane": 0,
+        "completionCondition": "ARRIVE_AT_TILE",
+        "completionDistance": 20,
+        "section": "Reward"
       }
     ]
   },
@@ -15787,22 +15897,71 @@
       }
     ],
     "locationDescription": "Rogues' Den beneath the Burthorpe pub",
-    "travelTip": "Games necklace -> Burthorpe",
+    "travelTip": "Games necklace -> Burthorpe, enter trapdoor in the pub basement",
+    "requirements": {
+      "skills": [
+        {
+          "skill": "THIEVING",
+          "level": 50
+        },
+        {
+          "skill": "AGILITY",
+          "level": 50
+        }
+      ]
+    },
     "guidanceSteps": [
       {
-        "description": "Travel to Rogues' Den beneath the Burthorpe pub.",
+        "description": "Travel to Burthorpe via Games necklace teleport. Enter the pub (Toad and Chicken) and use the trapdoor in the basement to reach Rogues' Den. Bring no weapons or armour - the maze requires light carry weight for some obstacles",
         "worldX": 2907,
         "worldY": 3537,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "travelTip": "Games necklace -> Burthorpe, trapdoor in pub basement",
+        "section": "Travel"
       },
       {
-        "description": "Complete the Rogues' Den maze to earn pieces of the rogue equipment set.",
+        "description": "Navigate the maze using Thieving and Agility. Avoid pressure pads (step around them), pick locks on doors, and cross balance beams. Failing an obstacle teleports you to the start - wear nothing in armour slots to minimise failures",
         "worldX": 2907,
         "worldY": 3537,
         "worldPlane": 0,
-        "completionCondition": "MANUAL"
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionZone": [
+          3033,
+          4970,
+          3060,
+          4990,
+          1
+        ],
+        "recommendedItemIds": [
+          13237,
+          13238,
+          13239,
+          13240,
+          13241,
+          13242
+        ],
+        "section": "Activity"
+      },
+      {
+        "description": "At the end of the maze, search the safe to receive a random piece of rogue equipment. Each piece has approximately a 5-in-8 chance per run. All 5 pieces are required for the full set",
+        "worldX": 3033,
+        "worldY": 4980,
+        "worldPlane": 1,
+        "completionCondition": "MANUAL",
+        "section": "Reward"
+      },
+      {
+        "description": "To get remaining pieces, return through the trapdoor in the pub basement and repeat the maze. The maze layout is fixed - memorise the safe route to complete runs in under 3 minutes",
+        "worldX": 2907,
+        "worldY": 3537,
+        "worldPlane": 0,
+        "completionCondition": "ARRIVE_AT_TILE",
+        "completionDistance": 20,
+        "section": "Travel",
+        "loopBackToStep": 1,
+        "loopCount": 0
       }
     ],
     "afkLevel": 0

--- a/src/test/java/com/collectionloghelper/data/D4Batch12a2aRegressionTest.java
+++ b/src/test/java/com/collectionloghelper/data/D4Batch12a2aRegressionTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ */
+package com.collectionloghelper.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.lang.reflect.Field;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * D4 batch 12a-2a audit guard - asserts the four minigame sources scoped in
+ * the batch 12 minigame wave carry the full deep-guidance bar after the
+ * authoring pass: travel tip, requirements object, at least four steps,
+ * an ARRIVE_AT_TILE step with world coordinates, a recommendedItemIds list
+ * on at least one step, and section labels on steps.
+ */
+public class D4Batch12a2aRegressionTest
+{
+	private static final List<String> BATCH_SOURCES = List.of(
+		"Fishing Trawler",
+		"Mage Training Arena",
+		"Brimhaven Agility Arena",
+		"Rogues' Den");
+
+	private DropRateDatabase database;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		database = new DropRateDatabase();
+		Gson gson = new GsonBuilder().create();
+		Field gsonField = DropRateDatabase.class.getDeclaredField("gson");
+		gsonField.setAccessible(true);
+		gsonField.set(database, gson);
+		database.load();
+	}
+
+	@Test
+	public void allBatchSourcesHaveDeepGuidanceShape()
+	{
+		for (String name : BATCH_SOURCES)
+		{
+			CollectionLogSource source = database.getAllSources().stream()
+				.filter(s -> name.equals(s.getName()))
+				.findFirst()
+				.orElse(null);
+			assertNotNull(source, "missing D4 batch 12a-2a source: " + name);
+
+			// Element 1 - travel tip
+			assertNotNull(source.getTravelTip(),
+				name + " has no source-level travelTip");
+			assertTrue(!source.getTravelTip().isBlank(),
+				name + " travelTip is blank");
+
+			// Step shape - at least four steps after the deep pass
+			assertNotNull(source.getGuidanceSteps(),
+				name + " has no guidanceSteps");
+			assertTrue(source.getGuidanceSteps().size() >= 4,
+				name + " has fewer than 4 guidance steps after the deep-guidance pass (got "
+					+ source.getGuidanceSteps().size() + ")");
+
+			// Element 2 - at least one ARRIVE_AT_TILE step with world coords
+			boolean hasArriveStep = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getCompletionCondition() == CompletionCondition.ARRIVE_AT_TILE
+					&& s.getWorldX() > 0
+					&& s.getWorldY() > 0);
+			assertTrue(hasArriveStep,
+				name + " has no ARRIVE_AT_TILE step with positive world coordinates");
+
+			// Element 3/4 - at least one step exposes recommendedItemIds or has a loop
+			boolean hasRecommendedGear = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getRecommendedItemIds() != null
+					&& !s.getRecommendedItemIds().isEmpty());
+			boolean hasLoop = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getLoopBackToStep() >= 0 && s.getLoopCount() == 0);
+			assertTrue(hasRecommendedGear || hasLoop,
+				name + " has neither recommendedItemIds nor an activity loop");
+
+			// Element 10 - section labels on steps for multi-step sources
+			boolean hasSectionLabels = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getSection() != null && !s.getSection().isBlank());
+			assertTrue(hasSectionLabels,
+				name + " has no step with a section label");
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- **Fishing Trawler** (4 steps): Travel -> board -> bail/repair activity loop -> reward. Adds Fishing 15 requirement, `requiredItemIds` for bucket (1925) and rope (954), `PLAYER_ON_PLANE` boarding detection, `loopCount: 0` activity loop.
- **Mage Training Arena** (4 steps): Travel -> room activity -> restock loop -> reward shop. Adds Magic 7 requirement, rune `recommendedItemIds` (air/mind/cosmic runes), `loopCount: 0` loop back to training rooms.
- **Brimhaven Agility Arena** (4 steps): Travel -> obstacle activity -> accumulation loop -> ticket award (`CHAT_MESSAGE_RECEIVED` on final step, preserving existing spot-check invariant). Adds Agility 40 requirement, Graceful `recommendedItemIds`, section labels.
- **Rogues' Den** (4 steps): Travel -> maze navigation (`ARRIVE_AT_ZONE`) -> safe search reward -> repeat-loop return step. Adds Thieving 50 + Agility 50 requirements, Graceful `recommendedItemIds`, `loopCount: 0` repeat loop.

All sources gain section labels (Travel / Activity / Reward), `requirements` objects, and E4 activity loops per the full deep-guidance bar (minigame half of Batch 12 targets the full 10-element bar per `deep-guidance-bar.md`).

## Validation

- `validate_drop_rates`: clean on all 4 sources
- `data_ascii_lint`: 0 violations
- `guidance_lint`: clean on all 4 sources
- `./gradlew test`: 1653 tests pass (including new `D4Batch12a2aRegressionTest` -- 1 test, 4 sources asserted)

## Data sources

- Drop rates: OSRS Wiki (Fishing Trawler, MTA, Brimhaven, Rogues' Den reward tables) -- rates unchanged from existing entries, structural guidance only
- Coordinates: existing `worldX/worldY` from each source's JSON entry; Rogues' Den safe zone approximate
- Item IDs: `recommendedItemIds` use Graceful set IDs (13237-13242); bucket (1925), rope (954) confirmed standard IDs
- Requirements: OSRS Wiki skill/access gates for each minigame
- Game version: current OSRS (May 2026)