### PR TITLE
fix(data): correct mis-authored recommended items for Swordfish + Aerial Fishing (#712)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -18499,10 +18499,7 @@
         "completionCondition": "MANUAL",
         "section": "Fish",
         "recommendedItemIds": [
-          22846,
-          22844,
-          22842,
-          1733
+          946
         ],
         "loopBackToStep": 3,
         "loopCount": 0
@@ -30026,8 +30023,8 @@
         "completionCondition": "MANUAL",
         "section": "Fish",
         "recommendedItemIds": [
-          311,
-          12637
+          21028,
+          21031
         ],
         "loopBackToStep": 3,
         "loopCount": 0


### PR DESCRIPTION
## What

Fixes two pre-existing `recommendedItemIds` authoring errors found during the recommended-as-aids audit. Closes #712.

| Source | Before | After | Why |
|--------|--------|-------|-----|
| Fishing (Swordfish) | `311` (Harpoon), `12637` (**Saradomin halo**) | `21028` (Dragon harpoon), `21031` (Infernal harpoon) | A Castle Wars halo is nonsensical for harpoon fishing. The basic harpoon is already the step-1 *required* item; the recommended list should surface the speed-boosting harpoon upgrades. |
| Aerial Fishing | `22846/22844/22842` (**Pearl rods**), `1733` (**Needle**) | `946` (Knife) | Pearl rods are molch-pearl shop rewards used for normal/fly/barbarian fishing, not cormorant aerial fishing. Needle (1733) was a typo for Knife (946), used to cut catches into fish offcuts for bait. |

All IDs verified via `runelite_id_lookup` (note `12637` = `CASTLEWARS_SARADOMIN_HALO`, `1733` = `NEEDLE`, `946` = `KNIFE`, `21028`/`21031` = Dragon/Infernal harpoon).

## Test plan

- [x] `./gradlew test --tests com.collectionloghelper.data.*` green (drop_rates regression suite).
- [x] `data_ascii_lint` clean.