### PR TITLE
fix(data): widen Slepe arrival to ARRIVE_AT_ZONE for Nightmare + Phosani (T3.1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -3324,8 +3324,14 @@
         "worldX": 3728,
         "worldY": 3302,
         "worldPlane": 0,
-        "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20,
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionZone": [
+          3700,
+          3290,
+          3770,
+          3360,
+          0
+        ],
         "conditionalAlternatives": [
           {
             "requirements": {
@@ -3518,8 +3524,14 @@
         "worldX": 3728,
         "worldY": 3302,
         "worldPlane": 0,
-        "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20,
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionZone": [
+          3700,
+          3290,
+          3770,
+          3360,
+          0
+        ],
         "conditionalAlternatives": [
           {
             "requirements": {


### PR DESCRIPTION
## Summary

Two sources, **The Nightmare** (npcId 9425) and **Phosani's Nightmare** (npcId 9423), shared an identical step 1 that walks to the Slepe church stairs at tile (3728,3302) with `ARRIVE_AT_TILE` and `completionDistance: 20`. The Drakan's medallion shortcut (and other teleport/shortcut entries) lands near (3730,3340), roughly 38 tiles north of that tile and outside the r=20 radius, so step 1 never auto-advanced and the whole guidance chain froze.

## Fix (data only)

For step 1 of **both** sources:
- `ARRIVE_AT_TILE` -> `ARRIVE_AT_ZONE`
- removed `completionDistance: 20`
- added `completionZone: [3700, 3290, 3770, 3360, 0]` covering the Slepe town surface

The zone contains both the medallion landing tile (3730,3340) and the church-stairs tile (3728,3302), plus the northern walk-in approach. It does not extend west far enough to overlap Mort'ton (~3490,3300) or Canifis (~3500,3490). Plane stays 0. The hint-arrow/overlay still points at the church stairs (worldX/worldY, description, and conditionalAlternatives are unchanged); only the auto-advance trigger widens to the zone.

No other source was modified.

## Validation

- `./gradlew build` succeeded.
- `./gradlew test` passed (1752 tests, 0 failures, 0 errors).
- JSON parses cleanly; ASCII lint clean (0 violations); validate_drop_rates and guidance_lint pass for both sources.

## Follow-up audit (not fixed here)

These step-1 travel steps share the same shape as the bug just fixed: an `ARRIVE_AT_TILE` arrival with `completionDistance <= 20` plus a `conditionalAlternatives` entry whose teleport landing may fall outside the radius. They are reported for a future iteration and intentionally left unchanged in this PR. The strongest analogs are the ones with an `equippedItemIds` teleport alternative (same mechanism as Drakan's medallion).

| Source | Step tile | completionDistance | Teleport (conditionalAlternative) | Why suspect |
|--------|-----------|--------------------|-----------------------------------|-------------|
| Duke Sucellus | (2846,3938) | 20 | Ring of Shadows -> Ghorrock Dungeon | Ring of Shadows lands at the awakener prep area; landing may sit outside r=20 from the marker tile |
| The Leviathan | (3104,3162) | 20 | Ring of Shadows -> The Scar | same Ring of Shadows mechanic; configurable destination landing may exceed r=20 |
| The Whisperer | (3007,3477) | 20 | Ring of Shadows -> Lassar Undercity | same Ring of Shadows mechanic; landing may exceed r=20 |
| Vardorvis | (1175,3424) | 20 | Ring of Shadows -> The Stranglewood | same Ring of Shadows mechanic; landing may exceed r=20 |
| Theatre of Blood | (3650,3218) | 15 | Drakan's medallion -> Ver Sinhaza | exact same medallion teleport as the Slepe bug; Ver Sinhaza landing plausibly >15 tiles from the step tile |
| Theatre of Blood (Hard Mode) | (3650,3218) | 15 | Drakan's medallion -> Ver Sinhaza | duplicate of the ToB step 1; same suspect medallion landing |

Lower-confidence candidates (travelTip-only, no equipped-item alternative, but a named teleport/fairy-ring/shortcut whose landing could exceed the radius): Pickpocketing Darkmeyer Vyre (3631,3325, r20, Drakan's medallion -> Darkmeyer), Temple Trekking (3479,3241, r20, Drakan's medallion -> Burgh de Rott), Cerberus (1310,1251, r8, Key master teleport), Abyssal Sire (3037,4763, r15, Fairy ring DIP).
