### PR TITLE
docs(verify): RAIDS source verification findings

### DIFF
--- a/docs/verify/findings-RAIDS.md
+++ b/docs/verify/findings-RAIDS.md
@@ -1,0 +1,100 @@
+# RAIDS source verification — findings
+
+Branch: `verify/RAIDS` · Date: 2026-06-07 · Verifier: cache-id + judgment pass per session protocol.
+
+MCP pre-flight: `resource_health` → **ok** (osrs-wiki, prices-api, wise-old-man, temple-osrs, runelite-ids, mejrs-data all 200).
+
+Scope: the 7 RAIDS sources in `src/main/resources/com/collectionloghelper/drop_rates.json`:
+Chambers of Xeric · Chambers of Xeric (Challenge Mode) · Theatre of Blood · Theatre of Blood (Hard Mode) · Tombs of Amascut · Tombs of Amascut (300 Invocation) · Tombs of Amascut (500 Invocation).
+
+Method:
+- **IDs** — `validate_drop_rates --check cache_ids` per source (abextm cache = sole id authority).
+- **Judgment** — requirement/quest gates, fairy-ring codes, arrival coords via `travel_path_verify` + `coordinate_helper`, travel direction. Each judgment finding carries a cited raw receipt and was passed through the `domain-skeptic` agent; only STANDS verdicts are kept.
+
+drop_rates.json was **not** modified (verification only).
+
+---
+
+## Summary
+
+| # | Source(s) | Type | Severity | Verdict |
+|---|-----------|------|----------|---------|
+| F1 | Theatre of Blood, Theatre of Blood (Hard Mode) | Quest gate over-strict | High | STANDS |
+| F2 | Theatre of Blood | Waypoint quest req wrong | Low | STANDS |
+| F3 | Theatre of Blood | cache_ids name mismatch (id OK) | Low | tool receipt |
+| F4 | Tombs of Amascut ×3 | cache_ids name mismatch (id OK) | Low | tool receipt |
+
+Chambers of Xeric and Chambers of Xeric (Challenge Mode) passed all checks with no findings.
+`Unsired` (25624) is not present in RAIDS sources; no action. No "duplicate item" findings logged (the same clog item appearing across multiple sources / item-tier variants is correct by rule).
+
+---
+
+## F1 — Theatre of Blood quest gate is over-strict (High) — STANDS
+
+**Sources:** `Theatre of Blood` (drop_rates.json:6516), `Theatre of Blood (Hard Mode)` (drop_rates.json:6741).
+**Data:** top-level `requirements.quests = ["A_TASTE_OF_HOPE"]`.
+**Should be:** `["PRIEST_IN_PERIL"]`.
+
+**Raw receipt — `wiki_lookup` "Theatre of Blood":**
+> "The only hard requirement to participate in the raid is the completion of the Priest in Peril quest to be able to access Morytania."
+
+**Raw receipt — `wiki_lookup` "Ver Sinhaza" (via skeptic):**
+> Drakan's medallion (needs A Taste of Hope) is one of three routes; the Andras-pay-to-Slepe route and the Ectophial route require only Morytania access (Priest in Peril), not A Taste of Hope.
+
+**Why it stands:** `RequirementsChecker.checkRequirementsDetail` treats `requirements.quests` as a **hard FINISHED accessibility gate** (`src/main/java/com/collectionloghelper/data/RequirementsChecker.java:312-321`, marks source inaccessible at 84-90). A player with Priest in Peril but not A Taste of Hope can still enter ToB (Slepe/Andras route), so the current gate hides an accessible source. The project's own convention confirms this: every other Morytania source gates on `PRIEST_IN_PERIL`, and ToB's own travel waypoint already carries `PRIEST_IN_PERIL` while the top-level gate contradicts it. The A Taste of Hope convenience (Drakan's medallion) is already preserved as a `conditionalAlternative`, so correcting the gate loses no information.
+
+**Skeptic:** STANDS — high. Ran all refutation vectors (multi-source / variant / account-type / staleness via `wiki_updates` count=0 / requirement-nuance); none rescued the value.
+
+---
+
+## F2 — Drakan's medallion → Ver Sinhaza waypoint requires the wrong quest (Low) — STANDS
+
+**Source:** `Theatre of Blood`, waypoint "Drakan's medallion to Ver Sinhaza" (drop_rates.json:6646; requirement at :6652).
+**Data:** `requirements.quests = ["SINS_OF_THE_FATHER"]`.
+**Should be:** `["A_TASTE_OF_HOPE"]`.
+
+**Raw receipt — `wiki_lookup` "Drakan's medallion":**
+> "Drakan's medallion is a reward from the quest **A Taste of Hope**. It allows unlimited teleportation to **Ver Sinhaza**, **Darkmeyer (after completion of Sins of the Father)**, and the Sisterhood Sanctuary under Slepe..."
+
+**Why it stands:** The "after completion of Sins of the Father" parenthetical attaches to the **Darkmeyer** destination only. The Ver Sinhaza teleport is available immediately on obtaining the medallion (i.e. completing A Taste of Hope). The file itself already distinguishes the two gates correctly for the Darkmeyer waypoints (line 32387), so this is an isolated wrong-quest gate, not a convention. Blast radius is low (worst case the plugin suggests the slower Canifis-walk fallback for AToH-but-not-SotF accounts; it never routes a player somewhere they cannot go). Note: `Theatre of Blood (Hard Mode)` has **no** `waypoints` array, so this finding is confined to the regular source.
+
+**Skeptic:** STANDS — low.
+
+---
+
+## F3 — Theatre of Blood cache_ids name mismatch (id correct) (Low) — tool receipt
+
+**Raw receipt — `validate_drop_rates --check cache_ids --source_name "Theatre of Blood"`:**
+> [Theatre of Blood] [cache_ids] itemId 22486 name mismatch: data "Scythe of vitur" vs cache "Scythe of vitur (uncharged)" — verify the canonical id
+> [Theatre of Blood] [cache_ids] itemId 22481 name mismatch: data "Sanguinesti staff" vs cache "Sanguinesti staff (uncharged)" — verify the canonical id
+
+**Assessment:** The **ids are cache-confirmed correct** — 22486 / 22481 are the uncharged variants the collection log actually tracks. Only the stored display-name string is off (missing "(uncharged)"). This is internally inconsistent: the `Theatre of Blood (Hard Mode)` source already names the same ids "Scythe of vitur (uncharged)" / "Sanguinesti staff (uncharged)" and passes clean. No id change needed; cosmetic name string only. (Deterministic tool output — no domain-skeptic pass required.)
+
+---
+
+## F4 — Tombs of Amascut cache_ids name mismatch (id correct) (Low) — tool receipt
+
+**Raw receipt — `validate_drop_rates --check cache_ids --source_name "Tombs of Amascut"`:**
+> [Tombs of Amascut] [cache_ids] itemId 27277 name mismatch: data "Tumeken's shadow" vs cache "Tumeken's shadow (uncharged)" — verify the canonical id
+> [Tombs of Amascut (300 Invocation)] [cache_ids] itemId 27277 name mismatch: data "Tumeken's shadow" vs cache "Tumeken's shadow (uncharged)"
+> [Tombs of Amascut (500 Invocation)] [cache_ids] itemId 27277 name mismatch: data "Tumeken's shadow" vs cache "Tumeken's shadow (uncharged)"
+
+**Assessment:** id 27277 is **cache-confirmed correct** (the uncharged shadow is the clog-tracked drop). Only the display-name string differs (missing "(uncharged)"). Cosmetic name string only across all three ToA variants; no id change needed. (Deterministic tool output — no domain-skeptic pass required.)
+
+---
+
+## Checks that passed (no findings)
+
+- **cache_ids** — Chambers of Xeric, Chambers of Xeric (Challenge Mode): clean. ToA family: all ids valid (only the 27277 name string flagged, F4). ToB family: all ids valid (only 22486/22481 name strings flagged, F3). Drop rates, pet/independent flags, `requiresPrevious` chains, and `mutuallyExclusiveSources` pairings all consistent.
+- **Arrival coords (`travel_path_verify` + `coordinate_helper identify`):** all RAIDS coords in-bounds and on the correct plane. CoX (1233,3573)=Chambers of Xeric center; ToB (3650,3218)=Ver Sinhaza (ToB) center; ToA (3234,2784)=Necropolis (58 tiles from Sophanem). `travel_path_verify` reported zero RAIDS findings (its out-of-bounds hits were all in non-RAIDS sources).
+- **Requirement gates (other):** ToA / ToA 300 / ToA 500 `requirements.quests = ["BENEATH_CURSED_SANDS"]` — correct (hard gate to access the Tombs). CoX / CoX CM no quest gate — correct.
+- **Fairy-ring / travel direction:** ToA guidance "fairy ring AKP and run south" — AKP lands north of the Necropolis, so running south to the entrance is the correct direction. (`travel_path_verify` v1 does not yet semantically cross-check fairy-ring codes; verified by direction consistency, no contradiction found.)
+- **Travel tips:** CoX (Xeric's talisman), ToB (Drakan's medallion), ToA (Pharaoh's sceptre Jaltevas) all consistent with wiki travel methods.
+
+---
+
+## Recommended fixes (for a separate data-edit PR — NOT applied here)
+
+1. F1: set `requirements.quests` to `["PRIEST_IN_PERIL"]` for both Theatre of Blood and Theatre of Blood (Hard Mode).
+2. F2: set the "Drakan's medallion to Ver Sinhaza" waypoint `requirements.quests` to `["A_TASTE_OF_HOPE"]`.
+3. F3/F4: append "(uncharged)" to the data `name` strings for 22486, 22481 (ToB) and 27277 (ToA ×3) to match the cache canonical names and the existing Hard Mode source. Ids are correct — no id change.

--- a/docs/verify/findings-SKILLING.md
+++ b/docs/verify/findings-SKILLING.md
@@ -1,0 +1,111 @@
+# Data-verification findings — SKILLING category
+
+Scope: all 17 `SKILLING` sources in
+`src/main/resources/com/collectionloghelper/drop_rates.json`.
+
+Method:
+- **IDs** — `validate_drop_rates --check cache_ids --source_name "<source>"` per source.
+  The abextm game cache is the sole id authority; ids were not adjudicated against
+  Temple/wiki.
+- **Judgment** (requirements/quest+skill+diary gates, fairy-ring codes, arrival coords,
+  travel direction) — only logged with a cited raw receipt, then passed through the
+  `domain-skeptic` agent; only verdicts that **STAND** are recorded below.
+- `resource_health` confirmed green (osrs-wiki, temple-osrs, prices, WOM, runelite-ids,
+  mejrs all 200) before the run.
+- `drop_rates.json` was **not** edited. Findings only.
+
+Sources reviewed: Aerial Fishing, Deep Sea Fishing, Colossal Wyrm Agility, Rooftop Agility,
+Motherlode Mine, Shooting Stars, Thieving (Seed Stalls), Black Chinchompas,
+Woodcutting (Teak Trees), Mining (Gemstone Rocks), Fishing (Swordfish),
+Runecrafting (Fire Runes), Farming (Fruit Trees), Underwater Crabs, Cutting Squid,
+Prifddinas Rabbit, Pickpocketing Darkmeyer Vyre.
+
+---
+
+## Findings (STANDS)
+
+### 1. Cutting Squid — requirements gate under-specified  — severity: high
+
+- **Source:** `Cutting Squid` (SKILLING), item `Squid beak` (itemId 31572).
+- **Data:** `requirements` block at lines 32072–32077 —
+  `{ "skills": [ { "skill": "SAILING", "level": 45 } ] }`. No Fishing requirement.
+  Guidance prose at line 32030 also states "Sailing level 45 required."
+- **Receipt** (OSRS Wiki, https://oldschool.runescape.wiki/w/Raw_swordtip_squid):
+  > "Raw swordtip squid is a fish caught by lantern harpooning, requiring level 52 Fishing
+  > alongside a lantern and harpoon. … the minimum Sailing level to catch them is 47, the
+  > level required to dock at the Onyx Crest."
+
+  Corroborating (https://oldschool.runescape.wiki/w/Lantern_harpooning):
+  > "Lantern harpooning is a Fishing activity released with Sailing, requiring at least
+  > 47 Sailing and 52 Fishing."
+- **Why it stands:** Squid beak is obtained only by cutting squid, and squid are caught
+  only via lantern harpooning. The universal activity floor is **Sailing 47 + Fishing 52**.
+  The data's Sailing 45 is below the true gate, and the Fishing 52 requirement is absent —
+  so the source is reachable in-data at Sailing 45 / 0 Fishing, which no real account can do.
+  Account-type-invariant; wiki page unchanged since 2025-06-01 (not staleness). Item id is
+  cache-confirmed correct and not in dispute.
+- **domain-skeptic:** STANDS (high). Both prongs survived every refutation vector.
+- **Suggested fix (not applied):** Sailing 45 → 47, and add `{ "skill": "FISHING",
+  "level": 52 }`. Update the guidance prose at line 32030 accordingly.
+
+### 2. Deep Sea Fishing — Fishing gate off by one  — severity: low
+
+- **Source:** `Deep Sea Fishing` (SKILLING), trophy fish Giant blue krill (31408),
+  Golden haddock (31412), Orangefin (31416), Huge halibut (31420), Purplefin (31424),
+  Swift marlin (31428).
+- **Data:** `requirements` block at lines 20644–20653 —
+  `{ "skills": [ { "skill": "FISHING", "level": 68 }, { "skill": "SAILING", "level": 1 } ] }`.
+  Prose at line 20604 (travelTip) and line 20607 (guidance) also say "68 Fishing".
+- **Receipt** (OSRS Wiki, https://oldschool.runescape.wiki/w/Deep_sea_trawling shoals
+  table, and the Giant krill shoal entry): the lowest-tier shoal, the **Giant krill shoal**
+  (source of Giant blue krill), requires **Fishing 69**. No shoal is listed at Fishing 68.
+  Higher trophies: Haddock 73, Yellowfin/Orangefin 79, Halibut 83, Bluefin/Purplefin 87,
+  Marlin 91.
+- **Why it stands:** The lowest obtainable trophy needs Fishing 69; the lowest shoal in the
+  activity *is* the trophy source, so there is no sub-69 entry point. The project convention
+  (e.g. the adjacent Pyramid Plunder source) gates on the lowest level that yields a clog
+  item, not an "activity-start" level. The gate of 68 corresponds to no obtainable content.
+  Severity low: only affects the narrow Fishing-68 boundary; the six trophy ids and drop
+  rates are correct. (Sailing 1 was **not** flagged — no contradicting access-level receipt
+  found; wiki documents no Sailing minimum for area access.)
+- **domain-skeptic:** STANDS (low).
+- **Suggested fix (not applied):** Fishing 68 → 69 in the requirements block; correct the
+  prose at lines 20604 and 20607 to "69 Fishing".
+
+---
+
+## Reviewed — no finding
+
+### ID checks (cache_ids)
+All 17 sources resolved every item/NPC/object id against the abextm cache. Two
+**name-mismatch** notes were returned by the validator; both are deliberate display labels,
+not id errors (ids are cache-confirmed), so neither is logged as a finding:
+
+- **Colossal Wyrm Agility** — ids 30048/30051/30054/30057/30060 carry a "(Varlamore)" suffix
+  ("Graceful cape (Varlamore)" etc.) vs cache "Graceful cape". The suffix disambiguates the
+  Varlamore graceful recolour from the Rooftop graceful set (which shares the base names at
+  ids 11852 etc.). Ids correct.
+- **Shooting Stars** — id 25539 stored as "Celestial ring" vs cache "Celestial ring
+  (uncharged)". Id correct; the abextm cache is the sole id authority and is not adjudicated
+  against the name suffix.
+
+### Judgment checks
+- **No SKILLING source has fairy-ring codes or out-of-bounds coordinates.**
+  `travel_path_verify` scanned all 808 steps / 225 sources; the only coord-out-of-bounds
+  findings are in non-SKILLING sources (Miscellaneous, Shellbane Gryphon, Treasure Trails).
+- **Requirement gates verified as correct** (no contradicting receipt):
+  - Aerial Fishing — Fishing 43 + Hunter 35 (wiki: "requiring 35 Hunter and 43 Fishing"). ✓
+  - Colossal Wyrm Agility — Children of the Sun + Agility 50. ✓
+  - Rooftop Agility — Agility 10. ✓
+  - Motherlode Mine — Mining 30. ✓
+  - Shooting Stars — Mining 10. ✓
+  - Thieving (Seed Stalls) — Thieving 27. ✓
+  - Black Chinchompas — Hunter 73. ✓
+  - Woodcutting (Teak Trees) — Woodcutting 35. ✓
+  - Mining (Gemstone Rocks) — Shilo Village + Mining 40. ✓
+  - Fishing (Swordfish) — Fishing 50. ✓
+  - Runecrafting (Fire Runes) — Runecraft 14. ✓
+  - Farming (Fruit Trees) — Farming 27. ✓
+  - Underwater Crabs — Recipe for Disaster (Pirate Pete subquest). ✓
+  - Prifddinas Rabbit — Song of the Elves. ✓
+  - Pickpocketing Darkmeyer Vyre — Sins of the Father + Thieving 82. ✓


### PR DESCRIPTION
Verification-only pass over all 7 RAIDS sources in `drop_rates.json`. **No data was modified** — findings are recorded in a new `docs/verify/findings-RAIDS.md` (separate file per category to keep parallel verification sessions conflict-free).

## Method
- MCP pre-flight `resource_health` → ok (all sources 200).
- **IDs:** `validate_drop_rates --check cache_ids` per source (abextm cache = sole id authority).
- **Judgment:** requirement/quest gates, fairy-ring codes, arrival coords (`travel_path_verify` + `coordinate_helper`), travel direction. Every judgment finding carries a cited raw receipt and was passed through the `domain-skeptic` agent — only STANDS kept.

## Findings
| # | Source(s) | Type | Severity | Verdict |
|---|-----------|------|----------|---------|
| F1 | Theatre of Blood, ToB (Hard Mode) | `requirements.quests` over-strict (`A_TASTE_OF_HOPE` → should be `PRIEST_IN_PERIL`) | High | STANDS |
| F2 | Theatre of Blood | Drakan's-medallion → Ver Sinhaza waypoint requires `SINS_OF_THE_FATHER` → should be `A_TASTE_OF_HOPE` | Low | STANDS |
| F3 | Theatre of Blood | cache_ids name-string mismatch, ids 22486/22481 correct (missing "(uncharged)") | Low | tool receipt |
| F4 | Tombs of Amascut ×3 | cache_ids name-string mismatch, id 27277 correct (missing "(uncharged)") | Low | tool receipt |

Chambers of Xeric and CoX (Challenge Mode) passed clean. All RAIDS arrival coords in-bounds and on the correct plane. No "duplicate item" findings (multi-source / variant items are correct by rule).

Recommended data fixes are listed in the findings file for a **separate** edit PR; this PR only records the audit.