### PR TITLE
fix(ui): wrap Recommended chip strip to avoid clipping at panel width

### DIFF
--- a/src/main/java/com/collectionloghelper/ui/widget/SourceRecommendedItemsChipPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/widget/SourceRecommendedItemsChipPanel.java
@@ -25,15 +25,18 @@
 package com.collectionloghelper.ui.widget;
 
 import java.awt.Color;
+import java.awt.Component;
+import java.awt.Container;
 import java.awt.Dimension;
+import java.awt.FlowLayout;
 import java.awt.Graphics2D;
+import java.awt.Insets;
 import java.awt.RenderingHints;
 import java.awt.image.BufferedImage;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
 import javax.swing.BorderFactory;
-import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
@@ -47,8 +50,14 @@ import net.runelite.client.ui.FontManager;
 import net.runelite.client.util.AsyncBufferedImage;
 
 /**
- * A horizontal strip of item-icon chips rendered in the source-detail header
- * for the source-level "Recommended Gear" list (#573).
+ * A "Recommended:" heading on its own full-width line followed by a strip of
+ * item-icon chips that wrap onto additional lines, rendered in the source-detail
+ * header for the source-level "Recommended Gear" list (#573).
+ *
+ * <p>The chips live in a {@link WrapLayout} container so that at the narrow
+ * 225px side-panel width several chips flow onto multiple rows instead of
+ * overflowing and clipping the rightmost chip(s). The heading matches the
+ * full-width style of the sibling "Requirements:" section.
  *
  * <p>This differs from {@link RecommendedItemsChipPanel} in three ways:
  * <ul>
@@ -87,8 +96,14 @@ public class SourceRecommendedItemsChipPanel extends JPanel
 	/** Muted neutral border — chip strip is informational only at this surface. */
 	static final Color BORDER_COLOR = new Color(180, 180, 180, 160);
 
-	/** Heading text shown to the left of the chip row. */
+	/** Heading text shown on its own full-width line above the chip strip. */
 	static final String HEADING_TEXT = "Recommended:";
+
+	/** Horizontal gap between wrapped chips, in pixels. */
+	private static final int CHIP_HGAP = 3;
+
+	/** Vertical gap between wrapped chip rows, in pixels. */
+	private static final int CHIP_VGAP = 3;
 
 	private final ItemManager itemManager;
 
@@ -100,7 +115,14 @@ public class SourceRecommendedItemsChipPanel extends JPanel
 	@Nullable
 	private final ClientThread clientThread;
 
-	/** The horizontal row that holds the heading label and chip labels. */
+	/** Full-width heading line ("Recommended:") shown above the chip strip. */
+	private final JLabel heading;
+
+	/**
+	 * The wrapping container that holds the chip labels. Uses {@link WrapLayout}
+	 * so chips flow onto additional rows at narrow panel widths instead of
+	 * clipping at the right edge.
+	 */
 	private final JPanel chipRow;
 
 	/**
@@ -144,8 +166,16 @@ public class SourceRecommendedItemsChipPanel extends JPanel
 		setAlignmentX(LEFT_ALIGNMENT);
 		setVisible(false);
 
-		chipRow = new JPanel();
-		chipRow.setLayout(new BoxLayout(chipRow, BoxLayout.X_AXIS));
+		heading = new JLabel(HEADING_TEXT);
+		heading.setFont(FontManager.getRunescapeSmallFont());
+		heading.setForeground(new Color(150, 150, 150));
+		heading.setAlignmentX(LEFT_ALIGNMENT);
+		add(heading);
+
+		// LEADING-aligned WrapLayout: chips fill left-to-right and wrap onto a new
+		// row when they exceed the panel width, so none clip. Zero left/right inset
+		// keeps the strip flush with the heading and the surrounding blocks.
+		chipRow = new JPanel(new WrapLayout(FlowLayout.LEADING, CHIP_HGAP, CHIP_VGAP));
 		chipRow.setBackground(BG);
 		chipRow.setAlignmentX(LEFT_ALIGNMENT);
 		add(chipRow);
@@ -183,13 +213,6 @@ public class SourceRecommendedItemsChipPanel extends JPanel
 				return;
 			}
 
-			JLabel heading = new JLabel(HEADING_TEXT);
-			heading.setFont(FontManager.getRunescapeSmallFont());
-			heading.setForeground(new Color(150, 150, 150));
-			heading.setAlignmentX(LEFT_ALIGNMENT);
-			chipRow.add(heading);
-			chipRow.add(Box.createHorizontalStrut(6));
-
 			for (Integer itemId : safeIds)
 			{
 				if (itemId == null || itemId <= 0)
@@ -198,7 +221,6 @@ public class SourceRecommendedItemsChipPanel extends JPanel
 				}
 				JLabel chip = buildChip(itemId);
 				chipRow.add(chip);
-				chipRow.add(Box.createHorizontalStrut(3));
 			}
 
 			setVisible(true);
@@ -321,5 +343,128 @@ public class SourceRecommendedItemsChipPanel extends JPanel
 		g.drawImage(source, 0, 0, width, height, null);
 		g.dispose();
 		return scaled;
+	}
+
+	/**
+	 * A {@link FlowLayout} that wraps its components onto additional rows and,
+	 * crucially, reports a preferred size whose <em>height</em> reflects the
+	 * wrapped row count at the container's actual (target) width.
+	 *
+	 * <p>Plain {@code FlowLayout} always reports a single-row preferred height,
+	 * so when nested inside a vertical {@code BoxLayout} it is given only enough
+	 * vertical space for one row and the wrapped rows are clipped. This subclass
+	 * computes the height by laying the children out against the available width
+	 * (taken from the container, an ancestor with a non-zero width, or the
+	 * preferred row width as a last resort), so the parent {@code BoxLayout}
+	 * allocates the correct vertical space.
+	 *
+	 * <p>Adapted from the long-standing public-domain "WrapLayout" pattern
+	 * (a FlowLayout that computes wrapped preferred height); trimmed to the
+	 * single LEADING use case this panel needs.
+	 */
+	static final class WrapLayout extends FlowLayout
+	{
+		WrapLayout(int align, int hgap, int vgap)
+		{
+			super(align, hgap, vgap);
+		}
+
+		@Override
+		public Dimension preferredLayoutSize(Container target)
+		{
+			return layoutSize(target, true);
+		}
+
+		@Override
+		public Dimension minimumLayoutSize(Container target)
+		{
+			Dimension minimum = layoutSize(target, false);
+			minimum.width -= (getHgap() + 1);
+			return minimum;
+		}
+
+		/**
+		 * Computes the layout size, flowing children onto rows constrained to the
+		 * effective target width and summing the resulting row heights.
+		 */
+		private Dimension layoutSize(Container target, boolean preferred)
+		{
+			synchronized (target.getTreeLock())
+			{
+				int targetWidth = resolveTargetWidth(target);
+
+				Insets insets = target.getInsets();
+				int horizontalInsetsAndGap = insets.left + insets.right + (getHgap() * 2);
+				int maxWidth = targetWidth - horizontalInsetsAndGap;
+
+				Dimension dim = new Dimension(0, 0);
+				int rowWidth = 0;
+				int rowHeight = 0;
+
+				int memberCount = target.getComponentCount();
+				for (int i = 0; i < memberCount; i++)
+				{
+					Component m = target.getComponent(i);
+					if (!m.isVisible())
+					{
+						continue;
+					}
+					Dimension d = preferred ? m.getPreferredSize() : m.getMinimumSize();
+
+					// Wrap to a new row when the next chip would exceed the width.
+					if (rowWidth + d.width > maxWidth)
+					{
+						addRow(dim, rowWidth, rowHeight);
+						rowWidth = 0;
+						rowHeight = 0;
+					}
+
+					if (rowWidth != 0)
+					{
+						rowWidth += getHgap();
+					}
+
+					rowWidth += d.width;
+					rowHeight = Math.max(rowHeight, d.height);
+				}
+
+				addRow(dim, rowWidth, rowHeight);
+
+				dim.width += horizontalInsetsAndGap;
+				dim.height += insets.top + insets.bottom + (getVgap() * 2);
+				return dim;
+			}
+		}
+
+		/**
+		 * Returns a usable width for wrapping: the target's own width if laid out,
+		 * else the nearest ancestor with a non-zero width, else the target's
+		 * preferred width (single-row fallback before the first real layout pass).
+		 */
+		private int resolveTargetWidth(Container target)
+		{
+			int width = target.getWidth();
+			Container ancestor = target.getParent();
+			while (width == 0 && ancestor != null)
+			{
+				width = ancestor.getWidth();
+				ancestor = ancestor.getParent();
+			}
+			if (width == 0)
+			{
+				width = target.getPreferredSize().width;
+			}
+			return width;
+		}
+
+		private void addRow(Dimension dim, int rowWidth, int rowHeight)
+		{
+			dim.width = Math.max(dim.width, rowWidth);
+			if (dim.height > 0)
+			{
+				dim.height += getVgap();
+			}
+			dim.height += rowHeight;
+		}
 	}
 }

--- a/src/test/java/com/collectionloghelper/ui/preview/PanelPreviewSnapshotTest.java
+++ b/src/test/java/com/collectionloghelper/ui/preview/PanelPreviewSnapshotTest.java
@@ -27,15 +27,22 @@ package com.collectionloghelper.ui.preview;
 import com.collectionloghelper.data.CollectionLogCategory;
 import com.collectionloghelper.ui.CollectionLogHelperPanel;
 import com.collectionloghelper.ui.CollectionLogHelperPanel.Mode;
+import com.collectionloghelper.ui.widget.SourceRecommendedItemsChipPanel;
 import java.awt.image.BufferedImage;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
+import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.PluginPanel;
+import net.runelite.client.util.AsyncBufferedImage;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -93,6 +100,86 @@ public class PanelPreviewSnapshotTest
 				.mode(Mode.EFFICIENT)
 				.slayerTaskActive(true)
 				.longLabels(true));
+	}
+
+	/**
+	 * Standalone render of just the source-level "Recommended:" chip strip with
+	 * enough chips (6) to force wrapping at the real 225px side-panel width. This
+	 * proves the heading sits on its own full-width line and the chips wrap onto
+	 * additional rows instead of clipping at the right edge (#573 fix). The chip
+	 * panel is hosted inside a vertical-BoxLayout container that mirrors the real
+	 * call sites (GuidanceBannerView / ItemDetailPanel).
+	 */
+	@Test
+	public void recommendedStripWrapScenario() throws Exception
+	{
+		AtomicReference<JPanel> hostRef = new AtomicReference<>();
+		AtomicReference<BufferedImage> result = new AtomicReference<>();
+		AtomicReference<Exception> error = new AtomicReference<>();
+
+		// Ten item IDs: a 30px chip plus 3px gaps fits about six per 225px row, so
+		// ten chips must wrap onto multiple rows. Real OSRS item IDs (gear) so
+		// icons load if present.
+		final List<Integer> itemIds = Arrays.asList(
+			11832, 11834, 11836, 4151, 11802, 12954, 11806, 11808, 11810, 11812);
+
+		SwingUtilities.invokeAndWait(() ->
+		{
+			try
+			{
+				ItemManager itemManager = Mockito.mock(ItemManager.class);
+				Mockito.when(itemManager.getImage(Mockito.anyInt())).thenAnswer(
+					inv -> new AsyncBufferedImage(null, 32, 32, BufferedImage.TYPE_INT_ARGB));
+
+				SourceRecommendedItemsChipPanel strip =
+					new SourceRecommendedItemsChipPanel(itemManager);
+				strip.update(itemIds);
+
+				JPanel host = new JPanel();
+				host.setLayout(new javax.swing.BoxLayout(host, javax.swing.BoxLayout.Y_AXIS));
+				host.add(strip);
+				hostRef.set(host);
+			}
+			catch (Exception e)
+			{
+				error.set(e);
+			}
+		});
+		if (error.get() != null)
+		{
+			throw error.get();
+		}
+
+		// Second EDT task: the strip's update() invokeLater has now run.
+		SwingUtilities.invokeAndWait(() ->
+		{
+			try
+			{
+				result.set(PanelSnapshot.render(hostRef.get(), WIDTH));
+			}
+			catch (Exception e)
+			{
+				error.set(e);
+			}
+		});
+		if (error.get() != null)
+		{
+			throw error.get();
+		}
+
+		BufferedImage img = result.get();
+		Path out = OUT_DIR.resolve("recommended-strip-wrap.png");
+		PanelSnapshot.writePng(img, out);
+
+		assertTrue(Files.exists(out), "PNG not written: " + out.toAbsolutePath());
+		assertTrue(Files.size(out) > 0, "PNG is empty: " + out.toAbsolutePath());
+		assertEquals(WIDTH, img.getWidth(), "render width must equal PANEL_WIDTH");
+		// Heading line + at least two wrapped chip rows => clearly taller than a
+		// single 30px chip row. Guards against the FlowLayout single-line-height pit.
+		// CHIP_SIZE is 30 (28px icon + 1px border each side); two rows + heading
+		// must exceed 60px.
+		assertTrue(img.getHeight() > 60,
+			"strip height (" + img.getHeight() + ") too short to have wrapped");
 	}
 
 	private void renderScenario(String name, PanelPreviewFixtures.Scenario scenario) throws Exception


### PR DESCRIPTION
## Problem
The "Recommended:" item-chip strip laid its heading and chips in a single horizontal row that overflowed and clipped the rightmost chips at the 225px side-panel width.

## Fix
Put the "Recommended:" heading on its own full-width line (matching the sibling "Requirements:" header), and wrap the chips across rows via a `WrapLayout` (FlowLayout subclass that reports correct wrapped height inside the vertical BoxLayout parent) so every chip is visible, none clipped. Preserves chip appearance, the async tooltip resolution path, and the `lastRenderedIds` idempotency short-circuit.

## Test plan
- [x] `./gradlew compileJava test` green
- [x] Preview-harness scenario renders the strip with 10 chips at 225px -> wraps to 2 rows, no clipping
- [ ] Confirm in live client: recommended chips wrap cleanly in guidance/detail view
