### PR TITLE
feat(ui): compact color-coded text list for guidance items

### DIFF
--- a/src/main/java/com/collectionloghelper/ui/widget/GuidanceBannerView.java
+++ b/src/main/java/com/collectionloghelper/ui/widget/GuidanceBannerView.java
@@ -68,15 +68,6 @@ public class GuidanceBannerView extends JPanel
 	// Per-source requirements section (quest / skill / diary rows)
 	private final RequirementsView requirementsView;
 
-	/**
-	 * Source-level Recommended Gear chip strip (#599). Rendered directly below
-	 * the per-source requirements section so recommended kit is visible from
-	 * step 1, not buried below the active step body. Null when constructed via
-	 * the legacy 1-arg constructor (no {@link ItemManager} available — strip is
-	 * silently omitted in that path).
-	 */
-	private final SourceRecommendedItemsChipPanel recommendedChipPanel;
-
 	// Clue-guidance banner (purple/blue)
 	private final JPanel clueGuidanceBanner;
 	private final JLabel clueGuidanceLabel;
@@ -152,28 +143,6 @@ public class GuidanceBannerView extends JPanel
 		requirementsView.setAlignmentX(CENTER_ALIGNMENT);
 		requirementsView.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
 		add(requirementsView);
-
-		// Source-level Recommended chip strip (#599) — rendered directly below
-		// the requirements section so it is visible from step 1 of guidance.
-		// Hidden by default; populated in showGuidance from
-		// CollectionLogSource.getEffectiveRecommendedItemIds().
-		if (itemManager != null)
-		{
-			recommendedChipPanel = new SourceRecommendedItemsChipPanel(itemManager, clientThread);
-			// Match the sibling "Requirements:" section: CENTER_ALIGNMENT plus a
-			// full-width maximum so the BoxLayout stretches the strip across the
-			// panel instead of shrinking it to the chips' preferred width (which
-			// reads as a narrow, off-centre block). Content inside the panel stays
-			// left-aligned via the heading/chip-row alignmentX.
-			recommendedChipPanel.setAlignmentX(CENTER_ALIGNMENT);
-			recommendedChipPanel.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
-			recommendedChipPanel.setBorder(BorderFactory.createEmptyBorder(2, 0, 4, 0));
-			add(recommendedChipPanel);
-		}
-		else
-		{
-			recommendedChipPanel = null;
-		}
 
 		// Clue guidance banner (hidden by default)
 		clueGuidanceBanner = new JPanel(new BorderLayout());
@@ -255,13 +224,6 @@ public class GuidanceBannerView extends JPanel
 
 		// Delegate to RequirementsView \u2014 hides itself when rows is empty
 		requirementsView.showRequirements(rows);
-
-		// #599 \u2014 populate source-level Recommended chip strip. Hides itself when
-		// the source has no effective recommended items.
-		if (recommendedChipPanel != null)
-		{
-			recommendedChipPanel.update(source.getEffectiveRecommendedItemIds());
-		}
 	}
 
 	/**
@@ -282,10 +244,6 @@ public class GuidanceBannerView extends JPanel
 			}
 		});
 		requirementsView.hideRequirements();
-		if (recommendedChipPanel != null)
-		{
-			recommendedChipPanel.update(Collections.<Integer>emptyList());
-		}
 	}
 
 	/**

--- a/src/main/java/com/collectionloghelper/ui/widget/StepProgressView.java
+++ b/src/main/java/com/collectionloghelper/ui/widget/StepProgressView.java
@@ -30,7 +30,6 @@ import java.awt.Color;
 import java.awt.Cursor;
 import java.awt.Dimension;
 import java.awt.Font;
-import java.awt.Graphics2D;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
@@ -50,7 +49,6 @@ import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.FontManager;
-import net.runelite.client.util.AsyncBufferedImage;
 
 /**
  * Shared widget that displays the multi-step guidance progress bar,
@@ -58,12 +56,15 @@ import net.runelite.client.util.AsyncBufferedImage;
  * the collapsible step sections (when any step carries a section label), and the
  * Next Step / Skip buttons.
  *
- * <h3>Required-items chip strip (B.5.1)</h3>
- * <p>The chip strip ({@link RequiredItemsChipPanel}) is rendered directly below
- * the step-progress label in the flat layout.  Each chip is a 28x28 item icon
- * with a colored border: green (held), white (in bank — tooltip reads
- * "Items can be found in your: Bank"), or red (missing).  The strip hides
- * itself when the active step has no required items.
+ * <h3>Required / recommended item text lists</h3>
+ * <p>Required-item and recommended-item rows render as a compact, icon-free
+ * color-coded text list: each row is a single line showing the item name
+ * coloured green (held), gold (in bank - tooltip suffix "in bank"), or red
+ * (missing). Rows stack vertically so long lists stay compact at the 225px
+ * side-panel width. Within a step, a recommended item that already appears in
+ * "Items needed" is filtered out (compared by item id). The legacy icon-chip
+ * strip ({@link RequiredItemsChipPanel}) is retained in the component tree but
+ * fed an empty list (hidden) so items render only once, as text.
  *
  * <h3>Section rendering (B.5.4)</h3>
  * <p>When the active source has at least one step with a non-null
@@ -554,13 +555,15 @@ public class StepProgressView extends JPanel
 
 			if (groups.isEmpty())
 			{
-				// Flat layout — hide sections, show chip strip + required/recommended items inline.
-				// recChipPanel is intentionally not updated; it was hoisted to source-level
-				// (#599) and is permanently hidden in this widget.
+				// Flat layout - hide sections, show required/recommended items as compact
+				// text lists. The icon chip strip (chipPanel) is intentionally fed an empty
+				// list so it hides: the text list is now the single display for required
+				// items (no double-render of icons + text). recChipPanel is likewise unused
+				// (it was hoisted to source-level, #599).
 				sectionsPanel.setVisible(false);
-				chipPanel.update(rows);
+				chipPanel.update(Collections.<RequiredItemDisplay>emptyList());
 				updateRequiredItemDisplay(rows);
-				updateRecommendedItemDisplay(recRows);
+				updateRecommendedItemDisplay(dedupRecommended(rows, recRows));
 			}
 			else
 			{
@@ -736,7 +739,9 @@ public class StepProgressView extends JPanel
 				body.add(itemsInSection);
 			}
 
-			if (isActive && recommendedItems != null && !recommendedItems.isEmpty())
+			List<RequiredItemDisplay> recForStep =
+				isActive ? dedupRecommended(requiredItems, recommendedItems) : Collections.emptyList();
+			if (isActive && !recForStep.isEmpty())
 			{
 				JPanel recInSection = new JPanel();
 				recInSection.setLayout(new BoxLayout(recInSection, BoxLayout.Y_AXIS));
@@ -752,7 +757,7 @@ public class StepProgressView extends JPanel
 				recInSection.add(recLabel);
 				recInSection.add(Box.createVerticalStrut(2));
 
-				for (RequiredItemDisplay row : recommendedItems)
+				for (RequiredItemDisplay row : recForStep)
 				{
 					JPanel rowPanel = buildItemRow(row);
 					rowPanel.setAlignmentX(LEFT_ALIGNMENT);
@@ -809,17 +814,48 @@ public class StepProgressView extends JPanel
 		return arrow + sectionName + " (" + stepCount + " step" + (stepCount == 1 ? "" : "s") + ")";
 	}
 
+	/**
+	 * Filters {@code recommended} so it excludes any item already present in
+	 * {@code required} (compared by item id). Within a single step an item that is
+	 * already in "Items needed" must not be repeated under "Recommended".
+	 * Order of the surviving recommended rows is preserved.
+	 */
+	private static List<RequiredItemDisplay> dedupRecommended(
+		List<RequiredItemDisplay> required, List<RequiredItemDisplay> recommended)
+	{
+		if (recommended == null || recommended.isEmpty()
+			|| required == null || required.isEmpty())
+		{
+			return recommended != null ? recommended : Collections.emptyList();
+		}
+
+		java.util.Set<Integer> requiredIds = new java.util.HashSet<>();
+		for (RequiredItemDisplay row : required)
+		{
+			requiredIds.add(row.getItemId());
+		}
+
+		List<RequiredItemDisplay> filtered = new java.util.ArrayList<>(recommended.size());
+		for (RequiredItemDisplay row : recommended)
+		{
+			if (!requiredIds.contains(row.getItemId()))
+			{
+				filtered.add(row);
+			}
+		}
+		return filtered;
+	}
+
 	// ── Flat required/recommended-items display ─────────────────────────────
 
 	/**
 	 * Rebuilds the required-items subsection from pre-resolved display rows.
 	 *
-	 * <p>Each row shows a 28×28 item sprite icon followed by the item name.
-	 * The name label is coloured by availability:
+	 * <p>Each row is a single-line, icon-free text label coloured by availability:
 	 * <ul>
-	 *   <li><b>Green</b> — held in inventory or equipped</li>
-	 *   <li><b>White</b> (+ tooltip suffix "ℹ in bank") — present in last bank scan</li>
-	 *   <li><b>Red</b> — not found anywhere</li>
+	 *   <li><b>Green</b> - held in inventory or equipped</li>
+	 *   <li><b>Gold</b> (+ tooltip suffix "in bank") - present in last bank scan</li>
+	 *   <li><b>Red</b> - not found anywhere</li>
 	 * </ul>
 	 * The subsection is hidden when {@code rows} is empty.
 	 * Must be called on the EDT.
@@ -835,7 +871,7 @@ public class StepProgressView extends JPanel
 	/**
 	 * Rebuilds the recommended-items subsection from pre-resolved display rows.
 	 * Uses the same row layout as {@link #updateRequiredItemDisplay} so colouring
-	 * (green/white+ℹ/red) is identical.
+	 * (green/gold/red) is identical.
 	 * The subsection is hidden when {@code rows} is empty.
 	 * Must be called on the EDT.
 	 *
@@ -886,25 +922,27 @@ public class StepProgressView extends JPanel
 	}
 
 	/**
-	 * Builds a single item row: a 28×28 sprite icon + a name label coloured
-	 * by the row's availability status.
+	 * Builds a single item row: a single-line name label coloured by the row's
+	 * availability status. No icon is rendered (the compact text list keeps long
+	 * item lists from overflowing the 225px side panel).
+	 *
+	 * <ul>
+	 *   <li><b>Green</b> ({@link RequiredItemDisplay#COLOR_HELD}) - held in inventory
+	 *       or equipped</li>
+	 *   <li><b>Gold</b> ({@link RequiredItemDisplay#COLOR_IN_BANK}) (+ tooltip suffix
+	 *       "in bank") - present in last bank scan</li>
+	 *   <li><b>Red</b> ({@link RequiredItemDisplay#COLOR_MISSING}) - not found
+	 *       anywhere</li>
+	 * </ul>
 	 */
 	private JPanel buildItemRow(RequiredItemDisplay row)
 	{
 		JPanel rowPanel = new JPanel();
 		rowPanel.setLayout(new BoxLayout(rowPanel, BoxLayout.X_AXIS));
 		rowPanel.setBackground(BG);
-		rowPanel.setMaximumSize(new Dimension(Integer.MAX_VALUE, 32));
+		rowPanel.setAlignmentX(LEFT_ALIGNMENT);
+		rowPanel.setMaximumSize(new Dimension(Integer.MAX_VALUE, 16));
 
-		// --- Icon ---
-		JLabel iconLabel = new JLabel();
-		iconLabel.setPreferredSize(new Dimension(28, 28));
-		iconLabel.setMinimumSize(new Dimension(28, 28));
-		iconLabel.setMaximumSize(new Dimension(28, 28));
-		iconLabel.setHorizontalAlignment(SwingConstants.CENTER);
-		iconLabel.setVerticalAlignment(SwingConstants.CENTER);
-
-		// --- Name label ---
 		Color nameColor;
 		String tooltipSuffix;
 		switch (row.getStatus())
@@ -914,7 +952,7 @@ public class StepProgressView extends JPanel
 				tooltipSuffix = "";
 				break;
 			case IN_BANK:
-				nameColor = Color.WHITE;
+				nameColor = RequiredItemDisplay.COLOR_IN_BANK;
 				tooltipSuffix = IN_BANK_TOOLTIP_SUFFIX;
 				break;
 			case MISSING:
@@ -928,58 +966,10 @@ public class StepProgressView extends JPanel
 		nameLabel.setFont(FontManager.getRunescapeSmallFont());
 		nameLabel.setForeground(nameColor);
 		nameLabel.setToolTipText(row.getName() + tooltipSuffix);
-		iconLabel.setToolTipText(row.getName() + tooltipSuffix);
+		nameLabel.setAlignmentX(LEFT_ALIGNMENT);
 
-		rowPanel.add(iconLabel);
-		rowPanel.add(Box.createHorizontalStrut(4));
 		rowPanel.add(nameLabel);
 
-		// Load sprite asynchronously; itemManager.getImage is safe to call on the EDT.
-		if (row.getItemId() > 0)
-		{
-			loadItemIcon(row.getItemId(), iconLabel);
-		}
-
 		return rowPanel;
-	}
-
-	/**
-	 * Loads the item sprite for the given item ID into {@code iconLabel} asynchronously.
-	 * Called after the row panel is constructed so the icon appears as soon as the
-	 * image is available. Safe to call when {@code itemManager} has no image for the
-	 * given ID (e.g., in tests) — the icon label is simply left empty.
-	 */
-	void loadItemIcon(int itemId, JLabel iconLabel)
-	{
-		AsyncBufferedImage asyncImage = itemManager.getImage(itemId);
-		if (asyncImage == null)
-		{
-			return;
-		}
-		asyncImage.onLoaded(() ->
-		{
-			if (asyncImage.getWidth() > 0)
-			{
-				BufferedImage scaled = scaleImage(asyncImage, 28, 28);
-				iconLabel.setIcon(new ImageIcon(scaled));
-				iconLabel.revalidate();
-				iconLabel.repaint();
-			}
-		});
-		// Apply synchronously in case the image is already loaded
-		if (asyncImage.getWidth() > 0)
-		{
-			BufferedImage scaled = scaleImage(asyncImage, 28, 28);
-			iconLabel.setIcon(new ImageIcon(scaled));
-		}
-	}
-
-	private static BufferedImage scaleImage(BufferedImage source, int width, int height)
-	{
-		BufferedImage scaled = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
-		Graphics2D g = scaled.createGraphics();
-		g.drawImage(source, 0, 0, width, height, null);
-		g.dispose();
-		return scaled;
 	}
 }

--- a/src/test/java/com/collectionloghelper/ui/preview/PanelPreviewSnapshotTest.java
+++ b/src/test/java/com/collectionloghelper/ui/preview/PanelPreviewSnapshotTest.java
@@ -25,9 +25,12 @@
 package com.collectionloghelper.ui.preview;
 
 import com.collectionloghelper.data.CollectionLogCategory;
+import com.collectionloghelper.guidance.RequiredItemDisplay;
+import com.collectionloghelper.guidance.RequiredItemDisplay.Status;
 import com.collectionloghelper.ui.CollectionLogHelperPanel;
 import com.collectionloghelper.ui.CollectionLogHelperPanel.Mode;
 import com.collectionloghelper.ui.widget.SourceRecommendedItemsChipPanel;
+import com.collectionloghelper.ui.widget.StepProgressView;
 import java.awt.image.BufferedImage;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -180,6 +183,86 @@ public class PanelPreviewSnapshotTest
 		// must exceed 60px.
 		assertTrue(img.getHeight() > 60,
 			"strip height (" + img.getHeight() + ") too short to have wrapped");
+	}
+
+	/**
+	 * Phase 1 guidance items redesign: renders a {@link StepProgressView} (flat
+	 * layout) with a mix of required and recommended items across all three
+	 * statuses (HELD / IN_BANK / MISSING), plus one recommended item whose id
+	 * duplicates a required item (to prove the dedup filter drops it). Proves the
+	 * compact color-coded text list renders icon-free, three-coloured, deduped,
+	 * and unclipped at the real 225px side-panel width.
+	 */
+	@Test
+	public void guidanceItemsTextListScenario() throws Exception
+	{
+		final int heldId = 590;     // Tinderbox
+		final int inBankId = 3438;  // Pyre logs
+		final int missingId = 3392; // Loar remains
+		final int recMissingId = 4151; // Abyssal whip (recommended, missing)
+
+		final List<RequiredItemDisplay> required = Arrays.asList(
+			new RequiredItemDisplay(heldId, "Tinderbox", Status.HELD),
+			new RequiredItemDisplay(inBankId, "Pyre logs", Status.IN_BANK),
+			new RequiredItemDisplay(missingId, "Loar remains", Status.MISSING));
+
+		// Recommended list includes a duplicate of the HELD required item
+		// (heldId) which the dedup filter must drop, plus one genuinely new item.
+		final List<RequiredItemDisplay> recommended = Arrays.asList(
+			new RequiredItemDisplay(heldId, "Tinderbox", Status.HELD),
+			new RequiredItemDisplay(recMissingId, "Abyssal whip", Status.MISSING));
+
+		AtomicReference<StepProgressView> viewRef = new AtomicReference<>();
+		AtomicReference<BufferedImage> result = new AtomicReference<>();
+		AtomicReference<Exception> error = new AtomicReference<>();
+
+		SwingUtilities.invokeAndWait(() ->
+		{
+			try
+			{
+				ItemManager itemManager = Mockito.mock(ItemManager.class);
+				Mockito.when(itemManager.getImage(Mockito.anyInt())).thenReturn(null);
+
+				StepProgressView view = new StepProgressView(itemManager);
+				view.showStep(2, 6, "Light the pyre and defeat the shade", false,
+					required, recommended, java.util.Collections.emptyList());
+				viewRef.set(view);
+			}
+			catch (Exception e)
+			{
+				error.set(e);
+			}
+		});
+		if (error.get() != null)
+		{
+			throw error.get();
+		}
+
+		// Second EDT task: the showStep invokeLater has now run and populated rows.
+		SwingUtilities.invokeAndWait(() ->
+		{
+			try
+			{
+				result.set(PanelSnapshot.render(viewRef.get(), WIDTH));
+			}
+			catch (Exception e)
+			{
+				error.set(e);
+			}
+		});
+		if (error.get() != null)
+		{
+			throw error.get();
+		}
+
+		BufferedImage img = result.get();
+		Path out = OUT_DIR.resolve("guidance-items-textlist.png");
+		PanelSnapshot.writePng(img, out);
+
+		assertTrue(Files.exists(out), "PNG not written: " + out.toAbsolutePath());
+		assertTrue(Files.size(out) > 0, "PNG is empty: " + out.toAbsolutePath());
+		assertEquals(WIDTH, img.getWidth(), "render width must equal PANEL_WIDTH");
+		assertTrue(img.getHeight() > 50, "render height too small (" + img.getHeight() + ")");
 	}
 
 	private void renderScenario(String name, PanelPreviewFixtures.Scenario scenario) throws Exception

--- a/src/test/java/com/collectionloghelper/ui/widget/StepProgressViewTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/StepProgressViewTest.java
@@ -29,7 +29,6 @@ import com.collectionloghelper.data.GuidanceStep;
 import com.collectionloghelper.guidance.RequiredItemDisplay;
 import com.collectionloghelper.guidance.RequiredItemDisplay.Status;
 import net.runelite.client.game.ItemManager;
-import java.awt.Color;
 import java.awt.Component;
 import java.util.Arrays;
 import java.util.Collections;
@@ -271,7 +270,7 @@ public class StepProgressViewTest
 
 		JLabel nameLabel = findFirstNameLabel(view);
 		assertNotNull( nameLabel,"Name label must be present for IN_BANK row");
-		assertEquals( Color.WHITE, nameLabel.getForeground(),"IN_BANK row must use white colour");
+		assertEquals( RequiredItemDisplay.COLOR_IN_BANK, nameLabel.getForeground(),"IN_BANK row must use gold colour");
 		assertTrue(
 			nameLabel.getToolTipText() != null
 				&& nameLabel.getToolTipText().contains("in bank"),"IN_BANK tooltip must contain 'in bank' hint");
@@ -313,7 +312,7 @@ public class StepProgressViewTest
 		List<JLabel> nameLabels = findAllNameLabels(view);
 		assertEquals( 3, nameLabels.size(),"Must have exactly 3 name labels");
 		assertEquals(RequiredItemDisplay.COLOR_HELD, nameLabels.get(0).getForeground());
-		assertEquals(Color.WHITE, nameLabels.get(1).getForeground());
+		assertEquals(RequiredItemDisplay.COLOR_IN_BANK, nameLabels.get(1).getForeground());
 		assertEquals(RequiredItemDisplay.COLOR_MISSING, nameLabels.get(2).getForeground());
 	}
 
@@ -688,7 +687,7 @@ public class StepProgressViewTest
 		JLabel label = findFirstRecommendedNameLabel(view);
 		assertNotNull(label);
 		assertEquals(
-			Color.WHITE, label.getForeground(),"IN_BANK recommended row must use white colour");
+			RequiredItemDisplay.COLOR_IN_BANK, label.getForeground(),"IN_BANK recommended row must use gold colour");
 		assertTrue(
 			label.getToolTipText() != null && label.getToolTipText().contains("in bank"),"IN_BANK recommended tooltip must contain 'in bank'");
 	}


### PR DESCRIPTION
## Phase 1 of the guidance items-display redesign (display only)

### Changes
- Guidance item rows are now a single **compact color-coded text list** per section ("Items needed" / "Recommended") instead of icon chips. Name colored by ownership: green = held, gold = in bank, red = missing; full detail in the tooltip. Keeps long requirement lists readable at 225px.
- Removed the **source-level "Recommended" roll-up strip** from the "Guiding" banner (`GuidanceBannerView`). It showed whole-source items unrelated to the hunted item (the "Bronze lock shows Fiyr remains / pyre logs" report). This **supersedes #704** (which only restyled that now-removed strip) — recommend closing #704.
- **Dedup**: a per-step Recommended item is hidden if it's already in that step's "Items needed".

### Scope
- Display only — no data/schema/overlay/resolver changes. "Items needed" content is unchanged (already correct via per-item overrides).
- Follow-up (Phase 2, data): re-author Recommended to show only task *aids* (combat gear / pots / food on dangerous tasks) and add an "obtainable during the activity" field + tag. Until then, Recommended may still list task materials on some sources — just compact/text now.

### Test plan
- [x] `./gradlew compileJava test` green
- [x] Harness snapshot: text-only rows, 3 distinct colors, deduped item, no clip at 225px
- [ ] Live client: confirm on real guidance (Shades / Bronze lock)
