### PR TITLE
fix(ui): restore flicker-free panel rebuild (regression from #700)

### DIFF
--- a/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
@@ -81,7 +81,6 @@ import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.PluginPanel;
-import net.runelite.client.util.SwingUtil;
 
 public class CollectionLogHelperPanel extends PluginPanel implements PanelShellContext
 {
@@ -397,7 +396,14 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 			{
 				PanelRebuildOrchestrator.RebuildSnapshot snapshot = rebuildOrchestrator.capture();
 
-				SwingUtil.fastRemoveAll(listContainer);
+				// Plain removeAll() rather than SwingUtil.fastRemoveAll(): the latter
+				// pumps pending AWT events mid-rebuild, which lets Swing paint the
+				// now-empty container before buildView() repopulates it -- the visible
+				// flash on frequent updates (e.g. every XP drop while on a Slayer task).
+				// removeAll() does not pump, so the EDT stays inside this runnable from
+				// clear through repopulate to the single revalidate/repaint below, and
+				// no empty intermediate frame is ever painted.
+				listContainer.removeAll();
 				updateCompletionHeader();
 				slayerStrategyView.refresh(isSlayerContext());
 


### PR DESCRIPTION
## Problem
The side-panel flicker-free rebuild fix regressed. PR #700 reverted `listContainer.removeAll()` back to `SwingUtil.fastRemoveAll(listContainer)` in `rebuild()`. `fastRemoveAll` pumps pending AWT events mid-rebuild, letting Swing paint the now-empty container before `buildView()` repopulates it -- the visible side-panel flash on frequent updates (e.g. every XP drop while on a Slayer task).

## Fix
Restore plain `removeAll()` (keeps the whole clear/repopulate/repaint inside one EDT runnable) and the explanatory comment; drop the now-unused `SwingUtil` import.

## Test plan
- [x] `./gradlew compileJava test` green
- [x] Diff matches the exact pre-#699 anti-flash code
- [ ] Confirm in live client: no side-panel flash on XP drops
