### PR TITLE
feat(guidance): keep recurring-item highlight active past the first pickup

### DIFF
--- a/src/main/java/com/collectionloghelper/guidance/GuidanceSequencer.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceSequencer.java
@@ -562,9 +562,18 @@ public class GuidanceSequencer
 
 		GuidanceStep step = getRawCurrentStep();
 
-		// Auto-advance if skipIfHasAnyItemIds is now satisfied (e.g., key just entered inventory)
+		// Auto-advance if skipIfHasAnyItemIds is now satisfied (e.g., key just entered inventory).
+		//
+		// Exception (#707): in a looping / restock activity the player must keep
+		// gathering many of a recurring item (e.g. several Shade keys per catacomb
+		// run) before moving on. Auto-advancing off the gather step after the FIRST
+		// pickup clears its in-game highlight prematurely, so the player loses sight
+		// of the remaining keys to collect. While the sequence is a looping/restock
+		// activity, suppress the skip auto-advance so the gather step — and its
+		// highlight — stays active until the player advances manually (Next/Skip) or
+		// the loop naturally re-enters it.
 		CompletionChecker.SkipIfHasAnyResult skip = completionChecker.evaluateSkipIfHasAny(step);
-		if (skip.matched())
+		if (skip.matched() && !isRecurringGatherSequence())
 		{
 			log.info("Step {} auto-advancing (skipIfHasAnyItemIds satisfied: item {})",
 				currentIndex + 1, skip.matchedItemId());
@@ -842,6 +851,33 @@ public class GuidanceSequencer
 			&& step.getLoopBackToStep() > 0
 			&& step.getLoopCount() > 0
 			&& loopIterationsCompleted + 1 < step.getLoopCount();
+	}
+
+	/**
+	 * Returns {@code true} when the active sequence is a looping / restock activity
+	 * — i.e. any step declares loop-fuel via {@code restockIfMissingAllItemIds}
+	 * (#719). Such sequences expect the player to keep gathering many of a recurring
+	 * consumable, so the gather step's {@code skipIfHasAnyItemIds} auto-advance is
+	 * suppressed to keep that step's highlight active past the first pickup (#707).
+	 *
+	 * <p>Reuses the existing restock-fuel signal rather than introducing a new
+	 * schema field: a sequence only carries that field when it is built around a
+	 * consume-many loop.
+	 */
+	private boolean isRecurringGatherSequence()
+	{
+		if (steps == null)
+		{
+			return false;
+		}
+		for (GuidanceStep step : steps)
+		{
+			if (step != null && !step.getRestockIfMissingAllItemIds().isEmpty())
+			{
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerRestockTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerRestockTest.java
@@ -165,6 +165,35 @@ public class GuidanceSequencerRestockTest
 		assertFalse(awaitingRestock());
 	}
 
+	/**
+	 * #707: in a looping / restock activity the gather step highlights a recurring
+	 * item (the shade keys). Obtaining the first key must NOT auto-advance off that
+	 * step via {@code skipIfHasAnyItemIds}, so the in-game highlight persists while
+	 * the player keeps collecting. The gather step stays active (its highlight target
+	 * unchanged) until the player advances manually or the loop re-enters it.
+	 */
+	@Test
+	public void recurringGatherStepKeepsHighlightAfterFirstPickup() throws Exception
+	{
+		AtomicReference<GuidanceStep> lastStep = new AtomicReference<>();
+		sequencer.setPlayerLocation(new WorldPoint(0, 0, 0));
+		sequencer.startSequence(makeSource(gatherLoopSteps()), lastStep::set, () -> { });
+
+		// Precondition: parked on the gather step (index 0) highlighting the keys.
+		assertEquals(0, sequencer.getCurrentIndex(), "precondition: on the gather step");
+		assertEquals(Collections.singletonList(KEY), lastStep.get().getGroundItemIds(),
+			"precondition: gather step highlights the recurring key");
+
+		// Player picks up ONE key — skipIfHasAnyItemIds would normally auto-advance.
+		when(inventoryState.hasItem(KEY)).thenReturn(true);
+		sequencer.onInventoryChanged();
+
+		assertEquals(0, sequencer.getCurrentIndex(),
+			"recurring gather step must stay active so its highlight persists past the first pickup");
+		assertEquals(Collections.singletonList(KEY), lastStep.get().getGroundItemIds(),
+			"highlight target should remain the recurring key");
+	}
+
 	// ---- Scenario helpers ----
 
 	private void startAtLoopStep(AtomicReference<GuidanceStep> lastStep)
@@ -179,6 +208,62 @@ public class GuidanceSequencerRestockTest
 			sequencer.advanceStep();
 		}
 		assertEquals(LOOP_STEP_INDEX, sequencer.getCurrentIndex(), "precondition: parked on the loop step");
+	}
+
+	/**
+	 * Minimal looping gather sequence (#707): a gather step that highlights the
+	 * recurring key on the ground and declares {@code skipIfHasAnyItemIds}, followed
+	 * by a MANUAL loop step carrying the restock fuel (which marks the whole sequence
+	 * as a looping / restock activity).
+	 */
+	private List<GuidanceStep> gatherLoopSteps()
+	{
+		return Arrays.asList(
+			gatherStep("Pick up your shade key", Collections.singletonList(KEY)),
+			step("Open chests matching your shade keys", null,
+				CompletionCondition.MANUAL, 0, 1, 50, Collections.singletonList(KEY)));
+	}
+
+	/**
+	 * Builds a gather step that highlights {@code keyIds} on the ground and skips
+	 * itself once the player holds any of them. Used to model #707's recurring
+	 * pickup step.
+	 */
+	private GuidanceStep gatherStep(String description, List<Integer> keyIds)
+	{
+		return new GuidanceStep(
+			description,
+			null,                  // perItemStepDescription
+			0, 0, 0,               // worldX, worldY, worldPlane
+			0, null, null, null,   // npcId, perItemNpcId, interactAction, dialogOptions
+			null, null,            // travelTip, requiredItemIds
+			null,                  // perItemRequiredItemIds
+			null,                  // recommendedItemIds
+			null,                  // perItemRecommendedItemIds
+			CompletionCondition.MANUAL,
+			0, 0, 0, 0,            // completionItemId, completionItemCount, completionDistance, completionNpcId
+			null,                  // completionNpcIds
+			null,                  // worldMessage
+			0, null, null,         // objectId, objectIds, objectInteractAction
+			null, keyIds,          // highlightItemIds, groundItemIds
+			null,                  // completionChatPattern
+			0, 0,                  // completionVarbitId, completionVarbitValue
+			false,                 // useItemOnObject
+			0,                     // objectMaxDistance
+			null,                  // objectFilterTiles
+			null,                  // highlightWidgetIds
+			0, 0,                  // loopBackToStep, loopCount
+			keyIds,                // skipIfHasAnyItemIds
+			null,                  // dynamicItemObjectTiers
+			null,                  // completionZone
+			null,                  // conditionalAlternatives
+			null,                  // section
+			null,                  // waypoints
+			null,                  // dynamicTargetEvaluator
+			null,                  // conditionTree
+			null,                  // perItemStepPriority
+			null,                  // activityObtainableItemIds
+			null);                 // restockIfMissingAllItemIds
 	}
 
 	private List<GuidanceStep> shadesLikeSteps()


### PR DESCRIPTION
## Summary

Keeps the in-game required-item highlight active past the first pickup for
looping / restock activities.

In a looping/restock activity (e.g. Shades of Mort'ton) the player gathers
many of a recurring consumable per run. The gather step highlights the keys
on the ground and declares `skipIfHasAnyItemIds`, so obtaining the **first**
key auto-advanced off the step in `onInventoryChanged` and cleared the key
highlight while more keys still needed collecting.

## Mechanism

Reuses the existing looping/restock signal — a sequence is a recurring
activity when any of its steps declares `restockIfMissingAllItemIds` (added
in #719/#721). When that signal is present, the `skipIfHasAnyItemIds`
auto-advance is suppressed, so the gather step (and its ground/item highlight)
stays active until the player advances manually (Next/Skip) or the loop
naturally re-enters it.

- New private helper `GuidanceSequencer.isRecurringGatherSequence()` scans the
  active steps for the restock-fuel signal.
- The single skip-auto-advance branch in `onInventoryChanged` now gates on
  `!isRecurringGatherSequence()`.
- **No new schema field** — the existing `restockIfMissingAllItemIds` already
  marks a sequence as a consume-many loop.

## Test plan

- [x] New unit test `recurringGatherStepKeepsHighlightAfterFirstPickup` in
  `GuidanceSequencerRestockTest`: a looping sequence's gather step stays active
  with its highlight target unchanged after one key enters inventory.
- [x] Existing restock/latch tests unchanged and green.
- [x] `./gradlew build` green (tests + coverage + drop-rate lint).

Closes #707
