### PR TITLE
feat(overlay): clean guidance object glow + CLH target marker

### DIFF
--- a/src/main/java/com/collectionloghelper/CollectionLogHelperConfig.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperConfig.java
@@ -239,11 +239,23 @@ public interface CollectionLogHelperConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "showGuidanceTargetMarker",
+		name = "Show Target Marker",
+		description = "Draw a small marker icon over the highlighted guidance target",
+		section = guidanceSection,
+		position = 3
+	)
+	default boolean showGuidanceTargetMarker()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "showHintArrow",
 		name = "Show Hint Arrow",
 		description = "Show the in-game yellow hint arrow at the guidance target",
 		section = guidanceSection,
-		position = 3
+		position = 4
 	)
 	default boolean showHintArrow()
 	{
@@ -255,7 +267,7 @@ public interface CollectionLogHelperConfig extends Config
 		name = "Shortest Path Integration",
 		description = "Request a path from the Shortest Path plugin (if installed) when guidance is activated",
 		section = guidanceSection,
-		position = 4
+		position = 5
 	)
 	default boolean useShortestPath()
 	{
@@ -267,7 +279,7 @@ public interface CollectionLogHelperConfig extends Config
 		name = "Overlay Color",
 		description = "Color used for guidance overlays",
 		section = guidanceSection,
-		position = 5
+		position = 6
 	)
 	default Color overlayColor()
 	{

--- a/src/main/java/com/collectionloghelper/overlay/GroundItemHighlightOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/GroundItemHighlightOverlay.java
@@ -33,6 +33,8 @@ import java.awt.FontMetrics;
 import java.awt.Graphics2D;
 import java.awt.Polygon;
 import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
+import lombok.extern.slf4j.Slf4j;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -49,7 +51,9 @@ import net.runelite.api.coords.LocalPoint;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.util.ImageUtil;
 
+@Slf4j
 @Singleton
 public class GroundItemHighlightOverlay extends Overlay
 {
@@ -57,12 +61,20 @@ public class GroundItemHighlightOverlay extends Overlay
 	private static final int ARROW_WIDTH = 12;
 	private static final int ARROW_GAP = 5;
 	private static final int TEXT_HEIGHT_OFFSET = 50;
+	private static final int MARKER_SIZE = 18;
+	private static final int MARKER_HEIGHT_OFFSET = 90;
 	private static final BasicStroke STROKE_2 = new BasicStroke(2.0f);
 	private static final Font BOLD_12 = new Font(Font.DIALOG, Font.BOLD, 12);
 
 	private final Client client;
 	private final CollectionLogHelperConfig config;
 	private final Polygon arrowPolygon = new Polygon();
+
+	/**
+	 * Marker icon drawn over each highlighted ground item. Loaded and resized
+	 * once at construction so the render hot-path performs no IO or allocation.
+	 */
+	private final BufferedImage markerIcon;
 
 	private volatile Set<Integer> targetGroundItemIds = Collections.emptySet();
 
@@ -80,8 +92,28 @@ public class GroundItemHighlightOverlay extends Overlay
 	{
 		this.client = client;
 		this.config = config;
+		this.markerIcon = loadMarkerIcon();
 		setPosition(OverlayPosition.DYNAMIC);
 		setLayer(OverlayLayer.ABOVE_SCENE);
+	}
+
+	private static BufferedImage loadMarkerIcon()
+	{
+		try
+		{
+			BufferedImage raw = ImageUtil.loadImageResource(
+				GroundItemHighlightOverlay.class, "/com/collectionloghelper/panel_icon.png");
+			if (raw == null)
+			{
+				return null;
+			}
+			return ImageUtil.resizeImage(raw, MARKER_SIZE, MARKER_SIZE);
+		}
+		catch (RuntimeException e)
+		{
+			log.warn("Failed to load guidance target marker icon", e);
+			return null;
+		}
 	}
 
 	public void setTargetGroundItemIds(Set<Integer> itemIds)
@@ -186,6 +218,27 @@ public class GroundItemHighlightOverlay extends Overlay
 			{
 				renderOutlinedText(graphics, textPoint, tracked.itemName, overlayColor);
 			}
+		}
+
+		drawTargetMarker(graphics, localPoint);
+	}
+
+	/**
+	 * Draws the cached marker icon centered above the ground item's on-screen
+	 * position. No-op when the icon failed to load, the config toggle is off,
+	 * or the tile has no projectable canvas location. Allocates nothing here.
+	 */
+	private void drawTargetMarker(Graphics2D graphics, LocalPoint localPoint)
+	{
+		if (markerIcon == null || !config.showGuidanceTargetMarker())
+		{
+			return;
+		}
+		Point canvasPoint = Perspective.getCanvasImageLocation(
+			client, localPoint, markerIcon, MARKER_HEIGHT_OFFSET);
+		if (canvasPoint != null)
+		{
+			graphics.drawImage(markerIcon, canvasPoint.getX(), canvasPoint.getY(), null);
 		}
 	}
 

--- a/src/main/java/com/collectionloghelper/overlay/ObjectHighlightOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/ObjectHighlightOverlay.java
@@ -31,6 +31,7 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Shape;
+import java.awt.image.BufferedImage;
 import lombok.extern.slf4j.Slf4j;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -52,24 +53,32 @@ import net.runelite.api.WallObject;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.ui.overlay.Overlay;
-import net.runelite.client.ui.overlay.OverlayUtil;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.outline.ModelOutlineRenderer;
 import net.runelite.client.ui.overlay.tooltip.Tooltip;
 import net.runelite.client.ui.overlay.tooltip.TooltipManager;
+import net.runelite.client.util.ImageUtil;
 
 @Slf4j
 @Singleton
 public class ObjectHighlightOverlay extends Overlay
 {
-	private static final int TEXT_HEIGHT_OFFSET = 130;
 	private static final BasicStroke STROKE_1_5 = new BasicStroke(1.5f);
-	private static final BasicStroke STROKE_2 = new BasicStroke(2.0f);
+	private static final int GLOW_OUTLINE_WIDTH = 2;
+	private static final int GLOW_FEATHER = 4;
+	private static final int MARKER_SIZE = 18;
+	private static final int MARKER_HEIGHT_OFFSET = 60;
 
 	private final Client client;
 	private final ClientThread clientThread;
 	private final CollectionLogHelperConfig config;
+
+	/**
+	 * Marker icon drawn over each highlighted target. Loaded and resized once
+	 * at construction so the render hot-path performs no IO or allocation.
+	 */
+	private final BufferedImage markerIcon;
 
 	@Inject
 	private TooltipManager tooltipManager;
@@ -84,7 +93,6 @@ public class ObjectHighlightOverlay extends Overlay
 	private volatile WorldPoint filterTile;
 	private volatile int filterMaxDistance;
 	private volatile List<WorldPoint> filterTiles;
-	private volatile String cachedDisplayText;
 
 	/**
 	 * Cached list of scene objects matching targetObjectIds.
@@ -100,8 +108,28 @@ public class ObjectHighlightOverlay extends Overlay
 		this.client = client;
 		this.clientThread = clientThread;
 		this.config = config;
+		this.markerIcon = loadMarkerIcon();
 		setPosition(OverlayPosition.DYNAMIC);
 		setLayer(OverlayLayer.ABOVE_SCENE);
+	}
+
+	private static BufferedImage loadMarkerIcon()
+	{
+		try
+		{
+			BufferedImage raw = ImageUtil.loadImageResource(
+				ObjectHighlightOverlay.class, "/com/collectionloghelper/panel_icon.png");
+			if (raw == null)
+			{
+				return null;
+			}
+			return ImageUtil.resizeImage(raw, MARKER_SIZE, MARKER_SIZE);
+		}
+		catch (RuntimeException e)
+		{
+			log.warn("Failed to load guidance target marker icon", e);
+			return null;
+		}
 	}
 
 	public void setTargetObjectId(int objectId)
@@ -119,13 +147,11 @@ public class ObjectHighlightOverlay extends Overlay
 	public void setObjectInteractAction(String action)
 	{
 		this.objectInteractAction = action;
-		rebuildDisplayText(action, this.useItemOnObject);
 	}
 
 	public void setUseItemOnObject(boolean value)
 	{
 		this.useItemOnObject = value;
-		rebuildDisplayText(this.objectInteractAction, value);
 	}
 
 	public void setTooltipText(String text)
@@ -171,19 +197,6 @@ public class ObjectHighlightOverlay extends Overlay
 		this.filterMaxDistance = 0;
 		this.filterTiles = null;
 		this.matchedObjects = Collections.emptyList();
-		this.cachedDisplayText = null;
-	}
-
-	private void rebuildDisplayText(String action, boolean useItem)
-	{
-		if (action != null)
-		{
-			cachedDisplayText = useItem ? "Use " + action + " \u2192" : action;
-		}
-		else
-		{
-			cachedDisplayText = null;
-		}
 	}
 
 	/**
@@ -305,7 +318,6 @@ public class ObjectHighlightOverlay extends Overlay
 		// Snapshot volatile fields to prevent thread-safety races
 		final List<TileObject> objects = this.matchedObjects;
 		final String action = this.objectInteractAction;
-		final boolean useItem = this.useItemOnObject;
 		final String tipText = this.tooltipText;
 
 		if (objects.isEmpty() || !config.showOverlays())
@@ -324,30 +336,42 @@ public class ObjectHighlightOverlay extends Overlay
 			LocalPoint localPoint = obj.getLocalLocation();
 			if (style == ObjectHighlightStyle.OUTLINE_GLOW)
 			{
-				// Wide feathered outline produces a soft glow effect around the model.
-				// outlineWidth=6 feather=4 (max) gives visible glow without performance cost.
-				modelOutlineRenderer.drawOutline(obj, 6, overlayColor, 4);
-				// Render action label above the object (tooltip not available without hull hitbox)
-				String displayText = this.cachedDisplayText;
-				if (localPoint != null && displayText != null)
-				{
-					Point textPoint = Perspective.getCanvasTextLocation(
-						client, graphics, localPoint, displayText, TEXT_HEIGHT_OFFSET);
-					if (textPoint != null)
-					{
-						OverlayUtil.renderTextLocation(graphics, textPoint, displayText, overlayColor);
-					}
-				}
+				// Thin feathered outline produces a clean single glow (matching the
+				// catacomb-chest reference look) rather than a thick stacked band.
+				// outlineWidth=2 feather=4 gives a soft edge without a heavy cluttered cluster
+				// when many objects match (e.g. funeral pyres at Shades of Mort'ton).
+				modelOutlineRenderer.drawOutline(obj, GLOW_OUTLINE_WIDTH, overlayColor, GLOW_FEATHER);
 			}
 			else
 			{
 				Shape hull = getHull(obj);
-				tooltipShown |= renderObjectHighlight(graphics, hull, localPoint,
-					overlayColor, action, useItem, mousePos, builtTooltip, tooltipShown);
+				tooltipShown |= renderObjectHighlight(graphics, hull,
+					overlayColor, mousePos, builtTooltip, tooltipShown);
 			}
+
+			drawTargetMarker(graphics, localPoint);
 		}
 
 		return null;
+	}
+
+	/**
+	 * Draws the cached marker icon centered above the target's on-screen position.
+	 * No-op when the icon failed to load, the config toggle is off, or the target
+	 * has no projectable canvas location. Allocates nothing on the render path.
+	 */
+	private void drawTargetMarker(Graphics2D graphics, LocalPoint localPoint)
+	{
+		if (markerIcon == null || localPoint == null || !config.showGuidanceTargetMarker())
+		{
+			return;
+		}
+		Point canvasPoint = Perspective.getCanvasImageLocation(
+			client, localPoint, markerIcon, MARKER_HEIGHT_OFFSET);
+		if (canvasPoint != null)
+		{
+			graphics.drawImage(markerIcon, canvasPoint.getX(), canvasPoint.getY(), null);
+		}
 	}
 
 	private boolean passesTileFilter(TileObject obj)
@@ -403,9 +427,8 @@ public class ObjectHighlightOverlay extends Overlay
 		return null;
 	}
 
-	private boolean renderObjectHighlight(Graphics2D graphics, Shape hull, LocalPoint localPoint,
-		Color overlayColor, String action, boolean useItem,
-		Point mousePos, String builtTooltip, boolean tooltipAlreadyShown)
+	private boolean renderObjectHighlight(Graphics2D graphics, Shape hull,
+		Color overlayColor, Point mousePos, String builtTooltip, boolean tooltipAlreadyShown)
 	{
 		boolean showedTooltip = false;
 		if (hull != null)
@@ -420,18 +443,6 @@ public class ObjectHighlightOverlay extends Overlay
 			{
 				tooltipManager.add(new Tooltip(builtTooltip));
 				showedTooltip = true;
-			}
-		}
-
-		// Render action text above the object
-		String displayText = this.cachedDisplayText;
-		if (localPoint != null && displayText != null)
-		{
-			Point textPoint = Perspective.getCanvasTextLocation(
-				client, graphics, localPoint, displayText, TEXT_HEIGHT_OFFSET);
-			if (textPoint != null)
-			{
-				OverlayUtil.renderTextLocation(graphics, textPoint, displayText, overlayColor);
 			}
 		}
 		return showedTooltip;

--- a/src/test/java/com/collectionloghelper/overlay/GuidanceTargetMarkerTest.java
+++ b/src/test/java/com/collectionloghelper/overlay/GuidanceTargetMarkerTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.overlay;
+
+import com.collectionloghelper.CollectionLogHelperConfig;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.awt.image.BufferedImage;
+import net.runelite.api.Client;
+import net.runelite.client.callback.ClientThread;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Verifies the guidance target marker icon is loaded and resized once at
+ * overlay construction (the render hot-path must not perform IO). The actual
+ * in-world drawing cannot be exercised headless, so these tests confirm the
+ * icon resource resolves and is sized as expected.
+ */
+public class GuidanceTargetMarkerTest
+{
+	private static final int EXPECTED_MARKER_SIZE = 18;
+
+	@Test
+	public void objectOverlayLoadsResizedMarkerIcon() throws Exception
+	{
+		Client client = mock(Client.class);
+		ClientThread clientThread = mock(ClientThread.class);
+		CollectionLogHelperConfig config = mock(CollectionLogHelperConfig.class);
+
+		Constructor<ObjectHighlightOverlay> ctor = ObjectHighlightOverlay.class
+			.getDeclaredConstructor(Client.class, ClientThread.class, CollectionLogHelperConfig.class);
+		ctor.setAccessible(true);
+		ObjectHighlightOverlay overlay = ctor.newInstance(client, clientThread, config);
+
+		BufferedImage icon = readMarkerIcon(overlay);
+		assertNotNull(icon, "marker icon should load from the classpath resource");
+		assertEquals(EXPECTED_MARKER_SIZE, icon.getWidth());
+		assertEquals(EXPECTED_MARKER_SIZE, icon.getHeight());
+	}
+
+	@Test
+	public void groundItemOverlayLoadsResizedMarkerIcon() throws Exception
+	{
+		Client client = mock(Client.class);
+		CollectionLogHelperConfig config = mock(CollectionLogHelperConfig.class);
+
+		Constructor<GroundItemHighlightOverlay> ctor = GroundItemHighlightOverlay.class
+			.getDeclaredConstructor(Client.class, CollectionLogHelperConfig.class);
+		ctor.setAccessible(true);
+		GroundItemHighlightOverlay overlay = ctor.newInstance(client, config);
+
+		BufferedImage icon = readMarkerIcon(overlay);
+		assertNotNull(icon, "marker icon should load from the classpath resource");
+		assertEquals(EXPECTED_MARKER_SIZE, icon.getWidth());
+		assertEquals(EXPECTED_MARKER_SIZE, icon.getHeight());
+	}
+
+	private static BufferedImage readMarkerIcon(Object overlay) throws Exception
+	{
+		Field field = overlay.getClass().getDeclaredField("markerIcon");
+		field.setAccessible(true);
+		return (BufferedImage) field.get(overlay);
+	}
+}

--- a/src/test/java/com/collectionloghelper/overlay/HighlightStyleSelectionTest.java
+++ b/src/test/java/com/collectionloghelper/overlay/HighlightStyleSelectionTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Verifies style-selection logic: enum values are well-formed, the default
@@ -140,5 +141,14 @@ public class HighlightStyleSelectionTest
 		{
 		};
 		assertEquals(ObjectHighlightStyle.OUTLINE_GLOW, cfg.objectHighlightStyle());
+	}
+
+	@Test
+	public void config_showGuidanceTargetMarkerDefaultsTrue()
+	{
+		CollectionLogHelperConfig cfg = new CollectionLogHelperConfig()
+		{
+		};
+		assertTrue(cfg.showGuidanceTargetMarker());
 	}
 }


### PR DESCRIPTION
## Clean guidance object glow + CLH target marker (closes #709, #706)

### #709 -- clean object highlighting
Object-highlight style is the global `objectHighlightStyle` config (default `OUTLINE_GLOW`). The glow path drew a thick feathered outline (width 6) AND stacked a menu-action ("Build") text label above every matched object; with many matched funeral pyres at Shades of Mort'ton this looked thick and cluttered vs the clean single catacomb chest.
- Reduced glow to outline width 2 / feather 4 (single clean glow).
- Removed the stacked action-text label from both the `OUTLINE_GLOW` and `HULL` paths (hover tooltip retained on the `HULL` path).
- Shared code path, so chests render with the same (now thinner) clean style; no chest-specific change.

### #706 -- CLH target marker
- Both `ObjectHighlightOverlay` and `GroundItemHighlightOverlay` load `/com/collectionloghelper/panel_icon.png` via `ImageUtil`, resize to 18px ONCE in the constructor, cache it (null-safe).
- A small marker is drawn over each highlighted target via `Perspective.getCanvasImageLocation` + `drawImage` (null-checked).
- New `showGuidanceTargetMarker` config (guidance section, default true) gates the draw.

### Performance
No per-frame allocation/IO -- icon + resize are one-time; render only projects a point and blits.

### Test plan
- [x] `compileJava compileTestJava test` green
- [x] Unit: config default + both overlays construct and load the icon without throwing
- [ ] **LIVE (required -- overlays can't be rendered headless):** at Shades of Mort'ton confirm the funeral-pyre glow is now clean (no thick stacked "Build"), and the CLH marker sits correctly over object + ground-item targets

### Deferred
#707 (keep highlighting recurring items after first pickup) is a design-level limitation (single-step-per-pickup auto-completes); left open with findings for a separate multi-pickup/loop-aware change.
