### PR TITLE
fix(guidance): auto-stop guidance when the target collection-log item is obtained

### DIFF
--- a/src/main/java/com/collectionloghelper/guidance/GuidanceSequencer.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceSequencer.java
@@ -407,6 +407,16 @@ public class GuidanceSequencer
 	/**
 	 * Called when a collection log item is obtained. Checks ITEM_OBTAINED condition
 	 * and sets {@link #targetSlotUnlocked} if the item belongs to the active source.
+	 *
+	 * <p>When the obtained item is one of the active source's target collection-log
+	 * slots, the guidance for that source is logically finished regardless of the
+	 * current step / inventory state (e.g., the player still holds a chest key) — so
+	 * the sequence is completed immediately. This routes through the normal
+	 * {@code onSequenceComplete} callback, which deactivates guidance and lets the
+	 * auto-advance logic roll to the next Top Pick (the target-slot-unlocked flag is
+	 * already set, so {@link #wasTargetSlotUnlocked()} reports {@code true}). Without
+	 * this, guidance could stay pinned on a completed item because the final step's
+	 * own completion condition (inventory / chat) had not yet fired (#708).
 	 */
 	public void onItemObtained(int itemId)
 	{
@@ -423,8 +433,12 @@ public class GuidanceSequencer
 				if (item.getItemId() == itemId)
 				{
 					targetSlotUnlocked = true;
-					log.info("Target slot unlocked for {} (itemId={})", activeSource.getName(), itemId);
-					break;
+					log.info("Target slot unlocked for {} (itemId={}) — completing guidance",
+						activeSource.getName(), itemId);
+					// The guided collection-log item was obtained: the sequence is done,
+					// even if the final step's completion condition has not fired yet.
+					fireSequenceComplete();
+					return;
 				}
 			}
 		}

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
@@ -548,6 +548,20 @@ public class GuidanceSequencerTest
 			steps, null, null, 0, null, cumulativeTrackThreshold, Collections.emptyList(), null, null, null);
 	}
 
+	private CollectionLogSource makeSourceWithItems(String name, List<GuidanceStep> steps,
+		List<CollectionLogItem> items)
+	{
+		return new CollectionLogSource(name, CollectionLogCategory.BOSSES, 3000, 3000, 0,
+			60, 0, name, Collections.emptyList(),
+			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null,
+			steps, null, null, 0, null, 0, items, null, null, null);
+	}
+
+	private CollectionLogItem makeItem(int itemId, String name)
+	{
+		return new CollectionLogItem(itemId, name, 0.0, false, null, 0, 0, false, false);
+	}
+
 	private void startSequence(List<GuidanceStep> steps)
 	{
 		startSequence(steps, s -> {}, () -> {});
@@ -670,6 +684,81 @@ public class GuidanceSequencerTest
 		sequencer.onItemObtained(targetItemId);
 		assertEquals(1, sequencer.getCurrentIndex());
 		assertEquals("After obtain", sequencer.getCurrentStep().getDescription());
+	}
+
+	/**
+	 * Regression test for #708: obtaining the active source's target collection-log
+	 * item must complete (and thus deactivate) guidance immediately, even when the
+	 * current step's own completion condition has not fired and inventory state is
+	 * still "incomplete" (e.g., Shades of Mort'ton — player obtains "Bronze locks"
+	 * while still holding a shade key on the final chest-opening step).
+	 *
+	 * <p>Before the fix, {@code onItemObtained} only set the target-slot-unlocked
+	 * flag and waited for the step/inventory condition to advance the sequence, so
+	 * guidance stayed pinned on the completed item indefinitely.
+	 */
+	@Test
+	public void testObtainingTargetItemCompletesGuidanceRegardlessOfStepState()
+	{
+		int targetItemId = 28163; // arbitrary clog item id (e.g. "Bronze locks")
+		int keyItemId = 4178;     // a consumable the player still holds
+
+		// Final step completes only when the key leaves the inventory — NOT obtained-based.
+		List<GuidanceStep> steps = Arrays.asList(
+			makeManualStep("Travel to Mort'ton"),
+			makeStep(CompletionCondition.INVENTORY_NOT_HAS_ITEM, keyItemId)
+		);
+
+		// Player still holds the key, so the final step's own condition is unsatisfied.
+		when(inventoryState.hasItem(keyItemId)).thenReturn(true);
+
+		AtomicBoolean completed = new AtomicBoolean(false);
+		CollectionLogSource source = makeSourceWithItems("Shades of Mort'ton", steps,
+			Arrays.asList(makeItem(targetItemId, "Bronze locks")));
+		sequencer.startSequence(source, s -> {}, () -> completed.set(true));
+
+		// Advance onto the final (chest-opening) step; it must not auto-complete.
+		sequencer.advanceStep();
+		assertEquals(1, sequencer.getCurrentIndex());
+		assertTrue(sequencer.isActive());
+		assertFalse(completed.get());
+
+		// Obtaining the target collection-log item must complete guidance now,
+		// even though the key is still in the inventory.
+		sequencer.onItemObtained(targetItemId);
+
+		assertTrue(sequencer.wasTargetSlotUnlocked());
+		assertTrue(completed.get(), "sequence-complete callback must fire on target obtain");
+		assertFalse(sequencer.isActive(), "guidance must deactivate on target obtain");
+	}
+
+	/**
+	 * Companion guard for #708: obtaining a collection-log item that is NOT the
+	 * active source's target must not complete or deactivate guidance. This keeps
+	 * the auto-stop scoped to the guided target only.
+	 */
+	@Test
+	public void testObtainingNonTargetItemDoesNotCompleteGuidance()
+	{
+		int targetItemId = 28163;
+		int unrelatedItemId = 99999;
+
+		List<GuidanceStep> steps = Arrays.asList(
+			makeManualStep("Step 1"),
+			makeManualStep("Step 2")
+		);
+
+		AtomicBoolean completed = new AtomicBoolean(false);
+		CollectionLogSource source = makeSourceWithItems("Shades of Mort'ton", steps,
+			Arrays.asList(makeItem(targetItemId, "Bronze locks")));
+		sequencer.startSequence(source, s -> {}, () -> completed.set(true));
+
+		sequencer.onItemObtained(unrelatedItemId);
+
+		assertFalse(sequencer.wasTargetSlotUnlocked());
+		assertFalse(completed.get());
+		assertTrue(sequencer.isActive());
+		assertEquals(0, sequencer.getCurrentIndex());
 	}
 
 	@Test


### PR DESCRIPTION
## Fix: guidance now auto-stops when the target collection-log item is obtained (closes #708)

### Root cause
Auto-stop was keyed off *sequence completion*, never off the collection-log-obtained event:
- `ChatEventHandler` calls `GuidanceSequencer.onItemObtained(itemId)` on the "new collection log item" message.
- Pre-fix, `onItemObtained` only set `targetSlotUnlocked = true` and advanced only if the *current step's* completion condition was `ITEM_OBTAINED`. For Shades of Mort'ton, the final step completes on inventory/chat, not the clog item -- so guidance never deactivated.
- The `targetSlotUnlocked` signal is consumed only when the sequence completes; since a shade key remained in inventory the sequence never "finished", so guidance stayed pinned on the obtained "Bronze locks".

### Fix
In `GuidanceSequencer.onItemObtained`, when the obtained item is one of the active source's target items, fire `fireSequenceComplete()` and return. This reuses the existing path: complete callback -> `GuidanceOverlayCoordinator.onSequenceComplete` -> `deactivateGuidance()` + `handleSequenceComplete()` (which, with `wasTargetSlotUnlocked()` true, rolls to the next Top Pick). Runs on the same client thread that delivers the chat event; no new wiring.

### Scope / non-regression
- Fires only when the obtained id is in the active source's target-item list; non-target items fall through to the unchanged step check.
- Normal step advancement, manual Stop Guidance, and next-Top-Pick selection share the same entry points and are unchanged.

### Test plan
- [x] `compileJava compileTestJava test` green
- [x] New `testObtainingTargetItemCompletesGuidanceRegardlessOfStepState` (target obtained with key still held -> guidance deactivates) and `testObtainingNonTargetItemDoesNotCompleteGuidance`
- [ ] Live: obtain a guided clog item mid-activity, confirm guidance stops/advances

### Note for review
For multi-item sources, obtaining *any* target item of the source completes guidance and re-ranks via Top Pick (consistent with letting Top Pick re-select). Flagging in case the intended multi-item UX differs.
