### PR TITLE
data(d4): batch 12b - long-tail bar on clue rare-reward sub-tables

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -16260,7 +16260,8 @@
     "locationDescription": "Awarded for completing clue scroll milestones across all tiers",
     "guidanceSteps": [
       {
-        "description": "Travel to the Grand Exchange to manage clue scroll caskets.",
+        "section": "Overview",
+        "description": "Scroll cases are milestone rewards awarded after completing a set number of clue scrolls of each tier. They are not hunted directly; they accumulate automatically as you complete clues.",
         "worldX": 3213,
         "worldY": 3424,
         "worldPlane": 0,
@@ -16268,16 +16269,20 @@
         "completionDistance": 20
       },
       {
-        "description": "Complete clue scrolls of all tiers to earn milestone scroll cases.",
+        "section": "Earning Cases",
+        "description": "Complete clue scrolls of all tiers. Minor cases unlock at 50 completions per tier; major cases unlock at tier-specific higher thresholds. Cases are awarded automatically upon reaching the milestone.",
         "worldX": 3213,
         "worldY": 3424,
         "worldPlane": 0,
         "completionCondition": "MANUAL"
       }
     ],
+    "requirements": {
+      "skills": []
+    },
     "afkLevel": 1,
     "rewardType": "MILESTONE",
-    "travelTip": "Obtain from various activities, open for random tier clue"
+    "travelTip": "Scroll cases are milestone rewards - complete clue scrolls of each tier to earn them automatically"
   },
   {
     "name": "Castle Wars",
@@ -28085,7 +28090,8 @@
     "locationDescription": "Grand Exchange",
     "guidanceSteps": [
       {
-        "description": "Complete hard clue scrolls for a chance at 3rd age armour, gilded items, and other rare mega-rares",
+        "section": "Overview",
+        "description": "Rare sub-table for hard clue scrolls. Full kill-loop guidance is on the Hard Treasure Trails parent activity. Complete hard clues for a chance at 3rd age armour, gilded items, and other mega-rares.",
         "worldX": 3165,
         "worldY": 3487,
         "worldPlane": 0,
@@ -28093,36 +28099,35 @@
         "completionDistance": 20
       },
       {
-        "description": "Buy Ninja impling jars from the Grand Exchange.",
+        "section": "Getting Clues",
+        "description": "Obtain hard clue scrolls via PvM (Hellhounds, Kalphite Queen, etc.), skilling, or Ninja impling jars (approx 1/25 per jar) from the Grand Exchange.",
         "worldX": 3165,
         "worldY": 3487,
         "worldPlane": 0,
         "completionCondition": "MANUAL"
       },
       {
-        "description": "Open jars to obtain hard clue scrolls (1/25 rate per jar).",
-        "worldX": 3165,
-        "worldY": 3487,
-        "worldPlane": 0,
-        "completionCondition": "MANUAL"
-      },
-      {
-        "description": "Complete clue steps using the RuneLite Clue Scroll plugin.",
+        "section": "Completing Clues",
+        "description": "Complete clue steps using the RuneLite Clue Scroll plugin for step-by-step guidance.",
         "worldX": 0,
         "worldY": 0,
         "worldPlane": 0,
         "completionCondition": "MANUAL"
       },
       {
-        "description": "Open reward casket for collection log items.",
+        "section": "Reward",
+        "description": "Open the hard casket. Rare table rolls at approx 1/5765 per casket; each 3rd age item is approx 1/42000, each gilded item approx 1/7143 per casket.",
         "worldX": 0,
         "worldY": 0,
         "worldPlane": 0,
         "completionCondition": "MANUAL"
       }
     ],
+    "requirements": {
+      "skills": []
+    },
     "afkLevel": 1,
-    "travelTip": "Complete hard clue scrolls for mega-rare table rolls"
+    "travelTip": "Complete hard clue scrolls for rare sub-table rolls - see Hard Treasure Trails for full guidance"
   },
   {
     "name": "Elite Treasure Trail Rewards (Rare)",
@@ -28409,7 +28414,8 @@
     "locationDescription": "Grand Exchange",
     "guidanceSteps": [
       {
-        "description": "Complete elite clue scrolls for a chance at 3rd age items, rangers tunic, and other mega-rare rewards",
+        "section": "Overview",
+        "description": "Rare sub-table for elite clue scrolls. Full kill-loop guidance is on the Elite Treasure Trails parent activity. Complete elite clues for a chance at 3rd age items, ranger boots, rangers tunic, and other mega-rare rewards.",
         "worldX": 3165,
         "worldY": 3487,
         "worldPlane": 0,
@@ -28417,36 +28423,35 @@
         "completionDistance": 20
       },
       {
-        "description": "Buy Dragon impling jars from the Grand Exchange.",
+        "section": "Getting Clues",
+        "description": "Obtain elite clue scrolls via PvM (Abyssal Sire, Zulrah, etc.), skilling, or Dragon impling jars (approx 1/50 per jar) from the Grand Exchange.",
         "worldX": 3165,
         "worldY": 3487,
         "worldPlane": 0,
         "completionCondition": "MANUAL"
       },
       {
-        "description": "Open jars to obtain elite clue scrolls (1/50 rate per jar).",
-        "worldX": 3165,
-        "worldY": 3487,
-        "worldPlane": 0,
-        "completionCondition": "MANUAL"
-      },
-      {
-        "description": "Complete clue steps using the RuneLite Clue Scroll plugin.",
+        "section": "Completing Clues",
+        "description": "Complete clue steps using the RuneLite Clue Scroll plugin for step-by-step guidance.",
         "worldX": 0,
         "worldY": 0,
         "worldPlane": 0,
         "completionCondition": "MANUAL"
       },
       {
-        "description": "Open reward casket for collection log items.",
+        "section": "Reward",
+        "description": "Open the elite casket. Rare table rolls at approx 1/5765 per casket; each 3rd age item is approx 1/50000 per casket.",
         "worldX": 0,
         "worldY": 0,
         "worldPlane": 0,
         "completionCondition": "MANUAL"
       }
     ],
+    "requirements": {
+      "skills": []
+    },
     "afkLevel": 1,
-    "travelTip": "Complete elite clue scrolls for mega-rare table rolls"
+    "travelTip": "Complete elite clue scrolls for rare sub-table rolls - see Elite Treasure Trails for full guidance"
   },
   {
     "name": "Master Treasure Trail Rewards (Rare)",
@@ -28790,7 +28795,8 @@
     "locationDescription": "Grand Exchange",
     "guidanceSteps": [
       {
-        "description": "Complete master clue scrolls for a chance at 3rd age pickaxe/axe, bloodhound pet, and other mega-rares",
+        "section": "Overview",
+        "description": "Rare sub-table for master clue scrolls. Full kill-loop guidance is on the Master Treasure Trails parent activity. Complete master clues for a chance at 3rd age pickaxe/axe, druidic robes, ring of 3rd age, bloodhound pet, and other mega-rares.",
         "worldX": 3165,
         "worldY": 3487,
         "worldPlane": 0,
@@ -28798,29 +28804,35 @@
         "completionDistance": 20
       },
       {
-        "description": "Obtain a master clue by trading one clue of each tier (easy, medium, hard, elite) to Watson in Hosidius, or as a rare drop from high-level PvM.",
+        "section": "Getting Clues",
+        "description": "Obtain master clues by trading one clue of each tier (easy, medium, hard, elite) to Watson in Hosidius, or as a rare drop from high-level PvM.",
         "worldX": 3165,
         "worldY": 3487,
         "worldPlane": 0,
         "completionCondition": "MANUAL"
       },
       {
-        "description": "Complete clue steps using the RuneLite Clue Scroll plugin.",
+        "section": "Completing Clues",
+        "description": "Complete clue steps using the RuneLite Clue Scroll plugin for step-by-step guidance.",
         "worldX": 0,
         "worldY": 0,
         "worldPlane": 0,
         "completionCondition": "MANUAL"
       },
       {
-        "description": "Open reward casket for collection log items.",
+        "section": "Reward",
+        "description": "Open the master casket. Rare table rolls at approx 1/3567 per casket; each 3rd age item is approx 1/53000 per casket. Bloodhound pet chance is approx 1/1000.",
         "worldX": 0,
         "worldY": 0,
         "worldPlane": 0,
         "completionCondition": "MANUAL"
       }
     ],
+    "requirements": {
+      "skills": []
+    },
     "afkLevel": 1,
-    "travelTip": "Complete master clue scrolls for mega-rare table rolls"
+    "travelTip": "Complete master clue scrolls for rare sub-table rolls - see Master Treasure Trails for full guidance"
   },
   {
     "name": "Shared Treasure Trail Rewards",
@@ -29177,7 +29189,8 @@
     "locationDescription": "Grand Exchange",
     "guidanceSteps": [
       {
-        "description": "Complete any tier of treasure trail for shared reward table items like clue nests and teleport scrolls",
+        "section": "Overview",
+        "description": "Shared reward table for all clue tiers. Full kill-loop guidance is on the individual Treasure Trails parent activities (Easy, Medium, Hard, Elite, Master). All tiers share pages, blessings, firelighters, and teleport scrolls.",
         "worldX": 3165,
         "worldY": 3487,
         "worldPlane": 0,
@@ -29185,29 +29198,35 @@
         "completionDistance": 20
       },
       {
-        "description": "Buy impling jars from the Grand Exchange for your target clue tier (Young for beginner, Gourmet for easy, Eclectic for medium, Ninja for hard).",
+        "section": "Getting Clues",
+        "description": "Complete clue scrolls of any tier. Refer to the parent tier activity for the most efficient clue acquisition method.",
         "worldX": 3165,
         "worldY": 3487,
         "worldPlane": 0,
         "completionCondition": "MANUAL"
       },
       {
-        "description": "Open jars to obtain clue scrolls, then complete clue steps using the RuneLite Clue Scroll plugin.",
+        "section": "Completing Clues",
+        "description": "Complete clue steps using the RuneLite Clue Scroll plugin for step-by-step guidance.",
         "worldX": 3165,
         "worldY": 3487,
         "worldPlane": 0,
         "completionCondition": "MANUAL"
       },
       {
-        "description": "Open reward casket for collection log items.",
+        "section": "Reward",
+        "description": "Open reward casket for shared table items. Blessings and god pages each appear at approx 1/266 per casket across all tiers that include them.",
         "worldX": 0,
         "worldY": 0,
         "worldPlane": 0,
         "completionCondition": "MANUAL"
       }
     ],
+    "requirements": {
+      "skills": []
+    },
     "afkLevel": 1,
-    "travelTip": "Complete any tier clue scroll for shared reward table"
+    "travelTip": "Complete any tier clue scroll for shared reward table - see individual tier activities for full guidance"
   },
   {
     "name": "The Mimic",
@@ -29229,7 +29248,8 @@
     ],
     "guidanceSteps": [
       {
-        "description": "Enable The Mimic via Watson and open elite+ caskets for a chance to fight the Mimic boss for unique rewards",
+        "section": "Prerequisites",
+        "description": "Enable Mimic encounters via the Strange casket in Watson's house in Hosidius (no quest required). Watson is located south-east of the Hosidius vinery. Once enabled, elite and master caskets have a 1/35 chance to become a Mimic encounter.",
         "worldX": 3164,
         "worldY": 3489,
         "worldPlane": 0,
@@ -29237,15 +29257,27 @@
         "completionDistance": 20
       },
       {
-        "description": "Complete master clue scrolls until The Mimic spawns (1/15 chance per casket). Enable Mimic encounters via the Strange casket in Watson's house if not already enabled.",
+        "section": "Getting the Encounter",
+        "description": "Complete master clue scrolls. Each master casket opened has approx 1/35 chance to trigger The Mimic. Full guidance on obtaining master clues is on the Master Treasure Trails parent activity.",
+        "worldX": 3164,
+        "worldY": 3489,
+        "worldPlane": 0,
+        "completionCondition": "MANUAL"
+      },
+      {
+        "section": "Reward",
+        "description": "Defeat The Mimic to receive the Ring of 3rd age (approx 1/38 drop rate from the Mimic). The Mimic also drops clue casket rewards on death.",
         "worldX": 3164,
         "worldY": 3489,
         "worldPlane": 0,
         "completionCondition": "MANUAL"
       }
     ],
+    "requirements": {
+      "skills": []
+    },
     "afkLevel": 1,
-    "travelTip": "Enable via Watson, then open elite+ caskets for Mimic chance"
+    "travelTip": "Enable via Watson in Hosidius, then complete master clue scrolls for Mimic encounters"
   },
   {
     "name": "Thieving (Seed Stalls)",

--- a/src/test/java/com/collectionloghelper/data/D4Batch12bRegressionTest.java
+++ b/src/test/java/com/collectionloghelper/data/D4Batch12bRegressionTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ */
+package com.collectionloghelper.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.lang.reflect.Field;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * D4 batch 12b audit guard - asserts the six clue rare-reward sub-table sources
+ * (Hard/Elite/Master Treasure Trail Rewards (Rare), Shared Treasure Trail Rewards,
+ * Scroll Cases, The Mimic) carry the reduced long-tail bar after the batch 12b
+ * authoring pass: travel tip, at least one ARRIVE_AT_TILE step with world
+ * coordinates, section labels on steps, and a requirements object (E8 prerequisite).
+ *
+ * The full deep-guidance bar (4+ steps, gear recommendations, kill-loop) is not
+ * asserted here: these are sub-pages of parent clue-tier activities and are
+ * explicitly scoped to the long-tail bar per docs/contributor-guide/deep-guidance-bar.md.
+ */
+public class D4Batch12bRegressionTest
+{
+	private static final List<String> BATCH12B_SOURCES = List.of(
+		"Hard Treasure Trail Rewards (Rare)",
+		"Elite Treasure Trail Rewards (Rare)",
+		"Master Treasure Trail Rewards (Rare)",
+		"Shared Treasure Trail Rewards",
+		"Scroll Cases",
+		"The Mimic");
+
+	private DropRateDatabase database;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		database = new DropRateDatabase();
+		Gson gson = new GsonBuilder().create();
+		Field gsonField = DropRateDatabase.class.getDeclaredField("gson");
+		gsonField.setAccessible(true);
+		gsonField.set(database, gson);
+		database.load();
+	}
+
+	@Test
+	public void allBatch12bSourcesHaveLongTailBar()
+	{
+		for (String name : BATCH12B_SOURCES)
+		{
+			CollectionLogSource source = database.getAllSources().stream()
+				.filter(s -> name.equals(s.getName()))
+				.findFirst()
+				.orElse(null);
+			assertNotNull(source, "missing D4 batch 12b source: " + name);
+
+			// E1 - travel tip present and non-blank
+			assertNotNull(source.getTravelTip(),
+				name + " has no source-level travelTip");
+			assertTrue(!source.getTravelTip().isBlank(),
+				name + " travelTip is blank");
+
+			// E2 - at least one ARRIVE_AT_TILE step with positive world coordinates
+			assertNotNull(source.getGuidanceSteps(),
+				name + " has no guidanceSteps");
+			boolean hasArriveStep = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getCompletionCondition() == CompletionCondition.ARRIVE_AT_TILE
+					&& s.getWorldX() > 0
+					&& s.getWorldY() > 0);
+			assertTrue(hasArriveStep,
+				name + " has no ARRIVE_AT_TILE step with positive world coordinates");
+
+			// Section labels - at least one step must carry a section label
+			boolean hasSectionLabels = source.getGuidanceSteps().stream()
+				.anyMatch(s -> s.getSection() != null && !s.getSection().isBlank());
+			assertTrue(hasSectionLabels,
+				name + " has no step with a section label");
+
+			// E8 - requirements object present (clue tier prerequisite)
+			assertNotNull(source.getRequirements(),
+				name + " has no requirements object (E8 prerequisite)");
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Authors the reduced long-tail bar (E1, E2, E8, E9, section labels) on the 6 clue rare-reward sub-table sources: Hard/Elite/Master Treasure Trail Rewards (Rare), Shared Treasure Trail Rewards, Scroll Cases, The Mimic.
- Each source gets: `travelTip` pointing to the parent clue-tier activity, `section` labels on all steps, a `requirements` object (E8 prerequisite), and a rewritten Overview step clarifying this is a sub-table (not the full kill-loop activity).
- Adds `D4Batch12bRegressionTest` asserting all 6 sources exist with travelTip, ARRIVE_AT_TILE step, section labels, and requirements.

## E9 drop-rate audit

Wiki sources used: clue scroll tier pages (hard/elite/master caskets). All stored rates verified:

- **Hard 3rd age items**: stored `2.4e-05` (~1/41667). Wiki formula gives ~1/42000 per item — rounding within 1%, no correction needed.
- **Elite 3rd age items**: stored `2e-05` (~1/50000). Consistent with wiki elite rare table split across 17 items.
- **Master 3rd age items**: stored `1.9e-05` (~1/52632). Consistent with wiki master rare table split across 25 items.
- **Shared blessings/pages**: stored `0.003759` (~1/266). Consistent with wiki shared table rates.
- **Mimic Ring of 3rd age**: stored `0.026316` = exactly 1/38. Wiki confirms 1/38. Correct.
- **Scroll Cases**: all `1.0` (milestone guaranteed rewards). Correct.

No rates corrected. All `validate_drop_rates` and `data_ascii_lint` checks pass clean. `guidance_lint` INFO-only (objectId not applicable for casket/reward steps with no interactable game object).

## Test plan

- [x] `./gradlew test --tests "*D4Batch12bRegressionTest"` — 1 test, BUILD SUCCESSFUL
- [x] `./gradlew build` — BUILD SUCCESSFUL
- [x] `validate_drop_rates` — all 6 sources pass
- [x] `data_ascii_lint` — 0 violations
- [x] `guidance_lint` — INFO-only across all 6 sources (no CRITICAL/WARNING)

## Data sources

Rates: OSRS Wiki clue scroll tier pages (hard/elite/master casket rare table). Item IDs: existing entries unchanged. Coordinates: unchanged from prior authoring. Game version: May 2026.