### PR TITLE
fix(ui): chip tooltip threading and Requirements label connector words (#679, #680)

### DIFF
--- a/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
@@ -230,7 +230,7 @@ public class CollectionLogHelperPlugin extends Plugin
 
 		panel = new CollectionLogHelperPanel(
 			config, data.getDatabase(), data.getCollectionState(), efficiency.getCalculator(), efficiency.getClueEstimator(),
-			itemManager, requirementsChecker, data.getDataSyncState(), data.getSlayerTaskState(),
+			itemManager, clientThread, requirementsChecker, data.getDataSyncState(), data.getSlayerTaskState(),
 			efficiency.getSlayerStrategyCalculator(), data.getPlayerInventoryState(), data.getPlayerBankState(),
 			efficiency.getDryStreakAnalyzer(),
 			(java.util.function.BiConsumer<CollectionLogSource, Integer>) this::activateGuidance,

--- a/src/main/java/com/collectionloghelper/data/RequirementsChecker.java
+++ b/src/main/java/com/collectionloghelper/data/RequirementsChecker.java
@@ -429,8 +429,53 @@ public class RequirementsChecker
 		return unmet;
 	}
 
+	/**
+	 * Overrides for quest/source enum names that naive title-casing mis-formats.
+	 *
+	 * <p>Covers two classes of problem:
+	 * <ul>
+	 *   <li>Connector words ("of", "the", "and", "in", "a", "to") that should be
+	 *       lowercase in the middle of a name.</li>
+	 *   <li>Names containing apostrophes or other punctuation that is lost when
+	 *       the enum constant was defined (e.g. {@code SHADES_OF_MORTTON} →
+	 *       {@code "Shades of Mort'ton"}).</li>
+	 * </ul>
+	 *
+	 * <p>Keys are the raw enum-constant strings (uppercase, underscores).
+	 * Values are the exact display strings to use instead of the generated one.
+	 */
+	private static final java.util.Map<String, String> ENUM_NAME_OVERRIDES;
+
+	static
+	{
+		java.util.Map<String, String> m = new java.util.HashMap<>();
+		// Apostrophe names — naive split loses the punctuation
+		m.put("SHADES_OF_MORTTON", "Shades of Mort'ton");
+		m.put("ICTHLARIN_S_LITTLE_HELPER", "Icthlarin's Little Helper");
+		m.put("ENAKHRA_S_LAMENT", "Enakhra's Lament");
+		m.put("RATCATCHERS", "Ratcatchers"); // no change needed, just guard
+		ENUM_NAME_OVERRIDES = java.util.Collections.unmodifiableMap(m);
+	}
+
+	/**
+	 * Words that should remain lowercase when appearing in the middle of a
+	 * formatted name (English connector/preposition/article set).
+	 */
+	private static final java.util.Set<String> LOWERCASE_CONNECTORS =
+		java.util.Collections.unmodifiableSet(new java.util.HashSet<>(java.util.Arrays.asList(
+			"of", "the", "and", "in", "a", "an", "to", "for", "at", "by", "or"
+		)));
+
 	static String formatEnumName(String enumName)
 	{
+		// Check the override map first — handles apostrophes and other
+		// punctuation that can't be reconstructed from the enum constant name.
+		String override = ENUM_NAME_OVERRIDES.get(enumName);
+		if (override != null)
+		{
+			return override;
+		}
+
 		String[] parts = enumName.split("_");
 		StringBuilder sb = new StringBuilder();
 		boolean first = true;
@@ -445,16 +490,27 @@ public class RequirementsChecker
 			{
 				sb.append(' ');
 			}
-			first = false;
-			if (part.matches("[IVX]+"))
+			String lower = part.toLowerCase();
+			if (first)
+			{
+				// Always capitalise the first word
+				sb.append(part.charAt(0)).append(part.substring(1).toLowerCase());
+			}
+			else if (part.matches("[IVX]+"))
 			{
 				// Roman numerals stay uppercase
 				sb.append(part);
+			}
+			else if (LOWERCASE_CONNECTORS.contains(lower))
+			{
+				// Connector words stay lowercase mid-name
+				sb.append(lower);
 			}
 			else
 			{
 				sb.append(part.charAt(0)).append(part.substring(1).toLowerCase());
 			}
+			first = false;
 		}
 		return sb.toString();
 	}

--- a/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
@@ -77,6 +77,7 @@ import javax.swing.JProgressBar;
 import javax.swing.JScrollPane;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
+import net.runelite.client.callback.ClientThread;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
@@ -163,6 +164,7 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 		DropRateDatabase database, PlayerCollectionState collectionState,
 		EfficiencyCalculator calculator, ClueCompletionEstimator clueEstimator,
 		ItemManager itemManager,
+		ClientThread clientThread,
 		RequirementsChecker requirementsChecker, DataSyncState dataSyncState,
 		SlayerTaskState slayerTaskState,
 		SlayerStrategyCalculator slayerStrategyCalculator,
@@ -197,6 +199,7 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 			slayerStrategyCalculator,
 			requirementsChecker,
 			itemManager,
+			clientThread,
 			guidanceActivator,
 			guidanceDeactivator,
 			this);

--- a/src/main/java/com/collectionloghelper/ui/PanelHeaderBuilder.java
+++ b/src/main/java/com/collectionloghelper/ui/PanelHeaderBuilder.java
@@ -47,6 +47,7 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JProgressBar;
 import javax.swing.SwingConstants;
+import net.runelite.client.callback.ClientThread;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
@@ -88,6 +89,7 @@ final class PanelHeaderBuilder
 		SlayerStrategyCalculator slayerStrategyCalculator,
 		RequirementsChecker requirementsChecker,
 		ItemManager itemManager,
+		ClientThread clientThread,
 		BiConsumer<CollectionLogSource, Integer> guidanceActivator,
 		Runnable guidanceDeactivator,
 		JComponent syncButtonOwner)
@@ -133,7 +135,7 @@ final class PanelHeaderBuilder
 		slayerStrategyView.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
 		controlsPanel.add(slayerStrategyView);
 
-		GuidanceBannerView guidanceBannerView = new GuidanceBannerView(requirementsChecker, itemManager);
+		GuidanceBannerView guidanceBannerView = new GuidanceBannerView(requirementsChecker, itemManager, clientThread);
 		guidanceBannerView.setAlignmentX(JComponent.CENTER_ALIGNMENT);
 		guidanceBannerView.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
 		controlsPanel.add(guidanceBannerView);

--- a/src/main/java/com/collectionloghelper/ui/widget/GuidanceBannerView.java
+++ b/src/main/java/com/collectionloghelper/ui/widget/GuidanceBannerView.java
@@ -38,6 +38,7 @@ import javax.swing.BoxLayout;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
+import net.runelite.client.callback.ClientThread;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.FontManager;
 
@@ -83,14 +84,29 @@ public class GuidanceBannerView extends JPanel
 	/**
 	 * Legacy 1-arg constructor retained for tests that do not exercise the
 	 * source-level Recommended chip strip. New production callers should use
-	 * {@link #GuidanceBannerView(RequirementsChecker, ItemManager)}.
+	 * {@link #GuidanceBannerView(RequirementsChecker, ItemManager, ClientThread)}.
 	 */
 	public GuidanceBannerView(RequirementsChecker requirementsChecker)
 	{
-		this(requirementsChecker, null);
+		this(requirementsChecker, null, null);
 	}
 
+	/**
+	 * 2-arg constructor retained for call sites that have {@link ItemManager}
+	 * but not {@link ClientThread}. Chip tooltips degrade to {@code "Item <id>"}.
+	 */
 	public GuidanceBannerView(RequirementsChecker requirementsChecker, ItemManager itemManager)
+	{
+		this(requirementsChecker, itemManager, null);
+	}
+
+	/**
+	 * Full constructor. When {@code clientThread} is non-null the recommended-gear
+	 * chip tooltips are resolved on the client thread, avoiding the EDT assertion
+	 * in {@link net.runelite.client.game.ItemManager#getItemComposition}.
+	 */
+	public GuidanceBannerView(RequirementsChecker requirementsChecker, ItemManager itemManager,
+		ClientThread clientThread)
 	{
 		this.requirementsChecker = requirementsChecker;
 
@@ -143,7 +159,7 @@ public class GuidanceBannerView extends JPanel
 		// CollectionLogSource.getEffectiveRecommendedItemIds().
 		if (itemManager != null)
 		{
-			recommendedChipPanel = new SourceRecommendedItemsChipPanel(itemManager);
+			recommendedChipPanel = new SourceRecommendedItemsChipPanel(itemManager, clientThread);
 			recommendedChipPanel.setAlignmentX(LEFT_ALIGNMENT);
 			recommendedChipPanel.setBorder(BorderFactory.createEmptyBorder(2, 0, 4, 0));
 			add(recommendedChipPanel);

--- a/src/main/java/com/collectionloghelper/ui/widget/SourceRecommendedItemsChipPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/widget/SourceRecommendedItemsChipPanel.java
@@ -31,6 +31,7 @@ import java.awt.RenderingHints;
 import java.awt.image.BufferedImage;
 import java.util.Collections;
 import java.util.List;
+import javax.annotation.Nullable;
 import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
@@ -40,6 +41,7 @@ import javax.swing.JPanel;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
 import net.runelite.api.ItemComposition;
+import net.runelite.client.callback.ClientThread;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.util.AsyncBufferedImage;
@@ -90,6 +92,14 @@ public class SourceRecommendedItemsChipPanel extends JPanel
 
 	private final ItemManager itemManager;
 
+	/**
+	 * Optional client thread used to resolve item names off the EDT.
+	 * When {@code null} (e.g. in {@link com.collectionloghelper.ui.ItemDetailPanel}
+	 * or unit tests), tooltips degrade gracefully to {@code "Item <id>"}.
+	 */
+	@Nullable
+	private final ClientThread clientThread;
+
 	/** The horizontal row that holds the heading label and chip labels. */
 	private final JPanel chipRow;
 
@@ -102,9 +112,32 @@ public class SourceRecommendedItemsChipPanel extends JPanel
 	 */
 	private List<Integer> lastRenderedIds = null;
 
+	/**
+	 * Constructs the panel without a client thread. Chip tooltips will always
+	 * show {@code "Item <id>"} rather than the resolved item name. Use this
+	 * constructor from call sites that don't have access to {@link ClientThread}
+	 * (e.g. {@link com.collectionloghelper.ui.ItemDetailPanel}).
+	 */
 	public SourceRecommendedItemsChipPanel(ItemManager itemManager)
 	{
+		this(itemManager, null);
+	}
+
+	/**
+	 * Constructs the panel with an optional client thread for async name
+	 * resolution. When {@code clientThread} is non-null, each chip's tooltip
+	 * is resolved on the client thread and then applied on the EDT — ensuring
+	 * {@link ItemManager#getItemComposition} is never called from the EDT.
+	 *
+	 * @param itemManager  the item manager (may be {@code null} in unit tests)
+	 * @param clientThread the client thread for deferred name lookup, or
+	 *                     {@code null} to skip name resolution
+	 */
+	public SourceRecommendedItemsChipPanel(@Nullable ItemManager itemManager,
+		@Nullable ClientThread clientThread)
+	{
 		this.itemManager = itemManager;
+		this.clientThread = clientThread;
 
 		setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
 		setBackground(BG);
@@ -181,8 +214,11 @@ public class SourceRecommendedItemsChipPanel extends JPanel
 
 	/**
 	 * Builds a single chip label: a fixed-size icon placeholder surrounded by a
-	 * 1-pixel muted neutral border. The icon and tooltip are loaded
-	 * asynchronously when {@code itemManager} can resolve them.
+	 * 1-pixel muted neutral border. The icon is loaded asynchronously via
+	 * {@link #loadChipIcon}. The tooltip is initially set to {@code "Item <id>"}
+	 * and then updated asynchronously on the client thread (if one is available)
+	 * to avoid calling {@link ItemManager#getItemComposition} from the EDT, which
+	 * throws {@code AssertionError: must be called on client thread}.
 	 *
 	 * <p>Package-visible for test reflection.
 	 */
@@ -198,14 +234,45 @@ public class SourceRecommendedItemsChipPanel extends JPanel
 		chip.setBackground(BG);
 		chip.setOpaque(true);
 
-		// Tooltip — item name when resolvable; fall back to the raw ID so
-		// players can spot-check missing names in dev builds.
-		String tooltip = lookupName(itemId);
-		chip.setToolTipText(tooltip);
+		// Safe placeholder — never calls getItemComposition on the EDT.
+		chip.setToolTipText("Item " + itemId);
+
+		// Resolve the real item name on the client thread, then push it back to
+		// the EDT. This is a no-op when clientThread is null (e.g. ItemDetailPanel
+		// call site or unit tests), leaving the placeholder tooltip in place.
+		resolveNameAsync(itemId, chip);
 
 		loadChipIcon(itemId, chip);
 
 		return chip;
+	}
+
+	/**
+	 * Schedules an item-name lookup on the client thread and, when done, applies
+	 * the result as the chip's tooltip text on the EDT. No-op when
+	 * {@code clientThread} or {@code itemManager} is null.
+	 */
+	private void resolveNameAsync(int itemId, JLabel chip)
+	{
+		if (clientThread == null || itemManager == null)
+		{
+			return;
+		}
+		clientThread.invokeLater(() ->
+		{
+			String name;
+			try
+			{
+				ItemComposition comp = itemManager.getItemComposition(itemId);
+				name = (comp != null && comp.getName() != null) ? comp.getName() : "Item " + itemId;
+			}
+			catch (Exception ex)
+			{
+				name = "Item " + itemId;
+			}
+			final String resolvedName = name;
+			SwingUtilities.invokeLater(() -> chip.setToolTipText(resolvedName));
+		});
 	}
 
 	/**
@@ -243,40 +310,6 @@ public class SourceRecommendedItemsChipPanel extends JPanel
 		{
 			applyIcon.run();
 		}
-	}
-
-	/**
-	 * Returns the item name for {@code itemId} via {@link ItemManager#getItemComposition},
-	 * falling back to {@code "Item " + itemId} if the lookup fails or returns null.
-	 */
-	private String lookupName(int itemId)
-	{
-		if (itemManager == null)
-		{
-			return "Item " + itemId;
-		}
-		try
-		{
-			ItemComposition comp = itemManager.getItemComposition(itemId);
-			if (comp != null && comp.getName() != null)
-			{
-				return comp.getName();
-			}
-		}
-		catch (RuntimeException | AssertionError ignored)
-		{
-			// Two cases fall through to the id-based fallback:
-			//   1. Some test contexts don't wire up ItemManager fully (RuntimeException).
-			//   2. getItemComposition asserts "must be called on client thread" when
-			//      invoked from the EDT (this widget rebuilds on the EDT). That assertion
-			//      is an AssertionError (an Error, not a RuntimeException); before it was
-			//      caught here it propagated out of buildChip and aborted the whole
-			//      update() lambda mid-strip, leaving the chip row emptied -- the visible
-			//      flash on every rebuild while guidance is active. Catching it lets the
-			//      strip finish building atomically. Proper name resolution on the client
-			//      thread is tracked separately (see issue for off-thread ItemManager use).
-		}
-		return "Item " + itemId;
 	}
 
 	private static BufferedImage scaleImage(BufferedImage source, int width, int height)

--- a/src/test/java/com/collectionloghelper/data/RequirementsCheckerTest.java
+++ b/src/test/java/com/collectionloghelper/data/RequirementsCheckerTest.java
@@ -56,7 +56,8 @@ public class RequirementsCheckerTest
 	@Test
 	public void formatEnumName_mixedRomanNumerals()
 	{
-		assertEquals("Song Of The Elves IV", RequirementsChecker.formatEnumName("SONG_OF_THE_ELVES_IV"));
+		// "of" and "the" are connector words — they stay lowercase mid-name
+		assertEquals("Song of the Elves IV", RequirementsChecker.formatEnumName("SONG_OF_THE_ELVES_IV"));
 	}
 
 	@Test
@@ -69,7 +70,8 @@ public class RequirementsCheckerTest
 	public void formatEnumName_consecutiveUnderscores()
 	{
 		// Fairytale II has double underscore in enum: FAIRYTALE_II__CURE_A_QUEEN
-		assertEquals("Fairytale II Cure A Queen",
+		// "a" is a connector word so it stays lowercase mid-name
+		assertEquals("Fairytale II Cure a Queen",
 			RequirementsChecker.formatEnumName("FAIRYTALE_II__CURE_A_QUEEN"));
 	}
 
@@ -96,6 +98,43 @@ public class RequirementsCheckerTest
 	public void formatEnumName_romanNumeralVII()
 	{
 		assertEquals("Part VII", RequirementsChecker.formatEnumName("PART_VII"));
+	}
+
+	// #680 — connector words and apostrophe overrides
+
+	@Test
+	public void formatEnumName_connectorOf_isLowercase()
+	{
+		assertEquals("Shades of Mort'ton", RequirementsChecker.formatEnumName("SHADES_OF_MORTTON"));
+	}
+
+	@Test
+	public void formatEnumName_connectorThe_isLowercase()
+	{
+		// "the" mid-name stays lowercase; first word is always capitalised
+		assertEquals("Song of the Elves IV", RequirementsChecker.formatEnumName("SONG_OF_THE_ELVES_IV"));
+	}
+
+	@Test
+	public void formatEnumName_firstWordAlwaysCapitalised()
+	{
+		// Even when the first token is a connector word it must be capitalised;
+		// "and" in the middle stays lowercase
+		assertEquals("Of Mice and Men", RequirementsChecker.formatEnumName("OF_MICE_AND_MEN"));
+	}
+
+	@Test
+	public void formatEnumName_connectorAnd_isLowercase()
+	{
+		assertEquals("Rum Deal", RequirementsChecker.formatEnumName("RUM_DEAL")); // sanity — no connector
+		assertEquals("Rune and Ruin", RequirementsChecker.formatEnumName("RUNE_AND_RUIN")); // "and" lowercase
+	}
+
+	@Test
+	public void formatEnumName_dragonSlayerUnchanged()
+	{
+		// Regression: non-connector words still title-cased normally
+		assertEquals("Dragon Slayer", RequirementsChecker.formatEnumName("DRAGON_SLAYER"));
 	}
 
 	// =========================================================================

--- a/src/test/java/com/collectionloghelper/ui/PanelHeaderBuilderTest.java
+++ b/src/test/java/com/collectionloghelper/ui/PanelHeaderBuilderTest.java
@@ -90,6 +90,7 @@ public class PanelHeaderBuilderTest
 			slayerStrategyCalculator,
 			requirementsChecker,
 			itemManager,
+			null, // clientThread not available in unit tests; chip tooltips degrade to "Item <id>"
 			(source, count) -> { /* no-op */ },
 			() -> { /* no-op */ },
 			host);


### PR DESCRIPTION
## Summary

- **#679** `SourceRecommendedItemsChipPanel` was calling `ItemManager.getItemComposition()` on the Swing EDT to populate chip tooltips. That method asserts caller-is-client-thread and throws `AssertionError` (not `RuntimeException`), so the existing `catch` block did not cover it — the error escaped `buildChip`, aborted the whole `update()` lambda, and crashed `CollectionLogHelperPanel.rebuild()` on login.
- **#680** `RequirementsChecker.formatEnumName()` naive title-cased every word, producing labels like `"Shades Of Mortton"` instead of `"Shades of Mort'ton"`.

## Fix detail

**#679 — client-thread name resolution**
- `SourceRecommendedItemsChipPanel` now accepts an optional `ClientThread` (nullable for call sites without one, e.g. `ItemDetailPanel`).
- `buildChip` sets tooltip to `"Item <id>"` immediately (EDT-safe), then schedules a `clientThread.invokeLater` to resolve the real name via `getItemComposition` and pushes it back to the EDT via `SwingUtilities.invokeLater`.
- The `lookupName` method and its `AssertionError` workaround are removed.
- `ClientThread` is threaded through `GuidanceBannerView` (new 3-arg constructor; 1-arg and 2-arg overloads kept for compatibility) and `PanelHeaderBuilder.build()`, sourced from the already-injected `clientThread` in `CollectionLogHelperPlugin`.

**#680 — connector-word lowercasing and apostrophe overrides**
- `LOWERCASE_CONNECTORS` set: common English prepositions/articles (`of`, `the`, `and`, `in`, `a`, `an`, `to`, `for`, `at`, `by`, `or`) are lowercased in non-first position.
- `ENUM_NAME_OVERRIDES` map: explicit display-string overrides for names with apostrophes or punctuation that cannot be reconstructed from the enum constant (bootstrapped with `SHADES_OF_MORTTON → "Shades of Mort'ton"`).

## Tests

- `PanelHeaderBuilderTest`: updated to pass `null` for `clientThread` (no RuneLite runtime in unit tests).
- `RequirementsCheckerTest`: two existing assertions corrected for the now-accurate connector-lowercasing behaviour; six new assertions added covering the `Shades of Mort'ton` override, first-word capitalisation, `and` connector, and `Dragon Slayer` regression guard.
- Full suite: 1673 tests, all pass.