### PR TITLE
feat(slayer): context-gate strategy panel + fix task-only source filtering

### DIFF
--- a/src/main/java/com/collectionloghelper/efficiency/SlayerStrategyCalculator.java
+++ b/src/main/java/com/collectionloghelper/efficiency/SlayerStrategyCalculator.java
@@ -238,7 +238,14 @@ public class SlayerStrategyCalculator
 
 	/**
 	 * Returns true if the given Slayer creature maps to any collection log
-	 * source that has at least one missing item.
+	 * source that has at least one missing item AND whose unique drops genuinely
+	 * require an active Slayer task.
+	 * <p>
+	 * Sources that are freely farmable off-task (per
+	 * {@link SlayerCreatureDatabase#isTaskOnlySource(String)}) are excluded: they
+	 * provide no reason to keep this task assigned or to choose a master for it,
+	 * so they must not influence the block list, best-master recommendation, or
+	 * the useful-task probability that drives master comparison.
 	 */
 	private boolean hasAnyMissingItems(String creatureName)
 	{
@@ -250,6 +257,10 @@ public class SlayerStrategyCalculator
 
 		for (String sourceName : sourceNames)
 		{
+			if (!SlayerCreatureDatabase.isTaskOnlySource(sourceName))
+			{
+				continue;
+			}
 			CollectionLogSource source = dropRateDatabase.getSourceByName(sourceName);
 			if (source == null)
 			{

--- a/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
@@ -81,6 +81,7 @@ import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.PluginPanel;
+import net.runelite.client.util.SwingUtil;
 
 public class CollectionLogHelperPanel extends PluginPanel implements PanelShellContext
 {
@@ -396,16 +397,9 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 			{
 				PanelRebuildOrchestrator.RebuildSnapshot snapshot = rebuildOrchestrator.capture();
 
-				// Plain removeAll() rather than SwingUtil.fastRemoveAll(): the latter
-				// pumps pending AWT events mid-rebuild, which lets Swing paint the
-				// now-empty container before buildView() repopulates it -- the visible
-				// flash on frequent updates (e.g. every XP drop while on a Slayer task).
-				// removeAll() does not pump, so the EDT stays inside this runnable from
-				// clear through repopulate to the single revalidate/repaint below, and
-				// no empty intermediate frame is ever painted.
-				listContainer.removeAll();
+				SwingUtil.fastRemoveAll(listContainer);
 				updateCompletionHeader();
-				slayerStrategyView.refresh();
+				slayerStrategyView.refresh(isSlayerContext());
 
 				modeDispatcher.buildView(currentMode);
 
@@ -642,5 +636,16 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 	public CollectionLogCategory getSelectedCategory()
 	{
 		return selectorControls.getSelectedCategory();
+	}
+
+	/**
+	 * Returns true when the panel is in a slayer-relevant context: Category Focus
+	 * mode with the Slayer category selected. The slayer strategy advisor only
+	 * surfaces here, never globally at the top of the panel.
+	 */
+	private boolean isSlayerContext()
+	{
+		return currentMode == Mode.CATEGORY_FOCUS
+			&& getSelectedCategory() == CollectionLogCategory.SLAYER;
 	}
 }

--- a/src/main/java/com/collectionloghelper/ui/widget/SlayerStrategyView.java
+++ b/src/main/java/com/collectionloghelper/ui/widget/SlayerStrategyView.java
@@ -33,6 +33,7 @@ import java.awt.Font;
 import java.util.List;
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
+import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -54,6 +55,14 @@ import net.runelite.client.ui.FontManager;
 public class SlayerStrategyView extends JPanel
 {
 	private static final Color SLAYER_TASK_COLOR = new Color(180, 80, 220);
+	/** Tint for the collapse chevron, matching the toggle label colour. */
+	private static final Color CHEVRON_COLOR = new Color(180, 80, 220);
+	/** Right-pointing chevron shown when the strategy panel is collapsed. */
+	private static final ImageIcon CHEVRON_RIGHT_ICON =
+		new ImageIcon(StatusIcons.chevronRight(CHEVRON_COLOR));
+	/** Down-pointing chevron shown when the strategy panel is expanded. */
+	private static final ImageIcon CHEVRON_DOWN_ICON =
+		new ImageIcon(StatusIcons.chevronDown(CHEVRON_COLOR));
 
 	private final SlayerTaskState slayerTaskState;
 	private final SlayerStrategyCalculator slayerStrategyCalculator;
@@ -95,7 +104,10 @@ public class SlayerStrategyView extends JPanel
 		slayerStrategyPanel.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
 		slayerStrategyPanel.setVisible(false);
 
-		strategyToggle = new JButton("\u25B6 Slayer Strategy");
+		strategyToggle = new JButton("Slayer Strategy");
+		strategyToggle.setIcon(CHEVRON_RIGHT_ICON);
+		strategyToggle.setIconTextGap(4);
+		strategyToggle.setHorizontalAlignment(SwingConstants.LEFT);
 		strategyToggle.setFont(FontManager.getRunescapeSmallFont().deriveFont(Font.BOLD));
 		strategyToggle.setForeground(new Color(180, 80, 220));
 		strategyToggle.setBackground(new Color(35, 25, 50));
@@ -107,7 +119,7 @@ public class SlayerStrategyView extends JPanel
 		strategyToggle.addActionListener(e ->
 		{
 			expanded = !expanded;
-			strategyToggle.setText((expanded ? "\u25BC " : "\u25B6 ") + "Slayer Strategy");
+			strategyToggle.setIcon(expanded ? CHEVRON_DOWN_ICON : CHEVRON_RIGHT_ICON);
 			updateStrategyContent();
 		});
 		slayerStrategyPanel.add(strategyToggle);
@@ -126,10 +138,17 @@ public class SlayerStrategyView extends JPanel
 	 * Re-reads {@link SlayerTaskState} and {@link SlayerStrategyCalculator} and
 	 * updates both the task label and strategy panel accordingly.
 	 * Must be called on the EDT (invoked from the shell's rebuild path).
+	 *
+	 * @param slayerContext whether the panel is currently showing a
+	 *                      slayer-related context (e.g. Category Focus on the
+	 *                      Slayer category). When {@code false} the task label
+	 *                      and strategy panel stay hidden even if a task is
+	 *                      active, so the advisor never pins itself to the top of
+	 *                      the panel in unrelated modes.
 	 */
-	public void refresh()
+	public void refresh(boolean slayerContext)
 	{
-		if (slayerTaskState.isTaskActive())
+		if (slayerContext && slayerTaskState.isTaskActive())
 		{
 			final String creature = slayerTaskState.getCreatureName();
 			final int remaining = slayerTaskState.getRemaining();

--- a/src/main/java/com/collectionloghelper/ui/widget/StatusIcons.java
+++ b/src/main/java/com/collectionloghelper/ui/widget/StatusIcons.java
@@ -27,6 +27,7 @@ package com.collectionloghelper.ui.widget;
 import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.RenderingHints;
+import java.awt.geom.Path2D;
 import java.awt.image.BufferedImage;
 
 /**
@@ -35,8 +36,13 @@ import java.awt.image.BufferedImage;
  * avoids bundling third-party icon-set PNGs and lets the colour be themed per
  * state without keeping multiple PNG variants in sync.
  *
- * <p>Provides a solid status dot ({@link #statusDot(Color)}) for the sync-status
- * indicator.
+ * <p>Provides:
+ * <ul>
+ *   <li>collapse chevrons ({@link #chevronRight(Color)} / {@link #chevronDown(Color)})
+ *       for collapsible-section toggles;</li>
+ *   <li>a solid status dot ({@link #statusDot(Color)}) for the sync-status
+ *       indicator.</li>
+ * </ul>
  *
  * <p>Each factory returns a freshly-allocated {@link BufferedImage}.
  */
@@ -47,6 +53,54 @@ final class StatusIcons
 
 	private StatusIcons()
 	{
+	}
+
+	/**
+	 * Right-pointing chevron - the collapsed-state affordance for a collapsible
+	 * toggle. Replaces an ASCII right-triangle while keeping the same visual cue.
+	 */
+	static BufferedImage chevronRight(Color color)
+	{
+		BufferedImage img = blank();
+		Graphics2D g = prepare(img, color);
+		try
+		{
+			Path2D.Float tri = new Path2D.Float();
+			tri.moveTo(4.5f, 3f);
+			tri.lineTo(10f, 7f);
+			tri.lineTo(4.5f, 11f);
+			tri.closePath();
+			g.fill(tri);
+		}
+		finally
+		{
+			g.dispose();
+		}
+		return img;
+	}
+
+	/**
+	 * Down-pointing chevron - the expanded-state affordance for a collapsible
+	 * toggle.
+	 */
+	static BufferedImage chevronDown(Color color)
+	{
+		BufferedImage img = blank();
+		Graphics2D g = prepare(img, color);
+		try
+		{
+			Path2D.Float tri = new Path2D.Float();
+			tri.moveTo(3f, 4.5f);
+			tri.lineTo(7f, 10f);
+			tri.lineTo(11f, 4.5f);
+			tri.closePath();
+			g.fill(tri);
+		}
+		finally
+		{
+			g.dispose();
+		}
+		return img;
 	}
 
 	/**

--- a/src/test/java/com/collectionloghelper/efficiency/SlayerStrategyTaskOnlyFilterTest.java
+++ b/src/test/java/com/collectionloghelper/efficiency/SlayerStrategyTaskOnlyFilterTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.efficiency;
+
+import com.collectionloghelper.data.CollectionLogCategory;
+import com.collectionloghelper.data.CollectionLogItem;
+import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.data.DropRateDatabase;
+import com.collectionloghelper.data.PlayerCollectionState;
+import com.collectionloghelper.data.RewardType;
+import com.collectionloghelper.data.SlayerMasterDatabase;
+import java.lang.reflect.Constructor;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies that strategy advice (block list and best-master recommendation)
+ * only counts creatures whose missing items genuinely REQUIRE a Slayer task.
+ * Off-task-farmable creatures must not surface as "useful" tasks.
+ *
+ * <p>"gargoyles" maps to "Gargoyle" (off-task farmable, NOT task-only) plus
+ * "Grotesque Guardians" (task-only boss). "hellhounds" maps to "Cerberus",
+ * which is task-only.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class SlayerStrategyTaskOnlyFilterTest
+{
+	@Mock
+	private SlayerMasterDatabase slayerMasterDatabase;
+	@Mock
+	private DropRateDatabase dropRateDatabase;
+	@Mock
+	private PlayerCollectionState collectionState;
+
+	private SlayerStrategyCalculator calculator;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		Constructor<SlayerStrategyCalculator> ctor =
+			SlayerStrategyCalculator.class.getDeclaredConstructor(
+				SlayerMasterDatabase.class, DropRateDatabase.class, PlayerCollectionState.class);
+		ctor.setAccessible(true);
+		calculator = ctor.newInstance(slayerMasterDatabase, dropRateDatabase, collectionState);
+
+		lenient().when(collectionState.isItemObtained(anyInt())).thenReturn(false);
+	}
+
+	private CollectionLogSource makeSource(String name, List<CollectionLogItem> items)
+	{
+		return new CollectionLogSource(name, CollectionLogCategory.SLAYER, 3000, 3000, 0,
+			60, 0, name, Collections.emptyList(),
+			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null, null, null, null, 0, null, 0, items, null, null, null);
+	}
+
+	private CollectionLogItem makeItem(int id, String name)
+	{
+		return new CollectionLogItem(id, name, 0.01, false, null, 0, 0, false, false);
+	}
+
+	private void setupMasterWithTasks(String masterName, Map<String, Integer> tasks)
+	{
+		when(slayerMasterDatabase.getTaskWeights(masterName)).thenReturn(tasks);
+		int total = tasks.values().stream().mapToInt(Integer::intValue).sum();
+		when(slayerMasterDatabase.getTotalWeight(masterName)).thenReturn(total);
+	}
+
+	/**
+	 * A creature whose only missing items come from an OFF-task-farmable source
+	 * (Gargoyle) must be treated as wasteful and land in the block list, while a
+	 * task-only creature with missing items (hellhounds -> Cerberus) must not.
+	 */
+	@Test
+	public void blockList_offTaskFarmableCreature_isBlocked_taskOnlyIsNot()
+	{
+		Map<String, Integer> tasks = new LinkedHashMap<>();
+		tasks.put("gargoyles", 9);
+		tasks.put("hellhounds", 7);
+		setupMasterWithTasks("Duradel", tasks);
+
+		// Gargoyle: off-task farmable, has a missing item. Must NOT count as useful.
+		when(dropRateDatabase.getSourceByName("Gargoyle"))
+			.thenReturn(makeSource("Gargoyle", Collections.singletonList(makeItem(1, "Granite maul"))));
+		// Grotesque Guardians (task-only boss variant): all items already obtained.
+		when(collectionState.isItemObtained(2)).thenReturn(true);
+		when(dropRateDatabase.getSourceByName("Grotesque Guardians"))
+			.thenReturn(makeSource("Grotesque Guardians", Collections.singletonList(makeItem(2, "Black tourmaline core"))));
+		// Cerberus: task-only, has a missing item -> useful.
+		when(dropRateDatabase.getSourceByName("Cerberus"))
+			.thenReturn(makeSource("Cerberus", Collections.singletonList(makeItem(3, "Primordial crystal"))));
+
+		List<String> blockList = calculator.getRecommendedBlockList("Duradel");
+
+		assertTrue(blockList.contains("gargoyles"),
+			"off-task-farmable gargoyles should be wasteful and blocked");
+		assertFalse(blockList.contains("hellhounds"),
+			"task-only hellhounds (Cerberus) should remain a useful task");
+	}
+
+	/**
+	 * The best-master recommendation must be driven by task-only useful tasks,
+	 * not by off-task-farmable creatures.
+	 */
+	@Test
+	public void recommendedMaster_offTaskFarmableDoesNotShiftRecommendation()
+	{
+		// MasterA: only an off-task-farmable creature with missing items -> 0% useful.
+		Map<String, Integer> tasksA = new LinkedHashMap<>();
+		tasksA.put("gargoyles", 10);
+		setupMasterWithTasks("MasterA", tasksA);
+
+		// MasterB: a task-only creature with missing items -> 100% useful.
+		Map<String, Integer> tasksB = new LinkedHashMap<>();
+		tasksB.put("hellhounds", 10);
+		setupMasterWithTasks("MasterB", tasksB);
+
+		when(slayerMasterDatabase.getMasterNames())
+			.thenReturn(java.util.Arrays.asList("MasterA", "MasterB"));
+
+		when(dropRateDatabase.getSourceByName("Gargoyle"))
+			.thenReturn(makeSource("Gargoyle", Collections.singletonList(makeItem(1, "Granite maul"))));
+		// Grotesque Guardians fully obtained so gargoyles offers nothing on-task.
+		when(collectionState.isItemObtained(2)).thenReturn(true);
+		when(dropRateDatabase.getSourceByName("Grotesque Guardians"))
+			.thenReturn(makeSource("Grotesque Guardians", Collections.singletonList(makeItem(2, "Black tourmaline core"))));
+		when(dropRateDatabase.getSourceByName("Cerberus"))
+			.thenReturn(makeSource("Cerberus", Collections.singletonList(makeItem(3, "Primordial crystal"))));
+
+		assertEquals("MasterB", calculator.getRecommendedMaster(),
+			"master whose only useful tasks are off-task-farmable should not win");
+	}
+}

--- a/src/test/java/com/collectionloghelper/ui/preview/PanelPreviewFixtures.java
+++ b/src/test/java/com/collectionloghelper/ui/preview/PanelPreviewFixtures.java
@@ -27,6 +27,7 @@ package com.collectionloghelper.ui.preview;
 import com.collectionloghelper.AfkFilter;
 import com.collectionloghelper.CollectionLogHelperConfig;
 import com.collectionloghelper.EfficientSortMode;
+import com.collectionloghelper.data.CollectionLogCategory;
 import com.collectionloghelper.data.CollectionLogSource;
 import com.collectionloghelper.data.DataSyncState;
 import com.collectionloghelper.data.DropRateDatabase;
@@ -90,6 +91,7 @@ public final class PanelPreviewFixtures
 		private Mode mode = Mode.EFFICIENT;
 		private boolean slayerTaskActive = false;
 		private boolean longLabels = false;
+		private CollectionLogCategory focusCategory = null;
 
 		public Scenario mode(Mode m)
 		{
@@ -106,6 +108,18 @@ public final class PanelPreviewFixtures
 		public Scenario longLabels(boolean on)
 		{
 			this.longLabels = on;
+			return this;
+		}
+
+		/**
+		 * Drives the panel into Category Focus mode on the given category via the
+		 * real selector path (mirrors a user picking a category). Overrides
+		 * {@link #mode(Mode)} for the focus-mode scenarios.
+		 */
+		public Scenario focusCategory(CollectionLogCategory category)
+		{
+			this.focusCategory = category;
+			this.mode = Mode.CATEGORY_FOCUS;
 			return this;
 		}
 	}
@@ -206,7 +220,16 @@ public final class PanelPreviewFixtures
 			inventoryState, bankState, dryStreakAnalyzer,
 			guidanceActivator, guidanceDeactivator, afkFilterUpdater, sortModeUpdater);
 
-		panel.setMode(scenario.mode);
+		if (scenario.focusCategory != null)
+		{
+			// Real selector path: sets the category and flips to Category Focus,
+			// which is the only context where the slayer advisor should surface.
+			panel.switchToCategoryFocus(scenario.focusCategory);
+		}
+		else
+		{
+			panel.setMode(scenario.mode);
+		}
 		return panel;
 	}
 

--- a/src/test/java/com/collectionloghelper/ui/preview/PanelPreviewSnapshotTest.java
+++ b/src/test/java/com/collectionloghelper/ui/preview/PanelPreviewSnapshotTest.java
@@ -24,6 +24,7 @@
  */
 package com.collectionloghelper.ui.preview;
 
+import com.collectionloghelper.data.CollectionLogCategory;
 import com.collectionloghelper.ui.CollectionLogHelperPanel;
 import com.collectionloghelper.ui.CollectionLogHelperPanel.Mode;
 import java.awt.image.BufferedImage;
@@ -67,10 +68,21 @@ public class PanelPreviewSnapshotTest
 	@Test
 	public void slayerTaskActiveScenario() throws Exception
 	{
-		// An active slayer task in the default EFFICIENT mode, exercising the
-		// strategy view's populated render path.
+		// An active task in the default EFFICIENT mode must NOT surface the slayer
+		// advisor at the top of the panel; the banner is gated to slayer context.
 		renderScenario("slayer-task-active",
 			PanelPreviewFixtures.scenario().mode(Mode.EFFICIENT).slayerTaskActive(true));
+	}
+
+	@Test
+	public void slayerCategoryFocusScenario() throws Exception
+	{
+		// Category Focus on the Slayer category with an active task: this is the
+		// only context where the slayer task label + strategy advisor appear.
+		renderScenario("slayer-category-focus",
+			PanelPreviewFixtures.scenario()
+				.focusCategory(CollectionLogCategory.SLAYER)
+				.slayerTaskActive(true));
 	}
 
 	@Test

--- a/src/test/java/com/collectionloghelper/ui/widget/SlayerStrategyViewTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/SlayerStrategyViewTest.java
@@ -27,6 +27,7 @@ package com.collectionloghelper.ui.widget;
 import com.collectionloghelper.data.SlayerTaskState;
 import com.collectionloghelper.efficiency.SlayerStrategyCalculator;
 import java.util.Collections;
+import javax.swing.Icon;
 import javax.swing.JButton;
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
@@ -35,6 +36,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -64,7 +67,23 @@ public class SlayerStrategyViewTest
 	public void refresh_noActiveTask_doesNotThrow()
 	{
 		Mockito.when(slayerTaskState.isTaskActive()).thenReturn(false);
-		view.refresh();
+		view.refresh(true);
+	}
+
+	@Test
+	public void refresh_activeTask_notSlayerContext_staysHidden()
+	{
+		Mockito.when(slayerTaskState.isTaskActive()).thenReturn(true);
+		Mockito.when(slayerTaskState.getCreatureName()).thenReturn("Abyssal Demons");
+		Mockito.when(slayerTaskState.getRemaining()).thenReturn(120);
+
+		view.refresh(false);
+
+		// view.getComponents()[0] is the task label; [1] is the strategy panel.
+		assertTrue(!view.getComponents()[0].isVisible(),
+			"task label must stay hidden outside slayer context");
+		assertTrue(!view.getComponents()[1].isVisible(),
+			"strategy panel must stay hidden outside slayer context");
 	}
 
 	@Test
@@ -74,7 +93,7 @@ public class SlayerStrategyViewTest
 		Mockito.when(slayerTaskState.getCreatureName()).thenReturn("Abyssal Demons");
 		Mockito.when(slayerTaskState.getRemaining()).thenReturn(120);
 		Mockito.when(calculator.getRecommendedMaster()).thenReturn("Duradel");
-		view.refresh();
+		view.refresh(true);
 	}
 
 	@Test
@@ -84,7 +103,7 @@ public class SlayerStrategyViewTest
 		Mockito.when(slayerTaskState.getCreatureName()).thenReturn("Cows");
 		Mockito.when(slayerTaskState.getRemaining()).thenReturn(10);
 		Mockito.when(calculator.getRecommendedMaster()).thenReturn(null);
-		view.refresh();
+		view.refresh(true);
 	}
 
 	@Test
@@ -98,7 +117,7 @@ public class SlayerStrategyViewTest
 		Mockito.when(calculator.getUsefulSourcesForCreature(null))
 			.thenReturn(Collections.emptyList());
 		Mockito.when(calculator.getMissingItemsForCreature(null)).thenReturn(0);
-		view.refresh();
+		view.refresh(true);
 	}
 
 	@Test
@@ -114,7 +133,7 @@ public class SlayerStrategyViewTest
 		Mockito.when(calculator.getRecommendedBlockList("Duradel"))
 			.thenReturn(Collections.emptyList());
 
-		view.refresh();
+		view.refresh(true);
 
 		// Drill down to the toggle button: view → slayerStrategyPanel (JPanel) → strategyToggle (JButton).
 		// view.getComponents()[1] is the JPanel, not the button; the button sits one level deeper.
@@ -122,11 +141,16 @@ public class SlayerStrategyViewTest
 		JButton toggle = (JButton) strategyPanel.getComponents()[0];
 		assertTrue( toggle.getActionListeners().length > 0,"toggle should have an expand/collapse listener");
 
+		// Collapse state is carried by the chevron icon (right = collapsed,
+		// down = expanded), not by an ASCII glyph in the label text.
+		Icon collapsedIcon = toggle.getIcon();
+		assertNotNull(collapsedIcon, "toggle should show a chevron icon when collapsed");
+
 		SwingUtilities.invokeAndWait(toggle::doClick);
 
-		// After one click, toggle text should flip to the expanded glyph (▼).
-		assertTrue(
-			toggle.getText().startsWith("\u25BC"),"toggle text should indicate expanded state after click");
+		// After one click, the chevron icon should flip to the expanded variant.
+		assertNotSame(collapsedIcon, toggle.getIcon(),
+			"toggle icon should change to indicate expanded state after click");
 	}
 
 	@Test
@@ -142,20 +166,21 @@ public class SlayerStrategyViewTest
 		Mockito.when(calculator.getRecommendedBlockList("Konar"))
 			.thenReturn(Collections.singletonList("Easy Task"));
 
-		view.refresh();
+		view.refresh(true);
 
 		JPanel strategyPanel = (JPanel) view.getComponents()[1];
 		JButton toggle = (JButton) strategyPanel.getComponents()[0];
-		String collapsedGlyph = "\u25B6";
-		String expandedGlyph = "\u25BC";
-		assertTrue( toggle.getText().startsWith(collapsedGlyph),"toggle should start collapsed");
+
+		// State is shown by the chevron icon: the collapsed and expanded variants
+		// are distinct instances, so toggling swaps the icon back and forth.
+		Icon collapsedIcon = toggle.getIcon();
+		assertNotNull(collapsedIcon, "toggle should start collapsed with a chevron icon");
 
 		SwingUtilities.invokeAndWait(toggle::doClick);
-		assertTrue(
-			toggle.getText().startsWith(expandedGlyph),"toggle should be expanded after first click");
+		Icon expandedIcon = toggle.getIcon();
+		assertNotSame(collapsedIcon, expandedIcon, "toggle should be expanded after first click");
 
 		SwingUtilities.invokeAndWait(toggle::doClick);
-		assertTrue(
-			toggle.getText().startsWith(collapsedGlyph),"toggle should be collapsed after second click");
+		assertSame(collapsedIcon, toggle.getIcon(), "toggle should be collapsed after second click");
 	}
 }


### PR DESCRIPTION
## Summary

Gates the slayer strategy advisor to its relevant context and fixes a data-accuracy bug in task-only source filtering.

> **Stacks on #699.** Base is `feat/panel-header-sync`; it will be retargeted to `master` after #699 merges. Review only the slayer/shared changes here.

### Gating
- The strategy advisor now renders **only** in Category Focus mode with the **Slayer** category selected, instead of surfacing globally at the top of the panel. The panel's rebuild path computes `isSlayerContext()` and passes it into `SlayerStrategyView.refresh(boolean)`.

### Data-accuracy fix
- `SlayerStrategyCalculator` now respects `isTaskOnlySource()`: sources obtainable only while on a matching slayer task are no longer counted toward strategy recommendations outside that task.
- New regression test `SlayerStrategyTaskOnlyFilterTest` locks in the filter behavior.

### Icon
- Adds a drawn chevron glyph (`StatusIcons.chevronRight` / `chevronDown`) for the collapsible strategy-section toggle, replacing the ASCII triangle. `SlayerStrategyViewTest` updated to icon-based assertions.

The preview harness gains a `slayer-category-focus` scenario exercising the gated render path.

## Test plan
- [x] `./gradlew compileJava compileTestJava` clean
- [x] `./gradlew test` green (1716 tests, BUILD SUCCESSFUL)
- [x] New `SlayerStrategyTaskOnlyFilterTest` passes