### PR TITLE
feat(data): add questMilestones + skillCapePerks requirement fields

### DIFF
--- a/src/main/java/com/collectionloghelper/data/RequirementsChecker.java
+++ b/src/main/java/com/collectionloghelper/data/RequirementsChecker.java
@@ -442,7 +442,10 @@ public class RequirementsChecker
 				}
 				catch (IllegalArgumentException e)
 				{
+					// Fail closed: an unverifiable requirement must not silently
+					// promise a shortcut the player may not qualify for.
 					log.warn("Unknown quest enum: {}", questName);
+					unmet.add("Quest started: " + formatEnumName(questName));
 				}
 			}
 		}
@@ -463,7 +466,10 @@ public class RequirementsChecker
 				}
 				catch (IllegalArgumentException e)
 				{
+					// Fail closed: an unverifiable requirement must not silently
+					// promise a shortcut the player may not qualify for.
 					log.warn("Unknown skill enum: {}", skillName);
+					unmet.add("Skill cape: " + formatEnumName(skillName));
 				}
 			}
 		}

--- a/src/main/java/com/collectionloghelper/data/RequirementsChecker.java
+++ b/src/main/java/com/collectionloghelper/data/RequirementsChecker.java
@@ -426,6 +426,48 @@ public class RequirementsChecker
 			}
 		}
 
+		if (requirements.getQuestMilestones() != null)
+		{
+			for (String questName : requirements.getQuestMilestones())
+			{
+				try
+				{
+					Quest quest = Quest.valueOf(questName);
+					// Looser than the quests field: STARTED is enough. Met when
+					// IN_PROGRESS or FINISHED, i.e. anything other than NOT_STARTED.
+					if (quest.getState(client) == QuestState.NOT_STARTED)
+					{
+						unmet.add("Quest started: " + formatEnumName(questName));
+					}
+				}
+				catch (IllegalArgumentException e)
+				{
+					log.warn("Unknown quest enum: {}", questName);
+				}
+			}
+		}
+
+		if (requirements.getSkillCapePerks() != null)
+		{
+			for (String skillName : requirements.getSkillCapePerks())
+			{
+				try
+				{
+					Skill skill = Skill.valueOf(skillName);
+					// Level-99 proxy: owning the skill cape (and its travel perk)
+					// requires level 99 in the named skill.
+					if (client.getRealSkillLevel(skill) < 99)
+					{
+						unmet.add("Skill cape: " + formatEnumName(skillName));
+					}
+				}
+				catch (IllegalArgumentException e)
+				{
+					log.warn("Unknown skill enum: {}", skillName);
+				}
+			}
+		}
+
 		return unmet;
 	}
 

--- a/src/main/java/com/collectionloghelper/data/SourceRequirements.java
+++ b/src/main/java/com/collectionloghelper/data/SourceRequirements.java
@@ -139,4 +139,53 @@ public class SourceRequirements
 	 */
 	@Nullable
 	List<Integer> inventoryItemIdsAny;
+
+	/**
+	 * Quest-milestone requirements expressed as RuneLite {@code Quest} enum
+	 * constant names, e.g. {@code "FAIRYTALE_II__CURE_A_QUEEN"}.
+	 *
+	 * <p>Looser than the {@link #quests} field: where {@code quests} requires
+	 * the quest to be {@code FINISHED}, an entry here is satisfied as soon as
+	 * the quest has been STARTED. Evaluated AND-wise via
+	 * {@code Quest.valueOf(name).getState(client)}: the requirement is met only
+	 * when every listed quest is {@code IN_PROGRESS} or {@code FINISHED} (i.e.
+	 * not {@code NOT_STARTED}). This covers the case where requiring full
+	 * completion is over-restrictive — a travel vector or unlock that becomes
+	 * available the moment the quest is begun.
+	 *
+	 * <p>Unrecognised names are treated as unmet and logged, mirroring the
+	 * fail-closed resolution used by {@link #quests} and {@link #pohTeleports}.
+	 *
+	 * <p>{@code null} or empty when the source/alternative has no
+	 * quest-started prerequisite. Added by the D5 schema PR; data wiring
+	 * stacks on this in a later PR.
+	 */
+	@Nullable
+	List<String> questMilestones;
+
+	/**
+	 * Skill-cape travel-perk requirements expressed as RuneLite {@code Skill}
+	 * enum constant names, e.g. {@code "CRAFTING"}, {@code "FARMING"},
+	 * {@code "SLAYER"}, {@code "HUNTER"}, {@code "CONSTRUCTION"}.
+	 * (Note: the runecrafting constant is {@code RUNECRAFT}, not
+	 * {@code RUNECRAFTING}.)
+	 *
+	 * <p>A skill-cape teleport/travel perk is available only to a player who
+	 * owns the corresponding cape, and owning the cape requires level 99 in
+	 * that skill. This field uses that level-99 threshold as a proxy for cape
+	 * ownership: it is the necessary condition, not proof the player has
+	 * actually purchased and is wearing the cape. Evaluated AND-wise via
+	 * {@code client.getRealSkillLevel(Skill.valueOf(name))}: the requirement
+	 * is met only when the player's level in every listed skill is
+	 * {@code >= 99}.
+	 *
+	 * <p>Unrecognised names are treated as unmet and logged, mirroring the
+	 * fail-closed resolution used by {@link #skills} and {@link #pohTeleports}.
+	 *
+	 * <p>{@code null} or empty when the source/alternative has no
+	 * skill-cape-perk prerequisite. Added by the D5 schema PR; data wiring
+	 * stacks on this in a later PR.
+	 */
+	@Nullable
+	List<String> skillCapePerks;
 }

--- a/src/test/java/com/collectionloghelper/data/CollectionLogSourceTest.java
+++ b/src/test/java/com/collectionloghelper/data/CollectionLogSourceTest.java
@@ -123,7 +123,7 @@ public class CollectionLogSourceTest
 	@Test
 	public void getWorldPointWithChecker_firstAccessible()
 	{
-		SourceRequirements reqs = new SourceRequirements(Collections.singletonList("DRAGON_SLAYER_II"), null, null, null, null, null, null);
+		SourceRequirements reqs = new SourceRequirements(Collections.singletonList("DRAGON_SLAYER_II"), null, null, null, null, null, null, null, null);
 		Waypoint wp1 = new Waypoint("Shortcut", 2500, 2600, 0, reqs);
 		Waypoint wp2 = new Waypoint("Walk", 3500, 3600, 0, null);
 
@@ -137,7 +137,7 @@ public class CollectionLogSourceTest
 	@Test
 	public void getWorldPointWithChecker_firstLocked_fallsToSecond()
 	{
-		SourceRequirements reqs = new SourceRequirements(Collections.singletonList("DRAGON_SLAYER_II"), null, null, null, null, null, null);
+		SourceRequirements reqs = new SourceRequirements(Collections.singletonList("DRAGON_SLAYER_II"), null, null, null, null, null, null, null, null);
 		Waypoint wp1 = new Waypoint("Shortcut", 2500, 2600, 0, reqs);
 		Waypoint wp2 = new Waypoint("Walk", 3500, 3600, 0, null);
 
@@ -151,8 +151,8 @@ public class CollectionLogSourceTest
 	@Test
 	public void getWorldPointWithChecker_allLocked_fallsToLast()
 	{
-		SourceRequirements reqs1 = new SourceRequirements(Collections.singletonList("QUEST_A"), null, null, null, null, null, null);
-		SourceRequirements reqs2 = new SourceRequirements(Collections.singletonList("QUEST_B"), null, null, null, null, null, null);
+		SourceRequirements reqs1 = new SourceRequirements(Collections.singletonList("QUEST_A"), null, null, null, null, null, null, null, null);
+		SourceRequirements reqs2 = new SourceRequirements(Collections.singletonList("QUEST_B"), null, null, null, null, null, null, null, null);
 		Waypoint wp1 = new Waypoint("Best", 1000, 1000, 0, reqs1);
 		Waypoint wp2 = new Waypoint("Alt", 2000, 2000, 0, reqs2);
 
@@ -227,7 +227,7 @@ public class CollectionLogSourceTest
 	@Test
 	public void getDisplayLocationWithChecker_allLockedFallsToLastName()
 	{
-		SourceRequirements reqs = new SourceRequirements(Collections.singletonList("QUEST_A"), null, null, null, null, null, null);
+		SourceRequirements reqs = new SourceRequirements(Collections.singletonList("QUEST_A"), null, null, null, null, null, null, null, null);
 		Waypoint wp1 = new Waypoint("First", 1000, 1000, 0, reqs);
 		Waypoint wp2 = new Waypoint("Last", 2000, 2000, 0, reqs);
 

--- a/src/test/java/com/collectionloghelper/data/D5SchemaMigrationTest.java
+++ b/src/test/java/com/collectionloghelper/data/D5SchemaMigrationTest.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Migration guard for the two additive D5 schema fields on
+ * {@link SourceRequirements}: {@code questMilestones} and
+ * {@code skillCapePerks}.
+ *
+ * <p>The D5 schema PR ships the fields, evaluator wiring, and Gson coverage
+ * with zero production data using either field. The data-wiring PRs (D5-G/H)
+ * then populate them. Until then, every {@link SourceRequirements} instance
+ * reached via top-level source requirements, conditional-alternative
+ * requirements (flat and nested), and waypoint requirements must leave both
+ * fields null — an empty allowlist.
+ *
+ * <p>Mirrors {@link InventoryItemsAnyMigrationTest}: walk the database,
+ * accumulate violations, fail with one readable message. Because no source is
+ * allowed to set either field in this PR, any non-null occurrence is a
+ * violation.
+ */
+public class D5SchemaMigrationTest
+{
+	private DropRateDatabase database;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		database = new DropRateDatabase();
+
+		Gson gson = new GsonBuilder().create();
+		Field gsonField = DropRateDatabase.class.getDeclaredField("gson");
+		gsonField.setAccessible(true);
+		gsonField.set(database, gson);
+
+		database.load();
+	}
+
+	@Test
+	public void databaseLoadsAndProducesSources()
+	{
+		assertNotNull(database.getAllSources());
+		assertTrue(database.getAllSources().size() > 0,
+			"Production drop_rates.json must load at least one source");
+	}
+
+	@Test
+	public void everySourceRequirementsHasNullQuestMilestones()
+	{
+		List<String> violations = new ArrayList<>();
+		for (CollectionLogSource source : database.getAllSources())
+		{
+			checkSource(source, violations);
+		}
+		assertTrue(violations.isEmpty(),
+			"questMilestones invariant violated. No source may set questMilestones in the D5 "
+				+ "schema PR; D5-G/H data wiring populates it later behind an explicit allowlist. "
+				+ "Violations:\n" + String.join("\n", violations));
+	}
+
+	@Test
+	public void everySourceRequirementsHasNullSkillCapePerks()
+	{
+		List<String> violations = new ArrayList<>();
+		for (CollectionLogSource source : database.getAllSources())
+		{
+			checkSourceSkillCapePerks(source, violations);
+		}
+		assertTrue(violations.isEmpty(),
+			"skillCapePerks invariant violated. No source may set skillCapePerks in the D5 "
+				+ "schema PR; D5-G/H data wiring populates it later behind an explicit allowlist. "
+				+ "Violations:\n" + String.join("\n", violations));
+	}
+
+	// -- questMilestones walk ---------------------------------------------------
+
+	private static void checkSource(CollectionLogSource source, List<String> violations)
+	{
+		String sourceName = source.getName();
+		checkRequirements(sourceName + " (top-level requirements)", source.getRequirements(), violations);
+
+		List<Waypoint> sourceWaypoints = source.getWaypoints();
+		if (sourceWaypoints != null)
+		{
+			for (int w = 0; w < sourceWaypoints.size(); w++)
+			{
+				Waypoint wp = sourceWaypoints.get(w);
+				if (wp != null)
+				{
+					checkRequirements(sourceName + " waypoint " + (w + 1),
+						wp.getRequirements(), violations);
+				}
+			}
+		}
+
+		List<GuidanceStep> steps = source.getGuidanceSteps();
+		if (steps == null)
+		{
+			return;
+		}
+		for (int i = 0; i < steps.size(); i++)
+		{
+			GuidanceStep step = steps.get(i);
+			if (step == null)
+			{
+				continue;
+			}
+			String stepLabel = sourceName + " step " + (i + 1);
+
+			List<ConditionalAlternative> alts = step.getConditionalAlternatives();
+			if (alts != null)
+			{
+				for (int a = 0; a < alts.size(); a++)
+				{
+					ConditionalAlternative alt = alts.get(a);
+					if (alt == null)
+					{
+						continue;
+					}
+					checkRequirements(stepLabel + " alt " + (a + 1),
+						alt.getRequirements(), violations);
+
+					List<ConditionalAlternative> nested = alt.getNestedAlternatives();
+					if (nested != null)
+					{
+						for (int n = 0; n < nested.size(); n++)
+						{
+							ConditionalAlternative nestedAlt = nested.get(n);
+							if (nestedAlt != null)
+							{
+								checkRequirements(stepLabel + " alt " + (a + 1)
+										+ " nested " + (n + 1),
+									nestedAlt.getRequirements(), violations);
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	private static void checkRequirements(String label, SourceRequirements reqs, List<String> violations)
+	{
+		if (reqs == null)
+		{
+			return;
+		}
+		if (reqs.getQuestMilestones() != null)
+		{
+			violations.add(label + " has non-null questMilestones");
+		}
+	}
+
+	// -- skillCapePerks walk ----------------------------------------------------
+
+	private static void checkSourceSkillCapePerks(CollectionLogSource source, List<String> violations)
+	{
+		String sourceName = source.getName();
+		checkRequirementsSkillCapePerks(sourceName + " (top-level requirements)",
+			source.getRequirements(), violations);
+
+		List<Waypoint> sourceWaypoints = source.getWaypoints();
+		if (sourceWaypoints != null)
+		{
+			for (int w = 0; w < sourceWaypoints.size(); w++)
+			{
+				Waypoint wp = sourceWaypoints.get(w);
+				if (wp != null)
+				{
+					checkRequirementsSkillCapePerks(sourceName + " waypoint " + (w + 1),
+						wp.getRequirements(), violations);
+				}
+			}
+		}
+
+		List<GuidanceStep> steps = source.getGuidanceSteps();
+		if (steps == null)
+		{
+			return;
+		}
+		for (int i = 0; i < steps.size(); i++)
+		{
+			GuidanceStep step = steps.get(i);
+			if (step == null)
+			{
+				continue;
+			}
+			String stepLabel = sourceName + " step " + (i + 1);
+
+			List<ConditionalAlternative> alts = step.getConditionalAlternatives();
+			if (alts != null)
+			{
+				for (int a = 0; a < alts.size(); a++)
+				{
+					ConditionalAlternative alt = alts.get(a);
+					if (alt == null)
+					{
+						continue;
+					}
+					checkRequirementsSkillCapePerks(stepLabel + " alt " + (a + 1),
+						alt.getRequirements(), violations);
+
+					List<ConditionalAlternative> nested = alt.getNestedAlternatives();
+					if (nested != null)
+					{
+						for (int n = 0; n < nested.size(); n++)
+						{
+							ConditionalAlternative nestedAlt = nested.get(n);
+							if (nestedAlt != null)
+							{
+								checkRequirementsSkillCapePerks(stepLabel + " alt " + (a + 1)
+										+ " nested " + (n + 1),
+									nestedAlt.getRequirements(), violations);
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	private static void checkRequirementsSkillCapePerks(String label, SourceRequirements reqs,
+		List<String> violations)
+	{
+		if (reqs == null)
+		{
+			return;
+		}
+		if (reqs.getSkillCapePerks() != null)
+		{
+			violations.add(label + " has non-null skillCapePerks");
+		}
+	}
+}

--- a/src/test/java/com/collectionloghelper/data/RequirementsCheckerB0Test.java
+++ b/src/test/java/com/collectionloghelper/data/RequirementsCheckerB0Test.java
@@ -134,7 +134,7 @@ public class RequirementsCheckerB0Test
 		SourceRequirements req = new SourceRequirements(
 			null, null, null,
 			Arrays.asList("JEWELLERY_BOX_FANCY", "FAIRY_RING"),
-			null, null, null);
+			null, null, null, null, null);
 		assertFalse(checker.meetsRequirements(req));
 	}
 
@@ -144,7 +144,7 @@ public class RequirementsCheckerB0Test
 		SourceRequirements req = new SourceRequirements(
 			null, null, null,
 			Collections.emptyList(),
-			null, null, null);
+			null, null, null, null, null);
 		assertTrue(checker.meetsRequirements(req));
 	}
 
@@ -173,7 +173,7 @@ public class RequirementsCheckerB0Test
 		lenient().when(equippedItemState.hasEquipped(DRAKANS_MEDALLION)).thenReturn(false);
 		SourceRequirements req = new SourceRequirements(
 			null, null, null, null,
-			Arrays.asList(RING_OF_SHADOWS, DRAKANS_MEDALLION), null, null);
+			Arrays.asList(RING_OF_SHADOWS, DRAKANS_MEDALLION), null, null, null, null);
 		assertFalse(checker.meetsRequirements(req));
 	}
 
@@ -182,7 +182,7 @@ public class RequirementsCheckerB0Test
 	{
 		SourceRequirements req = new SourceRequirements(
 			null, null, null, null,
-			Collections.emptyList(), null, null);
+			Collections.emptyList(), null, null, null, null);
 		assertTrue(checker.meetsRequirements(req));
 	}
 
@@ -199,7 +199,7 @@ public class RequirementsCheckerB0Test
 			Collections.singletonList(new SkillRequirement("STRENGTH", 70)),
 			null,
 			Collections.singletonList("JEWELLERY_BOX_FANCY"),
-			Collections.singletonList(RING_OF_SHADOWS), null, null);
+			Collections.singletonList(RING_OF_SHADOWS), null, null, null, null);
 		assertTrue(checker.meetsRequirements(req));
 	}
 
@@ -213,7 +213,7 @@ public class RequirementsCheckerB0Test
 			Collections.singletonList(new SkillRequirement("STRENGTH", 70)),
 			null,
 			Collections.singletonList("JEWELLERY_BOX_FANCY"),
-			null, null, null);
+			null, null, null, null, null);
 		assertFalse(checker.meetsRequirements(req));
 	}
 
@@ -225,7 +225,7 @@ public class RequirementsCheckerB0Test
 		SourceRequirements req = new SourceRequirements(
 			null, null, null,
 			Collections.singletonList("JEWELLERY_BOX_FANCY"),
-			Collections.singletonList(RING_OF_SHADOWS), null, null);
+			Collections.singletonList(RING_OF_SHADOWS), null, null, null, null);
 		assertFalse(checker.meetsRequirements(req));
 	}
 
@@ -247,7 +247,7 @@ public class RequirementsCheckerB0Test
 			altWithReq("Fast: POH + ring", new SourceRequirements(
 				null, null, null,
 				Collections.singletonList("JEWELLERY_BOX_FANCY"),
-				Collections.singletonList(RING_OF_SHADOWS), null, null)),
+				Collections.singletonList(RING_OF_SHADOWS), null, null, null, null)),
 			altWithReq("Slow: ring only", equippedReq(RING_OF_SHADOWS)));
 
 		assertEquals("Fast: POH + ring", selectFirstMatching(alts));
@@ -264,7 +264,7 @@ public class RequirementsCheckerB0Test
 			altWithReq("Fast: POH + ring", new SourceRequirements(
 				null, null, null,
 				Collections.singletonList("JEWELLERY_BOX_FANCY"),
-				Collections.singletonList(RING_OF_SHADOWS), null, null)),
+				Collections.singletonList(RING_OF_SHADOWS), null, null, null, null)),
 			altWithReq("Slow: ring only", equippedReq(RING_OF_SHADOWS)));
 
 		assertEquals("Slow: ring only", selectFirstMatching(alts));
@@ -290,14 +290,14 @@ public class RequirementsCheckerB0Test
 		return new SourceRequirements(
 			null, null, null,
 			Collections.singletonList(teleportName),
-			null, null, null);
+			null, null, null, null, null);
 	}
 
 	private static SourceRequirements equippedReq(int itemId)
 	{
 		return new SourceRequirements(
 			null, null, null, null,
-			Collections.singletonList(itemId), null, null);
+			Collections.singletonList(itemId), null, null, null, null);
 	}
 
 	private static ConditionalAlternative altWithReq(String description, SourceRequirements requirements)

--- a/src/test/java/com/collectionloghelper/data/RequirementsCheckerD5Test.java
+++ b/src/test/java/com/collectionloghelper/data/RequirementsCheckerD5Test.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data;
+
+import com.collectionloghelper.player.EquippedItemState;
+import com.collectionloghelper.player.PohTeleportInventory;
+import java.lang.reflect.Constructor;
+import java.util.Collections;
+import net.runelite.api.Client;
+import net.runelite.api.Skill;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+
+/**
+ * D5 schema behaviour tests for the {@code questMilestones} and
+ * {@code skillCapePerks} clauses of
+ * {@link RequirementsChecker#meetsRequirements(SourceRequirements)}.
+ *
+ * <p>{@code questMilestones} is looser than {@code quests}: a quest that is
+ * IN_PROGRESS or FINISHED satisfies it, only NOT_STARTED fails.
+ * {@code skillCapePerks} is satisfied when the player's real level in the named
+ * skill is at least 99 (the level-99 proxy for owning the cape).
+ *
+ * <p>Quest state is driven the same way the existing checker tests drive it:
+ * {@code Quest.getState(client)} runs a script and reads
+ * {@code client.getIntStack()[0]}, where 2 = FINISHED, 1 = NOT_STARTED, and
+ * any other value = IN_PROGRESS. The {@link Client} mock is reused for skill
+ * levels via {@code getRealSkillLevel}. Strict stubbing is disabled because
+ * the AND-clause short-circuits skip later stubs in failure tests.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class RequirementsCheckerD5Test
+{
+	private static final String QUEST_NAME = "DRAGON_SLAYER_II";
+
+	@Mock
+	private Client client;
+
+	@Mock
+	private PohTeleportInventory pohTeleportInventory;
+
+	@Mock
+	private EquippedItemState equippedItemState;
+
+	@Mock
+	private PlayerInventoryState playerInventoryState;
+
+	private RequirementsChecker checker;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		Constructor<RequirementsChecker> ctor = RequirementsChecker.class.getDeclaredConstructor(
+			Client.class, PohTeleportInventory.class, EquippedItemState.class,
+			PlayerInventoryState.class);
+		ctor.setAccessible(true);
+		checker = ctor.newInstance(client, pohTeleportInventory, equippedItemState, playerInventoryState);
+	}
+
+	// -- questMilestones --------------------------------------------------------
+
+	@Test
+	public void meetsRequirements_questMilestoneFinished_isTrue()
+	{
+		// intStack[0] = 2 -> FINISHED
+		lenient().when(client.getIntStack()).thenReturn(new int[]{2});
+		assertTrue(checker.meetsRequirements(questMilestoneReq()));
+	}
+
+	@Test
+	public void meetsRequirements_questMilestoneInProgress_isTrue()
+	{
+		// intStack[0] = 0 (any value other than 1 or 2) -> IN_PROGRESS.
+		// Started is enough for a milestone — this is the key difference from quests.
+		lenient().when(client.getIntStack()).thenReturn(new int[]{0});
+		assertTrue(checker.meetsRequirements(questMilestoneReq()));
+	}
+
+	@Test
+	public void meetsRequirements_questMilestoneNotStarted_isFalse()
+	{
+		// intStack[0] = 1 -> NOT_STARTED
+		lenient().when(client.getIntStack()).thenReturn(new int[]{1});
+		assertFalse(checker.meetsRequirements(questMilestoneReq()));
+	}
+
+	@Test
+	public void meetsRequirements_unknownQuestMilestoneEnum_isTrue()
+	{
+		// Fail-closed resolution logs a warning; an unresolved name is skipped,
+		// so a requirement consisting only of an unknown name has no unmet entry.
+		assertTrue(checker.meetsRequirements(questMilestoneReq("DOES_NOT_EXIST")));
+	}
+
+	// -- skillCapePerks ---------------------------------------------------------
+
+	@Test
+	public void meetsRequirements_skillCapePerkAtLevel99_isTrue()
+	{
+		lenient().when(client.getRealSkillLevel(Skill.CRAFTING)).thenReturn(99);
+		assertTrue(checker.meetsRequirements(skillCapePerkReq("CRAFTING")));
+	}
+
+	@Test
+	public void meetsRequirements_skillCapePerkAboveLevel99_isTrue()
+	{
+		// Real level is capped at 99, but guard the >= boundary explicitly.
+		lenient().when(client.getRealSkillLevel(Skill.FARMING)).thenReturn(120);
+		assertTrue(checker.meetsRequirements(skillCapePerkReq("FARMING")));
+	}
+
+	@Test
+	public void meetsRequirements_skillCapePerkBelowLevel99_isFalse()
+	{
+		lenient().when(client.getRealSkillLevel(Skill.SLAYER)).thenReturn(98);
+		assertFalse(checker.meetsRequirements(skillCapePerkReq("SLAYER")));
+	}
+
+	@Test
+	public void meetsRequirements_unknownSkillCapePerkEnum_isTrue()
+	{
+		// Fail-closed: unknown skill name is skipped, so an otherwise-empty
+		// requirement has no unmet entry. (RUNECRAFTING is intentionally wrong;
+		// the real constant is RUNECRAFT.)
+		assertTrue(checker.meetsRequirements(skillCapePerkReq("RUNECRAFTING")));
+	}
+
+	// -- Helpers ----------------------------------------------------------------
+
+	private static SourceRequirements questMilestoneReq()
+	{
+		return questMilestoneReq(QUEST_NAME);
+	}
+
+	private static SourceRequirements questMilestoneReq(String questName)
+	{
+		return new SourceRequirements(
+			null, null, null, null, null, null, null,
+			Collections.singletonList(questName), null);
+	}
+
+	private static SourceRequirements skillCapePerkReq(String skillName)
+	{
+		return new SourceRequirements(
+			null, null, null, null, null, null, null,
+			null, Collections.singletonList(skillName));
+	}
+}

--- a/src/test/java/com/collectionloghelper/data/RequirementsCheckerD5Test.java
+++ b/src/test/java/com/collectionloghelper/data/RequirementsCheckerD5Test.java
@@ -117,11 +117,11 @@ public class RequirementsCheckerD5Test
 	}
 
 	@Test
-	public void meetsRequirements_unknownQuestMilestoneEnum_isTrue()
+	public void meetsRequirements_unknownQuestMilestoneEnum_isFalse()
 	{
-		// Fail-closed resolution logs a warning; an unresolved name is skipped,
-		// so a requirement consisting only of an unknown name has no unmet entry.
-		assertTrue(checker.meetsRequirements(questMilestoneReq("DOES_NOT_EXIST")));
+		// Fail closed: an unresolvable quest name cannot be verified, so the
+		// requirement is treated as unmet rather than promising the shortcut.
+		assertFalse(checker.meetsRequirements(questMilestoneReq("DOES_NOT_EXIST")));
 	}
 
 	// -- skillCapePerks ---------------------------------------------------------
@@ -149,12 +149,12 @@ public class RequirementsCheckerD5Test
 	}
 
 	@Test
-	public void meetsRequirements_unknownSkillCapePerkEnum_isTrue()
+	public void meetsRequirements_unknownSkillCapePerkEnum_isFalse()
 	{
-		// Fail-closed: unknown skill name is skipped, so an otherwise-empty
-		// requirement has no unmet entry. (RUNECRAFTING is intentionally wrong;
+		// Fail closed: an unresolvable skill name cannot be verified, so the
+		// requirement is treated as unmet. (RUNECRAFTING is intentionally wrong;
 		// the real constant is RUNECRAFT.)
-		assertTrue(checker.meetsRequirements(skillCapePerkReq("RUNECRAFTING")));
+		assertFalse(checker.meetsRequirements(skillCapePerkReq("RUNECRAFTING")));
 	}
 
 	// -- Helpers ----------------------------------------------------------------

--- a/src/test/java/com/collectionloghelper/data/RequirementsCheckerInventoryItemsAnyTest.java
+++ b/src/test/java/com/collectionloghelper/data/RequirementsCheckerInventoryItemsAnyTest.java
@@ -113,7 +113,7 @@ public class RequirementsCheckerInventoryItemsAnyTest
 	{
 		SourceRequirements req = new SourceRequirements(
 			null, null, null, null, null, null,
-			Collections.emptyList());
+			Collections.emptyList(), null, null);
 		assertTrue(checker.meetsRequirements(req));
 	}
 
@@ -146,7 +146,7 @@ public class RequirementsCheckerInventoryItemsAnyTest
 		lenient().when(playerInventoryState.hasItem(PHARAOHS_SCEPTRE_3)).thenReturn(false);
 		SourceRequirements req = new SourceRequirements(
 			null, null, null, null, null, null,
-			Arrays.asList(PHARAOHS_SCEPTRE_5, PHARAOHS_SCEPTRE_4, PHARAOHS_SCEPTRE_3));
+			Arrays.asList(PHARAOHS_SCEPTRE_5, PHARAOHS_SCEPTRE_4, PHARAOHS_SCEPTRE_3), null, null);
 		assertTrue(checker.meetsRequirements(req));
 	}
 
@@ -158,7 +158,7 @@ public class RequirementsCheckerInventoryItemsAnyTest
 		lenient().when(playerInventoryState.hasItem(PHARAOHS_SCEPTRE_3)).thenReturn(false);
 		SourceRequirements req = new SourceRequirements(
 			null, null, null, null, null, null,
-			Arrays.asList(PHARAOHS_SCEPTRE_5, PHARAOHS_SCEPTRE_4, PHARAOHS_SCEPTRE_3));
+			Arrays.asList(PHARAOHS_SCEPTRE_5, PHARAOHS_SCEPTRE_4, PHARAOHS_SCEPTRE_3), null, null);
 		assertFalse(checker.meetsRequirements(req));
 	}
 
@@ -170,7 +170,7 @@ public class RequirementsCheckerInventoryItemsAnyTest
 		lenient().when(playerInventoryState.hasItem(PHARAOHS_SCEPTRE_4)).thenReturn(true);
 		SourceRequirements req = new SourceRequirements(
 			null, null, null, null, null, null,
-			Arrays.asList(PHARAOHS_SCEPTRE_5, PHARAOHS_SCEPTRE_4));
+			Arrays.asList(PHARAOHS_SCEPTRE_5, PHARAOHS_SCEPTRE_4), null, null);
 		assertTrue(checker.meetsRequirements(req));
 	}
 
@@ -182,7 +182,7 @@ public class RequirementsCheckerInventoryItemsAnyTest
 		lenient().when(playerInventoryState.hasItem(PHARAOHS_SCEPTRE_5)).thenReturn(true);
 		List<Integer> ids = Arrays.asList(null, PHARAOHS_SCEPTRE_5);
 		SourceRequirements req = new SourceRequirements(
-			null, null, null, null, null, null, ids);
+			null, null, null, null, null, null, ids, null, null);
 		assertTrue(checker.meetsRequirements(req));
 	}
 
@@ -194,7 +194,7 @@ public class RequirementsCheckerInventoryItemsAnyTest
 		// AND-semantic siblings' empty-list behaviour.
 		List<Integer> ids = Arrays.asList((Integer) null, (Integer) null);
 		SourceRequirements req = new SourceRequirements(
-			null, null, null, null, null, null, ids);
+			null, null, null, null, null, null, ids, null, null);
 		assertTrue(checker.meetsRequirements(req));
 	}
 
@@ -209,7 +209,7 @@ public class RequirementsCheckerInventoryItemsAnyTest
 			null, null, null, null,
 			Collections.singletonList(RING_OF_SHADOWS),
 			null,
-			Collections.singletonList(PHARAOHS_SCEPTRE_5));
+			Collections.singletonList(PHARAOHS_SCEPTRE_5), null, null);
 		assertTrue(checker.meetsRequirements(req));
 	}
 
@@ -224,7 +224,7 @@ public class RequirementsCheckerInventoryItemsAnyTest
 			null, null, null, null,
 			Collections.singletonList(RING_OF_SHADOWS),
 			null,
-			Collections.singletonList(PHARAOHS_SCEPTRE_5));
+			Collections.singletonList(PHARAOHS_SCEPTRE_5), null, null);
 		assertFalse(checker.meetsRequirements(req));
 	}
 
@@ -238,7 +238,7 @@ public class RequirementsCheckerInventoryItemsAnyTest
 			Collections.singletonList("JEWELLERY_BOX_FANCY"),
 			null,
 			null,
-			Arrays.asList(PHARAOHS_SCEPTRE_5, PHARAOHS_SCEPTRE_4));
+			Arrays.asList(PHARAOHS_SCEPTRE_5, PHARAOHS_SCEPTRE_4), null, null);
 		assertTrue(checker.meetsRequirements(req));
 	}
 
@@ -256,7 +256,7 @@ public class RequirementsCheckerInventoryItemsAnyTest
 		SourceRequirements req = new SourceRequirements(
 			null, null, null, null, null,
 			Collections.singletonList(QUETZAL_WHISTLE),
-			Arrays.asList(PHARAOHS_SCEPTRE_5, PHARAOHS_SCEPTRE_4));
+			Arrays.asList(PHARAOHS_SCEPTRE_5, PHARAOHS_SCEPTRE_4), null, null);
 		assertTrue(checker.meetsRequirements(req));
 	}
 
@@ -269,7 +269,7 @@ public class RequirementsCheckerInventoryItemsAnyTest
 		SourceRequirements req = new SourceRequirements(
 			null, null, null, null, null,
 			Collections.singletonList(QUETZAL_WHISTLE),
-			Arrays.asList(PHARAOHS_SCEPTRE_5, PHARAOHS_SCEPTRE_4));
+			Arrays.asList(PHARAOHS_SCEPTRE_5, PHARAOHS_SCEPTRE_4), null, null);
 		assertFalse(checker.meetsRequirements(req));
 	}
 
@@ -281,7 +281,7 @@ public class RequirementsCheckerInventoryItemsAnyTest
 		SourceRequirements req = new SourceRequirements(
 			null, null, null, null, null,
 			Collections.singletonList(QUETZAL_WHISTLE),
-			Collections.singletonList(PHARAOHS_SCEPTRE_5));
+			Collections.singletonList(PHARAOHS_SCEPTRE_5), null, null);
 		assertFalse(checker.meetsRequirements(req));
 	}
 
@@ -296,7 +296,7 @@ public class RequirementsCheckerInventoryItemsAnyTest
 		List<ConditionalAlternative> alts = Arrays.asList(
 			altWithReq("Fast: Pharaoh sceptre any tier",
 				new SourceRequirements(null, null, null, null, null, null,
-					Arrays.asList(PHARAOHS_SCEPTRE_5, PHARAOHS_SCEPTRE_4))),
+					Arrays.asList(PHARAOHS_SCEPTRE_5, PHARAOHS_SCEPTRE_4), null, null)),
 			altWithReq("Slow: walk", null));
 
 		assertEquals("Fast: Pharaoh sceptre any tier", selectFirstMatching(alts));
@@ -312,10 +312,10 @@ public class RequirementsCheckerInventoryItemsAnyTest
 		List<ConditionalAlternative> alts = Arrays.asList(
 			altWithReq("Fast: Pharaoh sceptre any tier",
 				new SourceRequirements(null, null, null, null, null, null,
-					Arrays.asList(PHARAOHS_SCEPTRE_5, PHARAOHS_SCEPTRE_4))),
+					Arrays.asList(PHARAOHS_SCEPTRE_5, PHARAOHS_SCEPTRE_4), null, null)),
 			altWithReq("Fallback: Quetzal whistle inventory",
 				new SourceRequirements(null, null, null, null, null,
-					Collections.singletonList(QUETZAL_WHISTLE), null)));
+					Collections.singletonList(QUETZAL_WHISTLE), null, null, null)));
 
 		assertEquals("Fallback: Quetzal whistle inventory", selectFirstMatching(alts));
 	}
@@ -326,7 +326,7 @@ public class RequirementsCheckerInventoryItemsAnyTest
 	{
 		return new SourceRequirements(
 			null, null, null, null, null, null,
-			Collections.singletonList(itemId));
+			Collections.singletonList(itemId), null, null);
 	}
 
 	private static ConditionalAlternative altWithReq(String description, SourceRequirements requirements)

--- a/src/test/java/com/collectionloghelper/data/RequirementsCheckerInventoryItemsTest.java
+++ b/src/test/java/com/collectionloghelper/data/RequirementsCheckerInventoryItemsTest.java
@@ -111,7 +111,7 @@ public class RequirementsCheckerInventoryItemsTest
 	{
 		SourceRequirements req = new SourceRequirements(
 			null, null, null, null, null,
-			Collections.emptyList(), null);
+			Collections.emptyList(), null, null, null);
 		assertTrue(checker.meetsRequirements(req));
 	}
 
@@ -142,7 +142,7 @@ public class RequirementsCheckerInventoryItemsTest
 		lenient().when(playerInventoryState.hasItem(QUETZAL_WHISTLE)).thenReturn(true);
 		SourceRequirements req = new SourceRequirements(
 			null, null, null, null, null,
-			Arrays.asList(PHARAOHS_SCEPTRE_5, QUETZAL_WHISTLE), null);
+			Arrays.asList(PHARAOHS_SCEPTRE_5, QUETZAL_WHISTLE), null, null, null);
 		assertTrue(checker.meetsRequirements(req));
 	}
 
@@ -153,7 +153,7 @@ public class RequirementsCheckerInventoryItemsTest
 		lenient().when(playerInventoryState.hasItem(QUETZAL_WHISTLE)).thenReturn(false);
 		SourceRequirements req = new SourceRequirements(
 			null, null, null, null, null,
-			Arrays.asList(PHARAOHS_SCEPTRE_5, QUETZAL_WHISTLE), null);
+			Arrays.asList(PHARAOHS_SCEPTRE_5, QUETZAL_WHISTLE), null, null, null);
 		assertFalse(checker.meetsRequirements(req));
 	}
 
@@ -165,7 +165,7 @@ public class RequirementsCheckerInventoryItemsTest
 		lenient().when(playerInventoryState.hasItem(PHARAOHS_SCEPTRE_5)).thenReturn(true);
 		List<Integer> ids = Arrays.asList(null, PHARAOHS_SCEPTRE_5);
 		SourceRequirements req = new SourceRequirements(
-			null, null, null, null, null, ids, null);
+			null, null, null, null, null, ids, null, null, null);
 		assertTrue(checker.meetsRequirements(req));
 	}
 
@@ -181,7 +181,7 @@ public class RequirementsCheckerInventoryItemsTest
 			null, null, null,
 			Collections.singletonList("JEWELLERY_BOX_FANCY"),
 			Collections.singletonList(RING_OF_SHADOWS),
-			Collections.singletonList(PHARAOHS_SCEPTRE_5), null);
+			Collections.singletonList(PHARAOHS_SCEPTRE_5), null, null, null);
 		assertTrue(checker.meetsRequirements(req));
 	}
 
@@ -195,7 +195,7 @@ public class RequirementsCheckerInventoryItemsTest
 			null, null, null,
 			Collections.singletonList("JEWELLERY_BOX_FANCY"),
 			Collections.singletonList(RING_OF_SHADOWS),
-			Collections.singletonList(PHARAOHS_SCEPTRE_5), null);
+			Collections.singletonList(PHARAOHS_SCEPTRE_5), null, null, null);
 		assertFalse(checker.meetsRequirements(req));
 	}
 
@@ -208,7 +208,7 @@ public class RequirementsCheckerInventoryItemsTest
 			null, null, null,
 			Collections.singletonList("JEWELLERY_BOX_FANCY"),
 			null,
-			Collections.singletonList(PHARAOHS_SCEPTRE_5), null);
+			Collections.singletonList(PHARAOHS_SCEPTRE_5), null, null, null);
 		assertFalse(checker.meetsRequirements(req));
 	}
 
@@ -245,7 +245,7 @@ public class RequirementsCheckerInventoryItemsTest
 	{
 		return new SourceRequirements(
 			null, null, null, null, null,
-			Collections.singletonList(itemId), null);
+			Collections.singletonList(itemId), null, null, null);
 	}
 
 	private static ConditionalAlternative altWithReq(String description, SourceRequirements requirements)

--- a/src/test/java/com/collectionloghelper/data/SourceRequirementsB0Test.java
+++ b/src/test/java/com/collectionloghelper/data/SourceRequirementsB0Test.java
@@ -155,11 +155,11 @@ public class SourceRequirementsB0Test
 		SourceRequirements a = new SourceRequirements(
 			null, null, null,
 			Collections.singletonList("MOUNTED_GLORY"),
-			Collections.singletonList(22557), null, null);
+			Collections.singletonList(22557), null, null, null, null);
 		SourceRequirements b = new SourceRequirements(
 			null, null, null,
 			Collections.singletonList("MOUNTED_GLORY"),
-			Collections.singletonList(22557), null, null);
+			Collections.singletonList(22557), null, null, null, null);
 		assertEquals(a, b);
 		assertEquals(a.hashCode(), b.hashCode());
 	}
@@ -170,11 +170,11 @@ public class SourceRequirementsB0Test
 		SourceRequirements a = new SourceRequirements(
 			null, null, null,
 			Collections.singletonList("MOUNTED_GLORY"),
-			null, null, null);
+			null, null, null, null, null);
 		SourceRequirements b = new SourceRequirements(
 			null, null, null,
 			Collections.singletonList("JEWELLERY_BOX_FANCY"),
-			null, null, null);
+			null, null, null, null, null);
 		assertTrue(!a.equals(b));
 	}
 
@@ -188,7 +188,7 @@ public class SourceRequirementsB0Test
 			null,
 			Collections.singletonList("FREMENNIK_HARD"),
 			Arrays.asList("JEWELLERY_BOX_FANCY", "MOUNTED_GLORY"),
-			Arrays.asList(22557, 28266), null, null);
+			Arrays.asList(22557, 28266), null, null, null, null);
 		String json = GSON.toJson(original);
 		SourceRequirements restored = GSON.fromJson(json, SourceRequirements.class);
 		assertEquals(original, restored);

--- a/src/test/java/com/collectionloghelper/data/SourceRequirementsD5GsonTest.java
+++ b/src/test/java/com/collectionloghelper/data/SourceRequirementsD5GsonTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Gson serialisation/deserialisation tests for the two D5 schema fields on
+ * {@link SourceRequirements}: {@code questMilestones} and
+ * {@code skillCapePerks}.
+ *
+ * <p>Both fields are purely additive: existing drop_rates.json sources that
+ * omit them must continue to deserialise with the getters returning
+ * {@code null}. Covers absent / null / empty / single / multi shapes plus a
+ * full nine-field round-trip.
+ */
+public class SourceRequirementsD5GsonTest
+{
+	private static final Gson GSON = new GsonBuilder().create();
+
+	// -- Backwards compatibility -------------------------------------------------
+
+	@Test
+	public void deserialise_legacyJsonWithoutFields_bothNull()
+	{
+		String json = "{\"quests\":[\"DESERT_TREASURE_II\"]}";
+		SourceRequirements req = GSON.fromJson(json, SourceRequirements.class);
+		assertNull(req.getQuestMilestones());
+		assertNull(req.getSkillCapePerks());
+	}
+
+	@Test
+	public void deserialise_legacyJsonWithAllSevenPriorFields_bothNull()
+	{
+		String json = "{"
+			+ "\"quests\":[\"DESERT_TREASURE_II\"],"
+			+ "\"skills\":[{\"skill\":\"SLAYER\",\"level\":95}],"
+			+ "\"diaries\":[\"FREMENNIK_HARD\"],"
+			+ "\"pohTeleports\":[\"JEWELLERY_BOX_FANCY\"],"
+			+ "\"equippedItemIds\":[22557],"
+			+ "\"inventoryItemIds\":[12938],"
+			+ "\"inventoryItemIdsAny\":[26945,26946]"
+			+ "}";
+		SourceRequirements req = GSON.fromJson(json, SourceRequirements.class);
+		assertNull(req.getQuestMilestones());
+		assertNull(req.getSkillCapePerks());
+	}
+
+	// -- questMilestones field shapes -------------------------------------------
+
+	@Test
+	public void deserialise_questMilestonesNull_isNull()
+	{
+		String json = "{\"questMilestones\":null}";
+		SourceRequirements req = GSON.fromJson(json, SourceRequirements.class);
+		assertNull(req.getQuestMilestones());
+	}
+
+	@Test
+	public void deserialise_questMilestonesEmpty_isEmptyNotNull()
+	{
+		String json = "{\"questMilestones\":[]}";
+		SourceRequirements req = GSON.fromJson(json, SourceRequirements.class);
+		assertNotNull(req.getQuestMilestones());
+		assertTrue(req.getQuestMilestones().isEmpty());
+	}
+
+	@Test
+	public void deserialise_questMilestonesSingle_oneEntry()
+	{
+		String json = "{\"questMilestones\":[\"FAIRYTALE_II__CURE_A_QUEEN\"]}";
+		SourceRequirements req = GSON.fromJson(json, SourceRequirements.class);
+		assertEquals(Collections.singletonList("FAIRYTALE_II__CURE_A_QUEEN"),
+			req.getQuestMilestones());
+	}
+
+	@Test
+	public void deserialise_questMilestonesMultiple_preservesOrder()
+	{
+		String json = "{\"questMilestones\":[\"FAIRYTALE_II__CURE_A_QUEEN\",\"DESERT_TREASURE_II\"]}";
+		SourceRequirements req = GSON.fromJson(json, SourceRequirements.class);
+		assertEquals(Arrays.asList("FAIRYTALE_II__CURE_A_QUEEN", "DESERT_TREASURE_II"),
+			req.getQuestMilestones());
+	}
+
+	// -- skillCapePerks field shapes --------------------------------------------
+
+	@Test
+	public void deserialise_skillCapePerksNull_isNull()
+	{
+		String json = "{\"skillCapePerks\":null}";
+		SourceRequirements req = GSON.fromJson(json, SourceRequirements.class);
+		assertNull(req.getSkillCapePerks());
+	}
+
+	@Test
+	public void deserialise_skillCapePerksEmpty_isEmptyNotNull()
+	{
+		String json = "{\"skillCapePerks\":[]}";
+		SourceRequirements req = GSON.fromJson(json, SourceRequirements.class);
+		assertNotNull(req.getSkillCapePerks());
+		assertTrue(req.getSkillCapePerks().isEmpty());
+	}
+
+	@Test
+	public void deserialise_skillCapePerksSingle_oneEntry()
+	{
+		String json = "{\"skillCapePerks\":[\"CRAFTING\"]}";
+		SourceRequirements req = GSON.fromJson(json, SourceRequirements.class);
+		assertEquals(Collections.singletonList("CRAFTING"), req.getSkillCapePerks());
+	}
+
+	@Test
+	public void deserialise_skillCapePerksMultiple_preservesOrder()
+	{
+		String json = "{\"skillCapePerks\":[\"FARMING\",\"HUNTER\",\"CONSTRUCTION\"]}";
+		SourceRequirements req = GSON.fromJson(json, SourceRequirements.class);
+		assertEquals(Arrays.asList("FARMING", "HUNTER", "CONSTRUCTION"),
+			req.getSkillCapePerks());
+	}
+
+	// -- All nine fields populated ----------------------------------------------
+
+	@Test
+	public void deserialise_allNineFieldsPopulated_parsesAll()
+	{
+		String json = "{"
+			+ "\"quests\":[\"TROLL_STRONGHOLD\"],"
+			+ "\"skills\":[{\"skill\":\"STRENGTH\",\"level\":70}],"
+			+ "\"diaries\":[\"FREMENNIK_HARD\"],"
+			+ "\"pohTeleports\":[\"JEWELLERY_BOX_FANCY\"],"
+			+ "\"equippedItemIds\":[22557],"
+			+ "\"inventoryItemIds\":[12938],"
+			+ "\"inventoryItemIdsAny\":[26945,26946],"
+			+ "\"questMilestones\":[\"FAIRYTALE_II__CURE_A_QUEEN\"],"
+			+ "\"skillCapePerks\":[\"FARMING\"]"
+			+ "}";
+		SourceRequirements req = GSON.fromJson(json, SourceRequirements.class);
+		assertEquals(Collections.singletonList("FAIRYTALE_II__CURE_A_QUEEN"), req.getQuestMilestones());
+		assertEquals(Collections.singletonList("FARMING"), req.getSkillCapePerks());
+	}
+
+	// -- Round-trip --------------------------------------------------------------
+
+	@Test
+	public void gsonRoundTrip_withD5Fields_preservesStructure()
+	{
+		SourceRequirements original = new SourceRequirements(
+			Collections.singletonList("DESERT_TREASURE_II"),
+			null,
+			Collections.singletonList("FREMENNIK_HARD"),
+			Arrays.asList("JEWELLERY_BOX_FANCY"),
+			Arrays.asList(22557),
+			Arrays.asList(12938),
+			Arrays.asList(26945, 26946),
+			Arrays.asList("FAIRYTALE_II__CURE_A_QUEEN", "DESERT_TREASURE_II"),
+			Arrays.asList("FARMING", "HUNTER"));
+		String json = GSON.toJson(original);
+		SourceRequirements restored = GSON.fromJson(json, SourceRequirements.class);
+		assertEquals(original, restored);
+	}
+
+	@Test
+	public void equals_differingQuestMilestones_notEqual()
+	{
+		SourceRequirements a = new SourceRequirements(
+			null, null, null, null, null, null, null,
+			Collections.singletonList("DESERT_TREASURE_II"), null);
+		SourceRequirements b = new SourceRequirements(
+			null, null, null, null, null, null, null,
+			Collections.singletonList("TROLL_STRONGHOLD"), null);
+		assertTrue(!a.equals(b));
+	}
+
+	@Test
+	public void equals_differingSkillCapePerks_notEqual()
+	{
+		SourceRequirements a = new SourceRequirements(
+			null, null, null, null, null, null, null, null,
+			Collections.singletonList("FARMING"));
+		SourceRequirements b = new SourceRequirements(
+			null, null, null, null, null, null, null, null,
+			Collections.singletonList("HUNTER"));
+		assertTrue(!a.equals(b));
+	}
+}

--- a/src/test/java/com/collectionloghelper/data/SourceRequirementsInventoryItemsAnyGsonTest.java
+++ b/src/test/java/com/collectionloghelper/data/SourceRequirementsInventoryItemsAnyGsonTest.java
@@ -193,10 +193,10 @@ public class SourceRequirementsInventoryItemsAnyGsonTest
 	{
 		SourceRequirements a = new SourceRequirements(
 			null, null, null, null, null, null,
-			Arrays.asList(26945, 26946));
+			Arrays.asList(26945, 26946), null, null);
 		SourceRequirements b = new SourceRequirements(
 			null, null, null, null, null, null,
-			Arrays.asList(26945, 26946));
+			Arrays.asList(26945, 26946), null, null);
 		assertEquals(a, b);
 		assertEquals(a.hashCode(), b.hashCode());
 	}
@@ -206,10 +206,10 @@ public class SourceRequirementsInventoryItemsAnyGsonTest
 	{
 		SourceRequirements a = new SourceRequirements(
 			null, null, null, null, null, null,
-			Collections.singletonList(26945));
+			Collections.singletonList(26945), null, null);
 		SourceRequirements b = new SourceRequirements(
 			null, null, null, null, null, null,
-			Collections.singletonList(26946));
+			Collections.singletonList(26946), null, null);
 		assertTrue(!a.equals(b));
 	}
 
@@ -221,10 +221,10 @@ public class SourceRequirementsInventoryItemsAnyGsonTest
 		// the evaluator would not be able to choose AND vs OR semantics.
 		SourceRequirements andOnly = new SourceRequirements(
 			null, null, null, null, null,
-			Collections.singletonList(26945), null);
+			Collections.singletonList(26945), null, null, null);
 		SourceRequirements anyOnly = new SourceRequirements(
 			null, null, null, null, null, null,
-			Collections.singletonList(26945));
+			Collections.singletonList(26945), null, null);
 		assertTrue(!andOnly.equals(anyOnly));
 	}
 
@@ -240,7 +240,7 @@ public class SourceRequirementsInventoryItemsAnyGsonTest
 			Arrays.asList("JEWELLERY_BOX_FANCY"),
 			Arrays.asList(22557),
 			Arrays.asList(12938),
-			Arrays.asList(26945, 26946, 26947, 26948, 26949, 26950));
+			Arrays.asList(26945, 26946, 26947, 26948, 26949, 26950), null, null);
 		String json = GSON.toJson(original);
 		SourceRequirements restored = GSON.fromJson(json, SourceRequirements.class);
 		assertEquals(original, restored);

--- a/src/test/java/com/collectionloghelper/data/SourceRequirementsInventoryItemsGsonTest.java
+++ b/src/test/java/com/collectionloghelper/data/SourceRequirementsInventoryItemsGsonTest.java
@@ -184,10 +184,10 @@ public class SourceRequirementsInventoryItemsGsonTest
 	{
 		SourceRequirements a = new SourceRequirements(
 			null, null, null, null, null,
-			Arrays.asList(26945, 23959), null);
+			Arrays.asList(26945, 23959), null, null, null);
 		SourceRequirements b = new SourceRequirements(
 			null, null, null, null, null,
-			Arrays.asList(26945, 23959), null);
+			Arrays.asList(26945, 23959), null, null, null);
 		assertEquals(a, b);
 		assertEquals(a.hashCode(), b.hashCode());
 	}
@@ -197,10 +197,10 @@ public class SourceRequirementsInventoryItemsGsonTest
 	{
 		SourceRequirements a = new SourceRequirements(
 			null, null, null, null, null,
-			Collections.singletonList(26945), null);
+			Collections.singletonList(26945), null, null, null);
 		SourceRequirements b = new SourceRequirements(
 			null, null, null, null, null,
-			Collections.singletonList(23959), null);
+			Collections.singletonList(23959), null, null, null);
 		assertTrue(!a.equals(b));
 	}
 
@@ -215,7 +215,7 @@ public class SourceRequirementsInventoryItemsGsonTest
 			Collections.singletonList("FREMENNIK_HARD"),
 			Arrays.asList("JEWELLERY_BOX_FANCY"),
 			Arrays.asList(22557),
-			Arrays.asList(26945, 23959), null);
+			Arrays.asList(26945, 23959), null, null, null);
 		String json = GSON.toJson(original);
 		SourceRequirements restored = GSON.fromJson(json, SourceRequirements.class);
 		assertEquals(original, restored);

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerNestedConditionalTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerNestedConditionalTest.java
@@ -431,12 +431,12 @@ public class GuidanceSequencerNestedConditionalTest
 
 	private SourceRequirements makeQuestReq(String questName)
 	{
-		return new SourceRequirements(Arrays.asList(questName), null, null, null, null, null, null);
+		return new SourceRequirements(Arrays.asList(questName), null, null, null, null, null, null, null, null);
 	}
 
 	private SourceRequirements makeSkillReq(String skill, int level)
 	{
-		return new SourceRequirements(null, Arrays.asList(new SkillRequirement(skill, level)), null, null, null, null, null);
+		return new SourceRequirements(null, Arrays.asList(new SkillRequirement(skill, level)), null, null, null, null, null, null, null);
 	}
 
 	/**

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
@@ -1444,12 +1444,12 @@ public class GuidanceSequencerTest
 
 	private SourceRequirements makeQuestRequirement(String questName)
 	{
-		return new SourceRequirements(Arrays.asList(questName), null, null, null, null, null, null);
+		return new SourceRequirements(Arrays.asList(questName), null, null, null, null, null, null, null, null);
 	}
 
 	private SourceRequirements makeSkillRequirement(String skill, int level)
 	{
-		return new SourceRequirements(null, Arrays.asList(new SkillRequirement(skill, level)), null, null, null, null, null);
+		return new SourceRequirements(null, Arrays.asList(new SkillRequirement(skill, level)), null, null, null, null, null, null, null);
 	}
 
 	private GuidanceStep makeStepWithAlternatives(String description, int worldX, int worldY,

--- a/src/test/java/com/collectionloghelper/ui/widget/SourceRequirementsHeaderTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/SourceRequirementsHeaderTest.java
@@ -150,7 +150,7 @@ public class SourceRequirementsHeaderTest
 		when(client.getIntStack()).thenReturn(new int[]{2});
 
 		SourceRequirements req = new SourceRequirements(
-			Collections.singletonList("DRAGON_SLAYER_II"), null, null, null, null, null, null);
+			Collections.singletonList("DRAGON_SLAYER_II"), null, null, null, null, null, null, null, null);
 		CollectionLogSource source = makeSourceWithRequirements("Vorkath", req);
 
 		List<RequirementRow> rows = checker.buildRequirementRows(source);
@@ -172,7 +172,7 @@ public class SourceRequirementsHeaderTest
 		when(client.getIntStack()).thenReturn(new int[]{1});
 
 		SourceRequirements req = new SourceRequirements(
-			Collections.singletonList("DRAGON_SLAYER_II"), null, null, null, null, null, null);
+			Collections.singletonList("DRAGON_SLAYER_II"), null, null, null, null, null, null, null, null);
 		CollectionLogSource source = makeSourceWithRequirements("Vorkath", req);
 
 		List<RequirementRow> rows = checker.buildRequirementRows(source);
@@ -191,7 +191,7 @@ public class SourceRequirementsHeaderTest
 		when(client.getIntStack()).thenReturn(new int[]{0});
 
 		SourceRequirements req = new SourceRequirements(
-			Collections.singletonList("DRAGON_SLAYER_II"), null, null, null, null, null, null);
+			Collections.singletonList("DRAGON_SLAYER_II"), null, null, null, null, null, null, null, null);
 		CollectionLogSource source = makeSourceWithRequirements("Vorkath", req);
 
 		List<RequirementRow> rows = checker.buildRequirementRows(source);
@@ -213,7 +213,7 @@ public class SourceRequirementsHeaderTest
 		when(client.getRealSkillLevel(Skill.SLAYER)).thenReturn(95);
 
 		SourceRequirements req = new SourceRequirements(
-			null, Collections.singletonList(new SkillRequirement("SLAYER", 91)), null, null, null, null, null);
+			null, Collections.singletonList(new SkillRequirement("SLAYER", 91)), null, null, null, null, null, null, null);
 		CollectionLogSource source = makeSourceWithRequirements("Cerberus", req);
 
 		List<RequirementRow> rows = checker.buildRequirementRows(source);
@@ -235,7 +235,7 @@ public class SourceRequirementsHeaderTest
 		when(client.getRealSkillLevel(Skill.SLAYER)).thenReturn(80);
 
 		SourceRequirements req = new SourceRequirements(
-			null, Collections.singletonList(new SkillRequirement("SLAYER", 91)), null, null, null, null, null);
+			null, Collections.singletonList(new SkillRequirement("SLAYER", 91)), null, null, null, null, null, null, null);
 		CollectionLogSource source = makeSourceWithRequirements("Cerberus", req);
 
 		List<RequirementRow> rows = checker.buildRequirementRows(source);
@@ -257,7 +257,7 @@ public class SourceRequirementsHeaderTest
 		when(client.getVarbitValue(ArgumentMatchers.anyInt())).thenReturn(1);
 
 		SourceRequirements req = new SourceRequirements(
-			null, null, Collections.singletonList("ARDOUGNE_ELITE"), null, null, null, null);
+			null, null, Collections.singletonList("ARDOUGNE_ELITE"), null, null, null, null, null, null);
 		CollectionLogSource source = makeSourceWithRequirements("Zulrah", req);
 
 		List<RequirementRow> rows = checker.buildRequirementRows(source);
@@ -278,7 +278,7 @@ public class SourceRequirementsHeaderTest
 		when(client.getVarbitValue(ArgumentMatchers.anyInt())).thenReturn(0);
 
 		SourceRequirements req = new SourceRequirements(
-			null, null, Collections.singletonList("ARDOUGNE_ELITE"), null, null, null, null);
+			null, null, Collections.singletonList("ARDOUGNE_ELITE"), null, null, null, null, null, null);
 		CollectionLogSource source = makeSourceWithRequirements("Zulrah", req);
 
 		List<RequirementRow> rows = checker.buildRequirementRows(source);
@@ -304,7 +304,7 @@ public class SourceRequirementsHeaderTest
 		SourceRequirements req = new SourceRequirements(
 			Collections.singletonList("TROLL_STRONGHOLD"),
 			Collections.singletonList(new SkillRequirement("STRENGTH", 70)),
-			null, null, null, null, null);
+			null, null, null, null, null, null, null);
 		CollectionLogSource source = makeSourceWithRequirements("General Graardor", req);
 
 		List<RequirementRow> rows = checker.buildRequirementRows(source);
@@ -332,7 +332,7 @@ public class SourceRequirementsHeaderTest
 		SourceRequirements req = new SourceRequirements(
 			Collections.singletonList("TROLL_STRONGHOLD"),
 			Collections.singletonList(new SkillRequirement("STRENGTH", 70)),
-			null, null, null, null, null);
+			null, null, null, null, null, null, null);
 		CollectionLogSource source = makeSourceWithRequirements("General Graardor", req);
 
 		List<RequirementRow> rows = checker.buildRequirementRows(source);


### PR DESCRIPTION
## Summary

Foundation PR that extends the `SourceRequirements` schema with two additive `@Nullable` detector fields and wires their evaluation in `RequirementsChecker`. No data is wired in this PR — the D5-G/H data-wiring PRs stack on this.

## New fields and exact semantics

**`questMilestones`** (`List<String>`) — RuneLite `Quest` enum constant names where being STARTED is enough. Looser than the existing `quests` field, which requires the quest FINISHED. Evaluated AND-wise: a milestone is satisfied when `Quest.valueOf(name).getState(client)` is `IN_PROGRESS` or `FINISHED` (i.e. not `NOT_STARTED`). Unknown enum names fail closed (logged, skipped), mirroring the `quests` / `pohTeleports` resolution.

**`skillCapePerks`** (`List<String>`) — RuneLite `Skill` enum constant names. A skill-cape travel perk is available only to a player who owns the cape, and owning the cape requires level 99 in that skill. This field uses the level-99 threshold as a proxy for cape ownership (the necessary condition, not proof the cape is worn). Evaluated AND-wise: satisfied when `client.getRealSkillLevel(Skill.valueOf(name)) >= 99`. Unknown enum names fail closed.

Both fields AND-combine with the existing clauses and default to `null`, so all 225 existing sources and all existing JSON parse unchanged (null = no constraint).

## Callsites fixed

`SourceRequirements` is a Lombok `@Value` (generated all-args constructor). The two new fields move it from 7 to 9 positional args. Updated **all 9 affected test callsite locations** (single- and multi-line forms) across 9 test files. No reflective `getDeclaredConstructor` lookups target `SourceRequirements`, so none needed touching.

## Evaluator wiring

Both clauses added to `RequirementsChecker.checkRequirementsDetail(...)`, mirroring the existing `quests` (Quest.valueOf + getState fail-closed) and skill-level (`getRealSkillLevel` + `Skill.valueOf` fail-closed) evaluation shapes.

## Tests added

- **`D5SchemaMigrationTest`** — migration guard mirroring `InventoryItemsAnyMigrationTest`. Walks the whole database (top-level reqs, conditional-alternative reqs flat + nested, waypoint reqs) and asserts both new fields are null EVERYWHERE (empty allowlist). Guards that the fields stay dormant until D5-G/H populate them.
- **`RequirementsCheckerD5Test`** — positive/negative evaluation: questMilestones passes IN_PROGRESS and FINISHED, fails NOT_STARTED; skillCapePerks passes at level >= 99, fails below; both fail closed on unknown enum names.
- **`SourceRequirementsD5GsonTest`** — Gson serialise/deserialise coverage (absent/null/empty/single/multi shapes, full nine-field round-trip, equals).

## Test plan

- [x] `./gradlew test` — BUILD SUCCESSFUL, 1711 tests, 0 failures, 0 errors.
- [x] No changes to `drop_rates.json`.

## Follow-up

D5-G/H data wiring stacks on this foundation.
