### PR TITLE
fix(data): correct Runecrafting (Fire Runes) skill enum to RUNECRAFT

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -29607,7 +29607,7 @@
     "requirements": {
       "skills": [
         {
-          "skill": "RUNECRAFTING",
+          "skill": "RUNECRAFT",
           "level": 14
         }
       ]


### PR DESCRIPTION
## Problem
The `Runecrafting (Fire Runes)` source's skill requirement used `"skill": "RUNECRAFTING"`. The RuneLite `Skill` enum constant is `RUNECRAFT` (no -ING), so the value would fail enum resolution silently and the level-14 gate would never apply.

## Fix
`RUNECRAFTING` -> `RUNECRAFT`. Single occurrence. Closes #678.

## Validation
JSON parses; full `./gradlew test` green; ASCII-clean.