### PR TITLE
feat(guidance): derive starting step from player state on activation

### DIFF
--- a/src/main/java/com/collectionloghelper/guidance/GuidanceSequencer.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceSequencer.java
@@ -184,6 +184,11 @@ public class GuidanceSequencer
 		// Skip any steps whose conditions are already met
 		skipSatisfiedSteps();
 
+		// Mid-activity re-sync (#719): if the player is already standing in a
+		// later step's confirmable area AND holds that step's required items,
+		// jump them forward to it instead of starting at step 1.
+		advanceToFurthestSatisfiedState();
+
 		// Mid-activity activation while already depleted (e.g. in the Shades
 		// catacombs with no keys and no remains) — park on the restock step.
 		checkDepletionAndMaybeReset();
@@ -379,6 +384,10 @@ public class GuidanceSequencer
 				activeSource != null ? activeSource.getName() : "?");
 			return;
 		}
+
+		// State-derived forward jump (#719): land on the furthest step whose
+		// area + required items the player demonstrably satisfies.
+		advanceToFurthestSatisfiedState();
 
 		// If the player synced while depleted, park on the restock step.
 		checkDepletionAndMaybeReset();
@@ -953,6 +962,78 @@ public class GuidanceSequencer
 			}
 		}
 		return -1;
+	}
+
+	/**
+	 * Mid-activity state-derivation (#719). Scans forward from the current index
+	 * for the FURTHEST-along step whose <em>area is positively confirmed</em>
+	 * (player within the step's {@code completionDistance} of its
+	 * {@code worldX/worldY/worldPlane}, or inside its {@code completionZone}) AND
+	 * whose effective required items the player fully holds. When such a step is
+	 * found, jumps {@link #currentIndex} to it so an activation mid-activity lands
+	 * the player where they actually are (e.g. already in the Shades catacomb
+	 * holding keys → the open-chests step) instead of step 1.
+	 *
+	 * <p>Conservative by design: a step whose location cannot be confirmed (no
+	 * coordinates and no zone, or the player's last-known location is unknown) is
+	 * never treated as a forward target — wrong-forward placement is worse than
+	 * starting earlier. No-op when nothing later qualifies, so it composes cleanly
+	 * with the skip-chain (already run) and the depletion/restock check (run
+	 * after). Pure index mutation — does not notify listeners.
+	 */
+	private void advanceToFurthestSatisfiedState()
+	{
+		if (!active || steps == null || lastKnownPlayerLocation == null)
+		{
+			return;
+		}
+		int furthest = -1;
+		for (int i = currentIndex + 1; i < steps.size(); i++)
+		{
+			GuidanceStep step = steps.get(i);
+			if (playerIsConfirmablyInStepArea(step) && playerHasAllRequiredItems(step))
+			{
+				furthest = i;
+			}
+		}
+		if (furthest > currentIndex)
+		{
+			log.info("State-derived start: player is in step {}/{}'s area holding its items — "
+				+ "starting there instead of step {}", furthest + 1, steps.size(), currentIndex + 1);
+			currentIndex = furthest;
+			loopIterationsCompleted = 0;
+			crossedWaypointIndex = 0;
+		}
+	}
+
+	/**
+	 * Returns true only when the player's last-known location can be POSITIVELY
+	 * confirmed to be inside the given step's area — either within the step's
+	 * {@code completionDistance} of its {@code worldX/worldY/worldPlane} tile, or
+	 * inside its {@code completionZone}. A step that declares neither a tile
+	 * ({@code worldX <= 0}) nor a zone returns {@code false}: its position is
+	 * unconfirmable, so it must not be treated as a state-derived jump target.
+	 */
+	private boolean playerIsConfirmablyInStepArea(GuidanceStep step)
+	{
+		if (step == null || lastKnownPlayerLocation == null)
+		{
+			return false;
+		}
+		Zone zone = step.getZone();
+		if (zone != null && zone.contains(lastKnownPlayerLocation))
+		{
+			return true;
+		}
+		if (step.getWorldX() > 0
+			&& lastKnownPlayerLocation.getPlane() == step.getWorldPlane()
+			&& lastKnownPlayerLocation.distanceTo2D(
+				new WorldPoint(step.getWorldX(), step.getWorldY(), step.getWorldPlane()))
+				<= step.getCompletionDistance())
+		{
+			return true;
+		}
+		return false;
 	}
 
 	/**

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerStateDerivationTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerStateDerivationTest.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.guidance;
+
+import com.collectionloghelper.data.CollectionLogCategory;
+import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.data.CompletionCondition;
+import com.collectionloghelper.data.GuidanceStep;
+import com.collectionloghelper.data.PlayerCollectionState;
+import com.collectionloghelper.data.PlayerInventoryState;
+import com.collectionloghelper.data.RequirementsChecker;
+import com.collectionloghelper.data.RewardType;
+import java.lang.reflect.Constructor;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import net.runelite.api.coords.WorldPoint;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies mid-activity state-derivation on guidance activation (#719): when the
+ * player activates guidance while already standing in a later step's confirmable
+ * area AND holding that step's required items, the sequencer starts them at that
+ * step instead of step 1. The conservative safety case — ambiguous state with no
+ * confirmable area / missing items — falls back to step 1 unchanged.
+ *
+ * <p>Models a minimal Shades-of-Mort'ton sequence: a bank step, three transit
+ * steps, and a final loop step gated to the catacomb zone whose required items
+ * are the shade keys.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class GuidanceSequencerStateDerivationTest
+{
+	private static final int KEY = 3450;
+	private static final int BANK_TILE_X = 3488;
+
+	// Catacomb zone bounds the open-chests loop step is gated to.
+	private static final int CAT_MIN_X = 3490;
+	private static final int CAT_MIN_Y = 9620;
+	private static final int CAT_MAX_X = 3520;
+	private static final int CAT_MAX_Y = 9650;
+	private static final int CAT_PLANE = 0;
+
+	private static final int LOOP_STEP_INDEX = 4;
+
+	@Mock
+	private PlayerInventoryState inventoryState;
+	@Mock
+	private PlayerCollectionState collectionState;
+	@Mock
+	private RequirementsChecker requirementsChecker;
+
+	private GuidanceSequencer sequencer;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		lenient().when(inventoryState.hasItem(anyInt())).thenReturn(false);
+		lenient().when(inventoryState.hasEquippedItem(anyInt())).thenReturn(false);
+		lenient().when(inventoryState.hasItemCount(anyInt(), anyInt())).thenReturn(false);
+		lenient().when(collectionState.isItemObtained(anyInt())).thenReturn(false);
+
+		Constructor<GuidanceSequencer> ctor = GuidanceSequencer.class.getDeclaredConstructor(
+			PlayerInventoryState.class, PlayerCollectionState.class, RequirementsChecker.class,
+			com.collectionloghelper.guidance.bosses.BossGuidanceRegistry.class);
+		ctor.setAccessible(true);
+		sequencer = ctor.newInstance(inventoryState, collectionState, requirementsChecker, null);
+	}
+
+	// ---- Tests ----
+
+	@Test
+	public void startsAtLoopStepWhenInCatacombHoldingKeys()
+	{
+		AtomicReference<GuidanceStep> lastStep = new AtomicReference<>();
+		// Player is inside the catacomb zone and holds a shade key.
+		when(inventoryState.hasItem(KEY)).thenReturn(true);
+		sequencer.setPlayerLocation(new WorldPoint(CAT_MIN_X + 5, CAT_MIN_Y + 5, CAT_PLANE));
+
+		sequencer.startSequence(makeSource(shadesLikeSteps()), lastStep::set, () -> { });
+
+		assertEquals(LOOP_STEP_INDEX, sequencer.getCurrentIndex(),
+			"in catacomb holding keys should start at the open-chests step");
+		assertEquals("Open chests matching your shade keys", lastStep.get().getDescription());
+	}
+
+	@Test
+	public void fallsBackToStepOneWhenStateAmbiguous()
+	{
+		AtomicReference<GuidanceStep> lastStep = new AtomicReference<>();
+		// Player is NOT in the catacomb (unconfirmable for later steps) and holds
+		// no keys — no later step's preconditions can be confirmed.
+		sequencer.setPlayerLocation(new WorldPoint(0, 0, 0));
+
+		sequencer.startSequence(makeSource(shadesLikeSteps()), lastStep::set, () -> { });
+
+		assertEquals(0, sequencer.getCurrentIndex(),
+			"ambiguous state must conservatively start at step 1");
+		assertEquals("Bank: bring keys", lastStep.get().getDescription());
+	}
+
+	@Test
+	public void doesNotJumpWhenInAreaButMissingRequiredItems()
+	{
+		AtomicReference<GuidanceStep> lastStep = new AtomicReference<>();
+		// Player is in the catacomb zone but holds NO keys — the loop step's
+		// required items are not satisfied, so no forward jump.
+		sequencer.setPlayerLocation(new WorldPoint(CAT_MIN_X + 5, CAT_MIN_Y + 5, CAT_PLANE));
+
+		sequencer.startSequence(makeSource(shadesLikeSteps()), lastStep::set, () -> { });
+
+		assertEquals(0, sequencer.getCurrentIndex(),
+			"in area but missing required keys must not jump forward");
+	}
+
+	// ---- Scenario helpers ----
+
+	private List<GuidanceStep> shadesLikeSteps()
+	{
+		return Arrays.asList(
+			tileStep("Bank: bring keys", Collections.singletonList(KEY),
+				CompletionCondition.ARRIVE_AT_TILE, BANK_TILE_X, 0, 0),
+			manualStep("Burn remains"),
+			manualStep("Pick up key"),
+			manualStep("Enter catacombs"),
+			catacombLoopStep());
+	}
+
+	private CollectionLogSource makeSource(List<GuidanceStep> steps)
+	{
+		return new CollectionLogSource("Shades-like", CollectionLogCategory.BOSSES, 3000, 3000, 0,
+			60, 0, "Shades-like", Collections.emptyList(),
+			RewardType.DROP, 0, null, 1, false, 0, null, 0, null, null,
+			steps, null, null, 0, null, 0, Collections.emptyList(), null, null, null);
+	}
+
+	private GuidanceStep manualStep(String desc)
+	{
+		return tileStep(desc, null, CompletionCondition.MANUAL, 0, 0, 0);
+	}
+
+	/** The final open-chests loop step: zone-gated to the catacomb, requires keys. */
+	private GuidanceStep catacombLoopStep()
+	{
+		return buildStep("Open chests matching your shade keys", Collections.singletonList(KEY),
+			CompletionCondition.ARRIVE_AT_ZONE, 0, 0,
+			new int[] {CAT_MIN_X, CAT_MIN_Y, CAT_MAX_X, CAT_MAX_Y, CAT_PLANE});
+	}
+
+	private GuidanceStep tileStep(String description, List<Integer> requiredItemIds,
+		CompletionCondition condition, int worldX, int worldY, int worldPlane)
+	{
+		return buildStep(description, requiredItemIds, condition, worldX, worldY, null);
+	}
+
+	private GuidanceStep buildStep(String description, List<Integer> requiredItemIds,
+		CompletionCondition condition, int worldX, int worldY, int[] completionZone)
+	{
+		return new GuidanceStep(
+			description,
+			null,                  // perItemStepDescription
+			worldX, worldY, 0,     // worldX, worldY, worldPlane
+			0, null, null, null,   // npcId, perItemNpcId, interactAction, dialogOptions
+			null, requiredItemIds, // travelTip, requiredItemIds
+			null,                  // perItemRequiredItemIds
+			null,                  // recommendedItemIds
+			null,                  // perItemRecommendedItemIds
+			condition,
+			0, 0, 0, 0,            // completionItemId, completionItemCount, completionDistance, completionNpcId
+			null,                  // completionNpcIds
+			null,                  // worldMessage
+			0, null, null,         // objectId, objectIds, objectInteractAction
+			null, null,            // highlightItemIds, groundItemIds
+			null,                  // completionChatPattern
+			0, 0,                  // completionVarbitId, completionVarbitValue
+			false,                 // useItemOnObject
+			0,                     // objectMaxDistance
+			null,                  // objectFilterTiles
+			null,                  // highlightWidgetIds
+			0, 0,                  // loopBackToStep, loopCount
+			null,                  // skipIfHasAnyItemIds
+			null,                  // dynamicItemObjectTiers
+			completionZone,        // completionZone
+			null,                  // conditionalAlternatives
+			null,                  // section
+			null,                  // waypoints
+			null,                  // dynamicTargetEvaluator
+			null,                  // conditionTree
+			null,                  // perItemStepPriority
+			null,                  // activityObtainableItemIds
+			null);                 // restockIfMissingAllItemIds
+	}
+}


### PR DESCRIPTION
## Summary

Implements the remaining half of #719: **mid-activity re-sync on guidance activation**. When the player activates guidance while already mid-activity, the sequencer now lands them on the correct step derived from their current STATE instead of always starting at step 1.

> Note: the loop-back / restock-on-depletion half of #719 was already shipped in #721 (`restockIfMissingAllItemIds` + restock latch). This PR does not touch it — the new derivation runs *before* the existing depletion check and composes with it.

## Design

On activation, after the forward skip-chain runs, scan forward for the **furthest-along** step whose:
- **area is positively confirmed** — player within the step's `completionDistance` of its `worldX/worldY/worldPlane` tile, OR inside its `completionZone` — AND
- **effective required items** are fully held (reuses the existing per-item-aware required-item predicate).

If a later qualifying step is found, jump there; otherwise leave the skip-chain result unchanged. A step whose location is unconfirmable (no tile and no zone, or unknown player location) is **never** a forward target — wrong-forward placement is worse than starting at step 1. No new schema field: derivation uses only existing step data. Wired into both `startSequence` and `syncToCurrentState` (the Sync button benefits too).

## Files changed

- `src/main/java/com/collectionloghelper/guidance/GuidanceSequencer.java` — `advanceToFurthestSatisfiedState()` + `playerIsConfirmablyInStepArea()`, called from `startSequence` and `syncToCurrentState`.
- `src/test/java/com/collectionloghelper/guidance/GuidanceSequencerStateDerivationTest.java` — positive case (in catacomb zone holding keys → open-chests step), safety case (ambiguous state → step 1), and an in-area-but-missing-items case (no jump).

## In-game validation TODO

Cannot be validated from the dev environment — manual repro needed:
- [ ] Activate guidance at Shades of Mort'ton while standing in the catacomb holding shade keys → expect to land on the open-chests step, not the bank/travel steps.
- [ ] Activate the same source while standing at the bank with no keys → expect step 1 (bank) unchanged.
- [ ] Stand in the catacomb with NO keys, activate → expect step 1 (no forward jump, items missing).
- [ ] Confirm the Sync button performs the same state-derived jump mid-session.
- [ ] Spot-check a non-looping multi-step source (e.g. a zone-gated source) to confirm no spurious forward jumps when the player is between areas.

Closes #719
