### PR TITLE
fix(overlay): rework guidance target marker (legible glyph above target)

### DIFF
--- a/src/main/java/com/collectionloghelper/overlay/GroundItemHighlightOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/GroundItemHighlightOverlay.java
@@ -33,7 +33,6 @@ import java.awt.FontMetrics;
 import java.awt.Graphics2D;
 import java.awt.Polygon;
 import java.awt.RenderingHints;
-import java.awt.image.BufferedImage;
 import lombok.extern.slf4j.Slf4j;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -51,7 +50,6 @@ import net.runelite.api.coords.LocalPoint;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
-import net.runelite.client.util.ImageUtil;
 
 @Slf4j
 @Singleton
@@ -61,8 +59,6 @@ public class GroundItemHighlightOverlay extends Overlay
 	private static final int ARROW_WIDTH = 12;
 	private static final int ARROW_GAP = 5;
 	private static final int TEXT_HEIGHT_OFFSET = 50;
-	private static final int MARKER_SIZE = 18;
-	private static final int MARKER_HEIGHT_OFFSET = 90;
 	private static final BasicStroke STROKE_2 = new BasicStroke(2.0f);
 	private static final Font BOLD_12 = new Font(Font.DIALOG, Font.BOLD, 12);
 
@@ -71,10 +67,11 @@ public class GroundItemHighlightOverlay extends Overlay
 	private final Polygon arrowPolygon = new Polygon();
 
 	/**
-	 * Marker icon drawn over each highlighted ground item. Loaded and resized
-	 * once at construction so the render hot-path performs no IO or allocation.
+	 * Floating collection-log marker drawn above each highlighted ground item.
+	 * The glyph is rasterised once at construction so the render hot-path
+	 * performs no IO or allocation.
 	 */
-	private final BufferedImage markerIcon;
+	private final GuidanceTargetMarker targetMarker = new GuidanceTargetMarker();
 
 	private volatile Set<Integer> targetGroundItemIds = Collections.emptySet();
 
@@ -92,28 +89,8 @@ public class GroundItemHighlightOverlay extends Overlay
 	{
 		this.client = client;
 		this.config = config;
-		this.markerIcon = loadMarkerIcon();
 		setPosition(OverlayPosition.DYNAMIC);
 		setLayer(OverlayLayer.ABOVE_SCENE);
-	}
-
-	private static BufferedImage loadMarkerIcon()
-	{
-		try
-		{
-			BufferedImage raw = ImageUtil.loadImageResource(
-				GroundItemHighlightOverlay.class, "/com/collectionloghelper/panel_icon.png");
-			if (raw == null)
-			{
-				return null;
-			}
-			return ImageUtil.resizeImage(raw, MARKER_SIZE, MARKER_SIZE);
-		}
-		catch (RuntimeException e)
-		{
-			log.warn("Failed to load guidance target marker icon", e);
-			return null;
-		}
 	}
 
 	public void setTargetGroundItemIds(Set<Integer> itemIds)
@@ -224,22 +201,17 @@ public class GroundItemHighlightOverlay extends Overlay
 	}
 
 	/**
-	 * Draws the cached marker icon centered above the ground item's on-screen
-	 * position. No-op when the icon failed to load, the config toggle is off,
-	 * or the tile has no projectable canvas location. Allocates nothing here.
+	 * Draws the floating collection-log marker above the ground item's on-screen
+	 * position. No-op when the config toggle is off or the tile has no
+	 * projectable canvas location. Allocates nothing here.
 	 */
 	private void drawTargetMarker(Graphics2D graphics, LocalPoint localPoint)
 	{
-		if (markerIcon == null || !config.showGuidanceTargetMarker())
+		if (!config.showGuidanceTargetMarker())
 		{
 			return;
 		}
-		Point canvasPoint = Perspective.getCanvasImageLocation(
-			client, localPoint, markerIcon, MARKER_HEIGHT_OFFSET);
-		if (canvasPoint != null)
-		{
-			graphics.drawImage(markerIcon, canvasPoint.getX(), canvasPoint.getY(), null);
-		}
+		targetMarker.draw(graphics, client, localPoint);
 	}
 
 

--- a/src/main/java/com/collectionloghelper/overlay/GuidanceTargetMarker.java
+++ b/src/main/java/com/collectionloghelper/overlay/GuidanceTargetMarker.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.overlay;
+
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
+import net.runelite.api.Client;
+import net.runelite.api.Perspective;
+import net.runelite.api.Point;
+import net.runelite.api.coords.LocalPoint;
+
+/**
+ * Shared floating "collection-log target" marker for in-world guidance overlays.
+ *
+ * <p>The previous implementation (#714) drew the panel's 16x16 cyan-on-transparent
+ * book PNG resized to 18px directly on top of the target. At that size the PNG is
+ * illegible against the game world - it reads as a blue blob with a line - and
+ * sitting on the target rather than above it hid the object. This helper instead
+ * draws a clean, programmatic book glyph (the same Java2D drawn-icon approach used
+ * by the panel's status/step icons) and projects it ABOVE the target with a
+ * vertical pixel offset, quest-helper style.
+ *
+ * <p>The glyph is rasterised once into a {@link BufferedImage} at construction so
+ * the render hot-path performs no allocation and no IO - it only projects a point
+ * and blits the cached image.
+ */
+final class GuidanceTargetMarker
+{
+	/** Glyph canvas size in pixels - large enough to be legible as a small book. */
+	private static final int SIZE = 26;
+
+	/** Pixels to lift the glyph above the target's canvas point so it floats clear. */
+	private static final int HEIGHT_OFFSET = 80;
+
+	private static final Color BOOK_FILL = new Color(0xE8, 0xC4, 0x6A);
+	private static final Color BOOK_OUTLINE = Color.BLACK;
+	private static final Color PAGE_LINE = new Color(0x3A, 0x2A, 0x10);
+
+	private final BufferedImage glyph;
+
+	GuidanceTargetMarker()
+	{
+		this.glyph = buildGlyph();
+	}
+
+	/**
+	 * Projects the target's local point to the canvas and blits the cached glyph
+	 * centred horizontally and floating {@link #HEIGHT_OFFSET} pixels above it.
+	 * No-op when the point cannot be projected. Allocates nothing.
+	 */
+	void draw(Graphics2D graphics, Client client, LocalPoint localPoint)
+	{
+		if (localPoint == null)
+		{
+			return;
+		}
+		Point canvasPoint = Perspective.getCanvasImageLocation(client, localPoint, glyph, HEIGHT_OFFSET);
+		if (canvasPoint != null)
+		{
+			graphics.drawImage(glyph, canvasPoint.getX(), canvasPoint.getY(), null);
+		}
+	}
+
+	/**
+	 * Rasterises a small open-book glyph: a rounded gold cover with a black outline
+	 * and two page lines, plus a subtle drop shadow for contrast against bright or
+	 * dark scenery. Drawn once at construction.
+	 */
+	private static BufferedImage buildGlyph()
+	{
+		BufferedImage img = new BufferedImage(SIZE, SIZE, BufferedImage.TYPE_INT_ARGB);
+		Graphics2D g = img.createGraphics();
+		try
+		{
+			g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+			g.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
+
+			// Book body inset from the canvas edges, leaving room for the outline.
+			final int x = 4;
+			final int y = 5;
+			final int w = SIZE - 8;
+			final int h = SIZE - 11;
+
+			// Drop shadow for contrast on light backgrounds.
+			g.setColor(new Color(0, 0, 0, 90));
+			g.fillRoundRect(x + 1, y + 2, w, h, 5, 5);
+
+			// Cover fill.
+			g.setColor(BOOK_FILL);
+			g.fillRoundRect(x, y, w, h, 5, 5);
+
+			// Outline.
+			g.setColor(BOOK_OUTLINE);
+			g.setStroke(new BasicStroke(1.5f));
+			g.drawRoundRect(x, y, w, h, 5, 5);
+
+			// Spine down the middle.
+			int spineX = x + w / 2;
+			g.drawLine(spineX, y + 2, spineX, y + h - 2);
+
+			// Two short page lines per side to read as text/pages.
+			g.setColor(PAGE_LINE);
+			g.setStroke(new BasicStroke(1f));
+			int leftStart = x + 3;
+			int leftEnd = spineX - 3;
+			int rightStart = spineX + 3;
+			int rightEnd = x + w - 3;
+			int line1Y = y + h / 3;
+			int line2Y = y + (2 * h) / 3;
+			g.drawLine(leftStart, line1Y, leftEnd, line1Y);
+			g.drawLine(leftStart, line2Y, leftEnd, line2Y);
+			g.drawLine(rightStart, line1Y, rightEnd, line1Y);
+			g.drawLine(rightStart, line2Y, rightEnd, line2Y);
+		}
+		finally
+		{
+			g.dispose();
+		}
+		return img;
+	}
+}

--- a/src/main/java/com/collectionloghelper/overlay/ObjectHighlightOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/ObjectHighlightOverlay.java
@@ -31,7 +31,6 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Shape;
-import java.awt.image.BufferedImage;
 import lombok.extern.slf4j.Slf4j;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -44,7 +43,6 @@ import net.runelite.client.callback.ClientThread;
 import net.runelite.api.DecorativeObject;
 import net.runelite.api.GameObject;
 import net.runelite.api.GroundObject;
-import net.runelite.api.Perspective;
 import net.runelite.api.Point;
 import net.runelite.api.Scene;
 import net.runelite.api.Tile;
@@ -58,7 +56,6 @@ import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.outline.ModelOutlineRenderer;
 import net.runelite.client.ui.overlay.tooltip.Tooltip;
 import net.runelite.client.ui.overlay.tooltip.TooltipManager;
-import net.runelite.client.util.ImageUtil;
 
 @Slf4j
 @Singleton
@@ -67,18 +64,17 @@ public class ObjectHighlightOverlay extends Overlay
 	private static final BasicStroke STROKE_1_5 = new BasicStroke(1.5f);
 	private static final int GLOW_OUTLINE_WIDTH = 2;
 	private static final int GLOW_FEATHER = 4;
-	private static final int MARKER_SIZE = 18;
-	private static final int MARKER_HEIGHT_OFFSET = 60;
 
 	private final Client client;
 	private final ClientThread clientThread;
 	private final CollectionLogHelperConfig config;
 
 	/**
-	 * Marker icon drawn over each highlighted target. Loaded and resized once
-	 * at construction so the render hot-path performs no IO or allocation.
+	 * Floating collection-log marker drawn above each highlighted target. The glyph
+	 * is rasterised once at construction so the render hot-path performs no IO or
+	 * allocation.
 	 */
-	private final BufferedImage markerIcon;
+	private final GuidanceTargetMarker targetMarker = new GuidanceTargetMarker();
 
 	@Inject
 	private TooltipManager tooltipManager;
@@ -108,28 +104,8 @@ public class ObjectHighlightOverlay extends Overlay
 		this.client = client;
 		this.clientThread = clientThread;
 		this.config = config;
-		this.markerIcon = loadMarkerIcon();
 		setPosition(OverlayPosition.DYNAMIC);
 		setLayer(OverlayLayer.ABOVE_SCENE);
-	}
-
-	private static BufferedImage loadMarkerIcon()
-	{
-		try
-		{
-			BufferedImage raw = ImageUtil.loadImageResource(
-				ObjectHighlightOverlay.class, "/com/collectionloghelper/panel_icon.png");
-			if (raw == null)
-			{
-				return null;
-			}
-			return ImageUtil.resizeImage(raw, MARKER_SIZE, MARKER_SIZE);
-		}
-		catch (RuntimeException e)
-		{
-			log.warn("Failed to load guidance target marker icon", e);
-			return null;
-		}
 	}
 
 	public void setTargetObjectId(int objectId)
@@ -356,22 +332,17 @@ public class ObjectHighlightOverlay extends Overlay
 	}
 
 	/**
-	 * Draws the cached marker icon centered above the target's on-screen position.
-	 * No-op when the icon failed to load, the config toggle is off, or the target
-	 * has no projectable canvas location. Allocates nothing on the render path.
+	 * Draws the floating collection-log marker above the target's on-screen
+	 * position. No-op when the config toggle is off or the target has no
+	 * projectable canvas location. Allocates nothing on the render path.
 	 */
 	private void drawTargetMarker(Graphics2D graphics, LocalPoint localPoint)
 	{
-		if (markerIcon == null || localPoint == null || !config.showGuidanceTargetMarker())
+		if (!config.showGuidanceTargetMarker())
 		{
 			return;
 		}
-		Point canvasPoint = Perspective.getCanvasImageLocation(
-			client, localPoint, markerIcon, MARKER_HEIGHT_OFFSET);
-		if (canvasPoint != null)
-		{
-			graphics.drawImage(markerIcon, canvasPoint.getX(), canvasPoint.getY(), null);
-		}
+		targetMarker.draw(graphics, client, localPoint);
 	}
 
 	private boolean passesTileFilter(TileObject obj)

--- a/src/test/java/com/collectionloghelper/overlay/GuidanceTargetMarkerTest.java
+++ b/src/test/java/com/collectionloghelper/overlay/GuidanceTargetMarkerTest.java
@@ -23,30 +23,61 @@
  */
 package com.collectionloghelper.overlay;
 
-import com.collectionloghelper.CollectionLogHelperConfig;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
-import java.awt.image.BufferedImage;
 import net.runelite.api.Client;
 import net.runelite.client.callback.ClientThread;
+import com.collectionloghelper.CollectionLogHelperConfig;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 /**
- * Verifies the guidance target marker icon is loaded and resized once at
- * overlay construction (the render hot-path must not perform IO). The actual
- * in-world drawing cannot be exercised headless, so these tests confirm the
- * icon resource resolves and is sized as expected.
+ * Verifies the floating guidance target marker glyph is rasterised once at
+ * construction (the render hot-path must not perform IO or allocation). The
+ * earlier implementation (#714) blitted the 16x16 panel book PNG resized to
+ * 18px, which read as an illegible blue blob on the target. The marker is now a
+ * programmatically-drawn book glyph that floats above the target. The in-world
+ * projection cannot be exercised headless, so these tests confirm the glyph
+ * builds, has positive dimensions, and that both overlays hold a marker
+ * instance.
  */
 public class GuidanceTargetMarkerTest
 {
-	private static final int EXPECTED_MARKER_SIZE = 18;
+	@Test
+	public void glyphIsBuiltWithPositiveDimensions()
+	{
+		GuidanceTargetMarker marker = new GuidanceTargetMarker();
+		BufferedImage glyph = readGlyph(marker);
+		assertNotNull(glyph, "marker glyph should be rasterised at construction");
+		assertTrue(glyph.getWidth() > 0, "glyph width should be positive");
+		assertTrue(glyph.getHeight() > 0, "glyph height should be positive");
+	}
 
 	@Test
-	public void objectOverlayLoadsResizedMarkerIcon() throws Exception
+	public void drawWithNullLocalPointIsNoOp()
+	{
+		GuidanceTargetMarker marker = new GuidanceTargetMarker();
+		Client client = mock(Client.class);
+		BufferedImage canvas = new BufferedImage(64, 64, BufferedImage.TYPE_INT_ARGB);
+		Graphics2D g = canvas.createGraphics();
+		try
+		{
+			assertDoesNotThrow(() -> marker.draw(g, client, null));
+		}
+		finally
+		{
+			g.dispose();
+		}
+	}
+
+	@Test
+	public void objectOverlayHoldsMarkerInstance() throws Exception
 	{
 		Client client = mock(Client.class);
 		ClientThread clientThread = mock(ClientThread.class);
@@ -57,14 +88,11 @@ public class GuidanceTargetMarkerTest
 		ctor.setAccessible(true);
 		ObjectHighlightOverlay overlay = ctor.newInstance(client, clientThread, config);
 
-		BufferedImage icon = readMarkerIcon(overlay);
-		assertNotNull(icon, "marker icon should load from the classpath resource");
-		assertEquals(EXPECTED_MARKER_SIZE, icon.getWidth());
-		assertEquals(EXPECTED_MARKER_SIZE, icon.getHeight());
+		assertNotNull(readMarker(overlay), "object overlay should hold a target marker");
 	}
 
 	@Test
-	public void groundItemOverlayLoadsResizedMarkerIcon() throws Exception
+	public void groundItemOverlayHoldsMarkerInstance() throws Exception
 	{
 		Client client = mock(Client.class);
 		CollectionLogHelperConfig config = mock(CollectionLogHelperConfig.class);
@@ -74,16 +102,27 @@ public class GuidanceTargetMarkerTest
 		ctor.setAccessible(true);
 		GroundItemHighlightOverlay overlay = ctor.newInstance(client, config);
 
-		BufferedImage icon = readMarkerIcon(overlay);
-		assertNotNull(icon, "marker icon should load from the classpath resource");
-		assertEquals(EXPECTED_MARKER_SIZE, icon.getWidth());
-		assertEquals(EXPECTED_MARKER_SIZE, icon.getHeight());
+		assertNotNull(readMarker(overlay), "ground-item overlay should hold a target marker");
 	}
 
-	private static BufferedImage readMarkerIcon(Object overlay) throws Exception
+	private static BufferedImage readGlyph(GuidanceTargetMarker marker)
 	{
-		Field field = overlay.getClass().getDeclaredField("markerIcon");
+		try
+		{
+			Field field = GuidanceTargetMarker.class.getDeclaredField("glyph");
+			field.setAccessible(true);
+			return (BufferedImage) field.get(marker);
+		}
+		catch (ReflectiveOperationException e)
+		{
+			throw new IllegalStateException(e);
+		}
+	}
+
+	private static GuidanceTargetMarker readMarker(Object overlay) throws Exception
+	{
+		Field field = overlay.getClass().getDeclaredField("targetMarker");
 		field.setAccessible(true);
-		return (BufferedImage) field.get(overlay);
+		return (GuidanceTargetMarker) field.get(overlay);
 	}
 }


### PR DESCRIPTION
Reworks the broken #706 marker shipped in #714. panel_icon.png (16px low-contrast side-panel icon) was illegible as a world marker. Now a programmatic 26px open-book glyph floats ~80px above object/ground-item targets; allocated once; gated by showGuidanceTargetMarker. Ground-item outline confirmed intact; NPC path unchanged.

Test plan: build+tests green; **LIVE validation needed** -- glyph legibility/size at game distances and the 80px float height above objects vs ground items.