### PR TITLE
feat(guidance): on-site item tag + recommended-as-aids (Shades pilot)

### DIFF
--- a/src/main/java/com/collectionloghelper/data/GuidanceStep.java
+++ b/src/main/java/com/collectionloghelper/data/GuidanceStep.java
@@ -310,9 +310,38 @@ public class GuidanceStep
 	@Nullable
 	Map<Integer, Integer> perItemStepPriority;
 
+	/**
+	 * Item IDs the player obtains DURING this step's activity and therefore need
+	 * not bring from the bank (Phase 2 guidance-items redesign). Examples: shade
+	 * remains dropped by shades killed on-site, or keys produced by cremation.
+	 *
+	 * <p>Used purely for display: the panel appends a muted "(from activity)" tag
+	 * to any required- or recommended-item row whose id is in this list, so the
+	 * player can tell at a glance that an item is sourced on-site rather than
+	 * carried in. It does NOT change ownership colouring or completion logic.
+	 *
+	 * <p>Null by default. Existing JSON without this field deserialises unchanged.
+	 * Use {@link #getActivityObtainableItemIds()} for a non-null view.
+	 */
+	@Nullable
+	List<Integer> activityObtainableItemIds;
+
 	public int getCompletionDistance()
 	{
 		return completionDistance > 0 ? completionDistance : 5;
+	}
+
+	/**
+	 * Returns the activity-obtainable item IDs for this step, never null.
+	 * Falls back to an empty list when the JSON omits the field.
+	 *
+	 * <p>Custom getter: Lombok's {@code @Value} skips generating an accessor when
+	 * one is declared by hand, so callers get a guaranteed non-null list instead
+	 * of the raw nullable field.
+	 */
+	public List<Integer> getActivityObtainableItemIds()
+	{
+		return activityObtainableItemIds != null ? activityObtainableItemIds : Collections.emptyList();
 	}
 
 	public int getCompletionItemCount()
@@ -565,7 +594,8 @@ public class GuidanceStep
 			null, // waypoints: merged steps inherit null; authors set waypoints on the base step
 			this.dynamicTargetEvaluator,
 			this.conditionTree, // tree is inherited from base; alternatives do not override it in B1
-			this.perItemStepPriority // priority map inherited from base; alternatives do not override it in B4.3.4
+			this.perItemStepPriority, // priority map inherited from base; alternatives do not override it in B4.3.4
+			this.activityObtainableItemIds // activity-obtainable IDs inherited from base; alternatives do not override
 		);
 	}
 }

--- a/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
@@ -339,8 +339,11 @@ public class GuidanceOverlayCoordinator
 						requiredItemResolver.resolve(rawForResolve);
 					final List<RequiredItemDisplay> resolvedRecommended =
 						requiredItemResolver.resolveRecommended(rawForResolve);
+					final java.util.Set<Integer> activityIds = rawForResolve != null
+						? new java.util.HashSet<>(rawForResolve.getActivityObtainableItemIds())
+						: java.util.Collections.emptySet();
 					panel.updateStepProgress(landedIdx, stepTotal, stepDesc, stepManual,
-						resolvedItems, resolvedRecommended, sourceSteps);
+						resolvedItems, resolvedRecommended, sourceSteps, activityIds);
 				});
 			}
 			// Add InfoBox showing the correct landed step (not always "1/N")

--- a/src/main/java/com/collectionloghelper/guidance/StepChangeHandler.java
+++ b/src/main/java/com/collectionloghelper/guidance/StepChangeHandler.java
@@ -167,8 +167,11 @@ public class StepChangeHandler
 					requiredItemResolver.resolve(rawStep);
 				final List<RequiredItemDisplay> resolvedRecommended =
 					requiredItemResolver.resolveRecommended(rawStep);
+				final java.util.Set<Integer> activityIds = rawStep != null
+					? new java.util.HashSet<>(rawStep.getActivityObtainableItemIds())
+					: Collections.emptySet();
 				panelRef.updateStepProgress(current, total, desc, isManual,
-					resolvedItems, resolvedRecommended, sourceSteps);
+					resolvedItems, resolvedRecommended, sourceSteps, activityIds);
 			});
 		}
 	}

--- a/src/main/java/com/collectionloghelper/guidance/bosses/CerberusGuidance.java
+++ b/src/main/java/com/collectionloghelper/guidance/bosses/CerberusGuidance.java
@@ -100,7 +100,8 @@ public class CerberusGuidance implements BossGuidance
 			null,              // waypoints
 			null,              // dynamicTargetEvaluator
 			null,              // conditionTree
-			null               // perItemStepPriority
+			null,              // perItemStepPriority
+			null               // activityObtainableItemIds
 		);
 
 		GuidanceStep gateStep = new GuidanceStep(
@@ -137,7 +138,8 @@ public class CerberusGuidance implements BossGuidance
 			null,              // waypoints
 			null,              // dynamicTargetEvaluator
 			null,              // conditionTree
-			null               // perItemStepPriority
+			null,              // perItemStepPriority
+			null               // activityObtainableItemIds
 		);
 
 		GuidanceStep killStep = new GuidanceStep(
@@ -173,7 +175,8 @@ public class CerberusGuidance implements BossGuidance
 			null,              // waypoints
 			null,              // dynamicTargetEvaluator
 			null,              // conditionTree
-			null               // perItemStepPriority
+			null,              // perItemStepPriority
+			null               // activityObtainableItemIds
 		);
 
 		return Arrays.asList(travelStep, gateStep, killStep);

--- a/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
+++ b/src/main/java/com/collectionloghelper/ui/CollectionLogHelperPanel.java
@@ -555,6 +555,24 @@ public class CollectionLogHelperPanel extends PluginPanel implements PanelShellC
 			requiredItems, recommendedItems, allSteps);
 	}
 
+	/**
+	 * Step-progress update variant that additionally tags item rows whose id is in
+	 * {@code activityObtainableIds} with a muted "(from activity)" suffix
+	 * (Phase 2 guidance-items redesign).
+	 *
+	 * @param activityObtainableIds item IDs obtained during the active step's activity;
+	 *                              may be {@code null} or empty
+	 */
+	public void updateStepProgress(int current, int total, String description, boolean isManual,
+		List<RequiredItemDisplay> requiredItems,
+		List<RequiredItemDisplay> recommendedItems,
+		List<com.collectionloghelper.data.GuidanceStep> allSteps,
+		java.util.Set<Integer> activityObtainableIds)
+	{
+		stepProgressView.showStep(current, total, description, isManual,
+			requiredItems, recommendedItems, allSteps, activityObtainableIds);
+	}
+
 	/** Hides the step progress banner. */
 	public void hideStepProgress()
 	{

--- a/src/main/java/com/collectionloghelper/ui/widget/StepProgressView.java
+++ b/src/main/java/com/collectionloghelper/ui/widget/StepProgressView.java
@@ -37,6 +37,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
@@ -95,6 +96,14 @@ public class StepProgressView extends JPanel
 {
 	/** Tooltip suffix appended to items whose status is IN_BANK. */
 	private static final String IN_BANK_TOOLTIP_SUFFIX = " ℹ in bank";
+
+	/** Visible suffix appended to item rows obtained during the step's activity. */
+	private static final String FROM_ACTIVITY_SUFFIX = " (from activity)";
+	/** Tooltip note explaining the "(from activity)" tag. */
+	private static final String FROM_ACTIVITY_TOOLTIP_SUFFIX =
+		" - obtained during the activity; no need to bring it";
+	/** Muted-gray colour for the "(from activity)" suffix label. */
+	private static final Color FROM_ACTIVITY_FG = new Color(140, 140, 140);
 
 	private static final Color BG = new Color(25, 35, 55);
 	private static final Color SECTION_HEADER_FG = new Color(200, 200, 200);
@@ -164,6 +173,7 @@ public class StepProgressView extends JPanel
 	private List<RequiredItemDisplay> lastRows = Collections.emptyList();
 	private List<RequiredItemDisplay> lastRecRows = Collections.emptyList();
 	private List<StepSectionGroup> lastGroups = Collections.emptyList();
+	private Set<Integer> lastActivityIds = Collections.emptySet();
 
 	private Runnable stepAdvancer;
 	private Runnable stepSkipper;
@@ -508,12 +518,44 @@ public class StepProgressView extends JPanel
 		List<RequiredItemDisplay> requiredItems, List<RequiredItemDisplay> recommendedItems,
 		List<GuidanceStep> allSteps)
 	{
+		showStep(current, total, description, isManual, requiredItems, recommendedItems,
+			allSteps, Collections.<Integer>emptySet());
+	}
+
+	/**
+	 * Shows and populates the step progress panel, additionally tagging any item
+	 * row whose id is in {@code activityObtainableIds} with a muted "(from activity)"
+	 * suffix (Phase 2 guidance-items redesign). The suffix is informational only and
+	 * does not change the row's ownership colour.
+	 * Safe to call from any thread.
+	 *
+	 * @param current               one-based step index
+	 * @param total                 total number of steps
+	 * @param description           human-readable step description
+	 * @param isManual              whether the Next Step button should be shown
+	 * @param requiredItems         pre-resolved required-item display rows (may be
+	 *                              {@code null} or empty)
+	 * @param recommendedItems      pre-resolved recommended-item display rows (may be
+	 *                              {@code null} or empty); hidden when empty
+	 * @param allSteps              full ordered step list for the active source; used to
+	 *                              compute section groups. Pass an empty list to force flat
+	 *                              layout.
+	 * @param activityObtainableIds item IDs obtained during the active step's activity;
+	 *                              rows with these ids get the "(from activity)" tag (may
+	 *                              be {@code null} or empty)
+	 */
+	public void showStep(int current, int total, String description, boolean isManual,
+		List<RequiredItemDisplay> requiredItems, List<RequiredItemDisplay> recommendedItems,
+		List<GuidanceStep> allSteps, Set<Integer> activityObtainableIds)
+	{
 		final List<RequiredItemDisplay> rows =
 			requiredItems != null ? requiredItems : Collections.emptyList();
 		final List<RequiredItemDisplay> recRows =
 			recommendedItems != null ? recommendedItems : Collections.emptyList();
 		final List<GuidanceStep> steps =
 			allSteps != null ? allSteps : Collections.emptyList();
+		final Set<Integer> activityIds =
+			activityObtainableIds != null ? activityObtainableIds : Collections.emptySet();
 		final List<StepSectionGroup> groups = StepSectionGrouper.group(steps);
 
 		SwingUtilities.invokeLater(() ->
@@ -531,7 +573,8 @@ public class StepProgressView extends JPanel
 				&& java.util.Objects.equals(lastDescription, description)
 				&& lastRows.equals(rows)
 				&& lastRecRows.equals(recRows)
-				&& lastGroups.equals(groups))
+				&& lastGroups.equals(groups)
+				&& lastActivityIds.equals(activityIds))
 			{
 				return;
 			}
@@ -543,6 +586,7 @@ public class StepProgressView extends JPanel
 			lastRows = new java.util.ArrayList<>(rows);
 			lastRecRows = new java.util.ArrayList<>(recRows);
 			lastGroups = new java.util.ArrayList<>(groups);
+			lastActivityIds = new java.util.HashSet<>(activityIds);
 
 			// Plain-text setText on a JTextArea word-wraps from the actual rendered
 			// width — no HTML, no pixel-width budget, no escaping needed. Previous
@@ -562,8 +606,8 @@ public class StepProgressView extends JPanel
 				// (it was hoisted to source-level, #599).
 				sectionsPanel.setVisible(false);
 				chipPanel.update(Collections.<RequiredItemDisplay>emptyList());
-				updateRequiredItemDisplay(rows);
-				updateRecommendedItemDisplay(dedupRecommended(rows, recRows));
+				updateRequiredItemDisplay(rows, activityIds);
+				updateRecommendedItemDisplay(dedupRecommended(rows, recRows), activityIds);
 			}
 			else
 			{
@@ -574,7 +618,7 @@ public class StepProgressView extends JPanel
 				requiredItemsPanel.setVisible(false);
 				recommendedItemsPanel.removeAll();
 				recommendedItemsPanel.setVisible(false);
-				updateSectionDisplay(groups, current, rows, recRows);
+				updateSectionDisplay(groups, current, rows, recRows, activityIds);
 			}
 
 			setVisible(true);
@@ -602,6 +646,7 @@ public class StepProgressView extends JPanel
 			// down, so the next showStep must rebuild even if its inputs match the
 			// last shown step.
 			lastRenderValid = false;
+			lastActivityIds = Collections.emptySet();
 			chipPanel.update(Collections.<RequiredItemDisplay>emptyList());
 			recChipPanel.update(Collections.<RequiredItemDisplay>emptyList());
 			requiredItemsPanel.removeAll();
@@ -639,6 +684,22 @@ public class StepProgressView extends JPanel
 	void updateSectionDisplay(List<StepSectionGroup> groups, int activeStepIndex,
 		List<RequiredItemDisplay> requiredItems, List<RequiredItemDisplay> recommendedItems)
 	{
+		updateSectionDisplay(groups, activeStepIndex, requiredItems, recommendedItems,
+			Collections.<Integer>emptySet());
+	}
+
+	/**
+	 * Section-display variant that also tags activity-obtainable item rows.
+	 * Must be called on the EDT.
+	 *
+	 * @param activityObtainableIds item IDs obtained during the active step's activity
+	 */
+	void updateSectionDisplay(List<StepSectionGroup> groups, int activeStepIndex,
+		List<RequiredItemDisplay> requiredItems, List<RequiredItemDisplay> recommendedItems,
+		Set<Integer> activityObtainableIds)
+	{
+		final Set<Integer> activityIds =
+			activityObtainableIds != null ? activityObtainableIds : Collections.emptySet();
 		sectionsPanel.removeAll();
 
 		String activeSectionName = StepSectionGrouper.sectionNameFor(groups, activeStepIndex);
@@ -655,7 +716,7 @@ public class StepProgressView extends JPanel
 			boolean expanded = sectionExpandState.getOrDefault(group.getName(), Boolean.FALSE);
 
 			JPanel block = buildSectionBlock(group, isActiveSection, expanded,
-				activeStepIndex, requiredItems, recommendedItems);
+				activeStepIndex, requiredItems, recommendedItems, activityIds);
 			block.setAlignmentX(LEFT_ALIGNMENT);
 			sectionsPanel.add(block);
 			sectionsPanel.add(Box.createVerticalStrut(2));
@@ -685,7 +746,7 @@ public class StepProgressView extends JPanel
 	 */
 	private JPanel buildSectionBlock(StepSectionGroup group, boolean isActiveSection,
 		boolean expanded, int activeStepIndex, List<RequiredItemDisplay> requiredItems,
-		List<RequiredItemDisplay> recommendedItems)
+		List<RequiredItemDisplay> recommendedItems, Set<Integer> activityObtainableIds)
 	{
 		JPanel block = new JPanel();
 		block.setLayout(new BoxLayout(block, BoxLayout.Y_AXIS));
@@ -730,7 +791,7 @@ public class StepProgressView extends JPanel
 
 				for (RequiredItemDisplay row : requiredItems)
 				{
-					JPanel rowPanel = buildItemRow(row);
+					JPanel rowPanel = buildItemRow(row, activityObtainableIds);
 					rowPanel.setAlignmentX(LEFT_ALIGNMENT);
 					itemsInSection.add(rowPanel);
 					itemsInSection.add(Box.createVerticalStrut(2));
@@ -759,7 +820,7 @@ public class StepProgressView extends JPanel
 
 				for (RequiredItemDisplay row : recForStep)
 				{
-					JPanel rowPanel = buildItemRow(row);
+					JPanel rowPanel = buildItemRow(row, activityObtainableIds);
 					rowPanel.setAlignmentX(LEFT_ALIGNMENT);
 					recInSection.add(rowPanel);
 					recInSection.add(Box.createVerticalStrut(2));
@@ -865,7 +926,15 @@ public class StepProgressView extends JPanel
 	 */
 	void updateRequiredItemDisplay(List<RequiredItemDisplay> rows)
 	{
-		updateItemSubsection(requiredItemsPanel, "Items needed:", rows);
+		updateRequiredItemDisplay(rows, Collections.<Integer>emptySet());
+	}
+
+	/**
+	 * Required-items variant that tags activity-obtainable rows. Must be called on the EDT.
+	 */
+	void updateRequiredItemDisplay(List<RequiredItemDisplay> rows, Set<Integer> activityObtainableIds)
+	{
+		updateItemSubsection(requiredItemsPanel, "Items needed:", rows, activityObtainableIds);
 	}
 
 	/**
@@ -880,7 +949,15 @@ public class StepProgressView extends JPanel
 	 */
 	void updateRecommendedItemDisplay(List<RequiredItemDisplay> rows)
 	{
-		updateItemSubsection(recommendedItemsPanel, "Recommended:", rows);
+		updateRecommendedItemDisplay(rows, Collections.<Integer>emptySet());
+	}
+
+	/**
+	 * Recommended-items variant that tags activity-obtainable rows. Must be called on the EDT.
+	 */
+	void updateRecommendedItemDisplay(List<RequiredItemDisplay> rows, Set<Integer> activityObtainableIds)
+	{
+		updateItemSubsection(recommendedItemsPanel, "Recommended:", rows, activityObtainableIds);
 	}
 
 	/**
@@ -890,7 +967,7 @@ public class StepProgressView extends JPanel
 	 * Must be called on the EDT.
 	 */
 	private void updateItemSubsection(JPanel panel, String headerText,
-		List<RequiredItemDisplay> rows)
+		List<RequiredItemDisplay> rows, Set<Integer> activityObtainableIds)
 	{
 		panel.removeAll();
 
@@ -910,7 +987,7 @@ public class StepProgressView extends JPanel
 
 		for (RequiredItemDisplay row : rows)
 		{
-			JPanel rowPanel = buildItemRow(row);
+			JPanel rowPanel = buildItemRow(row, activityObtainableIds);
 			rowPanel.setAlignmentX(LEFT_ALIGNMENT);
 			panel.add(rowPanel);
 			panel.add(Box.createVerticalStrut(2));
@@ -937,6 +1014,21 @@ public class StepProgressView extends JPanel
 	 */
 	private JPanel buildItemRow(RequiredItemDisplay row)
 	{
+		return buildItemRow(row, Collections.<Integer>emptySet());
+	}
+
+	/**
+	 * Builds a single item row, appending a muted-gray " (from activity)" suffix
+	 * when the row's item id is in {@code activityObtainableIds}. The item name keeps
+	 * its ownership colour (green/gold/red); only the appended suffix is muted, signalling
+	 * the item is obtained on-site during the step's activity and need not be brought.
+	 *
+	 * <p>The suffix is a second {@link JLabel} so the name colour is untouched. No icon
+	 * is rendered (the compact text list keeps long item lists from overflowing the
+	 * 225px side panel).
+	 */
+	private JPanel buildItemRow(RequiredItemDisplay row, Set<Integer> activityObtainableIds)
+	{
 		JPanel rowPanel = new JPanel();
 		rowPanel.setLayout(new BoxLayout(rowPanel, BoxLayout.X_AXIS));
 		rowPanel.setBackground(BG);
@@ -962,13 +1054,27 @@ public class StepProgressView extends JPanel
 				break;
 		}
 
+		final boolean fromActivity =
+			activityObtainableIds != null && activityObtainableIds.contains(row.getItemId());
+
 		JLabel nameLabel = new JLabel(row.getName());
 		nameLabel.setFont(FontManager.getRunescapeSmallFont());
 		nameLabel.setForeground(nameColor);
-		nameLabel.setToolTipText(row.getName() + tooltipSuffix);
+		nameLabel.setToolTipText(row.getName() + tooltipSuffix
+			+ (fromActivity ? FROM_ACTIVITY_TOOLTIP_SUFFIX : ""));
 		nameLabel.setAlignmentX(LEFT_ALIGNMENT);
 
 		rowPanel.add(nameLabel);
+
+		if (fromActivity)
+		{
+			JLabel activityLabel = new JLabel(FROM_ACTIVITY_SUFFIX);
+			activityLabel.setFont(FontManager.getRunescapeSmallFont());
+			activityLabel.setForeground(FROM_ACTIVITY_FG);
+			activityLabel.setToolTipText(row.getName() + FROM_ACTIVITY_TOOLTIP_SUFFIX);
+			activityLabel.setAlignmentX(LEFT_ALIGNMENT);
+			rowPanel.add(activityLabel);
+		}
 
 		return rowPanel;
 	}

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -15067,10 +15067,10 @@
         "completionChatPattern": "You attempt to light the funeral pyre",
         "section": "Skilling",
         "recommendedItemIds": [
-          590,
-          25630,
-          3404,
-          3446
+          25630
+        ],
+        "activityObtainableItemIds": [
+          3404
         ]
       },
       {

--- a/src/test/java/com/collectionloghelper/data/ActivityObtainableItemsTest.java
+++ b/src/test/java/com/collectionloghelper/data/ActivityObtainableItemsTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.lang.reflect.Type;
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression tests for the {@code activityObtainableItemIds} field added to
+ * {@link GuidanceStep} in the Phase 2 guidance-items redesign.
+ *
+ * <p>Acceptance criteria:
+ * <ol>
+ *   <li>JSON without the field deserialises so the raw field is null and the
+ *       non-null accessor returns an empty list (backwards-compatible for the
+ *       ~225 existing sources).</li>
+ *   <li>JSON with the field deserialises to the declared list.</li>
+ *   <li>The "Shades of Mort'ton" pilot: its burn step carries the on-site
+ *       Fiyr remains (3404) in {@code activityObtainableItemIds}, and its
+ *       recommended list no longer contains the materials/on-site items it
+ *       previously listed (Tinderbox 590, pyre logs 3446, remains 3404).</li>
+ * </ol>
+ */
+public class ActivityObtainableItemsTest
+{
+	/** Fiyr remains - shade remains obtained on-site by killing shades during the activity. */
+	private static final int FIYR_REMAINS = 3404;
+	/** Tinderbox - a brought material, not a task aid. */
+	private static final int TINDERBOX = 590;
+	/** Yew pyre logs - a brought material, not a task aid. */
+	private static final int YEW_PYRE_LOGS = 3446;
+	/** Flamtaer bag - the single convenience aid kept under Recommended. */
+	private static final int FLAMTAER_BAG = 25630;
+
+	private static List<CollectionLogSource> sources;
+
+	@BeforeAll
+	public static void loadModel() throws Exception
+	{
+		Gson gson = new GsonBuilder().create();
+		Type listType = new TypeToken<List<CollectionLogSource>>() {}.getType();
+		try (InputStream is = ActivityObtainableItemsTest.class
+			.getResourceAsStream("/com/collectionloghelper/drop_rates.json"))
+		{
+			assertNotNull(is, "drop_rates.json must be on the classpath");
+			sources = gson.fromJson(new InputStreamReader(is), listType);
+		}
+		assertNotNull(sources, "drop_rates.json must parse to a source list");
+	}
+
+	@Test
+	public void jsonWithoutField_rawNull_accessorEmpty()
+	{
+		Gson gson = new GsonBuilder().create();
+		GuidanceStep step = gson.fromJson("{\"description\":\"x\"}", GuidanceStep.class);
+		assertNotNull(step.getActivityObtainableItemIds(),
+			"accessor must never return null");
+		assertTrue(step.getActivityObtainableItemIds().isEmpty(),
+			"accessor must return an empty list when the field is absent");
+	}
+
+	@Test
+	public void jsonWithField_deserialisesToList()
+	{
+		Gson gson = new GsonBuilder().create();
+		GuidanceStep step = gson.fromJson(
+			"{\"description\":\"x\",\"activityObtainableItemIds\":[3404,3450]}",
+			GuidanceStep.class);
+		assertEquals(2, step.getActivityObtainableItemIds().size());
+		assertTrue(step.getActivityObtainableItemIds().contains(FIYR_REMAINS));
+		assertTrue(step.getActivityObtainableItemIds().contains(3450));
+	}
+
+	@Test
+	public void mostSources_haveNoActivityObtainableField()
+	{
+		// The field is a narrow, opt-in pilot: only Shades of Mort'ton uses it.
+		// Every OTHER source must leave it null so the existing data is untouched.
+		for (CollectionLogSource src : sources)
+		{
+			if ("Shades of Mort'ton".equals(src.getName()) || src.getGuidanceSteps() == null)
+			{
+				continue;
+			}
+			for (GuidanceStep step : src.getGuidanceSteps())
+			{
+				assertTrue(step.getActivityObtainableItemIds().isEmpty(),
+					"non-pilot source '" + src.getName()
+						+ "' must not set activityObtainableItemIds");
+			}
+		}
+	}
+
+	@Test
+	public void shadesPilot_burnStep_tagsFiyrRemainsFromActivity()
+	{
+		GuidanceStep burnStep = shadesBurnStep();
+		assertTrue(burnStep.getActivityObtainableItemIds().contains(FIYR_REMAINS),
+			"Shades burn step must tag Fiyr remains as obtained on-site");
+	}
+
+	@Test
+	public void shadesPilot_recommended_isAidsOnly()
+	{
+		GuidanceStep burnStep = shadesBurnStep();
+		List<Integer> recommended = burnStep.getRecommendedItemIds();
+		assertNotNull(recommended, "Shades burn step keeps a recommended list");
+		assertFalse(recommended.contains(TINDERBOX),
+			"Tinderbox is a brought material, not a recommended aid");
+		assertFalse(recommended.contains(YEW_PYRE_LOGS),
+			"pyre logs are a brought material, not a recommended aid");
+		assertFalse(recommended.contains(FIYR_REMAINS),
+			"shade remains are obtained on-site, not a recommended aid");
+		assertTrue(recommended.contains(FLAMTAER_BAG),
+			"the Flamtaer bag is the one convenience aid kept under Recommended");
+	}
+
+	/** Locates the Shades "burn shade remains" step (the only step with the activity field). */
+	private static GuidanceStep shadesBurnStep()
+	{
+		CollectionLogSource shades = sources.stream()
+			.filter(s -> "Shades of Mort'ton".equals(s.getName()))
+			.findFirst()
+			.orElseThrow(() -> new AssertionError("Shades of Mort'ton source missing"));
+		assertNotNull(shades.getGuidanceSteps(), "Shades must have guidance steps");
+		return shades.getGuidanceSteps().stream()
+			.filter(s -> !s.getActivityObtainableItemIds().isEmpty())
+			.findFirst()
+			.orElseThrow(() -> new AssertionError(
+				"Shades must have a step with activityObtainableItemIds"));
+	}
+}

--- a/src/test/java/com/collectionloghelper/data/CollectionLogSourceTest.java
+++ b/src/test/java/com/collectionloghelper/data/CollectionLogSourceTest.java
@@ -385,7 +385,8 @@ public class CollectionLogSourceTest
 			null,           // waypoints
 			null,            // dynamicTargetEvaluator
 			null,            // conditionTree
-			null            // perItemStepPriority
+						null, // perItemStepPriority
+						null  // activityObtainableItemIds
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/data/GuidanceStepPerItemStepPriorityIntegrationTest.java
+++ b/src/test/java/com/collectionloghelper/data/GuidanceStepPerItemStepPriorityIntegrationTest.java
@@ -171,7 +171,8 @@ public class GuidanceStepPerItemStepPriorityIntegrationTest
 			null,                       // waypoints
 			null,                       // dynamicTargetEvaluator
 			null,                       // conditionTree
-			perItemStepPriority         // perItemStepPriority
+						perItemStepPriority, // perItemStepPriority
+						null  // activityObtainableItemIds
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/data/GuidanceStepSectionTest.java
+++ b/src/test/java/com/collectionloghelper/data/GuidanceStepSectionTest.java
@@ -155,7 +155,8 @@ public class GuidanceStepSectionTest
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
 			null,  // conditionTree
-			null  // perItemStepPriority
+						null, // perItemStepPriority
+						null  // activityObtainableItemIds
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/data/GuidanceStepTest.java
+++ b/src/test/java/com/collectionloghelper/data/GuidanceStepTest.java
@@ -335,7 +335,8 @@ public class GuidanceStepTest
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
 			null,  // conditionTree
-			null  // perItemStepPriority
+						null, // perItemStepPriority
+						null  // activityObtainableItemIds
 		);
 	}
 
@@ -372,7 +373,8 @@ public class GuidanceStepTest
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
 			null,  // conditionTree
-			null  // perItemStepPriority
+						null, // perItemStepPriority
+						null  // activityObtainableItemIds
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/data/PerItemStepPriorityEvaluatorTest.java
+++ b/src/test/java/com/collectionloghelper/data/PerItemStepPriorityEvaluatorTest.java
@@ -193,7 +193,8 @@ public class PerItemStepPriorityEvaluatorTest
 			null,                       // waypoints
 			null,                       // dynamicTargetEvaluator
 			null,                       // conditionTree
-			perItemStepPriority         // perItemStepPriority (under test)
+						perItemStepPriority, // perItemStepPriority (under test)
+						null  // activityObtainableItemIds
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/data/condition/B1GuidanceStepIntegrationTest.java
+++ b/src/test/java/com/collectionloghelper/data/condition/B1GuidanceStepIntegrationTest.java
@@ -178,7 +178,8 @@ public class B1GuidanceStepIntegrationTest
 			0, 0, false, 0, null, null, 0, 0, null, null, null, null, null,
 			null /* waypoints */, null /* dynamicTargetEvaluator */,
 			tree,
-			null /* perItemStepPriority */
+						null, /* perItemStepPriority */
+						null  // activityObtainableItemIds
 		);
 	}
 

--- a/src/test/java/com/collectionloghelper/guidance/DynamicItemObjectTierResolverTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/DynamicItemObjectTierResolverTest.java
@@ -299,7 +299,8 @@ public class DynamicItemObjectTierResolverTest
 			null,           // waypoints
 			null,            // dynamicTargetEvaluator
 			null,            // conditionTree
-			null            // perItemStepPriority
+						null, // perItemStepPriority
+						null  // activityObtainableItemIds
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/guidance/DynamicTargetEvaluatorDispatchTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/DynamicTargetEvaluatorDispatchTest.java
@@ -421,7 +421,8 @@ public class DynamicTargetEvaluatorDispatchTest
 			null,  // waypoints
 			evaluatorKey,  // dynamicTargetEvaluator
 			null,  // conditionTree
-			null  // perItemStepPriority
+						null, // perItemStepPriority
+						null  // activityObtainableItemIds
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/guidance/DynamicTargetManagerTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/DynamicTargetManagerTest.java
@@ -254,7 +254,8 @@ public class DynamicTargetManagerTest
 			null,  // waypoints
 			evaluatorKey,  // dynamicTargetEvaluator
 			null,  // conditionTree
-			null  // perItemStepPriority
+						null, // perItemStepPriority
+						null  // activityObtainableItemIds
 		);
 	}
 

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorDescriptionTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorDescriptionTest.java
@@ -304,7 +304,8 @@ public class GuidanceOverlayCoordinatorDescriptionTest
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
 			null,  // conditionTree
-			null  // perItemStepPriority
+						null, // perItemStepPriority
+						null  // activityObtainableItemIds
 		);
 	}
 

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorNpcIdTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinatorNpcIdTest.java
@@ -311,7 +311,8 @@ public class GuidanceOverlayCoordinatorNpcIdTest
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
 			null,  // conditionTree
-			null  // perItemStepPriority
+						null, // perItemStepPriority
+						null  // activityObtainableItemIds
 		);
 	}
 

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerNestedConditionalTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerNestedConditionalTest.java
@@ -494,7 +494,8 @@ public class GuidanceSequencerNestedConditionalTest
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
 			null,  // conditionTree
-			null  // perItemStepPriority
+						null, // perItemStepPriority
+						null  // activityObtainableItemIds
 		);
 	}
 
@@ -531,7 +532,8 @@ public class GuidanceSequencerNestedConditionalTest
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
 			null,  // conditionTree
-			null  // perItemStepPriority
+						null, // perItemStepPriority
+						null  // activityObtainableItemIds
 		);
 	}
 

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
@@ -122,7 +122,8 @@ public class GuidanceSequencerTest
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
 			null,  // conditionTree
-			null  // perItemStepPriority
+						null, // perItemStepPriority
+						null  // activityObtainableItemIds
 		);
 	}
 
@@ -158,7 +159,8 @@ public class GuidanceSequencerTest
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
 			null,  // conditionTree
-			null  // perItemStepPriority
+						null, // perItemStepPriority
+						null  // activityObtainableItemIds
 		);
 	}
 
@@ -194,7 +196,8 @@ public class GuidanceSequencerTest
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
 			null,  // conditionTree
-			null  // perItemStepPriority
+						null, // perItemStepPriority
+						null  // activityObtainableItemIds
 		);
 	}
 
@@ -230,7 +233,8 @@ public class GuidanceSequencerTest
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
 			null,  // conditionTree
-			null  // perItemStepPriority
+						null, // perItemStepPriority
+						null  // activityObtainableItemIds
 		);
 	}
 
@@ -266,7 +270,8 @@ public class GuidanceSequencerTest
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
 			null,  // conditionTree
-			null  // perItemStepPriority
+						null, // perItemStepPriority
+						null  // activityObtainableItemIds
 		);
 	}
 
@@ -302,7 +307,8 @@ public class GuidanceSequencerTest
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
 			null,  // conditionTree
-			null  // perItemStepPriority
+						null, // perItemStepPriority
+						null  // activityObtainableItemIds
 		);
 	}
 
@@ -338,7 +344,8 @@ public class GuidanceSequencerTest
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
 			null,  // conditionTree
-			null  // perItemStepPriority
+						null, // perItemStepPriority
+						null  // activityObtainableItemIds
 		);
 	}
 
@@ -374,7 +381,8 @@ public class GuidanceSequencerTest
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
 			null,  // conditionTree
-			null  // perItemStepPriority
+						null, // perItemStepPriority
+						null  // activityObtainableItemIds
 		);
 	}
 
@@ -411,7 +419,8 @@ public class GuidanceSequencerTest
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
 			null,  // conditionTree
-			null  // perItemStepPriority
+						null, // perItemStepPriority
+						null  // activityObtainableItemIds
 		);
 	}
 
@@ -447,7 +456,8 @@ public class GuidanceSequencerTest
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
 			null,  // conditionTree
-			null  // perItemStepPriority
+						null, // perItemStepPriority
+						null  // activityObtainableItemIds
 		);
 	}
 
@@ -483,7 +493,8 @@ public class GuidanceSequencerTest
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
 			null,  // conditionTree
-			null  // perItemStepPriority
+						null, // perItemStepPriority
+						null  // activityObtainableItemIds
 		);
 	}
 
@@ -519,7 +530,8 @@ public class GuidanceSequencerTest
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
 			null,  // conditionTree
-			null  // perItemStepPriority
+						null, // perItemStepPriority
+						null  // activityObtainableItemIds
 		);
 	}
 
@@ -1009,7 +1021,8 @@ public class GuidanceSequencerTest
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
 			null,  // conditionTree
-			null  // perItemStepPriority
+						null, // perItemStepPriority
+						null  // activityObtainableItemIds
 		);
 
 		List<GuidanceStep> steps = Arrays.asList(
@@ -1485,7 +1498,8 @@ public class GuidanceSequencerTest
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
 			null,  // conditionTree
-			null  // perItemStepPriority
+						null, // perItemStepPriority
+						null  // activityObtainableItemIds
 		);
 	}
 
@@ -1723,7 +1737,8 @@ public class GuidanceSequencerTest
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
 			null,  // conditionTree
-			null  // perItemStepPriority
+						null, // perItemStepPriority
+						null  // activityObtainableItemIds
 		);
 
 		List<GuidanceStep> steps = Arrays.asList(step);

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerWaypointTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerWaypointTest.java
@@ -134,7 +134,8 @@ public class GuidanceSequencerWaypointTest
 			waypoints,
 			null,  // dynamicTargetEvaluator
 			null,  // conditionTree
-			null  // perItemStepPriority
+						null, // perItemStepPriority
+						null  // activityObtainableItemIds
 		);
 	}
 
@@ -173,7 +174,8 @@ public class GuidanceSequencerWaypointTest
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
 			null,  // conditionTree
-			null  // perItemStepPriority
+						null, // perItemStepPriority
+						null  // activityObtainableItemIds
 		);
 	}
 
@@ -288,7 +290,8 @@ public class GuidanceSequencerWaypointTest
 			null, // waypoints = null
 			null,  // dynamicTargetEvaluator
 			null,  // conditionTree
-			null  // perItemStepPriority
+						null, // perItemStepPriority
+						null  // activityObtainableItemIds
 		);
 
 		AtomicBoolean stepAdvanced = new AtomicBoolean(false);
@@ -340,7 +343,8 @@ public class GuidanceSequencerWaypointTest
 			Collections.emptyList(), // waypoints = empty list
 			null,  // dynamicTargetEvaluator
 			null,  // conditionTree
-			null  // perItemStepPriority
+						null, // perItemStepPriority
+						null  // activityObtainableItemIds
 		);
 
 		AtomicBoolean stepAdvanced = new AtomicBoolean(false);

--- a/src/test/java/com/collectionloghelper/guidance/RequiredItemResolverTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/RequiredItemResolverTest.java
@@ -655,7 +655,8 @@ public class RequiredItemResolverTest
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
 			null,  // conditionTree
-			null  // perItemStepPriority
+						null, // perItemStepPriority
+						null  // activityObtainableItemIds
 		);
 	}
 
@@ -697,7 +698,8 @@ public class RequiredItemResolverTest
 			null,  // waypoints
 			null,   // dynamicTargetEvaluator
 			null,   // conditionTree
-			null   // perItemStepPriority
+						null, // perItemStepPriority
+						null  // activityObtainableItemIds
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/guidance/bosses/BossGuidanceDispatchTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/bosses/BossGuidanceDispatchTest.java
@@ -105,7 +105,8 @@ public class BossGuidanceDispatchTest
 			0, 0, false, 0, null, null, 0, 0, null, null, null, null, null,
 			null /* waypoints */, null /* dynamicTargetEvaluator */,
 			null /* conditionTree */,
-			null /* perItemStepPriority */
+						null, /* perItemStepPriority */
+						null  // activityObtainableItemIds
 		);
 	}
 

--- a/src/test/java/com/collectionloghelper/guidance/dynamic/WintertodtBrazierEvaluatorTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/dynamic/WintertodtBrazierEvaluatorTest.java
@@ -234,7 +234,8 @@ public class WintertodtBrazierEvaluatorTest
 			null,  // waypoints
 			DynamicTargetEvaluatorRegistry.WINTERTODT_ACTIVE_BRAZIER,  // dynamicTargetEvaluator
 			null,  // conditionTree
-			null  // perItemStepPriority
+						null, // perItemStepPriority
+						null  // activityObtainableItemIds
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/lifecycle/GuidanceEventRouterTest.java
+++ b/src/test/java/com/collectionloghelper/lifecycle/GuidanceEventRouterTest.java
@@ -145,7 +145,8 @@ public class GuidanceEventRouterTest
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
 			null,  // conditionTree
-			null  // perItemStepPriority
+						null, // perItemStepPriority
+						null  // activityObtainableItemIds
 		);
 	}
 

--- a/src/test/java/com/collectionloghelper/ui/preview/PanelPreviewSnapshotTest.java
+++ b/src/test/java/com/collectionloghelper/ui/preview/PanelPreviewSnapshotTest.java
@@ -265,6 +265,79 @@ public class PanelPreviewSnapshotTest
 		assertTrue(img.getHeight() > 50, "render height too small (" + img.getHeight() + ")");
 	}
 
+	/**
+	 * Phase 2 guidance-items redesign (Shades of Mort'ton pilot): renders a
+	 * {@link StepProgressView} flat layout for the burn step. "Items needed" carries
+	 * the on-site Fiyr remains tagged with "(from activity)"; "Recommended" shows the
+	 * single convenience aid (Flamtaer bag) instead of the old material list. Proves
+	 * the aids-only recommended section and the muted on-site tag render correctly.
+	 */
+	@Test
+	public void shadesActivityObtainableScenario() throws Exception
+	{
+		final int fiyrRemainsId = 3404;  // shade remains, obtained on-site
+		final int tinderboxId = 590;     // brought material
+		final int flamtaerBagId = 25630; // convenience aid (the one recommended item)
+
+		final List<RequiredItemDisplay> required = Arrays.asList(
+			new RequiredItemDisplay(tinderboxId, "Tinderbox", Status.HELD),
+			new RequiredItemDisplay(fiyrRemainsId, "Fiyr remains", Status.HELD));
+		final List<RequiredItemDisplay> recommended = Arrays.asList(
+			new RequiredItemDisplay(flamtaerBagId, "Flamtaer bag", Status.IN_BANK));
+		final java.util.Set<Integer> activityIds = java.util.Collections.singleton(fiyrRemainsId);
+
+		AtomicReference<StepProgressView> viewRef = new AtomicReference<>();
+		AtomicReference<BufferedImage> result = new AtomicReference<>();
+		AtomicReference<Exception> error = new AtomicReference<>();
+
+		SwingUtilities.invokeAndWait(() ->
+		{
+			try
+			{
+				ItemManager itemManager = Mockito.mock(ItemManager.class);
+				Mockito.when(itemManager.getImage(Mockito.anyInt())).thenReturn(null);
+
+				StepProgressView view = new StepProgressView(itemManager);
+				view.showStep(2, 6, "Burn shade remains on the funeral pyres", false,
+					required, recommended, java.util.Collections.emptyList(), activityIds);
+				viewRef.set(view);
+			}
+			catch (Exception e)
+			{
+				error.set(e);
+			}
+		});
+		if (error.get() != null)
+		{
+			throw error.get();
+		}
+
+		SwingUtilities.invokeAndWait(() ->
+		{
+			try
+			{
+				result.set(PanelSnapshot.render(viewRef.get(), WIDTH));
+			}
+			catch (Exception e)
+			{
+				error.set(e);
+			}
+		});
+		if (error.get() != null)
+		{
+			throw error.get();
+		}
+
+		BufferedImage img = result.get();
+		Path out = OUT_DIR.resolve("shades-activity-obtainable.png");
+		PanelSnapshot.writePng(img, out);
+
+		assertTrue(Files.exists(out), "PNG not written: " + out.toAbsolutePath());
+		assertTrue(Files.size(out) > 0, "PNG is empty: " + out.toAbsolutePath());
+		assertEquals(WIDTH, img.getWidth(), "render width must equal PANEL_WIDTH");
+		assertTrue(img.getHeight() > 50, "render height too small (" + img.getHeight() + ")");
+	}
+
 	private void renderScenario(String name, PanelPreviewFixtures.Scenario scenario) throws Exception
 	{
 		BufferedImage img = buildAndRenderOnEdt(scenario);

--- a/src/test/java/com/collectionloghelper/ui/widget/BankScanIntegrationTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/BankScanIntegrationTest.java
@@ -347,7 +347,8 @@ public class BankScanIntegrationTest
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
 			null,  // conditionTree
-			null  // perItemStepPriority
+						null, // perItemStepPriority
+						null  // activityObtainableItemIds
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/ui/widget/StepProgressViewTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/StepProgressViewTest.java
@@ -317,6 +317,56 @@ public class StepProgressViewTest
 	}
 
 	/**
+	 * Phase 2 guidance-items redesign: a required row whose id is in the active
+	 * step's activityObtainableItemIds gets a muted "(from activity)" suffix label,
+	 * while the item name keeps its ownership colour.
+	 */
+	@Test
+	public void showStep_activityObtainable_appendsFromActivitySuffix() throws Exception
+	{
+		view.showStep(2, 6, "Burn the shade remains", false,
+			Collections.singletonList(
+				new RequiredItemDisplay(SHADE_REMAINS_ID, "Fiyr remains", Status.HELD)),
+			Collections.<RequiredItemDisplay>emptyList(),
+			Collections.<GuidanceStep>emptyList(),
+			Collections.singleton(SHADE_REMAINS_ID));
+		flushEdt();
+
+		// The name label keeps its ownership colour.
+		JLabel nameLabel = findFirstNameLabel(view);
+		assertNotNull(nameLabel, "Name label must be present");
+		assertEquals(RequiredItemDisplay.COLOR_HELD, nameLabel.getForeground(),
+			"ownership colour must be unchanged for activity-obtainable rows");
+
+		// A second, muted label carries the "(from activity)" suffix.
+		List<JLabel> labels = findAllNameLabels(view);
+		boolean hasSuffix = labels.stream()
+			.anyMatch(l -> l.getText() != null && l.getText().contains("(from activity)"));
+		assertTrue(hasSuffix, "a '(from activity)' suffix label must be rendered");
+	}
+
+	/**
+	 * A required row whose id is NOT in activityObtainableItemIds must render with
+	 * no "(from activity)" suffix label.
+	 */
+	@Test
+	public void showStep_notActivityObtainable_noSuffix() throws Exception
+	{
+		view.showStep(1, 3, "Bring the tinderbox", false,
+			Collections.singletonList(
+				new RequiredItemDisplay(TINDERBOX_ID, "Tinderbox", Status.HELD)),
+			Collections.<RequiredItemDisplay>emptyList(),
+			Collections.<GuidanceStep>emptyList(),
+			Collections.<Integer>emptySet());
+		flushEdt();
+
+		List<JLabel> labels = findAllNameLabels(view);
+		boolean hasSuffix = labels.stream()
+			.anyMatch(l -> l.getText() != null && l.getText().contains("(from activity)"));
+		assertFalse(hasSuffix, "no suffix when the row id is not activity-obtainable");
+	}
+
+	/**
 	 * State transition: colours must update when showStep is called a second time
 	 * with different availability data for the same item.
 	 */
@@ -1302,7 +1352,8 @@ public class StepProgressViewTest
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
 			null,  // conditionTree
-			null  // perItemStepPriority
+						null, // perItemStepPriority
+						null  // activityObtainableItemIds
 		);
 	}
 
@@ -1333,7 +1384,8 @@ public class StepProgressViewTest
 			null, // waypoints
 			null,   // dynamicTargetEvaluator
 			null,   // conditionTree
-			null   // perItemStepPriority
+						null, // perItemStepPriority
+						null  // activityObtainableItemIds
 		);
 	}
 }

--- a/src/test/java/com/collectionloghelper/ui/widget/StepSectionGrouperTest.java
+++ b/src/test/java/com/collectionloghelper/ui/widget/StepSectionGrouperTest.java
@@ -78,7 +78,8 @@ public class StepSectionGrouperTest
 			null, // waypoints
 			null,  // dynamicTargetEvaluator
 			null,  // conditionTree
-			null  // perItemStepPriority
+						null, // perItemStepPriority
+						null  // activityObtainableItemIds
 		);
 	}
 


### PR DESCRIPTION
## Phase 2 (pilot): on-site-obtainable tag + recommended-as-aids

Follows the Phase 1 text-list redesign (#705). Scoped data changes to **one source: Shades of Mort'ton** to establish the pattern; rollout to other sources is a follow-up.

### Schema
- New `@Nullable List<Integer> GuidanceStep.activityObtainableItemIds` (getter returns empty when null) — item IDs the player obtains during the step's own activity. Nullable so all ~225 sources parse unchanged; updated the ~43 positional `GuidanceStep` callsites (3 production, ~42 across 21 test files). No reflective constructor lookups affected.

### Display
- Item rows whose id is in the active step's `activityObtainableItemIds` get a muted-gray " (from activity)" suffix (name keeps its ownership color). Threaded through both flat and grouped step layouts; idempotency guard extended; production wiring via `GuidanceOverlayCoordinator` / `StepChangeHandler`.

### Data (Shades of Mort'ton only)
- Burn step `recommendedItemIds`: `[Tinderbox, Flamtaer bag, Fiyr remains, Pyre logs]` -> `[Flamtaer bag]` (the one genuine convenience aid; Shades is a safe activity so recommended is minimal). Materials are already in per-item required.
- `activityObtainableItemIds`: `[Fiyr remains]` — verified on-site-obtainable against the OSRS Wiki (shades drop remains during the activity).

### Test plan
- [x] `compileJava compileTestJava` + full `test` green
- [x] `validate_drop_rates` + `data_ascii_lint` pass
- [x] New `ActivityObtainableItemsTest` (parse null->empty, populated, non-pilot sources untouched, Shades aids-only + tag); `StepProgressViewTest` suffix cases; harness snapshot
- [ ] Live client: Shades shows `Fiyr remains (from activity)` + recommended = Flamtaer bag

### Open judgment for review
- Tagged Fiyr remains as the on-site item (it renders in the burn step's required list). Shade keys are also on-site but aren't in that step's lists, so tagging them wouldn't display — flag if keys should be surfaced in the rollout.

### Rollout pattern (other sources, later)
Per step: move on-site items out of `recommendedItemIds` into `activityObtainableItemIds`; keep `recommendedItemIds` to true aids (combat/prayer/restore/food on dangerous tasks, convenience tools otherwise); verify on-site vs brought against the wiki before tagging.
