### PR TITLE
fix(player): defer quest-state refresh off script context (#676)

### DIFF
--- a/src/main/java/com/collectionloghelper/player/PlayerQuestProgressState.java
+++ b/src/main/java/com/collectionloghelper/player/PlayerQuestProgressState.java
@@ -33,6 +33,7 @@ import net.runelite.api.Client;
 import net.runelite.api.Quest;
 import net.runelite.api.QuestState;
 import net.runelite.api.events.VarbitChanged;
+import net.runelite.client.callback.ClientThread;
 import net.runelite.client.eventbus.Subscribe;
 
 /**
@@ -82,6 +83,7 @@ public class PlayerQuestProgressState implements QuestProgressState
 	private static final int BIOHAZARD_COMPLETE_VALUE = 30;
 
 	private final Client client;
+	private final ClientThread clientThread;
 
 	/**
 	 * Cached snapshot of all milestone states.
@@ -90,10 +92,17 @@ public class PlayerQuestProgressState implements QuestProgressState
 	 */
 	private volatile Map<QuestSubMilestone, Boolean> snapshot = emptySnapshot();
 
+	/**
+	 * Guard ensuring the per-tick varbit storm coalesces into a single deferred
+	 * refresh. Accessed only on the client thread, so no volatile is needed.
+	 */
+	private boolean refreshQueued;
+
 	@Inject
-	PlayerQuestProgressState(Client client)
+	PlayerQuestProgressState(Client client, ClientThread clientThread)
 	{
 		this.client = client;
+		this.clientThread = clientThread;
 	}
 
 	@Override
@@ -138,11 +147,31 @@ public class PlayerQuestProgressState implements QuestProgressState
 	 * IDs span the full varbit space and change at every game update, so a
 	 * targeted filter is brittle. The full refresh is cheap (one varp read +
 	 * a small fixed number of {@code QUEST_STATUS_GET} script calls).
+	 *
+	 * <p>The refresh is deferred onto the client thread: {@code VarbitChanged}
+	 * can be posted from inside an executing client script (e.g. during login),
+	 * and the {@code QUEST_STATUS_GET} script run by {@link Quest#getState(Client)}
+	 * is not reentrant. Deferring runs it outside the current script context,
+	 * and a guard flag coalesces the per-tick varbit storm into one refresh.
 	 */
 	@Subscribe
 	public void onVarbitChanged(VarbitChanged event)
 	{
-		refresh();
+		// Quest.getState() runs the QUEST_STATUS_GET script. VarbitChanged can be
+		// posted from inside an executing script (e.g. during login), and scripts
+		// are not reentrant. Defer the refresh onto the client thread so the script
+		// runs outside the current script context, and coalesce the per-tick varbit
+		// storm into a single refresh.
+		if (refreshQueued)
+		{
+			return;
+		}
+		refreshQueued = true;
+		clientThread.invokeLater(() ->
+		{
+			refreshQueued = false;
+			refresh();
+		});
 	}
 
 	@Override

--- a/src/test/java/com/collectionloghelper/player/PlayerQuestProgressStateSubscribeTest.java
+++ b/src/test/java/com/collectionloghelper/player/PlayerQuestProgressStateSubscribeTest.java
@@ -27,6 +27,7 @@ package com.collectionloghelper.player;
 import java.lang.reflect.Constructor;
 import net.runelite.api.Client;
 import net.runelite.api.events.VarbitChanged;
+import net.runelite.client.callback.ClientThread;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,6 +36,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 /**
@@ -48,15 +50,25 @@ public class PlayerQuestProgressStateSubscribeTest
 	@Mock
 	private Client client;
 
+	@Mock
+	private ClientThread clientThread;
+
 	private PlayerQuestProgressState detector;
 
 	@BeforeEach
 	public void setUp() throws Exception
 	{
 		Constructor<PlayerQuestProgressState> ctor =
-			PlayerQuestProgressState.class.getDeclaredConstructor(Client.class);
+			PlayerQuestProgressState.class.getDeclaredConstructor(Client.class, ClientThread.class);
 		ctor.setAccessible(true);
-		detector = ctor.newInstance(client);
+		detector = ctor.newInstance(client, clientThread);
+
+		// Run the deferred refresh synchronously so the assertions below observe
+		// the updated snapshot immediately.
+		doAnswer(inv -> {
+			((Runnable) inv.getArgument(0)).run();
+			return null;
+		}).when(clientThread).invokeLater(any(Runnable.class));
 	}
 
 	@Test

--- a/src/test/java/com/collectionloghelper/player/QuestProgressStateTest.java
+++ b/src/test/java/com/collectionloghelper/player/QuestProgressStateTest.java
@@ -25,6 +25,7 @@
 package com.collectionloghelper.player;
 
 import net.runelite.api.Client;
+import net.runelite.client.callback.ClientThread;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -72,6 +73,9 @@ public class QuestProgressStateTest
 	@Mock
 	private Client client;
 
+	@Mock
+	private ClientThread clientThread;
+
 	private PlayerQuestProgressState state;
 
 	/** Backing array for getIntStack() — updated via stubScriptReturn(). */
@@ -85,7 +89,7 @@ public class QuestProgressStateTest
 		// Default all varplayer reads to 0 (not started)
 		when(client.getVarpValue(anyInt())).thenReturn(0);
 
-		state = new PlayerQuestProgressState(client);
+		state = new PlayerQuestProgressState(client, clientThread);
 	}
 
 	// -----------------------------------------------------------------------


### PR DESCRIPTION
@
## Root cause

`PlayerQuestProgressState.onVarbitChanged` called `refresh()` synchronously, which invokes `Quest.getState(client)` and runs the `QUEST_STATUS_GET` client script. During login, `VarbitChanged` is posted from inside an already-executing client script. Running another script from there throws `AssertionError: scripts are not reentrant`, aborting login (client stuck at "Connecting to server...").

## Fix

Defer the refresh onto the client thread via `ClientThread.invokeLater`, so the `QUEST_STATUS_GET` script runs outside the current script context. A boolean guard flag coalesces the per-tick varbit storm during login into a single deferred refresh rather than dozens.

- Inject `ClientThread` into the constructor.
- `onVarbitChanged` now queues one deferred `refresh()` (guarded by `refreshQueued`).
- `refresh()` itself is unchanged and still runs synchronously on the client thread.

## Tests

- `QuestProgressStateTest`: pass the new `ClientThread` mock to the constructor.
- `PlayerQuestProgressStateSubscribeTest`: updated reflective constructor lookup and made the mock `invokeLater` run the runnable synchronously so the existing synchronous-update assertions still hold.

Full suite: 1665 tests, 0 failures.

Closes #676
@