### PR TITLE
feat(overlay): use the real collection-log book sprite for the guidance target marker (#720)

### DIFF
--- a/src/main/java/com/collectionloghelper/overlay/GroundItemHighlightOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/GroundItemHighlightOverlay.java
@@ -47,6 +47,7 @@ import net.runelite.api.Point;
 import net.runelite.api.Tile;
 import net.runelite.api.TileItem;
 import net.runelite.api.coords.LocalPoint;
+import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -68,10 +69,10 @@ public class GroundItemHighlightOverlay extends Overlay
 
 	/**
 	 * Floating collection-log marker drawn above each highlighted ground item.
-	 * The glyph is rasterised once at construction so the render hot-path
-	 * performs no IO or allocation.
+	 * Assigned in the constructor (not inline) so the injected {@link ItemManager}
+	 * is available to resolve the real collection-log sprite (#720).
 	 */
-	private final GuidanceTargetMarker targetMarker = new GuidanceTargetMarker();
+	private final GuidanceTargetMarker targetMarker;
 
 	private volatile Set<Integer> targetGroundItemIds = Collections.emptySet();
 
@@ -85,10 +86,11 @@ public class GroundItemHighlightOverlay extends Overlay
 	private Color cachedFillColor;
 
 	@Inject
-	private GroundItemHighlightOverlay(Client client, CollectionLogHelperConfig config)
+	private GroundItemHighlightOverlay(Client client, CollectionLogHelperConfig config, ItemManager itemManager)
 	{
 		this.client = client;
 		this.config = config;
+		this.targetMarker = new GuidanceTargetMarker(itemManager);
 		setPosition(OverlayPosition.DYNAMIC);
 		setLayer(OverlayLayer.ABOVE_SCENE);
 	}

--- a/src/main/java/com/collectionloghelper/overlay/GuidanceTargetMarker.java
+++ b/src/main/java/com/collectionloghelper/overlay/GuidanceTargetMarker.java
@@ -29,49 +29,66 @@ import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.RenderingHints;
 import java.awt.image.BufferedImage;
+import javax.annotation.Nullable;
 import net.runelite.api.Client;
+import net.runelite.api.ItemID;
 import net.runelite.api.Perspective;
 import net.runelite.api.Point;
 import net.runelite.api.coords.LocalPoint;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.util.AsyncBufferedImage;
 
 /**
  * Shared floating "collection-log target" marker for in-world guidance overlays.
  *
- * <p>The previous implementation (#714) drew the panel's 16x16 cyan-on-transparent
- * book PNG resized to 18px directly on top of the target. At that size the PNG is
- * illegible against the game world - it reads as a blue blob with a line - and
- * sitting on the target rather than above it hid the object. This helper instead
- * draws a clean, programmatic book glyph (the same Java2D drawn-icon approach used
- * by the panel's status/step icons) and projects it ABOVE the target with a
- * vertical pixel offset, quest-helper style.
+ * <p>Renders the real OSRS collection-log book item sprite
+ * ({@link ItemID#COLLECTION_LOG}) floating ABOVE the target with a vertical pixel
+ * offset, quest-helper style — the same sprite the world-map destination overlay
+ * uses, for visual consistency (#720). The sprite is fetched once from
+ * {@link ItemManager} and cached; because {@code getImage} returns an
+ * {@link AsyncBufferedImage} that fills in on a later client tick, a programmatic
+ * book glyph is drawn as a fallback until the sprite has loaded (and remains the
+ * marker if no {@link ItemManager} is available).
  *
- * <p>The glyph is rasterised once into a {@link BufferedImage} at construction so
- * the render hot-path performs no allocation and no IO - it only projects a point
- * and blits the cached image.
+ * <p>Both the glyph and the resolved sprite are cached, so the render hot-path
+ * performs no allocation and no IO - it only projects a point and blits an image.
  */
 final class GuidanceTargetMarker
 {
 	/** Glyph canvas size in pixels - large enough to be legible as a small book. */
 	private static final int SIZE = 26;
 
-	/** Pixels to lift the glyph above the target's canvas point so it floats clear. */
+	/** Pixels to lift the marker above the target's canvas point so it floats clear. */
 	private static final int HEIGHT_OFFSET = 80;
 
 	private static final Color BOOK_FILL = new Color(0xE8, 0xC4, 0x6A);
 	private static final Color BOOK_OUTLINE = Color.BLACK;
 	private static final Color PAGE_LINE = new Color(0x3A, 0x2A, 0x10);
 
+	@Nullable
+	private final ItemManager itemManager;
+
+	/** Programmatic fallback glyph, drawn until the real item sprite has loaded. */
 	private final BufferedImage glyph;
 
-	GuidanceTargetMarker()
+	/** Real collection-log book sprite, lazily resolved from {@link ItemManager}. */
+	@Nullable
+	private BufferedImage sprite;
+
+	/** True once {@link #sprite} has finished loading and is safe to blit. */
+	private volatile boolean spriteReady;
+
+	GuidanceTargetMarker(@Nullable ItemManager itemManager)
 	{
+		this.itemManager = itemManager;
 		this.glyph = buildGlyph();
 	}
 
 	/**
-	 * Projects the target's local point to the canvas and blits the cached glyph
-	 * centred horizontally and floating {@link #HEIGHT_OFFSET} pixels above it.
-	 * No-op when the point cannot be projected. Allocates nothing.
+	 * Projects the target's local point to the canvas and blits the marker centred
+	 * horizontally and floating {@link #HEIGHT_OFFSET} pixels above it. Prefers the
+	 * real collection-log sprite once loaded, falling back to the glyph meanwhile.
+	 * No-op when the point cannot be projected. Allocates nothing on the hot path.
 	 */
 	void draw(Graphics2D graphics, Client client, LocalPoint localPoint)
 	{
@@ -79,11 +96,40 @@ final class GuidanceTargetMarker
 		{
 			return;
 		}
-		Point canvasPoint = Perspective.getCanvasImageLocation(client, localPoint, glyph, HEIGHT_OFFSET);
+		BufferedImage image = resolveImage();
+		Point canvasPoint = Perspective.getCanvasImageLocation(client, localPoint, image, HEIGHT_OFFSET);
 		if (canvasPoint != null)
 		{
-			graphics.drawImage(glyph, canvasPoint.getX(), canvasPoint.getY(), null);
+			graphics.drawImage(image, canvasPoint.getX(), canvasPoint.getY(), null);
 		}
+	}
+
+	/**
+	 * Returns the real collection-log sprite once it has loaded, otherwise the
+	 * fallback glyph. The sprite request is made lazily on first draw and cached;
+	 * {@link AsyncBufferedImage#onLoaded} flips {@link #spriteReady} when the pixels
+	 * are ready so we never blit a half-loaded (transparent) image.
+	 */
+	private BufferedImage resolveImage()
+	{
+		if (spriteReady && sprite != null)
+		{
+			return sprite;
+		}
+		if (sprite == null && itemManager != null)
+		{
+			BufferedImage requested = itemManager.getImage(ItemID.COLLECTION_LOG);
+			sprite = requested;
+			if (requested instanceof AsyncBufferedImage)
+			{
+				((AsyncBufferedImage) requested).onLoaded(() -> spriteReady = true);
+			}
+			else if (requested != null)
+			{
+				spriteReady = true;
+			}
+		}
+		return spriteReady && sprite != null ? sprite : glyph;
 	}
 
 	/**

--- a/src/main/java/com/collectionloghelper/overlay/ObjectHighlightOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/ObjectHighlightOverlay.java
@@ -50,6 +50,7 @@ import net.runelite.api.TileObject;
 import net.runelite.api.WallObject;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -70,11 +71,11 @@ public class ObjectHighlightOverlay extends Overlay
 	private final CollectionLogHelperConfig config;
 
 	/**
-	 * Floating collection-log marker drawn above each highlighted target. The glyph
-	 * is rasterised once at construction so the render hot-path performs no IO or
-	 * allocation.
+	 * Floating collection-log marker drawn above each highlighted target. Assigned
+	 * in the constructor (not inline) so the injected {@link ItemManager} is
+	 * available to resolve the real collection-log sprite (#720).
 	 */
-	private final GuidanceTargetMarker targetMarker = new GuidanceTargetMarker();
+	private final GuidanceTargetMarker targetMarker;
 
 	@Inject
 	private TooltipManager tooltipManager;
@@ -99,11 +100,13 @@ public class ObjectHighlightOverlay extends Overlay
 	private volatile List<TileObject> matchedObjects = Collections.emptyList();
 
 	@Inject
-	private ObjectHighlightOverlay(Client client, ClientThread clientThread, CollectionLogHelperConfig config)
+	private ObjectHighlightOverlay(Client client, ClientThread clientThread, CollectionLogHelperConfig config,
+		ItemManager itemManager)
 	{
 		this.client = client;
 		this.clientThread = clientThread;
 		this.config = config;
+		this.targetMarker = new GuidanceTargetMarker(itemManager);
 		setPosition(OverlayPosition.DYNAMIC);
 		setLayer(OverlayLayer.ABOVE_SCENE);
 	}

--- a/src/test/java/com/collectionloghelper/overlay/GuidanceTargetMarkerTest.java
+++ b/src/test/java/com/collectionloghelper/overlay/GuidanceTargetMarkerTest.java
@@ -27,32 +27,39 @@ import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import net.runelite.api.Client;
+import net.runelite.api.ItemID;
 import net.runelite.client.callback.ClientThread;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.util.AsyncBufferedImage;
 import com.collectionloghelper.CollectionLogHelperConfig;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 /**
- * Verifies the floating guidance target marker glyph is rasterised once at
- * construction (the render hot-path must not perform IO or allocation). The
- * earlier implementation (#714) blitted the 16x16 panel book PNG resized to
- * 18px, which read as an illegible blue blob on the target. The marker is now a
- * programmatically-drawn book glyph that floats above the target. The in-world
- * projection cannot be exercised headless, so these tests confirm the glyph
- * builds, has positive dimensions, and that both overlays hold a marker
- * instance.
+ * Verifies the floating guidance target marker. The marker now renders the real
+ * collection-log book item sprite ({@code ItemID.COLLECTION_LOG}) once it loads
+ * from {@link ItemManager} (#720), falling back to a programmatically-drawn book
+ * glyph rasterised once at construction while the async sprite loads (or when no
+ * {@link ItemManager} is available). The in-world projection cannot be exercised
+ * headless, so these tests confirm the glyph builds, the sprite is preferred once
+ * resolved, null local points are no-ops, and both overlays hold a marker.
  */
 public class GuidanceTargetMarkerTest
 {
 	@Test
 	public void glyphIsBuiltWithPositiveDimensions()
 	{
-		GuidanceTargetMarker marker = new GuidanceTargetMarker();
+		GuidanceTargetMarker marker = new GuidanceTargetMarker(null);
 		BufferedImage glyph = readGlyph(marker);
 		assertNotNull(glyph, "marker glyph should be rasterised at construction");
 		assertTrue(glyph.getWidth() > 0, "glyph width should be positive");
@@ -60,9 +67,33 @@ public class GuidanceTargetMarkerTest
 	}
 
 	@Test
+	public void fallsBackToGlyphWhenNoItemManager()
+	{
+		GuidanceTargetMarker marker = new GuidanceTargetMarker(null);
+		assertSame(readGlyph(marker), resolveImage(marker),
+			"with no ItemManager the marker must render the fallback glyph");
+	}
+
+	@Test
+	public void requestsCollectionLogSpriteAndShowsGlyphUntilLoaded()
+	{
+		// getImage returns an AsyncBufferedImage that has not finished loading, so
+		// the marker keeps showing the glyph until the async onLoaded callback fires.
+		AsyncBufferedImage sprite = mock(AsyncBufferedImage.class);
+		ItemManager itemManager = mock(ItemManager.class);
+		lenient().when(itemManager.getImage(anyInt())).thenReturn(sprite);
+
+		GuidanceTargetMarker marker = new GuidanceTargetMarker(itemManager);
+		assertSame(readGlyph(marker), resolveImage(marker),
+			"glyph shown until the async sprite reports loaded");
+		// The marker must request the real collection-log book sprite, not some other item.
+		verify(itemManager).getImage(ItemID.COLLECTION_LOG);
+	}
+
+	@Test
 	public void drawWithNullLocalPointIsNoOp()
 	{
-		GuidanceTargetMarker marker = new GuidanceTargetMarker();
+		GuidanceTargetMarker marker = new GuidanceTargetMarker(null);
 		Client client = mock(Client.class);
 		BufferedImage canvas = new BufferedImage(64, 64, BufferedImage.TYPE_INT_ARGB);
 		Graphics2D g = canvas.createGraphics();
@@ -82,11 +113,12 @@ public class GuidanceTargetMarkerTest
 		Client client = mock(Client.class);
 		ClientThread clientThread = mock(ClientThread.class);
 		CollectionLogHelperConfig config = mock(CollectionLogHelperConfig.class);
+		ItemManager itemManager = mock(ItemManager.class);
 
-		Constructor<ObjectHighlightOverlay> ctor = ObjectHighlightOverlay.class
-			.getDeclaredConstructor(Client.class, ClientThread.class, CollectionLogHelperConfig.class);
+		Constructor<ObjectHighlightOverlay> ctor = ObjectHighlightOverlay.class.getDeclaredConstructor(
+			Client.class, ClientThread.class, CollectionLogHelperConfig.class, ItemManager.class);
 		ctor.setAccessible(true);
-		ObjectHighlightOverlay overlay = ctor.newInstance(client, clientThread, config);
+		ObjectHighlightOverlay overlay = ctor.newInstance(client, clientThread, config, itemManager);
 
 		assertNotNull(readMarker(overlay), "object overlay should hold a target marker");
 	}
@@ -96,13 +128,28 @@ public class GuidanceTargetMarkerTest
 	{
 		Client client = mock(Client.class);
 		CollectionLogHelperConfig config = mock(CollectionLogHelperConfig.class);
+		ItemManager itemManager = mock(ItemManager.class);
 
 		Constructor<GroundItemHighlightOverlay> ctor = GroundItemHighlightOverlay.class
-			.getDeclaredConstructor(Client.class, CollectionLogHelperConfig.class);
+			.getDeclaredConstructor(Client.class, CollectionLogHelperConfig.class, ItemManager.class);
 		ctor.setAccessible(true);
-		GroundItemHighlightOverlay overlay = ctor.newInstance(client, config);
+		GroundItemHighlightOverlay overlay = ctor.newInstance(client, config, itemManager);
 
 		assertNotNull(readMarker(overlay), "ground-item overlay should hold a target marker");
+	}
+
+	private static BufferedImage resolveImage(GuidanceTargetMarker marker)
+	{
+		try
+		{
+			Method m = GuidanceTargetMarker.class.getDeclaredMethod("resolveImage");
+			m.setAccessible(true);
+			return (BufferedImage) m.invoke(marker);
+		}
+		catch (ReflectiveOperationException e)
+		{
+			throw new IllegalStateException(e);
+		}
 	}
 
 	private static BufferedImage readGlyph(GuidanceTargetMarker marker)


### PR DESCRIPTION
## What

Replaces the programmatic Java2D book glyph (#715) used for the in-world guidance target marker with the **actual OSRS collection-log book item sprite** (`ItemID.COLLECTION_LOG`) — the same sprite the world-map destination overlay already uses — for visual consistency. Closes #720.

## How

- `GuidanceTargetMarker` now takes an `ItemManager` and lazily resolves + caches the collection-log sprite. `ItemManager.getImage` returns an `AsyncBufferedImage` that fills in on a later client tick, so the programmatic glyph is kept as a **fallback** until the sprite reports loaded via `onLoaded` (and remains the marker when no `ItemManager` is available, e.g. in tests).
- `ObjectHighlightOverlay` and `GroundItemHighlightOverlay` inject `ItemManager` and construct the marker in their constructor bodies (an injected dependency is not available to an inline field initializer).
- Render hot-path still allocates nothing: glyph and resolved sprite are both cached; `draw` only projects a point and blits.
- The `showGuidanceTargetMarker` config toggle and the ~80px float offset are unchanged.

## Test plan

- [x] `GuidanceTargetMarkerTest`: glyph builds; falls back to glyph with no `ItemManager`; requests `ItemID.COLLECTION_LOG` and shows the glyph until the async sprite loads; null local point is a no-op; both overlays hold a marker (constructors updated for the new `ItemManager` param).
- [x] Full `./gradlew test` green.
- [ ] In-client: confirm the floating marker above object/ground-item targets shows the real book sprite (tune size/offset if needed).