### PR TITLE
fix(ui): eliminate guidance panel flash on inventory change (#681)

### DIFF
--- a/src/main/java/com/collectionloghelper/guidance/StepChangeHandler.java
+++ b/src/main/java/com/collectionloghelper/guidance/StepChangeHandler.java
@@ -65,6 +65,21 @@ public class StepChangeHandler
 	private final GuidanceSequencer guidanceSequencer;
 	private final RequiredItemResolver requiredItemResolver;
 
+	/**
+	 * Zero-based index of the last step this handler pushed to the panel, or {@code -1}
+	 * before the first push. Used to distinguish a genuine step CHANGE from a re-notify
+	 * of the SAME step (#681).
+	 *
+	 * <p>On a same-step re-notify — fired by {@code GuidanceSequencer.onInventoryChanged}
+	 * on every inventory change while guidance is active — the immediate empty-items push
+	 * is skipped so the "Items needed" section never blinks empty→full. The empty push
+	 * exists only to show step text snappily on a real step change while item names resolve
+	 * off the EDT (see #388); on a re-notify the items are already on screen and resolving
+	 * directly (then relying on the {@code StepProgressView} idempotency guard) avoids the
+	 * intermediate empty frame entirely.</p>
+	 */
+	private int lastShownStepIndex = -1;
+
 	@Inject
 	StepChangeHandler(
 		ClientThread clientThread,
@@ -121,13 +136,30 @@ public class StepChangeHandler
 				&& stepChangeSource.getGuidanceSteps() != null
 				? stepChangeSource.getGuidanceSteps() : Collections.emptyList();
 
+			// Distinguish a genuine step CHANGE from a re-notify of the SAME step (#681).
+			// onInventoryChanged re-notifies the current step on every inventory change;
+			// on those re-notifies the items are already on screen, so the immediate empty
+			// push would needlessly clear them and cause a visible flash.
+			final int currentIndex = guidanceSequencer.getCurrentIndex();
+			final boolean sameStepRenotify = currentIndex == lastShownStepIndex;
+			lastShownStepIndex = currentIndex;
+
 			// Push description + step progress to the panel immediately (safe from any thread
 			// because showStep dispatches to the EDT). Required-item resolution is deferred
 			// to the client thread because RequiredItemResolver.resolve() calls
 			// ItemManager.getItemComposition, which asserts caller-is-client-thread. See
 			// cha-ndler/collection-log-helper#388 for the original trace.
-			in.panel.updateStepProgress(current, total, desc, isManual,
-				Collections.emptyList(), Collections.emptyList(), sourceSteps);
+			//
+			// On a genuine step change we do the two-phase push: empty items immediately
+			// (snappy step text), resolved items ~1 tick later. On a same-step re-notify we
+			// SKIP the empty push and go straight to resolving — combined with the
+			// StepProgressView idempotency guard (#681) an unchanged re-notify is a complete
+			// no-op and one whose item availability changed updates in place with no blink.
+			if (!sameStepRenotify)
+			{
+				in.panel.updateStepProgress(current, total, desc, isManual,
+					Collections.emptyList(), Collections.emptyList(), sourceSteps);
+			}
 			final CollectionLogHelperPanel panelRef = in.panel;
 			clientThread.invokeLater(() ->
 			{

--- a/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
@@ -81,7 +81,6 @@ import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.PluginPanel;
-import net.runelite.client.util.SwingUtil;
 
 public class CollectionLogHelperPanel extends PluginPanel implements PanelShellContext
 {
@@ -434,7 +433,14 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 			{
 				PanelRebuildOrchestrator.RebuildSnapshot snapshot = rebuildOrchestrator.capture();
 
-				SwingUtil.fastRemoveAll(listContainer);
+				// Plain removeAll() rather than SwingUtil.fastRemoveAll(): the latter
+				// pumps pending AWT events mid-rebuild, which lets Swing paint the
+				// now-empty container before buildView() repopulates it -- the visible
+				// flash on frequent updates (e.g. every XP drop while on a Slayer task).
+				// removeAll() does not pump, so the EDT stays inside this runnable from
+				// clear through repopulate to the single revalidate/repaint below, and
+				// no empty intermediate frame is ever painted.
+				listContainer.removeAll();
 				updateCompletionHeader();
 				slayerStrategyView.refresh();
 

--- a/src/main/java/com/collectionloghelper/ui/widget/SourceRecommendedItemsChipPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/widget/SourceRecommendedItemsChipPanel.java
@@ -93,6 +93,15 @@ public class SourceRecommendedItemsChipPanel extends JPanel
 	/** The horizontal row that holds the heading label and chip labels. */
 	private final JPanel chipRow;
 
+	/**
+	 * Item IDs rendered on the last successful build. {@link #update(List)} is a
+	 * no-op when called again with an equal list -- without this guard the strip
+	 * tears down ({@code removeAll}) and reloads its async icons on every guidance
+	 * refresh, which manifested as a subtle flash on frequent updates (e.g. each
+	 * XP drop while guidance was active). Touched only on the EDT.
+	 */
+	private List<Integer> lastRenderedIds = null;
+
 	public SourceRecommendedItemsChipPanel(ItemManager itemManager)
 	{
 		this.itemManager = itemManager;
@@ -124,6 +133,15 @@ public class SourceRecommendedItemsChipPanel extends JPanel
 
 		SwingUtilities.invokeLater(() ->
 		{
+			// Idempotent: if the same IDs are already rendered, do nothing. This
+			// stops the strip from rebuilding (and reloading async icons) on every
+			// guidance refresh -- the subtle per-update flash.
+			if (safeIds.equals(lastRenderedIds))
+			{
+				return;
+			}
+			lastRenderedIds = new java.util.ArrayList<>(safeIds);
+
 			chipRow.removeAll();
 
 			if (safeIds.isEmpty())
@@ -245,9 +263,18 @@ public class SourceRecommendedItemsChipPanel extends JPanel
 				return comp.getName();
 			}
 		}
-		catch (RuntimeException ignored)
+		catch (RuntimeException | AssertionError ignored)
 		{
-			// Some test contexts don't wire up ItemManager fully.
+			// Two cases fall through to the id-based fallback:
+			//   1. Some test contexts don't wire up ItemManager fully (RuntimeException).
+			//   2. getItemComposition asserts "must be called on client thread" when
+			//      invoked from the EDT (this widget rebuilds on the EDT). That assertion
+			//      is an AssertionError (an Error, not a RuntimeException); before it was
+			//      caught here it propagated out of buildChip and aborted the whole
+			//      update() lambda mid-strip, leaving the chip row emptied -- the visible
+			//      flash on every rebuild while guidance is active. Catching it lets the
+			//      strip finish building atomically. Proper name resolution on the client
+			//      thread is tracked separately (see issue for off-thread ItemManager use).
 		}
 		return "Item " + itemId;
 	}

--- a/src/main/java/com/collectionloghelper/ui/widget/StepProgressView.java
+++ b/src/main/java/com/collectionloghelper/ui/widget/StepProgressView.java
@@ -140,6 +140,30 @@ public class StepProgressView extends JPanel
 	 */
 	private final Map<String, Boolean> sectionExpandState = new HashMap<>();
 
+	/**
+	 * Last-rendered inputs, used by {@link #showStep} to skip a teardown/rebuild when
+	 * the incoming render is identical to the one already on screen (#681).
+	 *
+	 * <p>Rationale: while guidance is active, {@code GuidanceSequencer.onInventoryChanged}
+	 * re-notifies the current (unchanged) step on every inventory change — effectively
+	 * every action during activities like Shades of Mort'ton. Each re-notify reaches
+	 * {@code showStep}; without this guard the item rows are torn down ({@code removeAll})
+	 * and rebuilt every time, making the "Items needed" section visibly flash. When the
+	 * full render signature is unchanged we return early and leave Swing untouched.
+	 *
+	 * <p>These fields are only ever read/written inside the {@code SwingUtilities.invokeLater}
+	 * body of {@link #showStep}, i.e. exclusively on the EDT, so no volatile/synchronization
+	 * is needed. {@code lastRenderValid} is {@code false} until the first render completes.
+	 */
+	private boolean lastRenderValid = false;
+	private int lastCurrent;
+	private int lastTotal;
+	private boolean lastIsManual;
+	private String lastDescription;
+	private List<RequiredItemDisplay> lastRows = Collections.emptyList();
+	private List<RequiredItemDisplay> lastRecRows = Collections.emptyList();
+	private List<StepSectionGroup> lastGroups = Collections.emptyList();
+
 	private Runnable stepAdvancer;
 	private Runnable stepSkipper;
 	private Runnable stepStopper;
@@ -493,6 +517,32 @@ public class StepProgressView extends JPanel
 
 		SwingUtilities.invokeLater(() ->
 		{
+			// Idempotency guard (#681): when the full render signature is identical to
+			// what is already on screen, skip the teardown/rebuild entirely. This makes a
+			// same-step re-notify (fired on every inventory change while guidance is active)
+			// a no-op instead of a visible flash. Section grouping is compared via the
+			// computed StepSectionGroup list, which carries Lombok-generated equals/hashCode,
+			// so List.equals gives a true content comparison. Runs on the EDT only.
+			if (lastRenderValid
+				&& lastCurrent == current
+				&& lastTotal == total
+				&& lastIsManual == isManual
+				&& java.util.Objects.equals(lastDescription, description)
+				&& lastRows.equals(rows)
+				&& lastRecRows.equals(recRows)
+				&& lastGroups.equals(groups))
+			{
+				return;
+			}
+			lastRenderValid = true;
+			lastCurrent = current;
+			lastTotal = total;
+			lastIsManual = isManual;
+			lastDescription = description;
+			lastRows = new java.util.ArrayList<>(rows);
+			lastRecRows = new java.util.ArrayList<>(recRows);
+			lastGroups = new java.util.ArrayList<>(groups);
+
 			// Plain-text setText on a JTextArea word-wraps from the actual rendered
 			// width — no HTML, no pixel-width budget, no escaping needed. Previous
 			// JLabel + <html><body width=...> approach dropped glyphs at the wrap
@@ -545,6 +595,10 @@ public class StepProgressView extends JPanel
 	{
 		SwingUtilities.invokeLater(() ->
 		{
+			// Invalidate the #681 idempotency cache: after a hide the panels are torn
+			// down, so the next showStep must rebuild even if its inputs match the
+			// last shown step.
+			lastRenderValid = false;
 			chipPanel.update(Collections.<RequiredItemDisplay>emptyList());
 			recChipPanel.update(Collections.<RequiredItemDisplay>emptyList());
 			requiredItemsPanel.removeAll();

--- a/src/test/java/com/collectionloghelper/ui/widget/StepProgressViewTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/StepProgressViewTest.java
@@ -343,6 +343,122 @@ public class StepProgressViewTest
 			RequiredItemDisplay.COLOR_HELD, updated.getForeground(),"After transition to HELD must be green");
 	}
 
+	// ── Idempotent-render tests (#681) ──────────────────────────────────────
+	//
+	// While guidance is active, GuidanceSequencer.onInventoryChanged re-notifies the
+	// current (unchanged) step on every inventory change. Each re-notify reaches
+	// showStep; without an idempotency guard the item rows are torn down (removeAll)
+	// and rebuilt every time, making the "Items needed" section visibly flash. The
+	// guard skips the rebuild when the full render signature is unchanged. These tests
+	// pin that contract via component identity: a true rebuild replaces the row JPanel
+	// instances, an idempotent skip leaves the exact same instances in place.
+
+	/**
+	 * A second showStep with byte-for-byte identical inputs must NOT rebuild: the row
+	 * panel instances must be the same objects as after the first call (no removeAll,
+	 * no teardown → no flash). This is the core #681 fix.
+	 */
+	@Test
+	public void showStep_identicalSecondCall_doesNotRebuild() throws Exception
+	{
+		List<RequiredItemDisplay> rows = Collections.singletonList(
+			new RequiredItemDisplay(TINDERBOX_ID, "Tinderbox", Status.MISSING));
+
+		view.showStep(1, 3, "Collect item", false, rows);
+		flushEdt();
+		List<Component> firstRows = rowComponents(findRequiredItemsPanel(view));
+		assertFalse(firstRows.isEmpty(), "First render must produce rows");
+
+		// Re-notify of the same step with identical resolved items (the inventory-change case)
+		view.showStep(1, 3, "Collect item", false,
+			Collections.singletonList(new RequiredItemDisplay(TINDERBOX_ID, "Tinderbox", Status.MISSING)));
+		flushEdt();
+		List<Component> secondRows = rowComponents(findRequiredItemsPanel(view));
+
+		assertEquals(firstRows.size(), secondRows.size(), "Row count must be unchanged");
+		for (int i = 0; i < firstRows.size(); i++)
+		{
+			assertTrue(
+				firstRows.get(i) == secondRows.get(i),
+				"Identical re-notify must reuse the same row instances (no rebuild) — #681");
+		}
+	}
+
+	/**
+	 * A second showStep with CHANGED content (item availability flipped) must rebuild:
+	 * the row panel instances must be replaced so the new colour/status is rendered.
+	 * Liveness must be preserved — only redundant re-notifies are skipped.
+	 */
+	@Test
+	public void showStep_changedSecondCall_rebuilds() throws Exception
+	{
+		view.showStep(1, 3, "Collect item", false, Collections.singletonList(
+			new RequiredItemDisplay(TINDERBOX_ID, "Tinderbox", Status.MISSING)));
+		flushEdt();
+		List<Component> firstRows = rowComponents(findRequiredItemsPanel(view));
+		assertFalse(firstRows.isEmpty());
+
+		// Player picked the item up — status flips MISSING → HELD, must re-render
+		view.showStep(1, 3, "Collect item", false, Collections.singletonList(
+			new RequiredItemDisplay(TINDERBOX_ID, "Tinderbox", Status.HELD)));
+		flushEdt();
+		List<Component> secondRows = rowComponents(findRequiredItemsPanel(view));
+
+		assertTrue(
+			firstRows.isEmpty() || secondRows.isEmpty() || firstRows.get(0) != secondRows.get(0),
+			"Changed content must rebuild row instances (liveness preserved)");
+		JLabel updated = findFirstNameLabel(view);
+		assertEquals(
+			RequiredItemDisplay.COLOR_HELD, updated.getForeground(),
+			"Changed re-notify must render the new HELD colour");
+	}
+
+	/**
+	 * After hideStep the idempotency cache must be invalidated: a subsequent showStep
+	 * with inputs identical to the pre-hide render must rebuild (the panels were torn
+	 * down by hideStep, so reusing the cache would leave them empty).
+	 */
+	@Test
+	public void showStep_afterHide_rebuildsEvenIfIdentical() throws Exception
+	{
+		List<RequiredItemDisplay> rows = Collections.singletonList(
+			new RequiredItemDisplay(TINDERBOX_ID, "Tinderbox", Status.HELD));
+
+		view.showStep(1, 1, "Do thing", false, rows);
+		flushEdt();
+		view.hideStep();
+		flushEdt();
+
+		view.showStep(1, 1, "Do thing", false,
+			Collections.singletonList(new RequiredItemDisplay(TINDERBOX_ID, "Tinderbox", Status.HELD)));
+		flushEdt();
+
+		assertTrue(
+			findRequiredItemsPanel(view).isVisible(),
+			"showStep after hideStep must rebuild and re-show the items panel");
+		assertFalse(
+			rowComponents(findRequiredItemsPanel(view)).isEmpty(),
+			"Items panel must contain rows again after a re-show");
+	}
+
+	/** Returns the row JPanel children of {@code panel} (the per-item rows, excluding labels/struts). */
+	private static List<Component> rowComponents(JPanel panel)
+	{
+		List<Component> rows = new java.util.ArrayList<>();
+		if (panel == null)
+		{
+			return rows;
+		}
+		for (Component c : panel.getComponents())
+		{
+			if (c instanceof JPanel)
+			{
+				rows.add(c);
+			}
+		}
+		return rows;
+	}
+
 	// ── Section rendering tests (B.5.4) ─────────────────────────────────────
 
 	/**


### PR DESCRIPTION
## Problem

While guidance is active, the side panel's **Items needed** section flashes on every inventory change. During activities like Shades of Mort'ton this is effectively every XP-dropping action.

### Root cause (instrumented + confirmed on #681)

`GuidanceSequencer.onInventoryChanged()` ends with an unconditional re-notify of the current (unchanged) step. Each re-notify -> `StepChangeHandler.handle` -> `StepProgressView.showStep`, which did a two-phase push: empty item lists immediately (to show step text without the off-EDT `ItemManager.getItemComposition` assert, see #388), then resolved items ~1 tick later. `StepProgressView` did `removeAll()` + rebuild both times, so the items section blinked empty->full on every inventory change. (`panel.rebuild()` is not involved.)

## Fix

**Part A - idempotent render (`StepProgressView`).** `showStep` records its last rendered inputs (current, total, isManual, description, required rows, recommended rows, and the computed `StepSectionGroup` list) and returns early on the EDT when the incoming render is identical, leaving Swing untouched. Section grouping is compared via the computed `StepSectionGroup` list, whose Lombok `@Value` gives `equals`/`hashCode`, so `List.equals` is a true content comparison. `RequiredItemDisplay` already implements `equals`/`hashCode`. The cache is invalidated in `hideStep` so a re-show always rebuilds. Fields are EDT-only, so no synchronization.

**Part B - skip the empty intermediate push on a same-step re-notify (`StepChangeHandler`).** The handler tracks the last pushed step index. On a same-step re-notify (the inventory-change case) it skips the immediate empty-items push and resolves items directly on the client thread. On a genuine step change it keeps the existing two-phase behavior. The coordinator's activation/landing push (skip-chain landing) is a genuine step change and is intentionally left two-phase.

Combined: an inventory change that does not alter item availability is a complete no-op; one that does updates in place with no empty frame. Item have/missing **liveness is preserved** -- the re-notify is not removed.

## Also on this branch (commit 1ddac5db, validated live)

1. `CollectionLogHelperPanel.rebuild()` -> plain `removeAll()` instead of `SwingUtil.fastRemoveAll()` (the latter pumped AWT events mid-rebuild, painting an empty frame).
2. `SourceRecommendedItemsChipPanel.lookupName()` -> catch the off-client-thread `AssertionError` from `ItemManager.getItemComposition` so the chip strip finishes building.
3. `SourceRecommendedItemsChipPanel.update()` -> idempotent guard: skip teardown + async icon reload when item IDs are unchanged.

## Tests

Added to `StepProgressViewTest`: identical second `showStep` reuses the same row instances (no rebuild); changed content rebuilds and renders the new colour; a re-show after `hideStep` rebuilds even with identical inputs. Full suite green: **1668 tests, 0 failures, 0 errors**.

Closes #681