### PR TITLE
data(d5): batch F - inventory-teleport alternatives on 5 sources

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -3836,6 +3836,16 @@
             },
             "description": "POH mounted Xeric's talisman -> Xeric's Heart, then run south-east to the Forthos trapdoor north of Hosidius",
             "travelTip": "POH Xeric's talisman -> Heart -> run south-east to Forthos trapdoor"
+          },
+          {
+            "requirements": {
+              "inventoryItemIdsAny": [
+                13393,
+                18465
+              ]
+            },
+            "description": "Rub the Xeric's talisman in your inventory and pick Xeric's Heart, then run south-east to the Forthos trapdoor north of Hosidius - faster than the Hosidius lodestone overland route",
+            "travelTip": "Inventory Xeric's talisman -> Heart -> run south-east to Forthos trapdoor"
           }
         ],
         "section": "Travel"
@@ -10981,6 +10991,25 @@
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
+        "conditionalAlternatives": [
+          {
+            "requirements": {
+              "inventoryItemIdsAny": [
+                11866,
+                11867,
+                11868,
+                11869,
+                11870,
+                11871,
+                11872,
+                11873,
+                21268
+              ]
+            },
+            "description": "Rub the Slayer ring in your inventory and pick Slayer Tower to land at the ground-floor entrance, then climb to the first floor - skipping the fairy ring CKS walk from Canifis",
+            "travelTip": "Inventory Slayer ring -> Slayer Tower entrance"
+          }
+        ],
         "section": "Travel"
       },
       {
@@ -11891,6 +11920,25 @@
           10050,
           0
         ],
+        "conditionalAlternatives": [
+          {
+            "requirements": {
+              "inventoryItemIdsAny": [
+                11866,
+                11867,
+                11868,
+                11869,
+                11870,
+                11871,
+                11872,
+                11873,
+                21268
+              ]
+            },
+            "description": "Rub the Slayer ring in your inventory and pick Fremennik Slayer Dungeon to land just inside the entrance, skipping the overland run east from Rellekka",
+            "travelTip": "Inventory Slayer ring -> Fremennik Slayer Dungeon entrance"
+          }
+        ],
         "section": "Travel"
       },
       {
@@ -12096,6 +12144,25 @@
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
         "travelTip": "Slayer ring -> Slayer Tower, or fairy ring CKS + walk north",
+        "conditionalAlternatives": [
+          {
+            "requirements": {
+              "inventoryItemIdsAny": [
+                11866,
+                11867,
+                11868,
+                11869,
+                11870,
+                11871,
+                11872,
+                11873,
+                21268
+              ]
+            },
+            "description": "Rub the Slayer ring in your inventory and pick Slayer Tower to land at the ground-floor entrance, then climb to the top floor - skipping the fairy ring CKS walk from Canifis",
+            "travelTip": "Inventory Slayer ring -> Slayer Tower entrance"
+          }
+        ],
         "section": "Travel"
       },
       {
@@ -12351,6 +12418,23 @@
             },
             "description": "POH jewellery box -> Combat bracelet -> Ranging Guild, then run south-east along the road to the Slayer Tower entrance",
             "travelTip": "POH Combat bracelet -> Ranging Guild -> run south-east to Slayer Tower"
+          },
+          {
+            "requirements": {
+              "inventoryItemIdsAny": [
+                11866,
+                11867,
+                11868,
+                11869,
+                11870,
+                11871,
+                11872,
+                11873,
+                21268
+              ]
+            },
+            "description": "Rub the Slayer ring in your inventory and pick Slayer Tower to land at the ground-floor entrance, then climb to the top floor - quicker than the fairy ring CKS walk from Canifis",
+            "travelTip": "Inventory Slayer ring -> Slayer Tower entrance"
           }
         ],
         "section": "Travel"

--- a/src/test/java/com/collectionloghelper/data/D5FBranchRegressionTest.java
+++ b/src/test/java/com/collectionloghelper/data/D5FBranchRegressionTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.lang.reflect.Field;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * D5 batch F regression guard - locks the inventory-teleport conditional
+ * alternatives wired on slayer + Kourend sources via {@code inventoryItemIdsAny}
+ * (OR-semantics over charge-tier / model variants):
+ *
+ * <ul>
+ *   <li>Sarachnis: inventory Xeric's talisman -&gt; Xeric's Heart (talisman models
+ *       13393 / 18465).</li>
+ *   <li>Nechryael: inventory Slayer ring -&gt; Slayer Tower entrance (rings 1-8 +
+ *       eternal).</li>
+ *   <li>Gargoyle: inventory Slayer ring -&gt; Slayer Tower entrance.</li>
+ *   <li>Kurask: inventory Slayer ring -&gt; Fremennik Slayer Dungeon entrance.</li>
+ *   <li>Bloodveld: inventory Slayer ring -&gt; Slayer Tower entrance.</li>
+ * </ul>
+ *
+ * <p>For each wired source, some guidance step must carry a
+ * {@code conditionalAlternatives} entry whose
+ * {@code requirements.inventoryItemIdsAny} equals the expected ID list, the
+ * alternative must override description + travelTip (mentioning the inventory
+ * teleport vector), and that step's base description must remain (the
+ * unrestricted route is the fallback). Index-agnostic: the alternative may sit
+ * on any step.
+ */
+public class D5FBranchRegressionTest
+{
+	private static final List<Integer> SLAYER_RING_ANY =
+		List.of(11866, 11867, 11868, 11869, 11870, 11871, 11872, 11873, 21268);
+	private static final List<Integer> XERIC_TALISMAN_ANY = List.of(13393, 18465);
+
+	private static final Map<String, List<Integer>> EXPECTED = buildExpected();
+
+	private static Map<String, List<Integer>> buildExpected()
+	{
+		Map<String, List<Integer>> map = new LinkedHashMap<>();
+		map.put("Sarachnis", XERIC_TALISMAN_ANY);
+		map.put("Nechryael", SLAYER_RING_ANY);
+		map.put("Gargoyle",  SLAYER_RING_ANY);
+		map.put("Kurask",    SLAYER_RING_ANY);
+		map.put("Bloodveld", SLAYER_RING_ANY);
+		return map;
+	}
+
+	private DropRateDatabase database;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		database = new DropRateDatabase();
+
+		Gson gson = new GsonBuilder().create();
+		Field gsonField = DropRateDatabase.class.getDeclaredField("gson");
+		gsonField.setAccessible(true);
+		gsonField.set(database, gson);
+
+		database.load();
+	}
+
+	@Test
+	public void wiredSourceCarriesInventoryTeleportConditionalAlternative()
+	{
+		for (Map.Entry<String, List<Integer>> entry : EXPECTED.entrySet())
+		{
+			String name = entry.getKey();
+			List<Integer> expectedAny = entry.getValue();
+
+			CollectionLogSource source = findSource(name);
+			assertNotNull(source, "Expected source: " + name);
+			assertNotNull(source.getGuidanceSteps(), name + ": guidanceSteps must not be null");
+
+			GuidanceStep wiredStep = null;
+			ConditionalAlternative wiredAlt = null;
+			for (GuidanceStep step : source.getGuidanceSteps())
+			{
+				List<ConditionalAlternative> alts = step.getConditionalAlternatives();
+				if (alts == null)
+				{
+					continue;
+				}
+				ConditionalAlternative match = findInventoryAlternative(alts, expectedAny);
+				if (match != null)
+				{
+					wiredStep = step;
+					wiredAlt = match;
+					break;
+				}
+			}
+
+			assertNotNull(wiredAlt,
+				name + ": expected a conditional alternative with inventoryItemIdsAny = " + expectedAny);
+
+			SourceRequirements altReqs = wiredAlt.getRequirements();
+			assertNotNull(altReqs, name + ": conditional alternative must declare requirements");
+			assertEquals(expectedAny, altReqs.getInventoryItemIdsAny(),
+				name + ": inventoryItemIdsAny mismatch");
+
+			assertNotNull(wiredAlt.getDescription(), name + ": alternative must override description");
+			assertTrue(wiredAlt.getDescription().toLowerCase().contains("inventory")
+					|| wiredAlt.getDescription().toLowerCase().contains("rub"),
+				name + ": alternative description should mention the inventory teleport; got: "
+					+ wiredAlt.getDescription());
+			assertNotNull(wiredAlt.getTravelTip(), name + ": alternative must override travelTip");
+			assertTrue(wiredAlt.getTravelTip().toLowerCase().contains("inventory"),
+				name + ": alternative travelTip should mention inventory; got: " + wiredAlt.getTravelTip());
+
+			// Fallback preserved: the step carrying the alternative still has a base description.
+			assertNotNull(wiredStep.getDescription(), name + ": base step description must remain");
+			assertFalse(wiredStep.getDescription().isBlank(), name + ": base step description must not be blank");
+		}
+	}
+
+	@Test
+	public void expectedSourcesArePresentInDatabase()
+	{
+		for (String name : EXPECTED.keySet())
+		{
+			assertNotNull(findSource(name), "Expected source missing from drop_rates.json: " + name);
+		}
+		assertEquals(5, EXPECTED.size(), "D5 batch F covers exactly 5 sources");
+	}
+
+	private static ConditionalAlternative findInventoryAlternative(
+		List<ConditionalAlternative> alternatives, List<Integer> expectedAny)
+	{
+		for (ConditionalAlternative candidate : alternatives)
+		{
+			SourceRequirements reqs = candidate.getRequirements();
+			if (reqs == null)
+			{
+				continue;
+			}
+			List<Integer> inventoryAny = reqs.getInventoryItemIdsAny();
+			if (inventoryAny != null && inventoryAny.equals(expectedAny))
+			{
+				return candidate;
+			}
+		}
+		return null;
+	}
+
+	private CollectionLogSource findSource(String name)
+	{
+		for (CollectionLogSource source : database.getAllSources())
+		{
+			if (name.equals(source.getName()))
+			{
+				return source;
+			}
+		}
+		return null;
+	}
+}

--- a/src/test/java/com/collectionloghelper/data/InventoryItemsAnyMigrationTest.java
+++ b/src/test/java/com/collectionloghelper/data/InventoryItemsAnyMigrationTest.java
@@ -70,7 +70,14 @@ public class InventoryItemsAnyMigrationTest
 		"Tombs of Amascut (500 Invocation)",
 		"Phantom Muspah",
 		"The Gauntlet",
-		"Corrupted Gauntlet");
+		"Corrupted Gauntlet",
+		// D5 batch F: inventory-teleport alternatives (Xeric's talisman / Slayer ring
+		// rub-from-inventory variants). Positive coverage in D5FBranchRegressionTest.
+		"Sarachnis",
+		"Nechryael",
+		"Gargoyle",
+		"Kurask",
+		"Bloodveld");
 
 	private DropRateDatabase database;
 


### PR DESCRIPTION
## D5-F: inventory-teleport conditional alternatives

Wires one `conditionalAlternatives` entry per source where an inventory-held teleport item lands closer to the arrival point than the base route. The unrestricted base step stays as the fallback. All five use `inventoryItemIdsAny` (OR-semantics over charge-tier / model variants).

### Sources wired

| Source | Item(s) | ID(s) | Field | Route |
|---|---|---|---|---|
| Sarachnis | Xeric's talisman | 13393, 18465 | inventoryItemIdsAny | Rub talisman -> Xeric's Heart -> run SE to Forthos trapdoor (beats Hosidius lodestone overland) |
| Nechryael | Slayer ring (1-8, eternal) | 11866-11873, 21268 | inventoryItemIdsAny | Rub ring -> Slayer Tower ground-floor entrance, climb to top (beats fairy ring CKS walk from Canifis) |
| Gargoyle | Slayer ring (1-8, eternal) | 11866-11873, 21268 | inventoryItemIdsAny | Rub ring -> Slayer Tower entrance |
| Kurask | Slayer ring (1-8, eternal) | 11866-11873, 21268 | inventoryItemIdsAny | Rub ring -> Fremennik Slayer Dungeon entrance (skips overland run east from Rellekka) |
| Bloodveld | Slayer ring (1-8, eternal) | 11866-11873, 21268 | inventoryItemIdsAny | Rub ring -> Slayer Tower entrance |

### ID verification

- `runelite_id_lookup` (ItemID): `SLAYER_RING_8`..`SLAYER_RING_1` = 11866-11873 contiguous, `SLAYER_RING_ETERNAL` = 21268. Duplicate cache-revision constants (14008, 21269, 21441) deliberately excluded.
- `runelite_id_lookup` (ItemID): `XERIC_TALISMAN` resolves to both 13393 and 18465 (pre/post-2019 model). 13392 is the inert/empty variant and is excluded.
- Slayer ring and Xeric's talisman both teleport when **rubbed/operated from the inventory** (verified via wiki), so they are genuine D5-F inventory vectors, not equipped (D5-E) jewellery.

### Route justification

Wiki confirms Slayer ring lands "just inside the entrance" of the Slayer Tower (ground floor) and Fremennik Slayer Dungeon - faster than the documented fairy-ring/overland fallbacks. Xeric's talisman -> Heart is the closest teleport node to the Forthos trapdoor.

### Tests

- New `D5FBranchRegressionTest` (2 tests): asserts each source carries an alternative with the expected `inventoryItemIdsAny`, that it overrides description + travelTip (mentioning the inventory route), that the base step description survives, and that exactly 5 sources are wired.
- `./gradlew test --tests "*D5FBranchRegressionTest" --tests "*DropRate*"` -> BUILD SUCCESSFUL (D5F 2/2, DropRate 33/33, 0 failures).
- `data_ascii_lint`: 0 violations. JSON parses clean. `validate_drop_rates` shows only pre-existing repo-wide last-step warnings, no new issues.