### PR TITLE
fix(guidance): don't auto-stop guidance mid-loop on target-item obtain

### DIFF
--- a/src/main/java/com/collectionloghelper/guidance/GuidanceSequencer.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceSequencer.java
@@ -417,6 +417,13 @@ public class GuidanceSequencer
 	 * already set, so {@link #wasTargetSlotUnlocked()} reports {@code true}). Without
 	 * this, guidance could stay pinned on a completed item because the final step's
 	 * own completion condition (inventory / chat) had not yet fired (#708).
+	 *
+	 * <p>The auto-complete shortcut only applies to single-pass guidance. When the
+	 * current step is mid-loop (it declares a loop-back and the loop is not yet
+	 * exhausted, e.g. Shades of Mort'ton cycling chest opens), obtaining a target
+	 * item only records the unlock flag and falls through to the normal
+	 * step-completion / loop-back path — completing the sequence here would kill the
+	 * loop and leave stale highlights (#715).
 	 */
 	public void onItemObtained(int itemId)
 	{
@@ -433,6 +440,15 @@ public class GuidanceSequencer
 				if (item.getItemId() == itemId)
 				{
 					targetSlotUnlocked = true;
+					if (isCurrentStepMidLoop())
+					{
+						// Looping source mid-loop: do NOT complete the sequence. Record the
+						// unlock and let the normal step-completion / loop-back logic continue
+						// cycling the loop.
+						log.info("Target slot unlocked for {} (itemId={}) mid-loop — keeping guidance active",
+							activeSource.getName(), itemId);
+						break;
+					}
 					log.info("Target slot unlocked for {} (itemId={}) — completing guidance",
 						activeSource.getName(), itemId);
 					// The guided collection-log item was obtained: the sequence is done,
@@ -717,6 +733,26 @@ public class GuidanceSequencer
 			log.info("{} step {}/{}: {}", label, currentIndex + 1, currentSteps.size(), step.getDescription());
 			notifyStepChanged(step);
 		}
+	}
+
+	/**
+	 * Returns {@code true} when the current step is part of an active, not-yet-exhausted
+	 * loop. A step loops when it declares both {@code loopBackToStep > 0} and
+	 * {@code loopCount > 0}; the loop is still active while more iterations remain.
+	 *
+	 * <p>The exhaustion test mirrors {@link StepAdvancer#advance}: completing the step
+	 * increments the iteration counter, and the loop only continues while
+	 * {@code loopIterationsCompleted + 1 < loopCount}. On the final iteration this
+	 * returns {@code false}, so a genuinely-last loop pass still allows the sequence to
+	 * complete normally.
+	 */
+	private boolean isCurrentStepMidLoop()
+	{
+		GuidanceStep step = getRawCurrentStep();
+		return step != null
+			&& step.getLoopBackToStep() > 0
+			&& step.getLoopCount() > 0
+			&& loopIterationsCompleted + 1 < step.getLoopCount();
 	}
 
 	private void fireSequenceComplete()

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
@@ -761,6 +761,79 @@ public class GuidanceSequencerTest
 		assertEquals(0, sequencer.getCurrentIndex());
 	}
 
+	/**
+	 * Regression test for #715: for a multi-step LOOPING source (e.g. Shades of
+	 * Mort'ton), obtaining a target collection-log item mid-loop must NOT deactivate
+	 * guidance. PR #713 added an auto-complete shortcut on target obtain; for an
+	 * active, not-yet-exhausted loop that shortcut killed the loop-back. The unlock
+	 * flag is still recorded, but guidance stays active and the loop logic proceeds.
+	 */
+	@Test
+	public void testObtainingTargetItemMidLoopKeepsGuidanceActive()
+	{
+		int targetItemId = 28163;
+
+		// Step 2 loops back to step 1 three times.
+		List<GuidanceStep> steps = Arrays.asList(
+			makeManualStep("Light a shade"),
+			makeLoopingStep("Open the chest", CompletionCondition.ACTOR_DEATH, 100, 1, 3)
+		);
+
+		AtomicBoolean completed = new AtomicBoolean(false);
+		CollectionLogSource source = makeSourceWithItems("Shades of Mort'ton", steps,
+			Arrays.asList(makeItem(targetItemId, "Bronze locks")));
+		sequencer.startSequence(source, s -> {}, () -> completed.set(true));
+
+		// Advance onto the looping step (index 1), loop not yet started.
+		sequencer.advanceStep();
+		assertEquals(1, sequencer.getCurrentIndex());
+		assertEquals(0, sequencer.getLoopIterationsCompleted());
+
+		// Obtaining the target item mid-loop must NOT deactivate guidance.
+		sequencer.onItemObtained(targetItemId);
+
+		assertTrue(sequencer.wasTargetSlotUnlocked(), "unlock flag still recorded");
+		assertFalse(completed.get(), "sequence-complete must NOT fire mid-loop");
+		assertTrue(sequencer.isActive(), "guidance must stay active mid-loop");
+
+		// Loop logic still proceeds: completing the step loops back to step 1.
+		sequencer.onNpcDeath(100);
+		assertEquals(1, sequencer.getLoopIterationsCompleted());
+		assertEquals(0, sequencer.getCurrentIndex());
+		assertTrue(sequencer.isActive());
+	}
+
+	/**
+	 * Companion to #715: a single-pass (non-looping) source must preserve #713's
+	 * behavior — obtaining the target item fires completion and deactivates guidance.
+	 */
+	@Test
+	public void testObtainingTargetItemSinglePassStillCompletes()
+	{
+		int targetItemId = 28163;
+
+		// No loop on any step.
+		List<GuidanceStep> steps = Arrays.asList(
+			makeManualStep("Travel"),
+			makeManualStep("Open the chest")
+		);
+
+		AtomicBoolean completed = new AtomicBoolean(false);
+		CollectionLogSource source = makeSourceWithItems("Some Boss", steps,
+			Arrays.asList(makeItem(targetItemId, "Pet")));
+		sequencer.startSequence(source, s -> {}, () -> completed.set(true));
+
+		sequencer.advanceStep();
+		assertEquals(1, sequencer.getCurrentIndex());
+		assertTrue(sequencer.isActive());
+
+		sequencer.onItemObtained(targetItemId);
+
+		assertTrue(sequencer.wasTargetSlotUnlocked());
+		assertTrue(completed.get(), "single-pass target obtain must fire completion (#713)");
+		assertFalse(sequencer.isActive(), "single-pass target obtain must deactivate guidance");
+	}
+
 	@Test
 	public void testInventoryHasItemCompletesStep()
 	{


### PR DESCRIPTION
Fixes the loop-back regression from #713 (reported live at Shades of Mort'ton, image #12).

## Cause
#713's `onItemObtained` fired `fireSequenceComplete()` on obtaining any target collection-log item, which for multi-step looping sources (Shades) killed the `loopBackToStep` cycle mid-loop.

## Fix
New guard `isCurrentStepMidLoop()` (loopBackToStep > 0 && loopCount > 0 && loopIterationsCompleted + 1 < loopCount -- identical to StepAdvancer's condition, so the final iteration still completes). When mid-loop, record the unlock and fall through to normal loop/step advancement instead of completing. Single-pass auto-stop (#713) preserved.

## Test plan
- [x] build + tests green
- [x] `testObtainingTargetItemMidLoopKeepsGuidanceActive` (looping: stays active, loops back) + `testObtainingTargetItemSinglePassStillCompletes` (#713 preserved)
- [ ] LIVE: at Shades, obtaining a lock mid-run no longer stops/derails guidance; loop continues