### PR TITLE
data(d5): batch H - skill-cape-perk alternatives on 3 sources

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -5959,7 +5959,18 @@
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 15,
         "travelTip": "Fairy ring CIR (Farming Guild), or Skills necklace -> Farming Guild",
-        "section": "Travel"
+        "section": "Travel",
+        "conditionalAlternatives": [
+          {
+            "requirements": {
+              "skillCapePerks": [
+                "FARMING"
+              ]
+            },
+            "description": "Farming cape: teleport straight into the Farming Guild (lands near the bank), then walk to the south room and plant the Hespori seed. Skips the fairy ring hop entirely",
+            "travelTip": "Farming cape -> Farming Guild -> south room"
+          }
+        ]
       },
       {
         "description": "Check the Hespori patch when ready (~32 hours after planting). The patch icon shows a glowing flower when the Hespori is fully grown and ready to fight",
@@ -29734,7 +29745,18 @@
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
         "travelTip": "Edgeville lever -> Wilderness Volcano -> run south-east; or Wilderness Obelisk level 35",
-        "section": "Travel"
+        "section": "Travel",
+        "conditionalAlternatives": [
+          {
+            "requirements": {
+              "skillCapePerks": [
+                "HUNTER"
+              ]
+            },
+            "description": "Hunter cape: teleport straight to the black chinchompa Wilderness hunting area (five uses per day), skipping the Edgeville lever and the long run south-east through the Wilderness. Still bank only what you can afford to lose - PKers patrol here",
+            "travelTip": "Hunter cape -> black chinchompa area (5/day)"
+          }
+        ]
       },
       {
         "description": "Set box traps to catch black chinchompas (73 Hunter required). Stay alert for PKers approaching from any direction - keep a teleport ready. Always check the mini-map for nearby players. Inventory fills quickly so bank or drop when full.",
@@ -30076,7 +30098,18 @@
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 30,
         "travelTip": "Fairy ring CIR -> Farming Guild; spirit tree -> Gnome Stronghold; gnome glider to Lleyta",
-        "section": "Plant"
+        "section": "Plant",
+        "conditionalAlternatives": [
+          {
+            "requirements": {
+              "skillCapePerks": [
+                "FARMING"
+              ]
+            },
+            "description": "Farming cape: teleport directly to the Farming Guild for its fruit tree patch (75+ Farming), skipping the fairy ring CIR hop, and the guild bank and spirit tree are a few tiles away for the rest of the run",
+            "travelTip": "Farming cape -> Farming Guild fruit tree patch"
+          }
+        ]
       },
       {
         "description": "Wait approximately 16 hours for fruit trees to fully grow (each tree takes 8 growth cycles at ~2 hours each). Tangleroot pet chance applies each time you check health of any fully grown tree. Return to all patches and check health to claim XP and log progress. Re-plant immediately to maximise pet attempts over time.",

--- a/src/test/java/com/collectionloghelper/data/D5HBranchRegressionTest.java
+++ b/src/test/java/com/collectionloghelper/data/D5HBranchRegressionTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.lang.reflect.Field;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * D5 batch H regression guard - locks the skill-cape-perk conditional
+ * alternatives wired on skilling sources via the new {@code skillCapePerks}
+ * field (a level-99 proxy for the cape's travel perk):
+ *
+ * <ul>
+ *   <li>Hespori: {@code FARMING} -&gt; Farming cape teleport into the Farming Guild.</li>
+ *   <li>Farming (Fruit Trees): {@code FARMING} -&gt; Farming cape to the guild fruit tree patch.</li>
+ *   <li>Black Chinchompas: {@code HUNTER} -&gt; Hunter cape to the black chinchompa area.</li>
+ * </ul>
+ *
+ * <p>For each wired source, some guidance step must carry a
+ * {@code conditionalAlternatives} entry whose {@code requirements.getSkillCapePerks()}
+ * equals the expected single-element list, the alternative must override
+ * description + travelTip (mentioning the skill cape), and that step's base
+ * description must remain (the unrestricted route is not replaced).
+ * Index-agnostic: the alternative may sit on any step.
+ */
+public class D5HBranchRegressionTest
+{
+	private static final Map<String, List<String>> EXPECTED = buildExpected();
+
+	private static Map<String, List<String>> buildExpected()
+	{
+		Map<String, List<String>> map = new LinkedHashMap<>();
+		map.put("Hespori",                List.of("FARMING"));
+		map.put("Farming (Fruit Trees)",  List.of("FARMING"));
+		map.put("Black Chinchompas",      List.of("HUNTER"));
+		return map;
+	}
+
+	private DropRateDatabase database;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		database = new DropRateDatabase();
+
+		Gson gson = new GsonBuilder().create();
+		Field gsonField = DropRateDatabase.class.getDeclaredField("gson");
+		gsonField.setAccessible(true);
+		gsonField.set(database, gson);
+
+		database.load();
+	}
+
+	@Test
+	public void wiredSourceCarriesSkillCapePerkConditionalAlternative()
+	{
+		for (Map.Entry<String, List<String>> entry : EXPECTED.entrySet())
+		{
+			String name = entry.getKey();
+			List<String> expectedPerks = entry.getValue();
+
+			CollectionLogSource source = findSource(name);
+			assertNotNull(source, "Expected source: " + name);
+			assertNotNull(source.getGuidanceSteps(), name + ": guidanceSteps must not be null");
+
+			GuidanceStep wiredStep = null;
+			ConditionalAlternative wiredAlt = null;
+			for (GuidanceStep step : source.getGuidanceSteps())
+			{
+				List<ConditionalAlternative> alts = step.getConditionalAlternatives();
+				if (alts == null)
+				{
+					continue;
+				}
+				ConditionalAlternative match = findSkillCapeAlternative(alts, expectedPerks);
+				if (match != null)
+				{
+					wiredStep = step;
+					wiredAlt = match;
+					break;
+				}
+			}
+
+			assertNotNull(wiredAlt,
+				name + ": expected a conditional alternative with skillCapePerks = " + expectedPerks);
+
+			SourceRequirements altReqs = wiredAlt.getRequirements();
+			assertNotNull(altReqs, name + ": conditional alternative must declare requirements");
+			assertEquals(expectedPerks, altReqs.getSkillCapePerks(), name + ": skillCapePerks mismatch");
+
+			assertNotNull(wiredAlt.getDescription(), name + ": alternative must override description");
+			assertTrue(wiredAlt.getDescription().toLowerCase().contains("cape"),
+				name + ": alternative description should mention the skill cape; got: "
+					+ wiredAlt.getDescription());
+			assertNotNull(wiredAlt.getTravelTip(), name + ": alternative must override travelTip");
+
+			// Fallback preserved: the step carrying the alternative still has a base description.
+			assertNotNull(wiredStep.getDescription(), name + ": base step description must remain");
+			assertFalse(wiredStep.getDescription().isBlank(), name + ": base step description must not be blank");
+		}
+	}
+
+	@Test
+	public void expectedSourcesArePresentInDatabase()
+	{
+		for (String name : EXPECTED.keySet())
+		{
+			assertNotNull(findSource(name), "Expected source missing from drop_rates.json: " + name);
+		}
+		assertEquals(3, EXPECTED.size(), "D5 batch H wires exactly 3 skill-cape-perk sources");
+	}
+
+	private static ConditionalAlternative findSkillCapeAlternative(
+		List<ConditionalAlternative> alternatives, List<String> expectedPerks)
+	{
+		for (ConditionalAlternative candidate : alternatives)
+		{
+			SourceRequirements reqs = candidate.getRequirements();
+			if (reqs == null)
+			{
+				continue;
+			}
+			List<String> perks = reqs.getSkillCapePerks();
+			if (perks != null && perks.equals(expectedPerks))
+			{
+				return candidate;
+			}
+		}
+		return null;
+	}
+
+	private CollectionLogSource findSource(String name)
+	{
+		for (CollectionLogSource source : database.getAllSources())
+		{
+			if (name.equals(source.getName()))
+			{
+				return source;
+			}
+		}
+		return null;
+	}
+}

--- a/src/test/java/com/collectionloghelper/data/D5SchemaMigrationTest.java
+++ b/src/test/java/com/collectionloghelper/data/D5SchemaMigrationTest.java
@@ -29,6 +29,7 @@ import com.google.gson.GsonBuilder;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -186,8 +187,19 @@ public class D5SchemaMigrationTest
 
 	// -- skillCapePerks walk ----------------------------------------------------
 
+	// D5-H wired skill-cape-perk alternatives on these sources; they are exempt
+	// from the "skillCapePerks must be null" invariant.
+	private static final Set<String> SKILL_CAPE_ALLOWED = Set.of(
+		"Hespori",
+		"Farming (Fruit Trees)",
+		"Black Chinchompas");
+
 	private static void checkSourceSkillCapePerks(CollectionLogSource source, List<String> violations)
 	{
+		if (SKILL_CAPE_ALLOWED.contains(source.getName()))
+		{
+			return;
+		}
 		String sourceName = source.getName();
 		checkRequirementsSkillCapePerks(sourceName + " (top-level requirements)",
 			source.getRequirements(), violations);


### PR DESCRIPTION
## D5-H: skill-cape-perk conditional alternatives

Wires the new `skillCapePerks` field (AND-semantic `List<String>` of RuneLite `Skill` enum constants; a level-99 proxy for the cape's travel perk) onto 3 collection-log sources where a skill-cape teleport gives a genuinely faster route (>~30s) to the arrival point. Each base step remains the unrestricted fallback.

### Wired sources

| Source | Skill constant | Route | Stacked on existing alt? |
|---|---|---|---|
| Hespori | `FARMING` | Farming cape teleports directly into the Farming Guild (lands ~16 tiles from bank), then walk to the south room to plant the Hespori seed. Skips the fairy ring CIR hop / Skills necklace fallback. | No (Travel step had no prior alternative) |
| Farming (Fruit Trees) | `FARMING` | Farming cape teleports straight to the Farming Guild fruit tree patch (75+ Farming), skipping the fairy ring CIR hop; guild bank + spirit tree are adjacent for the rest of the run. | No (Plant step had no prior alternative) |
| Black Chinchompas | `HUNTER` | Hunter cape teleports straight to the black chinchompa Wilderness hunting area (5 uses/day), skipping the Edgeville lever and the long run south-east through the Wilderness. | No (Travel step had no prior alternative) |

No stacking was needed: none of the three target steps carried a prior D5-A/B POH alternative.

### Skipped candidates

- **Crafting cape -> Crafting Guild:** no source in `drop_rates.json` is located at the Crafting Guild, so there is no arrival to shortcut.
- **Slayer cape -> any slayer master:** the Slayer cape has no teleport function (only task-related perks), so it creates no travel shortcut.
- **Construction cape -> POH-from-anywhere:** a POH-from-anywhere teleport saves no meaningful time over the player's normal house teleport before using a POH fixture; not a >30s shortcut, so not wired.

### Enum verification

All skill constants were verified against the RuneLite `Skill` enum (`runelite-api/.../Skill.java`, fetched from `master`). Constants used: `FARMING`, `HUNTER` - both present and spelled exactly as in the enum. (Confirmed the enum also defines `CRAFTING`, `CONSTRUCTION`, `SLAYER`, and `RUNECRAFT` (not `RUNECRAFTING`), though only FARMING/HUNTER are used here.) Teleport destinations confirmed via the OSRS Wiki skill-cape pages: Farming cape -> Farming Guild; Hunter cape -> 5/day to the black/carnivorous chinchompa Wilderness areas.

### Migration guard

Added a `SKILL_CAPE_ALLOWED` allowlist (`Hespori`, `Farming (Fruit Trees)`, `Black Chinchompas`) immediately above the `// -- skillCapePerks walk --` region in `D5SchemaMigrationTest`, with an early-return skip at the top of `checkSourceSkillCapePerks(...)` mirroring `InventoryItemsAnyMigrationTest`. The `questMilestones` walk / test / region was left completely untouched.

### Regression test

New `D5HBranchRegressionTest` (modeled on `D5BBranchRegressionTest`): index-agnostic scan asserting each source carries an alt whose `requirements.getSkillCapePerks()` equals the expected single-element list, that the alt overrides description (mentions "cape") + travelTip, that the base step description remains, and that exactly 3 sources are wired.

### Verification

- Full Gradle suite: `./gradlew test` -> BUILD SUCCESSFUL.
- `data_ascii_lint`: 0 violations.
- `validate_drop_rates`: only pre-existing warnings (last-step ARRIVE_AT_TILE on 200+ sources, intentional shared-drop duplicate IDs); none introduced by this change.

## Test plan

- [x] `./gradlew test` passes (full suite)
- [x] ASCII lint clean on `drop_rates.json`
- [x] Migration test allowlist covers exactly the 3 wired sources