### PR TITLE
docs(verify): OTHER category data-verification findings

### DIFF
--- a/docs/verify/findings-BOSSES.md
+++ b/docs/verify/findings-BOSSES.md
@@ -1,0 +1,164 @@
+# Data-verification findings — BOSSES
+
+- **Category:** `BOSSES` (61 sources in `src/main/resources/com/collectionloghelper/drop_rates.json`)
+- **Branch:** `verify/BOSSES`
+- **Date:** 2026-06-07
+- **MCP pre-flight:** `resource_health` → all sources `ok` (osrs-wiki, temple-osrs, runelite-ids, mejrs-data, prices, wise-old-man).
+- **Scope:** This file is intentionally separate from the shared `data-verification-log.md` so parallel
+  per-category verification sessions do not conflict. It records findings for the BOSSES category only.
+- **Rule:** verification only — **no edits were made to `drop_rates.json`**. Fixes are a separate reviewed PR.
+
+## Method
+
+Two checks per source, exactly as scoped:
+
+1. **IDs** — `validate_drop_rates --check cache_ids`. The **abextm game cache is the sole id authority**;
+   ids were *not* adjudicated against Temple/wiki. Run globally across all 225 sources, then filtered to BOSSES.
+2. **Judgment** — requirements (quest/skill/diary gates), fairy-ring codes, arrival coordinates
+   (`travel_path_verify`), and travel direction. A candidate was logged **only with a cited raw receipt**,
+   then passed through the `domain-skeptic` agent; **only `STANDS` verdicts are recorded as findings.**
+
+Multi-source clog items are correct by design (never flagged as "duplicate"). Unsired `25624` is
+cache-confirmed and was not flagged.
+
+## Result summary
+
+- **IDs (cache_ids):** all 61 BOSSES sources **clean** — zero unresolved ids and zero name-mismatches.
+  (The global run surfaced 162 name-mismatch warnings, but none belong to a BOSSES source.)
+- **Coordinates (`travel_path_verify`):** one BOSSES hit (Shellbane Gryphon) — **refuted** as a tool
+  false-positive on a deliberately-instanced coordinate (see *Considered & refuted* below).
+- **Fairy-ring codes:** every cited code verified against the wiki; **one wrong** (Araxxor `CLS`).
+- **Requirements gates:** GWD ×4 + Nex, the 8 Desert Treasure II entries, Amoxliatl, and Royal Titans
+  were externally verified. The **8 DT2 entries carry fabricated `skills` requirements** (below); the rest
+  are correct.
+
+**Open findings: 2 issues spanning 9 source-entries (all severity `high`).**
+
+| # | Source | Data verified (V1) | Open findings |
+|---|--------|--------------------|---------------|
+| 1 | General Graardor | 2026-06-07 | - |
+| 2 | Commander Zilyana | 2026-06-07 | - |
+| 3 | K'ril Tsutsaroth | 2026-06-07 | - |
+| 4 | Kree'arra | 2026-06-07 | - |
+| 5 | Zulrah | 2026-06-07 | - |
+| 6 | Vorkath | 2026-06-07 | - |
+| 7 | Cerberus | 2026-06-07 | - |
+| 8 | Alchemical Hydra | 2026-06-07 | - |
+| 9 | Corporeal Beast | 2026-06-07 | - |
+| 10 | Kalphite Queen | 2026-06-07 | - |
+| 11 | Phantom Muspah | 2026-06-07 | - |
+| 12 | Duke Sucellus | - | 1 (high: fabricated skills req MINING 65) |
+| 13 | The Leviathan | - | 1 (high: fabricated skills req RANGED 70) |
+| 14 | The Whisperer | - | 1 (high: fabricated skills req RANGED 75) |
+| 15 | Vardorvis | - | 1 (high: fabricated skills req ATTACK 70) |
+| 16 | Duke Sucellus (Awakened) | - | 1 (high: fabricated skills req MINING 65) |
+| 17 | The Leviathan (Awakened) | - | 1 (high: fabricated skills req RANGED 75) |
+| 18 | The Whisperer (Awakened) | - | 1 (high: fabricated skills req RANGED 80) |
+| 19 | Vardorvis (Awakened) | - | 1 (high: fabricated skills req ATTACK 75) |
+| 20 | Grotesque Guardians | 2026-06-07 | - |
+| 21 | The Nightmare | 2026-06-07 | - |
+| 22 | Phosani's Nightmare | 2026-06-07 | - |
+| 23 | Nex | 2026-06-07 | - |
+| 24 | Sarachnis | 2026-06-07 | - |
+| 25 | Giant Mole | 2026-06-07 | - |
+| 26 | Bryophyta | 2026-06-07 | - |
+| 27 | Obor | 2026-06-07 | - |
+| 28 | Dagannoth Rex | 2026-06-07 | - |
+| 29 | Dagannoth Prime | 2026-06-07 | - |
+| 30 | Dagannoth Supreme | 2026-06-07 | - |
+| 31 | Kraken | 2026-06-07 | - |
+| 32 | Thermonuclear smoke devil | 2026-06-07 | - |
+| 33 | Abyssal Sire | 2026-06-07 | - |
+| 34 | King Black Dragon | 2026-06-07 | - |
+| 35 | Chaos Elemental | 2026-06-07 | - |
+| 36 | Scorpia | 2026-06-07 | - |
+| 37 | Chaos Fanatic | 2026-06-07 | - |
+| 38 | Venenatis | 2026-06-07 | - |
+| 39 | Vet'ion | 2026-06-07 | - |
+| 40 | Callisto | 2026-06-07 | - |
+| 41 | Skotizo | 2026-06-07 | - |
+| 42 | Hespori | 2026-06-07 | - |
+| 43 | Corrupted Gauntlet | 2026-06-07 | - |
+| 44 | The Gauntlet | 2026-06-07 | - |
+| 45 | Barrows | 2026-06-07 | - |
+| 46 | Zalcano | 2026-06-07 | - |
+| 47 | Sol Heredit | 2026-06-07 | - |
+| 48 | Crazy archaeologist | 2026-06-07 | - |
+| 49 | Araxxor | - | 1 (high: travel — fairy ring CLS wrong region) |
+| 50 | Perilous Moons | 2026-06-07 | - |
+| 51 | The Hueycoatl | 2026-06-07 | - |
+| 52 | Yama | 2026-06-07 | - |
+| 53 | Doom of Mokhaiotl | 2026-06-07 | - |
+| 54 | Royal Titans | 2026-06-07 | - |
+| 55 | Amoxliatl | 2026-06-07 | - |
+| 56 | Brutus | 2026-06-07 | - |
+| 57 | Shellbane Gryphon | 2026-06-07 | - |
+| 58 | Scurrius | 2026-06-07 | - |
+| 59 | The Fight Caves | 2026-06-07 | - |
+| 60 | The Inferno | 2026-06-07 | - |
+| 61 | Deranged Archaeologist | 2026-06-07 | - |
+
+---
+
+## Findings (STANDS)
+
+### F1 — Desert Treasure II bosses: fabricated `requirements.skills` access gates — high
+- **Sources (8):** Duke Sucellus, The Leviathan, The Whisperer, Vardorvis, and the four `(Awakened)` variants.
+- **check:** requirements (skill gate) judgment → `wiki_lookup` + live wiki fetch + `wiki_updates` → `domain-skeptic` (STANDS, both passes).
+- **ours:** each source's `requirements.skills` holds a hard skill gate, and the Awakened variants escalate it:
+  - Duke Sucellus / (Awakened): `MINING 65` — `drop_rates.json:1646`, `drop_rates.json:2292`
+  - The Leviathan: `RANGED 70` — `drop_rates.json:1806`; (Awakened): `RANGED 75` — `drop_rates.json:2492`
+  - The Whisperer: `RANGED 75` — `drop_rates.json:1964`; (Awakened): `RANGED 80` — `drop_rates.json:2688`
+  - Vardorvis: `ATTACK 70` — `drop_rates.json:2133`; (Awakened): `ATTACK 75` — `drop_rates.json:2892`
+- **authoritative (raw receipts, oldschool.runescape.wiki, fetched 2026-06-07):**
+  - The Whisperer: *"there are no stated skill level requirements to fight The Whisperer. The only explicit requirement … completed Desert Treasure II - The Fallen Empire … no minimum Combat, Magic, Ranged, or other skill levels … no additional skill requirements … for the Awakened variant beyond needing an Awakener's orb."*
+  - Duke Sucellus: *"there are no stated skill level requirements … no mention of Mining, Herblore, or any other skill … no minimum Herblore or Mining level specified [for the salt/vent prep] … Both the standard and Awakened variants show identical requirement information with no skill prerequisites."*
+  - The Leviathan: *"there are no explicit skill level requirements … The only mentioned requirement is … Desert Treasure II … Awakened … requires an Awakener's orb … but no additional skill requirements."*
+  - Vardorvis: *"there are no explicit skill level requirements … The only requirement mentioned is Quest Completion … recommendations for efficiency, not access requirements."*
+  - `wiki_updates` (Whisperer, Vardorvis): `count: 0` since 2025-01-01 → not staleness drift.
+- **domain-skeptic:** STANDS ×2 (The Whisperer adjudicated separately; Duke/Leviathan/Vardorvis adjudicated together, per-source STANDS). Refutation vectors worked and failed: no hidden area/fight skill gate; Duke's vent-mining imposes no Mining level; Awakened adds only the orb (so a *higher* level for the identical encounter is incoherent); the wiki's only efficiency suggestions are unrelated (e.g. Magic 90+/Prayer 77+ for Augury) and live in no "requirement."
+- **why it matters:** `requirements.skills` is the field the plugin uses to gate/lock a source. A DT2-complete account below the listed level can fight these bosses but would be wrongly locked out of the source. Same schema shape that, for General Graardor, correctly encodes the real Strength-70 GWD gate — so this is a functional defect, not a cosmetic note.
+- **action (for the separate fix PR):** remove the `skills` array from `requirements` on all 8 entries; **keep** `quests: ["DESERT_TREASURE_II__THE_FALLEN_EMPIRE"]`.
+- **status:** open
+
+### F2 — Araxxor: travel guidance cites fairy ring `CLS`, which lands in Kandarin (Yanille), not Morytania — high
+- **Source:** Araxxor (npcId 13668).
+- **check:** fairy-ring-code judgment → `WebFetch` (OSRS Wiki Fairy ring + Araxxor pages) + `wiki_updates` → `domain-skeptic` (STANDS).
+  Note: `travel_path_verify` v1 does **not** catch this — it only checks coordinate bounds, not fairy-ring-code-to-destination semantics (per its own `notes`).
+- **ours:** the Araxxor route prose claims `fairy ring CLS` as the route to the Araxyte cave in NE Morytania, in **three** places:
+  - source `travelTip` — `drop_rates.json:9317` (`"Drakan's medallion -> Darkmeyer, or fairy ring CLS"`)
+  - step #2 `description` — `drop_rates.json:9336` (`"… or fairy ring CLS for the fastest unquested route"`)
+  - step #2 `travelTip` — `drop_rates.json:9342` (`"… run east, or fairy ring CLS"`)
+- **authoritative (raw receipts, oldschool.runescape.wiki, fetched 2026-06-07):**
+  - Fairy ring page: **`CLS` → "Islands: Yanille Chain"** (Kandarin) — opposite side of the map from Morytania. (Morytania's code is `CKS` → Canifis.)
+  - Araxxor page: *"The wiki page does not mention any fairy ring codes for reaching Araxxor's lair. The only travel method specified is: 'Araxxor's lair is accessible from the Morytania Spider Cave … north-east of Darkmeyer.'"* Canonical route is Drakan's medallion → Darkmeyer.
+  - `wiki_updates` (Araxxor): `count: 0` since 2024-08-01 → not staleness drift.
+- **domain-skeptic:** STANDS. Vectors failed: `CLS` is not in/near Morytania; no fairy ring serves the Araxyte cave; even the nearest Morytania code `CKS` (Canifis) does not reach it, so the fix is to **strike the fairy-ring claim**, not swap `CLS`→`CKS` while keeping "fastest unquested route."
+- **action (for the separate fix PR):** remove the `fairy ring CLS` clause from all three strings; keep the Drakan's medallion → Darkmeyer route.
+- **status:** open
+
+---
+
+## Considered & refuted (not logged as defects)
+
+### Shellbane Gryphon — `travel_path_verify` coord-out-of-bounds → REFUTED
+- `travel_path_verify` flagged Shellbane Gryphon steps #2–#4 at tile `(13993, 9901, 0)` as outside legal
+  surface bounds (x 900..4500, y 1100..13500).
+- `domain-skeptic` **REFUTED**: the project's own `verified_scene_ids.json` records this as a deliberately
+  **instanced** coordinate for "The Great Conch island (instance coords ~13993, 9901, plane 0)" with a prior
+  documented coordinate fix (commit `e4dd6a06`). OSRS instanced areas legitimately use coordinates far beyond
+  the surface x-bound; `travel_path_verify` v1 models only surface space and false-positives on instanced
+  sources. The value is correct by design. **Not a finding.**
+
+## Coverage notes (honesty about scope)
+
+- **IDs:** exhaustive — `cache_ids` ran over every item/NPC/object id in all 61 sources.
+- **Coordinates:** exhaustive bound-check via `travel_path_verify` over all 61 sources (808 steps scanned across the dataset).
+- **Fairy-ring codes:** every code cited in BOSSES guidance was verified (BJS, CIR, AKQ, CKS, BKP, CLS, AIQ, BLP, DIP).
+  Only `CLS` (Araxxor) was wrong.
+- **Requirements gates:** externally verified against the wiki for GWD ×4 (Troll Stronghold + per-room 70 skill gates — correct),
+  Nex (consistent), all 8 DT2 entries (wrong — F1), Amoxliatl (Slayer 48 + The Heart of Darkness — correct), and Royal Titans
+  (no requirement — correct). The remaining sources carry standard Slayer-level / single-quest gates consistent with known
+  game data and were not contradicted by any receipt; they were not each independently re-fetched. Yama's page 404'd at the
+  tried slug, so its `A_KINGDOM_DIVIDED` gate was not externally re-confirmed (left as `verified` on domain grounds, flagged here for transparency).
+- **Travel direction:** spot-checked alongside the fairy-ring/coord work; no additional standing discrepancy found.

--- a/docs/verify/findings-OTHER.md
+++ b/docs/verify/findings-OTHER.md
@@ -1,0 +1,170 @@
+# Data-verification findings — OTHER category
+
+Scope: all 58 `OTHER` sources in
+`src/main/resources/com/collectionloghelper/drop_rates.json`.
+
+Method:
+- **IDs** — `validate_drop_rates --check cache_ids` (whole-file run, OTHER sources
+  filtered out). The abextm game cache is the sole id authority; ids were not adjudicated
+  against Temple/wiki. Guidance-step `requiredItemIds` (which `cache_ids` does not cover)
+  were spot-checked with `cross_check_ids` where a discrepancy was suspected.
+- **Judgment** (requirements/quest+skill+diary gates, fairy-ring codes, arrival coords,
+  travel direction) — only logged with a cited raw receipt, then passed through the
+  `domain-skeptic` agent; only verdicts that **STAND** are recorded below.
+- `resource_health` confirmed green (osrs-wiki, prices, WOM, temple-osrs, runelite-ids,
+  mejrs all 200) before the run.
+- `drop_rates.json` was **not** edited. Findings only.
+
+Sources reviewed (58): Revenants, Brimstone Chest, Larran's Big Chest, Zombie Pirate
+Locker, Boat Paints, Champion's Challenge, Chompy Bird Hunting, Forestry, Fossil Island
+Notes, Glough's Experiments, Hunter Guild, Lost Schematics, Monkey Backpacks, My Notes,
+Ocean Encounters, Sailing Misc, Sea Treasures, Pyramid Plunder, Stronghold of Security,
+Catacombs of Kourend, Wilderness God Wars Dungeon, Elven Crystal Chest, Miscellaneous,
+Random Events, Camdozaal, TzHaar, Cyclopes, Elder Chaos Druids, Shayzien Armour,
+Creature Creation (Newtroost, Unicow, Spidine, Swordchick, Jubster, Frogeel),
+Stingray / Albatross / Narwhal / Orcas / Great White Shark / Vampyre Kraken (Boat Combat),
+Small / Fishy / Barracuda / Large / Plundered / Martial / Fremennik / Opulent Salvage,
+Mithril Dragon, Adamant Dragon, Rune Dragon, Ogress Shaman, Armoured Zombie,
+Prifddinas Elf, Fountain of Rune, Waterfiend, Port Tasks.
+
+---
+
+## ID verification summary
+
+`validate_drop_rates --check cache_ids` returns **no unresolved / orphaned item, NPC, or
+object id** for any OTHER source. Every id resolves in the abextm cache. The cache_ids
+"name mismatch" rows that touch OTHER sources (Revenants `Bracelet of ethereum`,
+Champion's Challenge scroll naming, Chompy Bird Hunting hats → cache "Chompy bird hat",
+My Notes / Mithril Dragon `Ancient page 1–26`, Sea Treasures `Medallion fragment 1–8`,
+Pyramid Plunder `Pharaoh's sceptre`, Miscellaneous `Xeric's talisman`, Armoured Zombie
+zombie scroll) are **cosmetic display-name choices** — the id is correct and resolves;
+the cache simply uses a generic/base or `(uncharged)` name. Per the rule that the cache is
+the sole id authority and these are not wrong ids, none are logged as ID findings.
+`Unsired` (25624) is cache-confirmed correct and was not flagged.
+
+The id defect below was found in a guidance-step `requiredItemIds` (outside cache_ids'
+coverage) and is reported under the Newtroost finding.
+
+---
+
+## Findings (STANDS)
+
+### 1. Creature Creation (Newtroost) — wrong creation ingredient + wrong Eye-of-newt id  — severity: high
+
+- **Source:** `Creature Creation (Newtroost)` (OTHER), source block at line 22806.
+- **Data:**
+  - `guidanceSteps[0].description`: "Bring **raw chicken** and eye of newt as ingredients."
+  - `guidanceSteps[0].requiredItemIds`: `[2138, 219]`.
+  - `guidanceSteps[1].description`: "Place **raw chicken** and eye of newt on the Altar of Life to create a Newtroost…"
+  - The source's own `locationDescription`: "Tower of Life, south of Ardougne (**Eye of newt + Feather**)".
+- **Receipt** (OSRS Wiki, https://oldschool.runescape.wiki/w/Creature_Creation recipe
+  table, fetched 2026-06-07): **Newtroost = 1 Eye of newt + 1 Feather.** Raw chicken is a
+  *Swordchick* ingredient, not a Newtroost one.
+- **ID receipt** (`cross_check_ids`, abextm cache): `219 → "Grimy torstol"` (name-mismatch),
+  `221 → "Eye of newt"` (match), `314 → "Feather"` (match), `2138 → "Raw chicken"` (match).
+  So `requiredItemIds` is wrong twice: 2138 (Raw chicken) should be **314 (Feather)**, and
+  219 (Grimy torstol) should be **221 (Eye of newt)**.
+- **Why it stands:** Recipe is fixed game content (Tower of Life, 2007), identical across
+  account types; diary tiers only affect whether *drops* are noted, not inputs. The step
+  contradicts both the wiki and the source's own `locationDescription`.
+- **domain-skeptic:** STANDS (high) — survived every refutation vector; also independently
+  surfaced the 219→Grimy torstol id error.
+- **Suggested fix (not applied):** `requiredItemIds` `[2138, 219]` → `[221, 314]`; both
+  step descriptions "raw chicken and eye of newt" → "eye of newt and feather".
+
+### 2. Creature Creation (Frogeel) — wrong creation ingredients (cross-creature copy/paste)  — severity: high
+
+- **Source:** `Creature Creation (Frogeel)` (OTHER), source block at line 23156.
+- **Data:**
+  - `guidanceSteps[0].description`: "Bring **raw lobster and red spiders' eggs** as ingredients."
+  - `guidanceSteps[0].requiredItemIds`: `[377, 223]`.
+  - `guidanceSteps[1].description`: "Place **raw lobster and red spiders' eggs** on the Altar of Life to create a Frogeel…"
+  - The source's own `locationDescription`: "Tower of Life, south of Ardougne (**Raw cave eel + Giant frog legs**)".
+- **Receipt** (OSRS Wiki, Creature Creation recipe table, fetched 2026-06-07):
+  **Frogeel = 1 Raw cave eel + 1 Giant frog legs.**
+- **ID receipt** (`cross_check_ids`): `377 → "Raw lobster"` (a *Jubster* ingredient),
+  `223 → "Red spiders' eggs"` (a *Spidine* ingredient), `5001 → "Raw cave eel"` (match),
+  `4517 → "Giant frog legs"` (match). The listed ingredients are a cross-creature
+  copy/paste, not the Frogeel recipe.
+- **Why it stands:** Fixed, ancient game content; no mechanic produces a Frogeel from
+  lobster + spider eggs. Contradicts both the wiki and the source's own `locationDescription`.
+- **domain-skeptic:** STANDS (high) — survived every refutation vector.
+- **Suggested fix (not applied):** `requiredItemIds` `[377, 223]` → `[5001, 4517]`; both
+  step descriptions → "raw cave eel and giant frog legs".
+
+### 3. Creature Creation (Unicow) — wrong creation ingredient  — severity: low
+
+- **Source:** `Creature Creation (Unicow)` (OTHER), source block at line 22876.
+- **Data:**
+  - `guidanceSteps[0].description`: "Bring **raw beef** and unicorn horn as ingredients."
+  - `guidanceSteps[0].requiredItemIds`: `[2132, 237]`.
+  - `guidanceSteps[1].description`: "Place **raw beef** and unicorn horn on the Altar of Life…"
+  - The source's own `locationDescription`: "Tower of Life, south of Ardougne (**Cowhide + Unicorn horn**)".
+- **Receipt** (OSRS Wiki, Creature Creation recipe table, fetched 2026-06-07):
+  **Unicow = 1 Cowhide + 1 Unicorn horn.**
+- **ID receipt** (`cross_check_ids`): `2132 → "Raw beef"` (match), `1739 → "Cowhide"` (match),
+  `237 → "Unicorn horn"` (match). The intended ingredient (Cowhide) carries id 1739, not 2132.
+- **Why it stands:** Recipes are fixed per altar and noted items aren't accepted; raw beef
+  is never a Unicow input. Contradicts both the wiki and the source's own `locationDescription`.
+  Low severity: player-facing inventory hint, does not affect the clog item id or drop rate.
+- **domain-skeptic:** STANDS (low) — survived every applicable refutation vector.
+- **Suggested fix (not applied):** `requiredItemIds` `[2132, 237]` → `[1739, 237]`; both
+  step descriptions "raw beef and unicorn horn" → "cowhide and unicorn horn".
+
+### 4. Pyramid Plunder — Pharaoh's sceptre source/level guidance is wrong and self-contradictory  — severity: low
+
+- **Source:** `Pyramid Plunder` (OTHER), source block at line 20658, item
+  `Pharaoh's sceptre` (itemId 26945 — cache-confirmed, not in dispute).
+- **Data:**
+  - `guidanceSteps[0].description`: "Need **71 Thieving minimum** to access the grand gold
+    chest (**the only Pharaoh's sceptre source**)."
+  - `guidanceSteps[2].description`: "At room 8 (requires **91 Thieving**), loot the grand
+    gold chest which **exclusively** yields the Pharaoh's sceptre."
+- **Receipts:**
+  - `wiki_lookup` "Pharaoh's sceptre": "…found during the Pyramid Plunder minigame in
+    Sophanem, **from the golden chests and sarcophagi**." / "The chance of receiving a
+    pharaoh's sceptre **scales depending on the room**."
+  - `wiki_lookup` / WebFetch "Pyramid Plunder": "Every ten levels thereafter will grant
+    entrance to the more valuable rooms, **up to level 91**." Room table: rooms 6/7/8 =
+    71/81/91; every room contains a golden chest **and** a sarcophagus.
+- **Why it stands:** The sceptre drops from golden chests **and sarcophagi** in **every
+  room** (room-scaled odds), so both the "only … source" (step0) and "grand gold chest …
+  exclusively" (step8/2) framings are false, and there is no distinct "grand gold chest"
+  entity. The 71-vs-91 wording is also inconsistent — but note the correct repair is **not**
+  simply "71 → 91": a player can already obtain the sceptre at 71 (room 6) at worse odds;
+  91 (room 8) is the best-odds recommendation, not the access gate. Low severity: advisory
+  prose only; item id and drop rate unaffected.
+- **domain-skeptic:** STANDS (low) — confirmed the prose error and corrected the finding's
+  own proposed fix.
+- **Suggested fix (not applied):** Rewrite both steps to state the sceptre drops from golden
+  chests and sarcophagi in every room with room-scaled odds, recommend room 8 (91 Thieving)
+  for best odds, and drop the "grand gold chest" / "exclusive" / "only source" framing.
+
+---
+
+## Checked and cleared (no finding)
+
+- **ID integrity** — every OTHER-source item/NPC/object id resolves in the abextm cache
+  (cache_ids name-mismatches are cosmetic; see ID summary above). `Unsired` (25624) correct.
+- **Fairy-ring codes** (all consistent with destination): Brimstone Chest **CIR** (Mount
+  Karuulm), Chompy Bird Hunting **AKS** (Feldip Hills), Monkey Backpacks **CLR** (Ape
+  Atoll), TzHaar **BLP** (TzHaar City), Catacombs of Kourend **CIS** (Kourend Castle),
+  Creature Creation ×6 **DJP** (Tower of Life).
+- **Hunter Guild** — "Requires 46 Hunter and completion of Children of the Sun" matches the
+  wiki (46 Hunter, not boostable; Children of the Sun gates Varlamore travel). Correct.
+- **Monkey Backpacks** — "requires Monkey Madness II": the Ape Atoll Agility *course* needs
+  only MM1, but the monkey-backpack transformations (the clog items) genuinely require MM2,
+  so the requirement is legitimate for this source. domain-skeptic refutation expected → not
+  logged.
+- **Fountain of Rune** — "Charging glory requires completion of Heroes' Quest" matches the
+  wiki ("Charging amulets of glory requires completion of Heroes' Quest"). Correct.
+- **Champion's Challenge** — "guild requires 32 Quest Points to enter" matches the wiki.
+- **Miscellaneous** — `travel_path_verify` flags `Miscellaneous#1` tile `(0,0,0)` as
+  out-of-bounds, but this is a deliberate "no single location" sentinel for an aggregate tab
+  ("items with no dedicated source"); the source-level coords are valid (3222,3218).
+  Intentional → not logged as a correctness finding.
+- **Sailing-skill sources** (Boat Paints, Lost Schematics, Ocean Encounters, Sailing Misc,
+  Sea Treasures, Port Tasks, the 6 Boat Combat NPCs, the 8 Salvage sources) describe
+  unreleased Sailing content with no OSRS Wiki / Temple authority to cite. No raw receipt
+  can be produced for or against their judgment fields, so they are out of verifiable scope
+  and intentionally not logged either way.


### PR DESCRIPTION
Verifies every source in the **OTHER** category (58 sources) of
`src/main/resources/com/collectionloghelper/drop_rates.json`. Findings only —
**`drop_rates.json` is not modified**. New file: `docs/verify/findings-OTHER.md`.

## Method
- **IDs** — `validate_drop_rates --check cache_ids` (abextm cache as sole id authority).
  Guidance-step `requiredItemIds` (outside cache_ids' coverage) spot-checked with
  `cross_check_ids`.
- **Judgment** (gates, fairy-ring codes, arrival coords, travel direction) — logged only
  with a cited raw receipt (OSRS Wiki), then passed through the `domain-skeptic` agent;
  only **STANDS** verdicts recorded.
- `resource_health` green before the run.

## Findings (4, all STANDS)
1. **Creature Creation (Newtroost)** — *high* — guidance lists Raw chicken instead of
   Feather; `requiredItemIds [2138, 219]` also uses 219 (= "Grimy torstol" in cache) for
   Eye of newt. Recipe is Eye of newt (221) + Feather (314). Contradicts the source's own
   `locationDescription`.
2. **Creature Creation (Frogeel)** — *high* — guidance lists Raw lobster + Red spiders'
   eggs (a Jubster/Spidine cross-paste); recipe is Raw cave eel (5001) + Giant frog legs
   (4517). Contradicts its own `locationDescription`.
3. **Creature Creation (Unicow)** — *low* — guidance lists Raw beef; recipe is Cowhide
   (1739) + Unicorn horn. Contradicts its own `locationDescription`.
4. **Pyramid Plunder** — *low* — guidance's Pharaoh's-sceptre source/level prose is wrong
   and self-contradictory (71 vs 91 Thieving; "only/exclusive grand gold chest"). The
   sceptre drops from golden chests **and** sarcophagi in **every** room with room-scaled
   odds.

## ID summary
No unresolved/orphaned item/NPC/object id in any OTHER source. cache_ids "name mismatch"
rows on OTHER sources are cosmetic display-name choices (correct ids). `Unsired` (25624)
confirmed correct, not flagged.

## Out of verifiable scope
The Sailing-skill sources (Boat Combat, Salvage, Ocean/Sea, Port Tasks, Paints,
Schematics) describe unreleased content with no Wiki/Temple authority to cite, so no raw
receipt can be produced either way — noted, not logged.

See `docs/verify/findings-OTHER.md` for full receipts and suggested (un-applied) fixes.