### PR TITLE
data(d5): batch E - inventory-teleport jewellery alternatives on 4 sources

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -4117,6 +4117,21 @@
             },
             "description": "POH mounted glory -> Edgeville, landing directly at the Edgeville bank to restock before entering the Edgeville Dungeon",
             "travelTip": "POH mounted glory -> Edgeville bank"
+          },
+          {
+            "requirements": {
+              "inventoryItemIdsAny": [
+                1706,
+                1708,
+                1710,
+                1712,
+                11976,
+                11978,
+                19707
+              ]
+            },
+            "description": "Rub an Amulet of glory from your inventory and select Edgeville to land at the Edgeville bank, then run east to the dungeon trapdoor north of the bank.",
+            "travelTip": "Amulet of glory (inventory) -> Edgeville bank"
           }
         ],
         "section": "Bank"
@@ -5152,6 +5167,24 @@
           1704,
           385,
           2434
+        ],
+        "conditionalAlternatives": [
+          {
+            "requirements": {
+              "inventoryItemIdsAny": [
+                2552,
+                2554,
+                2556,
+                2558,
+                2560,
+                2562,
+                2564,
+                2566
+              ]
+            },
+            "description": "Rub a Ring of dueling from your inventory and select Ferox Enclave to bank instantly, restock the cheap kit, and recharge amulets at the fountain before entering the Wilderness.",
+            "travelTip": "Ring of dueling (inventory) -> Ferox Enclave bank"
+          }
         ],
         "section": "Bank"
       },
@@ -9985,6 +10018,23 @@
           391,
           2434,
           2444
+        ],
+        "conditionalAlternatives": [
+          {
+            "requirements": {
+              "inventoryItemIdsAny": [
+                1706,
+                1708,
+                1710,
+                1712,
+                11976,
+                11978,
+                19707
+              ]
+            },
+            "description": "Rub an Amulet of glory from your inventory and select Edgeville to bank at the Edgeville bank, restock the cheap Wilderness kit, then head north toward the Revenant Caves.",
+            "travelTip": "Amulet of glory (inventory) -> Edgeville bank"
+          }
         ],
         "section": "Bank"
       },
@@ -16845,7 +16895,25 @@
         "worldY": 3089,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20
+        "completionDistance": 20,
+        "conditionalAlternatives": [
+          {
+            "requirements": {
+              "inventoryItemIdsAny": [
+                2552,
+                2554,
+                2556,
+                2558,
+                2560,
+                2562,
+                2564,
+                2566
+              ]
+            },
+            "description": "Rub a Ring of dueling from your inventory and select Castle Wars to teleport straight to the arena lobby, skipping the Minigame teleport interface and its cooldown.",
+            "travelTip": "Ring of dueling (inventory) -> Castle Wars"
+          }
+        ]
       },
       {
         "section": "Queue",

--- a/src/test/java/com/collectionloghelper/data/D5EBranchRegressionTest.java
+++ b/src/test/java/com/collectionloghelper/data/D5EBranchRegressionTest.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.lang.reflect.Field;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * D5 batch E regression guard - locks the inventory-teleport-jewellery
+ * conditional alternatives wired with {@code inventoryItemIdsAny} over the
+ * charged-tier item IDs only.
+ *
+ * <p>Per the D5-E decision (mirroring the D5-F vector): charged teleport
+ * jewellery is modelled with {@code inventoryItemIdsAny} over the
+ * charged-variant IDs, NOT {@code equippedItemIds}. An equipped chargeable
+ * item reads true at 0 charges (a false promise); a depleted item carries a
+ * different ID, and a fully-depleted Ring of dueling crumbles to nothing, so
+ * listing only the charged-variant IDs is the correct true-inventory vector.
+ * One alternative per source; the unrestricted base step stays as fallback.
+ *
+ * <p>Wired sources and vectors:
+ * <ul>
+ *   <li>Castle Wars   - Ring of dueling (charged) -&gt; Castle Wars lobby</li>
+ *   <li>Chaos Fanatic - Ring of dueling (charged) -&gt; Ferox Enclave bank</li>
+ *   <li>Obor          - Amulet of glory (charged) -&gt; Edgeville bank
+ *       (stacked behind the pre-existing MOUNTED_GLORY POH alternative)</li>
+ *   <li>Revenants     - Amulet of glory (charged) -&gt; Edgeville bank</li>
+ * </ul>
+ *
+ * <p>Pattern mirrors {@link CExtensionInventoryTeleportRegressionTest} and
+ * {@link D5CBranchRegressionTest}.
+ */
+public class D5EBranchRegressionTest
+{
+	/** Ring of dueling charged tiers 8..1 (even IDs). No 0-charge variant - it crumbles to dust. */
+	private static final List<Integer> RING_OF_DUELING_CHARGED = List.of(
+		2552, 2554, 2556, 2558, 2560, 2562, 2564, 2566);
+
+	/** Amulet of glory charged tiers 1..6 plus eternal glory (unlimited). Excludes uncharged 1704. */
+	private static final List<Integer> AMULET_OF_GLORY_CHARGED = List.of(
+		1706, 1708, 1710, 1712, 11976, 11978, 19707);
+
+	/**
+	 * Per-source expectation: source name -&gt; expected charged-tier ID list
+	 * that must appear on exactly one first-step conditional alternative via
+	 * {@code inventoryItemIdsAny}. Insertion order is preserved for stable
+	 * failure reporting.
+	 */
+	private static final Map<String, List<Integer>> EXPECTED_IDS_BY_SOURCE = buildExpected();
+
+	private static Map<String, List<Integer>> buildExpected()
+	{
+		Map<String, List<Integer>> map = new LinkedHashMap<>();
+		map.put("Castle Wars", RING_OF_DUELING_CHARGED);
+		map.put("Chaos Fanatic", RING_OF_DUELING_CHARGED);
+		map.put("Obor", AMULET_OF_GLORY_CHARGED);
+		map.put("Revenants", AMULET_OF_GLORY_CHARGED);
+		return map;
+	}
+
+	/**
+	 * Per-source base-step description tokens that must remain in the
+	 * unrestricted fallback step after D5E wiring.
+	 */
+	private static final Map<String, String> EXPECTED_BASE_MARKER = buildBaseMarkers();
+
+	private static Map<String, String> buildBaseMarkers()
+	{
+		Map<String, String> map = new LinkedHashMap<>();
+		map.put("Castle Wars", "Travel to Castle Wars via the Minigame teleport");
+		map.put("Chaos Fanatic", "Bank in Ferox Enclave");
+		map.put("Obor", "Bank in Edgeville");
+		map.put("Revenants", "Bank in Edgeville or Ferox Enclave");
+		return map;
+	}
+
+	private DropRateDatabase database;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		database = new DropRateDatabase();
+
+		Gson gson = new GsonBuilder().create();
+		Field gsonField = DropRateDatabase.class.getDeclaredField("gson");
+		gsonField.setAccessible(true);
+		gsonField.set(database, gson);
+
+		database.load();
+	}
+
+	@Test
+	public void firstStepCarriesChargedInventoryAlternative()
+	{
+		for (Map.Entry<String, List<Integer>> entry : EXPECTED_IDS_BY_SOURCE.entrySet())
+		{
+			String name = entry.getKey();
+			List<Integer> expectedIds = entry.getValue();
+
+			CollectionLogSource source = findSource(name);
+			assertNotNull(source, "Expected source: " + name);
+			assertNotNull(source.getGuidanceSteps(), name + ": guidanceSteps must not be null");
+			assertFalse(source.getGuidanceSteps().isEmpty(), name + ": guidanceSteps must not be empty");
+
+			GuidanceStep firstStep = source.getGuidanceSteps().get(0);
+			List<ConditionalAlternative> alternatives = firstStep.getConditionalAlternatives();
+			assertNotNull(alternatives, name + ": first step must declare conditionalAlternatives");
+			assertFalse(alternatives.isEmpty(),
+				name + ": expected at least one conditional alternative for the jewellery route");
+
+			ConditionalAlternative alt = findInventoryAnyAlternative(alternatives, expectedIds);
+			assertNotNull(alt,
+				name + ": expected a conditional alternative with inventoryItemIdsAny == " + expectedIds
+					+ ", but none matched");
+
+			SourceRequirements reqs = alt.getRequirements();
+			assertNotNull(reqs, name + ": jewellery alternative must declare requirements");
+			assertNull(reqs.getInventoryItemIds(),
+				name + ": inventoryItemIds must be null on this OR-semantic jewellery alternative");
+			assertNull(reqs.getEquippedItemIds(),
+				name + ": equippedItemIds must be null - charged jewellery is an inventory vector here");
+			assertEquals(expectedIds, reqs.getInventoryItemIdsAny(),
+				name + ": inventoryItemIdsAny must equal the charged-tier ID list exactly");
+
+			assertNotNull(alt.getDescription(),
+				name + ": jewellery alternative must override description");
+			assertNotNull(alt.getTravelTip(),
+				name + ": jewellery alternative must override travelTip");
+			assertTrue(
+				alt.getDescription().toLowerCase().contains("ring of dueling")
+					|| alt.getDescription().toLowerCase().contains("amulet of glory"),
+				name + ": description should name the jewellery; got: " + alt.getDescription());
+			assertTrue(alt.getTravelTip().toLowerCase().contains("inventory"),
+				name + ": travelTip should mention the inventory rub; got: " + alt.getTravelTip());
+		}
+	}
+
+	@Test
+	public void baseStepDescriptionIsUntouched()
+	{
+		for (Map.Entry<String, String> entry : EXPECTED_BASE_MARKER.entrySet())
+		{
+			String name = entry.getKey();
+			String expectedMarker = entry.getValue();
+
+			CollectionLogSource source = findSource(name);
+			assertNotNull(source, "Expected source: " + name);
+
+			GuidanceStep firstStep = source.getGuidanceSteps().get(0);
+			String baseDescription = firstStep.getDescription();
+			assertNotNull(baseDescription, name + ": base step description must not be null");
+			assertTrue(baseDescription.contains(expectedMarker),
+				name + ": base step description must still contain the original fallback wording '"
+					+ expectedMarker + "'. Got: " + baseDescription);
+		}
+	}
+
+	@Test
+	public void oborKeepsPreExistingPohAlternativeAhead()
+	{
+		// Obor's Bank step already had a MOUNTED_GLORY POH alternative; the D5E
+		// inventory-glory alternative stacks behind it, so the POH alt must survive at index 0.
+		ConditionalAlternative poh =
+			findSource("Obor").getGuidanceSteps().get(0).getConditionalAlternatives().get(0);
+		assertNotNull(poh.getRequirements());
+		assertEquals(List.of("MOUNTED_GLORY"), poh.getRequirements().getPohTeleports(),
+			"Obor: pre-existing MOUNTED_GLORY POH alternative must remain at index 0");
+	}
+
+	@Test
+	public void wiredSourcesArePresentAndCountMatches()
+	{
+		for (String name : EXPECTED_IDS_BY_SOURCE.keySet())
+		{
+			assertNotNull(findSource(name),
+				"Expected source missing from drop_rates.json: " + name);
+		}
+		assertEquals(4, EXPECTED_IDS_BY_SOURCE.size(),
+			"D5E wires exactly 4 inventory-teleport-jewellery sources");
+	}
+
+	private static ConditionalAlternative findInventoryAnyAlternative(
+		List<ConditionalAlternative> alternatives, List<Integer> expectedIds)
+	{
+		for (ConditionalAlternative candidate : alternatives)
+		{
+			SourceRequirements reqs = candidate.getRequirements();
+			if (reqs == null)
+			{
+				continue;
+			}
+			List<Integer> any = reqs.getInventoryItemIdsAny();
+			if (any != null && any.equals(expectedIds))
+			{
+				return candidate;
+			}
+		}
+		return null;
+	}
+
+	private CollectionLogSource findSource(String name)
+	{
+		for (CollectionLogSource source : database.getAllSources())
+		{
+			if (name.equals(source.getName()))
+			{
+				return source;
+			}
+		}
+		return null;
+	}
+}

--- a/src/test/java/com/collectionloghelper/data/InventoryItemsAnyMigrationTest.java
+++ b/src/test/java/com/collectionloghelper/data/InventoryItemsAnyMigrationTest.java
@@ -77,7 +77,12 @@ public class InventoryItemsAnyMigrationTest
 		"Nechryael",
 		"Gargoyle",
 		"Kurask",
-		"Bloodveld");
+		"Bloodveld",
+		// D5 batch E - inventory teleport jewellery (charged-tier inventoryItemIdsAny)
+		"Castle Wars",
+		"Chaos Fanatic",
+		"Obor",
+		"Revenants");
 
 	private DropRateDatabase database;
 


### PR DESCRIPTION
## Summary

D5 batch E layers one `inventoryItemIdsAny` conditional alternative onto the
arrival/bank step of four collection-log sources where rubbing teleport
jewellery from the inventory gives a genuinely faster route (>~30s saved) to
the step's arrival point. The unrestricted base step stays as the fallback.

Per the D5-E decision: charged teleport jewellery is modelled with
`inventoryItemIdsAny` over the **charged-tier IDs only**, not `equippedItemIds`.
An equipped chargeable item reads true at 0 charges (a false promise); a
depleted item carries a different ID, so listing only the charged variants is
the correct true-inventory vector. No separate equipped-path alternative is
authored.

## Sources wired

### Castle Wars - Ring of dueling -> Castle Wars lobby (Travel step)
Rub from inventory teleports straight to the arena lobby, skipping the Minigame
teleport interface and its cooldown.
- IDs (charged 8..1, even): 2552, 2554, 2556, 2558, 2560, 2562, 2564, 2566
- Verification: oldschool.runescape.wiki/w/Ring_of_dueling + runelite ItemID cross-check (all `RING_OF_DUELING_*` match). No 0-charge variant exists (crumbles to dust at last use).

### Chaos Fanatic - Ring of dueling -> Ferox Enclave bank (Bank step)
Ferox Enclave bank + amulet-recharge fountain is the canonical pre-trip stop;
Ring of dueling lands on it instantly.
- IDs: same Ring of dueling charged set as above.

### Obor - Amulet of glory -> Edgeville bank (Bank step, stacked)
Stacked behind the pre-existing `MOUNTED_GLORY` POH alternative at index 0.
Glory rub lands at the Edgeville bank to restock before the Edgeville Dungeon.
- IDs (glory 1..6 + eternal): 1706, 1708, 1710, 1712, 11976, 11978, 19707
- Verification: oldschool.runescape.wiki/w/Amulet_of_glory + /Amulet_of_eternal_glory + runelite ItemID cross-check. Uncharged glory (1704) excluded - it does not teleport. Eternal glory (19707, `AMULET_OF_GLORY_INF`) has unlimited charges and rubs from inventory.

### Revenants - Amulet of glory -> Edgeville bank (Bank step)
Base step banks "in Edgeville or Ferox Enclave"; glory rub lands at the
Edgeville bank to restock the cheap Wilderness kit.
- IDs: same Amulet of glory charged set as Obor.

## Rejected candidates
- **Guilds (Fishing/Crafting/Mining/Woodcutting/Ranging), Fist of Guthix, Lava dragons, Brutal blue dragons**: not standalone sources in `drop_rates.json`.
- **Scorpia / Venenatis / Vet'ion / Callisto**: combined Travel steps arrive at the boss area via burning amulet, not a clean Ferox-bank step a Ring of dueling would serve; no clean inventory vector to the step's arrival tile.
- **D5-F set (Sarachnis, Nechryael, Gargoyle, Kurask, Bloodveld)**: explicitly out of scope, untouched.

## Tests
- New `D5EBranchRegressionTest` (4 tests): asserts each source's first step carries an `inventoryItemIdsAny` alternative equal to the expected charged-ID list, that it overrides description+travelTip, that `equippedItemIds`/`inventoryItemIds` stay null, that the base step description survives, that Obor's prior POH alt stays at index 0, and count == 4.
- `InventoryItemsAnyMigrationTest` allowlist extended with the four wired sources.
- Full `./gradlew test` suite: BUILD SUCCESSFUL. Migration guard passed (2 tests, 0 failures); D5E regression passed (4 tests, 0 failures).
- `data_ascii_lint`: 0 violations. `validate_drop_rates`: no new issues introduced (pre-existing last-step / duplicate-ID warnings only).