### PR TITLE
fix: correct recommended items for Swordfish and Aerial Fishing

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -18499,10 +18499,7 @@
         "completionCondition": "MANUAL",
         "section": "Fish",
         "recommendedItemIds": [
-          22846,
-          22844,
-          22842,
-          1733
+          946
         ],
         "loopBackToStep": 3,
         "loopCount": 0
@@ -30027,7 +30024,9 @@
         "section": "Fish",
         "recommendedItemIds": [
           311,
-          12637
+          21028,
+          21031,
+          23762
         ],
         "loopBackToStep": 3,
         "loopCount": 0

--- a/src/test/java/com/collectionloghelper/data/RecommendedItemsIssue712RegressionTest.java
+++ b/src/test/java/com/collectionloghelper/data/RecommendedItemsIssue712RegressionTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ */
+package com.collectionloghelper.data;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Issue #712 guard - two skilling sources carried mis-authored recommendedItemIds.
+ *
+ * Fishing (Swordfish) listed Saradomin halo (12637), which has nothing to do with
+ * harpoon fishing; the correct aids are a Harpoon or better.
+ *
+ * Aerial Fishing listed three Pearl fishing rods (22842/22844/22846) plus Needle
+ * (1733); aerial fishing equips a free cormorant glove and uses gathered bait, so
+ * the only genuine recommended item is a Knife (946) for cutting fish offcuts.
+ */
+public class RecommendedItemsIssue712RegressionTest
+{
+	private static final String SWORDFISH = "Fishing (Swordfish)";
+	private static final String AERIAL_FISHING = "Aerial Fishing";
+
+	private static final int SARADOMIN_HALO = 12637;
+	private static final int HARPOON = 311;
+	private static final int DRAGON_HARPOON = 21028;
+	private static final int INFERNAL_HARPOON = 21031;
+	private static final int CRYSTAL_HARPOON = 23762;
+
+	private static final int KNIFE = 946;
+	private static final int NEEDLE = 1733;
+	private static final List<Integer> PEARL_RODS = List.of(22842, 22844, 22846);
+
+	private DropRateDatabase database;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		database = new DropRateDatabase();
+		Gson gson = new GsonBuilder().create();
+		Field gsonField = DropRateDatabase.class.getDeclaredField("gson");
+		gsonField.setAccessible(true);
+		gsonField.set(database, gson);
+		database.load();
+	}
+
+	private CollectionLogSource source(String name)
+	{
+		CollectionLogSource source = database.getAllSources().stream()
+			.filter(s -> name.equals(s.getName()))
+			.findFirst()
+			.orElse(null);
+		assertNotNull(source, "missing source: " + name);
+		return source;
+	}
+
+	private List<Integer> recommendedItemIds(String name)
+	{
+		return source(name).getGuidanceSteps().stream()
+			.filter(s -> s.getRecommendedItemIds() != null && !s.getRecommendedItemIds().isEmpty())
+			.flatMap(s -> s.getRecommendedItemIds().stream())
+			.distinct()
+			.collect(Collectors.toList());
+	}
+
+	@Test
+	public void swordfishHasHarpoonsNotHalo()
+	{
+		List<Integer> recommended = recommendedItemIds(SWORDFISH);
+
+		assertFalse(recommended.contains(SARADOMIN_HALO),
+			SWORDFISH + " must not recommend Saradomin halo (12637)");
+
+		assertTrue(recommended.contains(HARPOON),
+			SWORDFISH + " should recommend Harpoon (311)");
+		assertTrue(recommended.contains(DRAGON_HARPOON),
+			SWORDFISH + " should recommend Dragon harpoon (21028)");
+		assertTrue(recommended.contains(INFERNAL_HARPOON),
+			SWORDFISH + " should recommend Infernal harpoon (21031)");
+		assertTrue(recommended.contains(CRYSTAL_HARPOON),
+			SWORDFISH + " should recommend Crystal harpoon (23762)");
+	}
+
+	@Test
+	public void aerialFishingHasKnifeNotPearlRodsOrNeedle()
+	{
+		List<Integer> recommended = recommendedItemIds(AERIAL_FISHING);
+
+		assertFalse(recommended.contains(NEEDLE),
+			AERIAL_FISHING + " must not recommend Needle (1733)");
+		for (int pearlRod : PEARL_RODS)
+		{
+			assertFalse(recommended.contains(pearlRod),
+				AERIAL_FISHING + " must not recommend Pearl rod (" + pearlRod + ")");
+		}
+
+		assertTrue(recommended.contains(KNIFE),
+			AERIAL_FISHING + " should recommend Knife (946)");
+	}
+}


### PR DESCRIPTION
## Summary

Fixes two pre-existing mis-authored `recommendedItemIds` entries surfaced in #712. These were authoring errors (wrong items), unrelated to the aids/on-site model.

### Fishing (Swordfish)
- **Before:** `[311, 12637]` — Harpoon + Saradomin halo. The halo (12637) has nothing to do with harpoon fishing.
- **After:** `[311, 21028, 21031, 23762]` — Harpoon, Dragon harpoon, Infernal harpoon, Crystal harpoon.

### Aerial Fishing
- **Before:** `[22846, 22844, 22842, 1733]` — three Pearl fishing rods + Needle. Pearl rods are point-shop rewards (not used in the activity); the activity equips a free cormorant glove from Alry the Angler and uses gathered bait. Needle (1733) was a typo.
- **After:** `[946]` — Knife, used to cut catches into stackable fish offcuts (the only genuine on-hand item per the wiki).

All item IDs verified against RuneLite `ItemID` constants. Note: RuneLite's `CRYSTAL_HARPOON` constant is 23762 (23864 is `GAUNTLET_HARPOON`).

## Test plan

- [x] Added `RecommendedItemsIssue712RegressionTest` asserting bad IDs (12637; 22842/22844/22846; 1733) are absent and the corrected IDs are present.
- [x] `./gradlew build` passes (includes `lintDropRates` + full JUnit suite).
- [x] `validate_drop_rates` clean for both sources; `data_ascii_lint` clean.

Fixes #712
