### PR TITLE
fix(overlay): stop guidance overlay flashing on same-step re-notify

### DIFF
--- a/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
@@ -138,6 +138,38 @@ public class GuidanceOverlayCoordinator
 	/** Last guidance step index for which a worldMessage was sent (prevents spam). */
 	private int lastMessagedStepIndex = -1;
 
+	/**
+	 * Identity of the step whose data was last applied to the in-game overlays by
+	 * {@link #onStepChanged(GuidanceStep)}, or {@code -1} / {@code null} before the
+	 * first application. Used to distinguish a genuine step CHANGE from a re-notify
+	 * of the SAME step (#683).
+	 *
+	 * <p>{@code GuidanceSequencer.onInventoryChanged} re-notifies the current
+	 * (unchanged) step on every {@code ItemContainerChanged} while guidance is
+	 * active - effectively every action during activities like Shades of Mort'ton.
+	 * Each re-notify reaches {@link #onStepChanged(GuidanceStep)}, which previously
+	 * tore down ({@link #clearGuidanceOverlays()}) and rebuilt
+	 * ({@link #applyStepToOverlays(GuidanceStep, String, CollectionLogSource)}) the
+	 * in-game blue box / highlights every time, producing a visible blink.</p>
+	 *
+	 * <p>This mirrors the side-panel idempotency guards added in #681
+	 * ({@code StepProgressView.lastRenderValid} + {@code StepChangeHandler.lastShownStepIndex}):
+	 * track the last-applied identity and early-return when an incoming re-notify
+	 * matches. Identity is the sequencer step index PLUS the resolved
+	 * {@link GuidanceStep} reference - the index catches ordinary re-notifies and the
+	 * step reference catches a same-index conditional-alternative swap (resolved steps
+	 * are cached per index by the sequencer, so reference identity is stable and a
+	 * genuine swap yields a different object). Reset to the sentinel by
+	 * {@link #deactivateGuidance()} so re-activating any source re-applies on the
+	 * first step.</p>
+	 *
+	 * <p>Read/written only on the path that fires {@code onStepChanged} (the client
+	 * thread that drives the sequencer), so no synchronization is needed.</p>
+	 */
+	private int lastAppliedOverlayStepIndex = -1;
+	@Nullable
+	private GuidanceStep lastAppliedOverlayStep;
+
 	/** Pending ShortestPath target -- set after "clear", sent as "path" on the next game tick. */
 	private WorldPoint pendingShortestPathTarget;
 
@@ -373,6 +405,11 @@ public class GuidanceOverlayCoordinator
 	{
 		activeTargetItemId = null;
 		lastMessagedStepIndex = -1;
+		// Reset the #683 overlay idempotency identity so re-activating any source
+		// (including the same one) re-applies overlays on its first step instead of
+		// being suppressed as a "same step" re-notify.
+		lastAppliedOverlayStepIndex = -1;
+		lastAppliedOverlayStep = null;
 		OverlayDeactivator.Result result = overlayDeactivator.deactivate(
 			new OverlayDeactivator.Input(activeInfoBox, pendingShortestPathTarget, panel));
 		activeMapPoint = result.activeMapPoint;
@@ -548,19 +585,42 @@ public class GuidanceOverlayCoordinator
 	}
 
 	/**
-	 * Callback from GuidanceSequencer when the current step changes.
-	 * Performs the overlay clear + apply + NPC-tracker scan locally (those
-	 * paths mutate coordinator-owned state such as {@code lastMessagedStepIndex}
-	 * and {@code activeMapPoint}), then delegates the InfoBox/panel
-	 * progress refresh to {@link StepChangeHandler}.
+	 * Callback from GuidanceSequencer when the current step changes (or is re-notified).
+	 * On a genuine step change, performs the overlay clear + apply + NPC-tracker scan
+	 * locally (those paths mutate coordinator-owned state such as
+	 * {@code lastMessagedStepIndex} and {@code activeMapPoint}). On a same-step re-notify
+	 * (fired by {@code GuidanceSequencer.onInventoryChanged} on every inventory change)
+	 * the clear + re-apply is skipped to avoid an overlay blink (#683). The InfoBox/panel
+	 * progress refresh is always delegated to {@link StepChangeHandler}, whose own #681
+	 * guards keep an unchanged re-notify a no-op.
 	 */
 	private void onStepChanged(GuidanceStep step)
 	{
-		clearGuidanceOverlays();
-		CollectionLogSource activeSource = guidanceSequencer.getActiveSource();
-		String sourceName = activeSource != null ? activeSource.getName() : "";
-		applyStepToOverlays(step, sourceName, activeSource);
-		npcTrackerHelper.scanForTrackedNpc(step, activeTargetItemId);
+		// Same-step idempotency guard (#683), mirroring the side-panel guards from #681
+		// (StepProgressView.lastRenderValid / StepChangeHandler.lastShownStepIndex).
+		// onInventoryChanged re-notifies the current (unchanged) step on every inventory
+		// change while guidance is active; without this guard each re-notify clears and
+		// re-applies the in-game overlays, producing a visible blink. Identity is the
+		// sequencer step index plus the resolved step reference (catches a same-index
+		// conditional-alternative swap). When both match the last application this is a
+		// redundant re-notify, so skip the clear + re-apply entirely.
+		//
+		// The StepChangeHandler delegation below is NOT skipped: its own #681 guards make
+		// an unchanged re-notify a no-op while still letting genuine item-availability
+		// changes update the panel in place.
+		final int currentIndex = guidanceSequencer.getCurrentIndex();
+		final boolean sameStepRenotify = lastAppliedOverlayStepIndex == currentIndex
+			&& lastAppliedOverlayStep == step;
+		if (!sameStepRenotify)
+		{
+			lastAppliedOverlayStepIndex = currentIndex;
+			lastAppliedOverlayStep = step;
+			clearGuidanceOverlays();
+			CollectionLogSource applySource = guidanceSequencer.getActiveSource();
+			String applySourceName = applySource != null ? applySource.getName() : "";
+			applyStepToOverlays(step, applySourceName, applySource);
+			npcTrackerHelper.scanForTrackedNpc(step, activeTargetItemId);
+		}
 
 		stepChangeHandler.handle(step,
 			new StepChangeHandler.Input(activeInfoBox, panel, activeTargetItemId));

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorStepGuardTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorStepGuardTest.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.guidance;
+
+import com.collectionloghelper.CollectionLogHelperConfig;
+import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.data.GuidanceStep;
+import com.collectionloghelper.data.PlayerInventoryState;
+import com.collectionloghelper.data.PlayerTravelCapabilities;
+import com.collectionloghelper.data.RequirementsChecker;
+import com.collectionloghelper.overlay.DialogHighlightOverlay;
+import com.collectionloghelper.overlay.GroundItemHighlightOverlay;
+import com.collectionloghelper.overlay.GuidanceMinimapOverlay;
+import com.collectionloghelper.overlay.GuidanceOverlay;
+import com.collectionloghelper.overlay.ItemHighlightOverlay;
+import com.collectionloghelper.overlay.ObjectHighlightOverlay;
+import com.collectionloghelper.overlay.WidgetHighlightOverlay;
+import com.collectionloghelper.overlay.WorldMapDestinationOverlay;
+import com.collectionloghelper.overlay.WorldMapRouteOverlay;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import net.runelite.api.Client;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.eventbus.EventBus;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
+import net.runelite.client.ui.overlay.worldmap.WorldMapPointManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Guards the in-game OVERLAY idempotency fix (#683): {@code onStepChanged} must
+ * clear + re-apply the overlays on a genuine step change but must NOT do so on a
+ * same-step re-notify (fired by {@code GuidanceSequencer.onInventoryChanged} on every
+ * inventory change while guidance is active), which otherwise produces a visible blink.
+ *
+ * <p>This mirrors the side-panel guard tests added in #681 ({@code StepProgressViewTest}):
+ * the collaborators that perform the visible teardown/rebuild are mocked, and the test
+ * asserts the invocation counts of the clear ({@code OverlayDeactivator.clearOverlays})
+ * and apply ({@code OverlayStepApplier.apply}) calls. {@code onStepChanged} is package-
+ * private-only as a sequencer callback, so it is invoked via reflection.</p>
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class GuidanceOverlayCoordinatorStepGuardTest
+{
+	@Mock
+	private Client client;
+	@Mock
+	private ClientThread clientThread;
+	@Mock
+	private EventBus eventBus;
+	@Mock
+	private CollectionLogHelperConfig config;
+	@Mock
+	private GuidanceSequencer guidanceSequencer;
+	@Mock
+	private RequirementsChecker requirementsChecker;
+	@Mock
+	private PlayerTravelCapabilities travelCapabilities;
+	@Mock
+	private PlayerInventoryState playerInventoryState;
+	@Mock
+	private ItemManager itemManager;
+	@Mock
+	private RequiredItemResolver requiredItemResolver;
+	@Mock
+	private WorldMapPointManager worldMapPointManager;
+	@Mock
+	private InfoBoxManager infoBoxManager;
+	@Mock
+	private GuidanceOverlay guidanceOverlay;
+	@Mock
+	private GuidanceMinimapOverlay guidanceMinimapOverlay;
+	@Mock
+	private DialogHighlightOverlay dialogHighlightOverlay;
+	@Mock
+	private ObjectHighlightOverlay objectHighlightOverlay;
+	@Mock
+	private ItemHighlightOverlay itemHighlightOverlay;
+	@Mock
+	private WorldMapRouteOverlay worldMapRouteOverlay;
+	@Mock
+	private WorldMapDestinationOverlay worldMapDestinationOverlay;
+	@Mock
+	private GroundItemHighlightOverlay groundItemHighlightOverlay;
+	@Mock
+	private WidgetHighlightOverlay widgetHighlightOverlay;
+
+	// Collaborators that own the visible overlay teardown/rebuild; mocked so the test
+	// can count clear vs apply invocations directly.
+	@Mock
+	private OverlayStepApplier overlayStepApplier;
+	@Mock
+	private OverlaySourceApplier overlaySourceApplier;
+	@Mock
+	private OverlayDeactivator overlayDeactivator;
+	@Mock
+	private WorldMapController worldMapController;
+	@Mock
+	private DynamicTargetManager dynamicTargetManager;
+	@Mock
+	private NpcTrackerHelper npcTrackerHelper;
+	@Mock
+	private StepChangeHandler stepChangeHandler;
+	@Mock
+	private DynamicItemObjectTierResolver dynamicItemObjectTierResolver;
+
+	private GuidanceOverlayCoordinator coordinator;
+	private Method onStepChanged;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		Constructor<GuidanceOverlayCoordinator> ctor =
+			GuidanceOverlayCoordinator.class.getDeclaredConstructor(
+				Client.class, ClientThread.class, EventBus.class, CollectionLogHelperConfig.class,
+				GuidanceSequencer.class, RequirementsChecker.class, PlayerTravelCapabilities.class,
+				PlayerInventoryState.class, ItemManager.class, RequiredItemResolver.class,
+				WorldMapPointManager.class, InfoBoxManager.class, GuidanceOverlay.class,
+				GuidanceMinimapOverlay.class, DialogHighlightOverlay.class, ObjectHighlightOverlay.class,
+				ItemHighlightOverlay.class, WorldMapRouteOverlay.class, WorldMapDestinationOverlay.class,
+				GroundItemHighlightOverlay.class, WidgetHighlightOverlay.class, OverlayStepApplier.class,
+				OverlaySourceApplier.class, OverlayDeactivator.class, WorldMapController.class,
+				DynamicTargetManager.class, NpcTrackerHelper.class, StepChangeHandler.class,
+				DynamicItemObjectTierResolver.class);
+		ctor.setAccessible(true);
+		coordinator = ctor.newInstance(
+			client, clientThread, eventBus, config,
+			guidanceSequencer, requirementsChecker, travelCapabilities,
+			playerInventoryState, itemManager, requiredItemResolver,
+			worldMapPointManager, infoBoxManager,
+			guidanceOverlay, guidanceMinimapOverlay, dialogHighlightOverlay,
+			objectHighlightOverlay, itemHighlightOverlay,
+			worldMapRouteOverlay, worldMapDestinationOverlay,
+			groundItemHighlightOverlay, widgetHighlightOverlay,
+			overlayStepApplier, overlaySourceApplier, overlayDeactivator,
+			worldMapController, dynamicTargetManager, npcTrackerHelper, stepChangeHandler,
+			dynamicItemObjectTierResolver);
+
+		onStepChanged = GuidanceOverlayCoordinator.class.getDeclaredMethod(
+			"onStepChanged", GuidanceStep.class);
+		onStepChanged.setAccessible(true);
+
+		// Stub the mocked collaborators that onStepChanged threads results back from.
+		when(overlayDeactivator.clearOverlays(any())).thenReturn(
+			new OverlayDeactivator.Result(null, null, null));
+		when(overlayStepApplier.apply(any(), anyString(), any(), any(), any(), any(), any()))
+			.thenReturn(new OverlayStepApplier.Result(-1, null));
+		// applyDynamicItemObjectOverlays() runs inside applyStepToOverlays; keep it a no-op.
+		when(dynamicItemObjectTierResolver.resolve(any()))
+			.thenReturn(DynamicItemObjectTierResolver.Result.EMPTY);
+
+		CollectionLogSource source = mock(CollectionLogSource.class);
+		when(source.getName()).thenReturn("Shades of Mort'ton");
+		when(guidanceSequencer.getActiveSource()).thenReturn(source);
+	}
+
+	private void fireStepChanged(GuidanceStep step) throws Exception
+	{
+		onStepChanged.invoke(coordinator, step);
+	}
+
+	/**
+	 * A same-step re-notify (same sequencer index AND same resolved step reference)
+	 * must NOT clear + re-apply the overlays after the first application: the first
+	 * genuine notify applies once, and the following identical re-notifies are no-ops.
+	 */
+	@Test
+	public void sameStepRenotify_doesNotClearOrReapplyOverlays() throws Exception
+	{
+		GuidanceStep step = mock(GuidanceStep.class);
+		when(guidanceSequencer.getCurrentIndex()).thenReturn(0);
+
+		// First notify: genuine application.
+		fireStepChanged(step);
+		// Two identical re-notifies, as onInventoryChanged would fire on inventory churn.
+		fireStepChanged(step);
+		fireStepChanged(step);
+
+		// Cleared / applied exactly once, despite three notifications.
+		verify(overlayDeactivator, times(1)).clearOverlays(any());
+		verify(overlayStepApplier, times(1)).apply(any(), anyString(), any(), any(), any(), any(), any());
+		// The panel/InfoBox delegation still runs on every notify (its own #681 guards
+		// keep an unchanged re-notify a no-op without suppressing genuine item changes).
+		verify(stepChangeHandler, times(3)).handle(any(), any());
+	}
+
+	/**
+	 * A genuine step change (advance to a new index with a new resolved step) must
+	 * clear + re-apply the overlays, even though the previous step had already applied.
+	 */
+	@Test
+	public void genuineStepChange_clearsAndReappliesOverlays() throws Exception
+	{
+		GuidanceStep stepOne = mock(GuidanceStep.class);
+		GuidanceStep stepTwo = mock(GuidanceStep.class);
+
+		when(guidanceSequencer.getCurrentIndex()).thenReturn(0);
+		fireStepChanged(stepOne);
+
+		// Advance: new index, new step object.
+		when(guidanceSequencer.getCurrentIndex()).thenReturn(1);
+		fireStepChanged(stepTwo);
+
+		// Each genuine step applied once -> two clears, two applies.
+		verify(overlayDeactivator, times(2)).clearOverlays(any());
+		verify(overlayStepApplier, times(2)).apply(any(), anyString(), any(), any(), any(), any(), any());
+	}
+
+	/**
+	 * Deactivation must reset the tracked overlay-step identity so re-activating the
+	 * SAME step (same index + same step object) re-applies on the first notify rather
+	 * than being suppressed as a stale "same step" match (avoids a stuck-blank overlay).
+	 */
+	@Test
+	public void deactivateThenSameStep_reappliesOverlays() throws Exception
+	{
+		when(overlayDeactivator.deactivate(any())).thenReturn(
+			new OverlayDeactivator.Result(null, null, null));
+
+		GuidanceStep step = mock(GuidanceStep.class);
+		when(guidanceSequencer.getCurrentIndex()).thenReturn(0);
+
+		fireStepChanged(step);
+		coordinator.deactivateGuidance();
+		// Re-activate onto the identical step index + reference.
+		fireStepChanged(step);
+
+		// Two genuine applications: one before deactivation, one after the identity reset.
+		verify(overlayDeactivator, times(2)).clearOverlays(any());
+		verify(overlayStepApplier, times(2)).apply(any(), anyString(), any(), any(), any(), any(), any());
+	}
+}


### PR DESCRIPTION
## Problem
The in-game guidance overlay flashes during combat/skilling. `GuidanceSequencer.onInventoryChanged()` re-notifies the current (unchanged) step on every `ItemContainerChanged`, and `GuidanceOverlayCoordinator.onStepChanged()` unconditionally ran `clearGuidanceOverlays()` + `applyStepToOverlays()` each time -- a visible blink. The inventory-change flash fix (#681) added same-step idempotency guards to the side-panel step views but never extended them to the in-game overlay path. This is a similar issue on a different path, not a regression.

## Fix
Add a same-step idempotency guard in `GuidanceOverlayCoordinator.onStepChanged()` (track last applied step index + step identity); skip the clear+reapply on a redundant same-step re-notify, while genuine step changes and the first apply still run. Reset the tracked identity on deactivation/restart.

## Test plan
- [x] `./gradlew compileJava test` green
- [x] New `GuidanceOverlayCoordinatorStepGuardTest`: same-step re-notify -> no clear/reapply; genuine change -> clear/reapply; reset re-applies
- [ ] Confirm in live client: no overlay flash while training with guidance active
