### PR TITLE
fix(ui): stretch Recommended strip to full width to match sibling sections

### DIFF
--- a/src/main/java/com/collectionloghelper/ui/widget/GuidanceBannerView.java
+++ b/src/main/java/com/collectionloghelper/ui/widget/GuidanceBannerView.java
@@ -160,7 +160,13 @@ public class GuidanceBannerView extends JPanel
 		if (itemManager != null)
 		{
 			recommendedChipPanel = new SourceRecommendedItemsChipPanel(itemManager, clientThread);
-			recommendedChipPanel.setAlignmentX(LEFT_ALIGNMENT);
+			// Match the sibling "Requirements:" section: CENTER_ALIGNMENT plus a
+			// full-width maximum so the BoxLayout stretches the strip across the
+			// panel instead of shrinking it to the chips' preferred width (which
+			// reads as a narrow, off-centre block). Content inside the panel stays
+			// left-aligned via the heading/chip-row alignmentX.
+			recommendedChipPanel.setAlignmentX(CENTER_ALIGNMENT);
+			recommendedChipPanel.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
 			recommendedChipPanel.setBorder(BorderFactory.createEmptyBorder(2, 0, 4, 0));
 			add(recommendedChipPanel);
 		}


### PR DESCRIPTION
## Problem
Follow-up to #703. The "Recommended:" strip no longer clips, but it renders as a narrow, off-centre block instead of spanning the panel like the sibling "Requirements:" / guidance sections.

## Cause
In `GuidanceBannerView`, the strip was added with `LEFT_ALIGNMENT` and no `maximumSize`, so the vertical `BoxLayout` sized it to the chips' preferred width. The sibling `RequirementsView` is added with `CENTER_ALIGNMENT` + a full-width `maximumSize`, which is why it spans the panel.

## Fix
Mirror the `RequirementsView` host setup for the recommended strip: `CENTER_ALIGNMENT` + `maximumSize(MAX, MAX)`. The strip now spans the full panel width; its heading and chips remain left-aligned inside via their own alignmentX.

## Test plan
- [x] `./gradlew compileJava test` green
- [ ] Live client: Recommended strip spans full width, matching the Requirements section
