### PR TITLE
data(d5): batch B (partial) - POH-teleport alternatives on 4 skilling + wilderness sources

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -8825,7 +8825,18 @@
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 15,
         "travelTip": "Crystal teleport seed -> Prifddinas, or Lletya teleport + run north",
-        "section": "Travel"
+        "section": "Travel",
+        "conditionalAlternatives": [
+          {
+            "requirements": {
+              "pohTeleports": [
+                "FAIRY_RING"
+              ]
+            },
+            "description": "POH fairy ring -> BIS (Prifddinas), then run south-east to the Trahaearn mining area and enter Zalcano's chamber",
+            "travelTip": "POH fairy ring BIS -> Prifddinas -> run SE to Zalcano"
+          }
+        ]
       },
       {
         "description": "Enter the Zalcano chamber portal. The group fight starts as soon as you arrive on the mining tiles - you can join in progress",
@@ -15679,7 +15690,18 @@
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 15,
         "travelTip": "Digsite pendant -> Mushroom Forest + run NE, or Fairy ring DLR",
-        "section": "Travel"
+        "section": "Travel",
+        "conditionalAlternatives": [
+          {
+            "requirements": {
+              "pohTeleports": [
+                "DIGSITE_PENDANT"
+              ]
+            },
+            "description": "POH mounted digsite pendant -> Fossil Island, then run north-east to the Volcanic Mine entrance",
+            "travelTip": "POH digsite pendant -> Fossil Island -> run NE to Volcanic Mine"
+          }
+        ]
       },
       {
         "description": "Enter the Volcanic Mine entrance and join a game lobby. Worlds 408/409 are the official VM theme worlds; solo runs are possible but team play multiplies points/hour by 3-5x.",
@@ -20623,7 +20645,18 @@
           0
         ],
         "travelTip": "Xeric's talisman (Xeric's Heart); or fairy ring CIS",
-        "section": "Travel"
+        "section": "Travel",
+        "conditionalAlternatives": [
+          {
+            "requirements": {
+              "pohTeleports": [
+                "XERICS_TALISMAN"
+              ]
+            },
+            "description": "POH mounted Xeric's talisman -> Xeric's Heart, then run south to the Kourend Castle statue entrance",
+            "travelTip": "POH Xeric's talisman -> Xeric's Heart -> run south to Catacombs statue"
+          }
+        ]
       },
       {
         "description": "Investigate the Statue of King Rada I in the castle courtyard to enter the Catacombs of Kourend.",
@@ -22419,7 +22452,18 @@
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 15,
         "travelTip": "Skills necklace -> Mining Guild entrance; or Falador tele + Dwarven Mine NE Falador",
-        "section": "Travel"
+        "section": "Travel",
+        "conditionalAlternatives": [
+          {
+            "requirements": {
+              "pohTeleports": [
+                "JEWELLERY_BOX_FANCY"
+              ]
+            },
+            "description": "POH jewellery box -> Skills necklace -> Mining Guild entrance, then run east into the Dwarven Mine to Motherlode Mine",
+            "travelTip": "POH Skills necklace -> Mining Guild -> run east to Motherlode Mine"
+          }
+        ]
       },
       {
         "description": "Mine pay-dirt from ore veins. Each vein lasts 23-27 seconds (36-40 on upper level). Use the coal bag to carry extra capacity. Amulet of glory increases uncut gem rates from veins.",

--- a/src/test/java/com/collectionloghelper/data/D5BBranchRegressionTest.java
+++ b/src/test/java/com/collectionloghelper/data/D5BBranchRegressionTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.lang.reflect.Field;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * D5 batch B regression guard - locks the POH-teleport conditional alternatives
+ * wired on skilling and wilderness sources:
+ *
+ * <ul>
+ *   <li>Zalcano: {@code FAIRY_RING} -&gt; BIS (Prifddinas).</li>
+ *   <li>Volcanic Mine: {@code DIGSITE_PENDANT} -&gt; Fossil Island.</li>
+ *   <li>Catacombs of Kourend: {@code XERICS_TALISMAN} -&gt; Xeric's Heart.</li>
+ *   <li>Motherlode Mine: {@code JEWELLERY_BOX_FANCY} -&gt; Skills necklace -&gt; Mining Guild.</li>
+ * </ul>
+ *
+ * <p>This batch shipped 4 of its 8 scoped sources; Hallowed Sepulchre, Rooftop
+ * Agility, Colossal Wyrm Agility, and Revenants are deferred to a follow-up.
+ *
+ * <p>For each wired source, some guidance step must carry a
+ * {@code conditionalAlternatives} entry whose {@code requirements.pohTeleports}
+ * equals the expected single-element list, the alternative must override
+ * description + travelTip (mentioning POH), and that step's base description
+ * must remain (the unrestricted route is not replaced). Index-agnostic: the
+ * alternative may sit on any step.
+ */
+public class D5BBranchRegressionTest
+{
+	private static final Map<String, List<String>> EXPECTED = buildExpected();
+
+	private static Map<String, List<String>> buildExpected()
+	{
+		Map<String, List<String>> map = new LinkedHashMap<>();
+		map.put("Zalcano",              List.of("FAIRY_RING"));
+		map.put("Volcanic Mine",        List.of("DIGSITE_PENDANT"));
+		map.put("Catacombs of Kourend", List.of("XERICS_TALISMAN"));
+		map.put("Motherlode Mine",      List.of("JEWELLERY_BOX_FANCY"));
+		return map;
+	}
+
+	private DropRateDatabase database;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		database = new DropRateDatabase();
+
+		Gson gson = new GsonBuilder().create();
+		Field gsonField = DropRateDatabase.class.getDeclaredField("gson");
+		gsonField.setAccessible(true);
+		gsonField.set(database, gson);
+
+		database.load();
+	}
+
+	@Test
+	public void wiredSourceCarriesPohTeleportConditionalAlternative()
+	{
+		for (Map.Entry<String, List<String>> entry : EXPECTED.entrySet())
+		{
+			String name = entry.getKey();
+			List<String> expectedPoh = entry.getValue();
+
+			CollectionLogSource source = findSource(name);
+			assertNotNull(source, "Expected source: " + name);
+			assertNotNull(source.getGuidanceSteps(), name + ": guidanceSteps must not be null");
+
+			GuidanceStep wiredStep = null;
+			ConditionalAlternative wiredAlt = null;
+			for (GuidanceStep step : source.getGuidanceSteps())
+			{
+				List<ConditionalAlternative> alts = step.getConditionalAlternatives();
+				if (alts == null)
+				{
+					continue;
+				}
+				ConditionalAlternative match = findPohAlternative(alts, expectedPoh);
+				if (match != null)
+				{
+					wiredStep = step;
+					wiredAlt = match;
+					break;
+				}
+			}
+
+			assertNotNull(wiredAlt,
+				name + ": expected a conditional alternative with pohTeleports = " + expectedPoh);
+
+			SourceRequirements altReqs = wiredAlt.getRequirements();
+			assertNotNull(altReqs, name + ": conditional alternative must declare requirements");
+			assertEquals(expectedPoh, altReqs.getPohTeleports(), name + ": pohTeleports mismatch");
+
+			assertNotNull(wiredAlt.getDescription(), name + ": alternative must override description");
+			assertTrue(wiredAlt.getDescription().toUpperCase().contains("POH"),
+				name + ": alternative description should mention POH; got: " + wiredAlt.getDescription());
+			assertNotNull(wiredAlt.getTravelTip(), name + ": alternative must override travelTip");
+
+			// Fallback preserved: the step carrying the alternative still has a base description.
+			assertNotNull(wiredStep.getDescription(), name + ": base step description must remain");
+			assertFalse(wiredStep.getDescription().isBlank(), name + ": base step description must not be blank");
+		}
+	}
+
+	@Test
+	public void expectedSourcesArePresentInDatabase()
+	{
+		for (String name : EXPECTED.keySet())
+		{
+			assertNotNull(findSource(name), "Expected source missing from drop_rates.json: " + name);
+		}
+		assertEquals(4, EXPECTED.size(), "D5 batch B (partial) covers exactly 4 sources");
+	}
+
+	private static ConditionalAlternative findPohAlternative(
+		List<ConditionalAlternative> alternatives, List<String> expectedPoh)
+	{
+		for (ConditionalAlternative candidate : alternatives)
+		{
+			SourceRequirements reqs = candidate.getRequirements();
+			if (reqs == null)
+			{
+				continue;
+			}
+			List<String> pohTeleports = reqs.getPohTeleports();
+			if (pohTeleports != null && pohTeleports.equals(expectedPoh))
+			{
+				return candidate;
+			}
+		}
+		return null;
+	}
+
+	private CollectionLogSource findSource(String name)
+	{
+		for (CollectionLogSource source : database.getAllSources())
+		{
+			if (name.equals(source.getName()))
+			{
+				return source;
+			}
+		}
+		return null;
+	}
+}


### PR DESCRIPTION
## Summary
D5 batch B, partial (4 of 8 scoped sources). Layers a `conditionalAlternatives` POH-teleport shortcut onto the arrival step of each source, with the unrestricted base step retained as fallback (the C6 pattern).

| Source | pohTeleports | Route |
|--------|--------------|-------|
| Zalcano | `FAIRY_RING` | BIS (Prifddinas) -> Trahaearn mine |
| Volcanic Mine | `DIGSITE_PENDANT` | Fossil Island -> mine entrance |
| Catacombs of Kourend | `XERICS_TALISMAN` | Xeric's Heart -> castle statue |
| Motherlode Mine | `JEWELLERY_BOX_FANCY` | Skills necklace -> Mining Guild |

All four constants verified present in `PohTeleport.java`. Adds `D5BBranchRegressionTest` (index-agnostic: alternative + base fallback).

## Deferred
Hallowed Sepulchre, Rooftop Agility, Colossal Wyrm Agility, Revenants -> a D5-B follow-up (several need per-source route research). D5-D (diary skilling/minigame) was dropped this wave: minigame teleports are already optimal, so the cluster has no meaningful diary shortcuts.