### PR TITLE
feat(data): add @Builder to CollectionLogSource

### DIFF
--- a/src/main/java/com/collectionloghelper/data/CollectionLogSource.java
+++ b/src/main/java/com/collectionloghelper/data/CollectionLogSource.java
@@ -26,10 +26,15 @@ package com.collectionloghelper.data;
 
 import java.util.List;
 import javax.annotation.Nullable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Value;
 import net.runelite.api.coords.WorldPoint;
 
 @Value
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+@Builder
 public class CollectionLogSource
 {
 	String name;


### PR DESCRIPTION
Adds a Lombok `@Builder` to `CollectionLogSource` so it can be constructed concisely and order-independently — useful for generated test fixtures and authoring workflows — instead of the 25-argument all-args constructor.

`@AllArgsConstructor(access = AccessLevel.PUBLIC)` is added alongside because `@Builder` on a `@Value` class otherwise demotes the all-args constructor to package-private, which breaks the existing cross-package `new CollectionLogSource(...)` calls in the test suite.

**Verified locally:** `./gradlew build` passes — compile + 179 tests + jacoco coverage + lintDropRates all green. Existing constructor usage is unchanged.

Follow-up (optional): migrate the `makeMinimalSource`/`makeSource` test helpers to the builder to drop the 25-null boilerplate.