### PR TITLE
docs(verify): consolidated data-verification findings (all 6 categories)

### DIFF
--- a/docs/verify/README.md
+++ b/docs/verify/README.md
@@ -1,0 +1,34 @@
+# Data-verification findings (consolidated)
+
+Per-category verification of the auto-grabbed `drop_rates.json` data. Each category was
+verified independently (separate file so parallel sessions don't conflict); this folder is
+the consolidated record. **Verification only - no `drop_rates.json` edits.** Fixes are a
+separate, reviewed step gated by `validate_drop_rates --check cache_ids`.
+
+## Method
+- **IDs:** `validate_drop_rates --check cache_ids` - the abextm game cache is the sole id
+  authority. Result across all 225 sources: **0 wrong/missing ids.** (Name-mismatch warnings
+  are display-string divergences with correct ids, not bugs.)
+- **Semantics:** requirements, fairy-ring codes, arrival coords, travel direction - each
+  finding cited and passed through the `domain-skeptic` agent; only `STANDS` recorded.
+
+## Actionable fix backlog (the real bugs - all `STANDS`)
+The auto-grab's failure mode is **fabricated requirements** and **copy/paste-wrong items**,
+not ids. Highest-value fixes:
+
+- **BOSSES** (`findings-BOSSES.md`): 8 Desert Treasure II entries carry **fabricated `skills`
+  requirements** (e.g. Duke Sucellus `MINING 65`); Araxxor fairy-ring `CLS` is wrong.
+- **OTHER** (`findings-OTHER.md`): Creature Creation **wrong recipe item ids** (Newtroost uses
+  Raw chicken `2138` -> Feather `314`; Grimy torstol `219` -> Eye of newt `221`), plus
+  cross-creature copy/paste ingredients.
+- **MINIGAMES** (`findings-MINIGAMES.md`): Brimhaven Agility Arena **fabricated `AGILITY 40`**
+  gate; 3 wrong fairy-ring codes.
+- **SLAYER** (`findings-SLAYER.md`): Terror Dog wrong fairy-ring code + bearing; 2 low.
+- **RAIDS** (`findings-RAIDS.md`): ToB waypoint **wrong quest gates** (PRIEST_IN_PERIL,
+  A_TASTE_OF_HOPE); Scythe/Sang display names missing "(uncharged)" (ids correct, cosmetic).
+- **SKILLING** (`findings-SKILLING.md`): see file.
+
+## Not a fix backlog
+The `cache_ids` name-mismatch list (24 after suffix/word-order tuning) is mostly display-name
+divergence with **correct ids** (Chompy hat rank names, `lock`/`locks` plurals, `glory (t)` vs
+`(t4)`); optional cosmetic cleanup, not data bugs.

--- a/docs/verify/findings-BOSSES.md
+++ b/docs/verify/findings-BOSSES.md
@@ -1,0 +1,164 @@
+# Data-verification findings — BOSSES
+
+- **Category:** `BOSSES` (61 sources in `src/main/resources/com/collectionloghelper/drop_rates.json`)
+- **Branch:** `verify/BOSSES`
+- **Date:** 2026-06-07
+- **MCP pre-flight:** `resource_health` → all sources `ok` (osrs-wiki, temple-osrs, runelite-ids, mejrs-data, prices, wise-old-man).
+- **Scope:** This file is intentionally separate from the shared `data-verification-log.md` so parallel
+  per-category verification sessions do not conflict. It records findings for the BOSSES category only.
+- **Rule:** verification only — **no edits were made to `drop_rates.json`**. Fixes are a separate reviewed PR.
+
+## Method
+
+Two checks per source, exactly as scoped:
+
+1. **IDs** — `validate_drop_rates --check cache_ids`. The **abextm game cache is the sole id authority**;
+   ids were *not* adjudicated against Temple/wiki. Run globally across all 225 sources, then filtered to BOSSES.
+2. **Judgment** — requirements (quest/skill/diary gates), fairy-ring codes, arrival coordinates
+   (`travel_path_verify`), and travel direction. A candidate was logged **only with a cited raw receipt**,
+   then passed through the `domain-skeptic` agent; **only `STANDS` verdicts are recorded as findings.**
+
+Multi-source clog items are correct by design (never flagged as "duplicate"). Unsired `25624` is
+cache-confirmed and was not flagged.
+
+## Result summary
+
+- **IDs (cache_ids):** all 61 BOSSES sources **clean** — zero unresolved ids and zero name-mismatches.
+  (The global run surfaced 162 name-mismatch warnings, but none belong to a BOSSES source.)
+- **Coordinates (`travel_path_verify`):** one BOSSES hit (Shellbane Gryphon) — **refuted** as a tool
+  false-positive on a deliberately-instanced coordinate (see *Considered & refuted* below).
+- **Fairy-ring codes:** every cited code verified against the wiki; **one wrong** (Araxxor `CLS`).
+- **Requirements gates:** GWD ×4 + Nex, the 8 Desert Treasure II entries, Amoxliatl, and Royal Titans
+  were externally verified. The **8 DT2 entries carry fabricated `skills` requirements** (below); the rest
+  are correct.
+
+**Open findings: 2 issues spanning 9 source-entries (all severity `high`).**
+
+| # | Source | Data verified (V1) | Open findings |
+|---|--------|--------------------|---------------|
+| 1 | General Graardor | 2026-06-07 | - |
+| 2 | Commander Zilyana | 2026-06-07 | - |
+| 3 | K'ril Tsutsaroth | 2026-06-07 | - |
+| 4 | Kree'arra | 2026-06-07 | - |
+| 5 | Zulrah | 2026-06-07 | - |
+| 6 | Vorkath | 2026-06-07 | - |
+| 7 | Cerberus | 2026-06-07 | - |
+| 8 | Alchemical Hydra | 2026-06-07 | - |
+| 9 | Corporeal Beast | 2026-06-07 | - |
+| 10 | Kalphite Queen | 2026-06-07 | - |
+| 11 | Phantom Muspah | 2026-06-07 | - |
+| 12 | Duke Sucellus | - | 1 (high: fabricated skills req MINING 65) |
+| 13 | The Leviathan | - | 1 (high: fabricated skills req RANGED 70) |
+| 14 | The Whisperer | - | 1 (high: fabricated skills req RANGED 75) |
+| 15 | Vardorvis | - | 1 (high: fabricated skills req ATTACK 70) |
+| 16 | Duke Sucellus (Awakened) | - | 1 (high: fabricated skills req MINING 65) |
+| 17 | The Leviathan (Awakened) | - | 1 (high: fabricated skills req RANGED 75) |
+| 18 | The Whisperer (Awakened) | - | 1 (high: fabricated skills req RANGED 80) |
+| 19 | Vardorvis (Awakened) | - | 1 (high: fabricated skills req ATTACK 75) |
+| 20 | Grotesque Guardians | 2026-06-07 | - |
+| 21 | The Nightmare | 2026-06-07 | - |
+| 22 | Phosani's Nightmare | 2026-06-07 | - |
+| 23 | Nex | 2026-06-07 | - |
+| 24 | Sarachnis | 2026-06-07 | - |
+| 25 | Giant Mole | 2026-06-07 | - |
+| 26 | Bryophyta | 2026-06-07 | - |
+| 27 | Obor | 2026-06-07 | - |
+| 28 | Dagannoth Rex | 2026-06-07 | - |
+| 29 | Dagannoth Prime | 2026-06-07 | - |
+| 30 | Dagannoth Supreme | 2026-06-07 | - |
+| 31 | Kraken | 2026-06-07 | - |
+| 32 | Thermonuclear smoke devil | 2026-06-07 | - |
+| 33 | Abyssal Sire | 2026-06-07 | - |
+| 34 | King Black Dragon | 2026-06-07 | - |
+| 35 | Chaos Elemental | 2026-06-07 | - |
+| 36 | Scorpia | 2026-06-07 | - |
+| 37 | Chaos Fanatic | 2026-06-07 | - |
+| 38 | Venenatis | 2026-06-07 | - |
+| 39 | Vet'ion | 2026-06-07 | - |
+| 40 | Callisto | 2026-06-07 | - |
+| 41 | Skotizo | 2026-06-07 | - |
+| 42 | Hespori | 2026-06-07 | - |
+| 43 | Corrupted Gauntlet | 2026-06-07 | - |
+| 44 | The Gauntlet | 2026-06-07 | - |
+| 45 | Barrows | 2026-06-07 | - |
+| 46 | Zalcano | 2026-06-07 | - |
+| 47 | Sol Heredit | 2026-06-07 | - |
+| 48 | Crazy archaeologist | 2026-06-07 | - |
+| 49 | Araxxor | - | 1 (high: travel — fairy ring CLS wrong region) |
+| 50 | Perilous Moons | 2026-06-07 | - |
+| 51 | The Hueycoatl | 2026-06-07 | - |
+| 52 | Yama | 2026-06-07 | - |
+| 53 | Doom of Mokhaiotl | 2026-06-07 | - |
+| 54 | Royal Titans | 2026-06-07 | - |
+| 55 | Amoxliatl | 2026-06-07 | - |
+| 56 | Brutus | 2026-06-07 | - |
+| 57 | Shellbane Gryphon | 2026-06-07 | - |
+| 58 | Scurrius | 2026-06-07 | - |
+| 59 | The Fight Caves | 2026-06-07 | - |
+| 60 | The Inferno | 2026-06-07 | - |
+| 61 | Deranged Archaeologist | 2026-06-07 | - |
+
+---
+
+## Findings (STANDS)
+
+### F1 — Desert Treasure II bosses: fabricated `requirements.skills` access gates — high
+- **Sources (8):** Duke Sucellus, The Leviathan, The Whisperer, Vardorvis, and the four `(Awakened)` variants.
+- **check:** requirements (skill gate) judgment → `wiki_lookup` + live wiki fetch + `wiki_updates` → `domain-skeptic` (STANDS, both passes).
+- **ours:** each source's `requirements.skills` holds a hard skill gate, and the Awakened variants escalate it:
+  - Duke Sucellus / (Awakened): `MINING 65` — `drop_rates.json:1646`, `drop_rates.json:2292`
+  - The Leviathan: `RANGED 70` — `drop_rates.json:1806`; (Awakened): `RANGED 75` — `drop_rates.json:2492`
+  - The Whisperer: `RANGED 75` — `drop_rates.json:1964`; (Awakened): `RANGED 80` — `drop_rates.json:2688`
+  - Vardorvis: `ATTACK 70` — `drop_rates.json:2133`; (Awakened): `ATTACK 75` — `drop_rates.json:2892`
+- **authoritative (raw receipts, oldschool.runescape.wiki, fetched 2026-06-07):**
+  - The Whisperer: *"there are no stated skill level requirements to fight The Whisperer. The only explicit requirement … completed Desert Treasure II - The Fallen Empire … no minimum Combat, Magic, Ranged, or other skill levels … no additional skill requirements … for the Awakened variant beyond needing an Awakener's orb."*
+  - Duke Sucellus: *"there are no stated skill level requirements … no mention of Mining, Herblore, or any other skill … no minimum Herblore or Mining level specified [for the salt/vent prep] … Both the standard and Awakened variants show identical requirement information with no skill prerequisites."*
+  - The Leviathan: *"there are no explicit skill level requirements … The only mentioned requirement is … Desert Treasure II … Awakened … requires an Awakener's orb … but no additional skill requirements."*
+  - Vardorvis: *"there are no explicit skill level requirements … The only requirement mentioned is Quest Completion … recommendations for efficiency, not access requirements."*
+  - `wiki_updates` (Whisperer, Vardorvis): `count: 0` since 2025-01-01 → not staleness drift.
+- **domain-skeptic:** STANDS ×2 (The Whisperer adjudicated separately; Duke/Leviathan/Vardorvis adjudicated together, per-source STANDS). Refutation vectors worked and failed: no hidden area/fight skill gate; Duke's vent-mining imposes no Mining level; Awakened adds only the orb (so a *higher* level for the identical encounter is incoherent); the wiki's only efficiency suggestions are unrelated (e.g. Magic 90+/Prayer 77+ for Augury) and live in no "requirement."
+- **why it matters:** `requirements.skills` is the field the plugin uses to gate/lock a source. A DT2-complete account below the listed level can fight these bosses but would be wrongly locked out of the source. Same schema shape that, for General Graardor, correctly encodes the real Strength-70 GWD gate — so this is a functional defect, not a cosmetic note.
+- **action (for the separate fix PR):** remove the `skills` array from `requirements` on all 8 entries; **keep** `quests: ["DESERT_TREASURE_II__THE_FALLEN_EMPIRE"]`.
+- **status:** open
+
+### F2 — Araxxor: travel guidance cites fairy ring `CLS`, which lands in Kandarin (Yanille), not Morytania — high
+- **Source:** Araxxor (npcId 13668).
+- **check:** fairy-ring-code judgment → `WebFetch` (OSRS Wiki Fairy ring + Araxxor pages) + `wiki_updates` → `domain-skeptic` (STANDS).
+  Note: `travel_path_verify` v1 does **not** catch this — it only checks coordinate bounds, not fairy-ring-code-to-destination semantics (per its own `notes`).
+- **ours:** the Araxxor route prose claims `fairy ring CLS` as the route to the Araxyte cave in NE Morytania, in **three** places:
+  - source `travelTip` — `drop_rates.json:9317` (`"Drakan's medallion -> Darkmeyer, or fairy ring CLS"`)
+  - step #2 `description` — `drop_rates.json:9336` (`"… or fairy ring CLS for the fastest unquested route"`)
+  - step #2 `travelTip` — `drop_rates.json:9342` (`"… run east, or fairy ring CLS"`)
+- **authoritative (raw receipts, oldschool.runescape.wiki, fetched 2026-06-07):**
+  - Fairy ring page: **`CLS` → "Islands: Yanille Chain"** (Kandarin) — opposite side of the map from Morytania. (Morytania's code is `CKS` → Canifis.)
+  - Araxxor page: *"The wiki page does not mention any fairy ring codes for reaching Araxxor's lair. The only travel method specified is: 'Araxxor's lair is accessible from the Morytania Spider Cave … north-east of Darkmeyer.'"* Canonical route is Drakan's medallion → Darkmeyer.
+  - `wiki_updates` (Araxxor): `count: 0` since 2024-08-01 → not staleness drift.
+- **domain-skeptic:** STANDS. Vectors failed: `CLS` is not in/near Morytania; no fairy ring serves the Araxyte cave; even the nearest Morytania code `CKS` (Canifis) does not reach it, so the fix is to **strike the fairy-ring claim**, not swap `CLS`→`CKS` while keeping "fastest unquested route."
+- **action (for the separate fix PR):** remove the `fairy ring CLS` clause from all three strings; keep the Drakan's medallion → Darkmeyer route.
+- **status:** open
+
+---
+
+## Considered & refuted (not logged as defects)
+
+### Shellbane Gryphon — `travel_path_verify` coord-out-of-bounds → REFUTED
+- `travel_path_verify` flagged Shellbane Gryphon steps #2–#4 at tile `(13993, 9901, 0)` as outside legal
+  surface bounds (x 900..4500, y 1100..13500).
+- `domain-skeptic` **REFUTED**: the project's own `verified_scene_ids.json` records this as a deliberately
+  **instanced** coordinate for "The Great Conch island (instance coords ~13993, 9901, plane 0)" with a prior
+  documented coordinate fix (commit `e4dd6a06`). OSRS instanced areas legitimately use coordinates far beyond
+  the surface x-bound; `travel_path_verify` v1 models only surface space and false-positives on instanced
+  sources. The value is correct by design. **Not a finding.**
+
+## Coverage notes (honesty about scope)
+
+- **IDs:** exhaustive — `cache_ids` ran over every item/NPC/object id in all 61 sources.
+- **Coordinates:** exhaustive bound-check via `travel_path_verify` over all 61 sources (808 steps scanned across the dataset).
+- **Fairy-ring codes:** every code cited in BOSSES guidance was verified (BJS, CIR, AKQ, CKS, BKP, CLS, AIQ, BLP, DIP).
+  Only `CLS` (Araxxor) was wrong.
+- **Requirements gates:** externally verified against the wiki for GWD ×4 (Troll Stronghold + per-room 70 skill gates — correct),
+  Nex (consistent), all 8 DT2 entries (wrong — F1), Amoxliatl (Slayer 48 + The Heart of Darkness — correct), and Royal Titans
+  (no requirement — correct). The remaining sources carry standard Slayer-level / single-quest gates consistent with known
+  game data and were not contradicted by any receipt; they were not each independently re-fetched. Yama's page 404'd at the
+  tried slug, so its `A_KINGDOM_DIVIDED` gate was not externally re-confirmed (left as `verified` on domain grounds, flagged here for transparency).
+- **Travel direction:** spot-checked alongside the fairy-ring/coord work; no additional standing discrepancy found.

--- a/docs/verify/findings-MINIGAMES.md
+++ b/docs/verify/findings-MINIGAMES.md
@@ -1,0 +1,150 @@
+# Data-verification findings — MINIGAMES
+
+- **Category:** `MINIGAMES` (25 sources in `src/main/resources/com/collectionloghelper/drop_rates.json`)
+- **Branch:** `verify/MINIGAMES`
+- **Date:** 2026-06-07
+- **MCP pre-flight:** `resource_health` → all sources `ok` (osrs-wiki, prices-api, wise-old-man, temple-osrs, runelite-ids, mejrs-data).
+- **Scope:** This file is intentionally separate from the shared `data-verification-log.md` so parallel
+  per-category verification sessions do not conflict. It records findings for the MINIGAMES category only.
+- **Rule:** verification only — **no edits were made to `drop_rates.json`**. Fixes are a separate reviewed PR.
+
+## Method
+
+Two checks per source, exactly as scoped:
+
+1. **IDs** — `validate_drop_rates --check cache_ids --source_name "<source>"`, run per source. The
+   **abextm game cache is the sole id authority**; ids were *not* adjudicated against Temple/wiki.
+2. **Judgment** — requirements (quest/skill/diary gates), fairy-ring codes, arrival coordinates
+   (`travel_path_verify`), and travel direction. A candidate was logged **only with a cited raw receipt**,
+   then passed through the `domain-skeptic` agent; **only `STANDS` verdicts are recorded as findings.**
+
+Multi-source clog items are correct by design (never flagged as "duplicate"). Unsired `25624` is
+cache-confirmed and was not flagged.
+
+## Result summary
+
+- **IDs (cache_ids):** all 25 MINIGAMES sources **id-clean** — every item/NPC/object id resolves in the
+  abextm cache. The per-source runs surfaced name-display *mismatches* on 7 sources (Hallowed Sepulchre,
+  Brimhaven Agility Arena, Pest Control, Shades of Mort'ton, Mastering Mixology, Castle Wars, Soul Wars,
+  Trouble Brewing). **None is an id error** — each is an intentional collection-log disambiguation label
+  (variant/charge/colour suffixes such as `(Brimhaven)`, `Mysterious page 1..5`, `(red)/(white)/(gold)`,
+  `(uncharged)`, `(disassembled)`). Cache is the id authority and the ids are valid, so these are **not
+  findings**. See *Considered & not logged* below.
+- **Coordinates (`travel_path_verify`):** zero MINIGAMES hits. The global run (808 steps / 225 sources)
+  flagged only non-MINIGAMES sources (Treasure Trails, Shellbane Gryphon, Miscellaneous). All MINIGAMES
+  coords are within legal world bounds.
+- **Fairy-ring codes:** every cited code verified against the wiki fairy-ring code table. **Three wrong**
+  (Brimhaven `CKR`, Volcanic Mine `DLR`, Fishing Trawler `BKP`).
+- **Requirements gates:** quest+skill gates spot-verified against the wiki. Mage Training Arena
+  (`MAGIC 7`) and Vale Totems (`Vale Totems` miniquest + `FLETCHING 20`) **confirmed correct**. Brimhaven
+  Agility Arena carries a **fabricated hard `AGILITY 40`** gate (below).
+
+**Open findings: 4 (1 × high, 3 × low). All four passed the `domain-skeptic` gate as `STANDS`.**
+
+| # | Source | Data verified (V1) | Open findings |
+|---|--------|--------------------|---------------|
+| 1 | Tempoross | 2026-06-07 | - |
+| 2 | Wintertodt | 2026-06-07 | - |
+| 3 | Hallowed Sepulchre | 2026-06-07 | - |
+| 4 | Guardians of the Rift | 2026-06-07 | - |
+| 5 | Brimhaven Agility Arena | - | 2 (high: fabricated `AGILITY 40` gate; low: wrong fairy ring `CKR`) |
+| 6 | Giants' Foundry | 2026-06-07 | - |
+| 7 | Pest Control | 2026-06-07 | - |
+| 8 | Mage Training Arena | 2026-06-07 | - |
+| 9 | Shades of Mort'ton | 2026-06-07 | - |
+| 10 | Mahogany Homes | 2026-06-07 | - |
+| 11 | Mastering Mixology | 2026-06-07 | - |
+| 12 | Volcanic Mine | - | 1 (low: fabricated fairy ring `DLR` fallback) |
+| 13 | Tithe Farm | 2026-06-07 | - |
+| 14 | Gnome Restaurant (Scarfs) | 2026-06-07 | - |
+| 15 | Fishing Trawler | - | 1 (low: wrong fairy ring `BKP`, should be `DJP`) |
+| 16 | Temple Trekking | 2026-06-07 | - |
+| 17 | Rogues' Den | 2026-06-07 | - |
+| 18 | Castle Wars | 2026-06-07 | - |
+| 19 | Soul Wars | 2026-06-07 | - |
+| 20 | Last Man Standing | 2026-06-07 | - |
+| 21 | Vale Totems | 2026-06-07 | - |
+| 22 | Trouble Brewing | 2026-06-07 | - |
+| 23 | Barbarian Assault | 2026-06-07 | - |
+| 24 | Barracuda Trials | 2026-06-07 (unreleased Sailing content; not externally verifiable) | - |
+| 25 | Gnome Restaurant (Seed Pods) | 2026-06-07 | - |
+
+## Findings
+
+### Finding 1 — Brimhaven Agility Arena: fabricated `AGILITY 40` requirement — severity high
+
+- **Where:** `Brimhaven Agility Arena` → `requirements.skills` = `[{"skill":"AGILITY","level":40}]`.
+- **Receipt (OSRS Wiki, Brimhaven Agility Arena):** *"The course has no requirements to access other
+  than a 200 coins fee paid to Cap'n Izzy No-Beard before each entry... Though it is possible to reach
+  dispensers without any Agility levels, level 20 Agility is required to pass the pressure pad and floor
+  spike obstacles, while level 40 Agility is required for the spinning blades and darts."*
+- **Why it's wrong:** there is no access/reward gate at 40 Agility. Tickets and the clog rewards
+  (Brimhaven Graceful recolours, Pirate's hook) are obtainable below 40 (even at 0) Agility — level 40
+  only unlocks specific obstacles, not the source. A hard `AGILITY 40` gate incorrectly hides a
+  reachable clog source from the low-level accounts who most need the recommendation.
+- **domain-skeptic:** `STANDS` (high). No account type makes 40 Agility a hard requirement to obtain
+  rewards; the multi-source / variant / account-type vectors do not apply.
+- **Suggested fix (separate PR):** drop the gate, or model it as a soft/efficiency note (~20–40 Agility),
+  not a blocking requirement.
+
+### Finding 2 — Brimhaven Agility Arena: wrong fairy ring code `CKR` — severity low
+
+- **Where:** top-level `travelTip` "Fairy ring CKR -> Brimhaven, or charter ship to Brimhaven" and
+  `guidanceSteps[0].travelTip` "Fairy ring CKR -> run east to arena entrance".
+- **Receipt (OSRS Wiki fairy-ring code table):** `CKR` = "Karamja: South of Tai Bwo Wannai Village"
+  (deep south-central Karamja). The wiki Brimhaven travel section lists **no** fairy-ring route.
+- **Why it's wrong:** the arena is at `(2809,3194)` in **northern** Karamja; CKR (~`2801,3003`) is
+  ~191 tiles **south** (`coordinate_helper` distance). The route is a long run north, not "east", and CKR
+  is not a sensible Brimhaven approach.
+- **domain-skeptic:** `STANDS` (low) — travel-hint accuracy only; does not hide the source or affect ids.
+
+### Finding 3 — Volcanic Mine: fabricated fairy ring `DLR` fallback — severity low
+
+- **Where:** `guidanceSteps[1].travelTip` "Digsite pendant -> Mushroom Forest + run NE, or Fairy ring DLR"
+  and the step description "...or use Fairy ring DLR for the closest fairy ring fallback".
+- **Receipt (OSRS Wiki, Volcanic Mine travel section):** lists only the Volcanic mine teleport and
+  Digsite-pendant routes — **no fairy ring**. Fossil Island is reached by barge and has no fairy ring.
+  `DLR` = "Islands: Poison Waste south of Isafdar" (Tirannwn), an unrelated region.
+- **Why it's wrong:** there is no fairy-ring route to the Volcanic Mine; DLR lands in Tirannwn. (The
+  top-level `travelTip` "Digsite pendant -> Fossil Island" is correct — only the DLR addition is wrong.)
+- **domain-skeptic:** `STANDS` (low) — misleading fallback hint; does not hide the source or affect ids.
+
+### Finding 4 — Fishing Trawler: wrong fairy ring code `BKP` — severity low
+
+- **Where:** top-level `travelTip` "fairy ring BKP -> Port Khazard" and `guidanceSteps[0].travelTip`/
+  description "fairy ring BKP -> run south".
+- **Receipt (OSRS Wiki):** `BKP` = "Feldip Hills: Chompy Marsh, south of Castle Wars". The Fishing
+  Trawler page's fairy-ring bullet is **`DJP`** ("Fairy ring code DJP, then run south") — DJP is by the
+  Tower of Life, just north of Port Khazard.
+- **Why it's wrong:** a fairy-ring-then-south route to the Trawler is legitimate, but the code is wrong —
+  BKP is in Feldip Hills, far south of and unconnected to Port Khazard; running south from BKP heads away
+  from Khazard. The correct code is `DJP`.
+- **domain-skeptic:** `STANDS` (low) — route shape is right, only the code letters are wrong; does not
+  hide the source or affect ids.
+
+## Considered & not logged
+
+- **cache_ids name-display mismatches (7 sources, ~57 entries):** every flagged id resolves in the abextm
+  cache; the warnings are name-label differences vs the cache canonical name, all intentional
+  collection-log disambiguations:
+  - Hallowed Sepulchre — `Mysterious page 1..5` (5 distinct ids 24763/24765/24767/24769/24771, cache name
+    "Mysterious page"); `Strange old lockpick` (24740, cache "(full)"); `Ring of endurance` (24844, cache
+    "(uncharged)") — the uncharged variant is the clog-tracked item.
+  - Brimhaven Agility Arena — Graceful `(Brimhaven)` recolour suffixes (21061/21067/21070/21073/21076/21064).
+  - Pest Control — `Void seal` (11666, cache "Void seal(8)").
+  - Shades of Mort'ton — `Amulet of the damned` (12851, cache "(full)"); lock colour names
+    (`Bronze/Steel/Black/Silver/Gold lock` vs cache "…locks").
+  - Mastering Mixology — `Chugging barrel` (30002, cache "(disassembled)").
+  - Castle Wars — `Decorative …` colour/slot suffixes and `Castlewars hood/cloak (Saradomin/Zamorak)`.
+  - Soul Wars — `Soul cape (blue)` (25346, cache "Soul cape").
+  - Trouble Brewing — `Rum (red)`/`Rum (blue)` (8940/8941, cache "Rum").
+  Cache is the sole id authority and the ids are valid → **not findings**.
+- **Mage Training Arena `MAGIC 7`** — wiki: *"Players need a minimum of level 7 Magic to participate"* →
+  correct.
+- **Vale Totems `Vale Totems` miniquest + `FLETCHING 20`** — wiki: *"Completion of the Vale Totems
+  miniquest. Level 20 Fletching is required"* → both correct.
+- **Shades of Mort'ton `BKR`, Tithe Farm `CIR`** — fairy-ring codes verified against the kingdom they
+  serve (Mort Myre/Canifis and Kebos/Kourend respectively); within the correct region, not logged.
+- **Pest Control / Soul Wars combat-level gates** — the schema models skill/quest/diary gates only;
+  combat-level minimums are not representable and were not flagged.
+- **Multi-source clog items** — left as correct by design.

--- a/docs/verify/findings-OTHER.md
+++ b/docs/verify/findings-OTHER.md
@@ -1,0 +1,170 @@
+# Data-verification findings — OTHER category
+
+Scope: all 58 `OTHER` sources in
+`src/main/resources/com/collectionloghelper/drop_rates.json`.
+
+Method:
+- **IDs** — `validate_drop_rates --check cache_ids` (whole-file run, OTHER sources
+  filtered out). The abextm game cache is the sole id authority; ids were not adjudicated
+  against Temple/wiki. Guidance-step `requiredItemIds` (which `cache_ids` does not cover)
+  were spot-checked with `cross_check_ids` where a discrepancy was suspected.
+- **Judgment** (requirements/quest+skill+diary gates, fairy-ring codes, arrival coords,
+  travel direction) — only logged with a cited raw receipt, then passed through the
+  `domain-skeptic` agent; only verdicts that **STAND** are recorded below.
+- `resource_health` confirmed green (osrs-wiki, prices, WOM, temple-osrs, runelite-ids,
+  mejrs all 200) before the run.
+- `drop_rates.json` was **not** edited. Findings only.
+
+Sources reviewed (58): Revenants, Brimstone Chest, Larran's Big Chest, Zombie Pirate
+Locker, Boat Paints, Champion's Challenge, Chompy Bird Hunting, Forestry, Fossil Island
+Notes, Glough's Experiments, Hunter Guild, Lost Schematics, Monkey Backpacks, My Notes,
+Ocean Encounters, Sailing Misc, Sea Treasures, Pyramid Plunder, Stronghold of Security,
+Catacombs of Kourend, Wilderness God Wars Dungeon, Elven Crystal Chest, Miscellaneous,
+Random Events, Camdozaal, TzHaar, Cyclopes, Elder Chaos Druids, Shayzien Armour,
+Creature Creation (Newtroost, Unicow, Spidine, Swordchick, Jubster, Frogeel),
+Stingray / Albatross / Narwhal / Orcas / Great White Shark / Vampyre Kraken (Boat Combat),
+Small / Fishy / Barracuda / Large / Plundered / Martial / Fremennik / Opulent Salvage,
+Mithril Dragon, Adamant Dragon, Rune Dragon, Ogress Shaman, Armoured Zombie,
+Prifddinas Elf, Fountain of Rune, Waterfiend, Port Tasks.
+
+---
+
+## ID verification summary
+
+`validate_drop_rates --check cache_ids` returns **no unresolved / orphaned item, NPC, or
+object id** for any OTHER source. Every id resolves in the abextm cache. The cache_ids
+"name mismatch" rows that touch OTHER sources (Revenants `Bracelet of ethereum`,
+Champion's Challenge scroll naming, Chompy Bird Hunting hats → cache "Chompy bird hat",
+My Notes / Mithril Dragon `Ancient page 1–26`, Sea Treasures `Medallion fragment 1–8`,
+Pyramid Plunder `Pharaoh's sceptre`, Miscellaneous `Xeric's talisman`, Armoured Zombie
+zombie scroll) are **cosmetic display-name choices** — the id is correct and resolves;
+the cache simply uses a generic/base or `(uncharged)` name. Per the rule that the cache is
+the sole id authority and these are not wrong ids, none are logged as ID findings.
+`Unsired` (25624) is cache-confirmed correct and was not flagged.
+
+The id defect below was found in a guidance-step `requiredItemIds` (outside cache_ids'
+coverage) and is reported under the Newtroost finding.
+
+---
+
+## Findings (STANDS)
+
+### 1. Creature Creation (Newtroost) — wrong creation ingredient + wrong Eye-of-newt id  — severity: high
+
+- **Source:** `Creature Creation (Newtroost)` (OTHER), source block at line 22806.
+- **Data:**
+  - `guidanceSteps[0].description`: "Bring **raw chicken** and eye of newt as ingredients."
+  - `guidanceSteps[0].requiredItemIds`: `[2138, 219]`.
+  - `guidanceSteps[1].description`: "Place **raw chicken** and eye of newt on the Altar of Life to create a Newtroost…"
+  - The source's own `locationDescription`: "Tower of Life, south of Ardougne (**Eye of newt + Feather**)".
+- **Receipt** (OSRS Wiki, https://oldschool.runescape.wiki/w/Creature_Creation recipe
+  table, fetched 2026-06-07): **Newtroost = 1 Eye of newt + 1 Feather.** Raw chicken is a
+  *Swordchick* ingredient, not a Newtroost one.
+- **ID receipt** (`cross_check_ids`, abextm cache): `219 → "Grimy torstol"` (name-mismatch),
+  `221 → "Eye of newt"` (match), `314 → "Feather"` (match), `2138 → "Raw chicken"` (match).
+  So `requiredItemIds` is wrong twice: 2138 (Raw chicken) should be **314 (Feather)**, and
+  219 (Grimy torstol) should be **221 (Eye of newt)**.
+- **Why it stands:** Recipe is fixed game content (Tower of Life, 2007), identical across
+  account types; diary tiers only affect whether *drops* are noted, not inputs. The step
+  contradicts both the wiki and the source's own `locationDescription`.
+- **domain-skeptic:** STANDS (high) — survived every refutation vector; also independently
+  surfaced the 219→Grimy torstol id error.
+- **Suggested fix (not applied):** `requiredItemIds` `[2138, 219]` → `[221, 314]`; both
+  step descriptions "raw chicken and eye of newt" → "eye of newt and feather".
+
+### 2. Creature Creation (Frogeel) — wrong creation ingredients (cross-creature copy/paste)  — severity: high
+
+- **Source:** `Creature Creation (Frogeel)` (OTHER), source block at line 23156.
+- **Data:**
+  - `guidanceSteps[0].description`: "Bring **raw lobster and red spiders' eggs** as ingredients."
+  - `guidanceSteps[0].requiredItemIds`: `[377, 223]`.
+  - `guidanceSteps[1].description`: "Place **raw lobster and red spiders' eggs** on the Altar of Life to create a Frogeel…"
+  - The source's own `locationDescription`: "Tower of Life, south of Ardougne (**Raw cave eel + Giant frog legs**)".
+- **Receipt** (OSRS Wiki, Creature Creation recipe table, fetched 2026-06-07):
+  **Frogeel = 1 Raw cave eel + 1 Giant frog legs.**
+- **ID receipt** (`cross_check_ids`): `377 → "Raw lobster"` (a *Jubster* ingredient),
+  `223 → "Red spiders' eggs"` (a *Spidine* ingredient), `5001 → "Raw cave eel"` (match),
+  `4517 → "Giant frog legs"` (match). The listed ingredients are a cross-creature
+  copy/paste, not the Frogeel recipe.
+- **Why it stands:** Fixed, ancient game content; no mechanic produces a Frogeel from
+  lobster + spider eggs. Contradicts both the wiki and the source's own `locationDescription`.
+- **domain-skeptic:** STANDS (high) — survived every refutation vector.
+- **Suggested fix (not applied):** `requiredItemIds` `[377, 223]` → `[5001, 4517]`; both
+  step descriptions → "raw cave eel and giant frog legs".
+
+### 3. Creature Creation (Unicow) — wrong creation ingredient  — severity: low
+
+- **Source:** `Creature Creation (Unicow)` (OTHER), source block at line 22876.
+- **Data:**
+  - `guidanceSteps[0].description`: "Bring **raw beef** and unicorn horn as ingredients."
+  - `guidanceSteps[0].requiredItemIds`: `[2132, 237]`.
+  - `guidanceSteps[1].description`: "Place **raw beef** and unicorn horn on the Altar of Life…"
+  - The source's own `locationDescription`: "Tower of Life, south of Ardougne (**Cowhide + Unicorn horn**)".
+- **Receipt** (OSRS Wiki, Creature Creation recipe table, fetched 2026-06-07):
+  **Unicow = 1 Cowhide + 1 Unicorn horn.**
+- **ID receipt** (`cross_check_ids`): `2132 → "Raw beef"` (match), `1739 → "Cowhide"` (match),
+  `237 → "Unicorn horn"` (match). The intended ingredient (Cowhide) carries id 1739, not 2132.
+- **Why it stands:** Recipes are fixed per altar and noted items aren't accepted; raw beef
+  is never a Unicow input. Contradicts both the wiki and the source's own `locationDescription`.
+  Low severity: player-facing inventory hint, does not affect the clog item id or drop rate.
+- **domain-skeptic:** STANDS (low) — survived every applicable refutation vector.
+- **Suggested fix (not applied):** `requiredItemIds` `[2132, 237]` → `[1739, 237]`; both
+  step descriptions "raw beef and unicorn horn" → "cowhide and unicorn horn".
+
+### 4. Pyramid Plunder — Pharaoh's sceptre source/level guidance is wrong and self-contradictory  — severity: low
+
+- **Source:** `Pyramid Plunder` (OTHER), source block at line 20658, item
+  `Pharaoh's sceptre` (itemId 26945 — cache-confirmed, not in dispute).
+- **Data:**
+  - `guidanceSteps[0].description`: "Need **71 Thieving minimum** to access the grand gold
+    chest (**the only Pharaoh's sceptre source**)."
+  - `guidanceSteps[2].description`: "At room 8 (requires **91 Thieving**), loot the grand
+    gold chest which **exclusively** yields the Pharaoh's sceptre."
+- **Receipts:**
+  - `wiki_lookup` "Pharaoh's sceptre": "…found during the Pyramid Plunder minigame in
+    Sophanem, **from the golden chests and sarcophagi**." / "The chance of receiving a
+    pharaoh's sceptre **scales depending on the room**."
+  - `wiki_lookup` / WebFetch "Pyramid Plunder": "Every ten levels thereafter will grant
+    entrance to the more valuable rooms, **up to level 91**." Room table: rooms 6/7/8 =
+    71/81/91; every room contains a golden chest **and** a sarcophagus.
+- **Why it stands:** The sceptre drops from golden chests **and sarcophagi** in **every
+  room** (room-scaled odds), so both the "only … source" (step0) and "grand gold chest …
+  exclusively" (step8/2) framings are false, and there is no distinct "grand gold chest"
+  entity. The 71-vs-91 wording is also inconsistent — but note the correct repair is **not**
+  simply "71 → 91": a player can already obtain the sceptre at 71 (room 6) at worse odds;
+  91 (room 8) is the best-odds recommendation, not the access gate. Low severity: advisory
+  prose only; item id and drop rate unaffected.
+- **domain-skeptic:** STANDS (low) — confirmed the prose error and corrected the finding's
+  own proposed fix.
+- **Suggested fix (not applied):** Rewrite both steps to state the sceptre drops from golden
+  chests and sarcophagi in every room with room-scaled odds, recommend room 8 (91 Thieving)
+  for best odds, and drop the "grand gold chest" / "exclusive" / "only source" framing.
+
+---
+
+## Checked and cleared (no finding)
+
+- **ID integrity** — every OTHER-source item/NPC/object id resolves in the abextm cache
+  (cache_ids name-mismatches are cosmetic; see ID summary above). `Unsired` (25624) correct.
+- **Fairy-ring codes** (all consistent with destination): Brimstone Chest **CIR** (Mount
+  Karuulm), Chompy Bird Hunting **AKS** (Feldip Hills), Monkey Backpacks **CLR** (Ape
+  Atoll), TzHaar **BLP** (TzHaar City), Catacombs of Kourend **CIS** (Kourend Castle),
+  Creature Creation ×6 **DJP** (Tower of Life).
+- **Hunter Guild** — "Requires 46 Hunter and completion of Children of the Sun" matches the
+  wiki (46 Hunter, not boostable; Children of the Sun gates Varlamore travel). Correct.
+- **Monkey Backpacks** — "requires Monkey Madness II": the Ape Atoll Agility *course* needs
+  only MM1, but the monkey-backpack transformations (the clog items) genuinely require MM2,
+  so the requirement is legitimate for this source. domain-skeptic refutation expected → not
+  logged.
+- **Fountain of Rune** — "Charging glory requires completion of Heroes' Quest" matches the
+  wiki ("Charging amulets of glory requires completion of Heroes' Quest"). Correct.
+- **Champion's Challenge** — "guild requires 32 Quest Points to enter" matches the wiki.
+- **Miscellaneous** — `travel_path_verify` flags `Miscellaneous#1` tile `(0,0,0)` as
+  out-of-bounds, but this is a deliberate "no single location" sentinel for an aggregate tab
+  ("items with no dedicated source"); the source-level coords are valid (3222,3218).
+  Intentional → not logged as a correctness finding.
+- **Sailing-skill sources** (Boat Paints, Lost Schematics, Ocean Encounters, Sailing Misc,
+  Sea Treasures, Port Tasks, the 6 Boat Combat NPCs, the 8 Salvage sources) describe
+  unreleased Sailing content with no OSRS Wiki / Temple authority to cite. No raw receipt
+  can be produced for or against their judgment fields, so they are out of verifiable scope
+  and intentionally not logged either way.

--- a/docs/verify/findings-RAIDS.md
+++ b/docs/verify/findings-RAIDS.md
@@ -1,0 +1,100 @@
+# RAIDS source verification — findings
+
+Branch: `verify/RAIDS` · Date: 2026-06-07 · Verifier: cache-id + judgment pass per session protocol.
+
+MCP pre-flight: `resource_health` → **ok** (osrs-wiki, prices-api, wise-old-man, temple-osrs, runelite-ids, mejrs-data all 200).
+
+Scope: the 7 RAIDS sources in `src/main/resources/com/collectionloghelper/drop_rates.json`:
+Chambers of Xeric · Chambers of Xeric (Challenge Mode) · Theatre of Blood · Theatre of Blood (Hard Mode) · Tombs of Amascut · Tombs of Amascut (300 Invocation) · Tombs of Amascut (500 Invocation).
+
+Method:
+- **IDs** — `validate_drop_rates --check cache_ids` per source (abextm cache = sole id authority).
+- **Judgment** — requirement/quest gates, fairy-ring codes, arrival coords via `travel_path_verify` + `coordinate_helper`, travel direction. Each judgment finding carries a cited raw receipt and was passed through the `domain-skeptic` agent; only STANDS verdicts are kept.
+
+drop_rates.json was **not** modified (verification only).
+
+---
+
+## Summary
+
+| # | Source(s) | Type | Severity | Verdict |
+|---|-----------|------|----------|---------|
+| F1 | Theatre of Blood, Theatre of Blood (Hard Mode) | Quest gate over-strict | High | STANDS |
+| F2 | Theatre of Blood | Waypoint quest req wrong | Low | STANDS |
+| F3 | Theatre of Blood | cache_ids name mismatch (id OK) | Low | tool receipt |
+| F4 | Tombs of Amascut ×3 | cache_ids name mismatch (id OK) | Low | tool receipt |
+
+Chambers of Xeric and Chambers of Xeric (Challenge Mode) passed all checks with no findings.
+`Unsired` (25624) is not present in RAIDS sources; no action. No "duplicate item" findings logged (the same clog item appearing across multiple sources / item-tier variants is correct by rule).
+
+---
+
+## F1 — Theatre of Blood quest gate is over-strict (High) — STANDS
+
+**Sources:** `Theatre of Blood` (drop_rates.json:6516), `Theatre of Blood (Hard Mode)` (drop_rates.json:6741).
+**Data:** top-level `requirements.quests = ["A_TASTE_OF_HOPE"]`.
+**Should be:** `["PRIEST_IN_PERIL"]`.
+
+**Raw receipt — `wiki_lookup` "Theatre of Blood":**
+> "The only hard requirement to participate in the raid is the completion of the Priest in Peril quest to be able to access Morytania."
+
+**Raw receipt — `wiki_lookup` "Ver Sinhaza" (via skeptic):**
+> Drakan's medallion (needs A Taste of Hope) is one of three routes; the Andras-pay-to-Slepe route and the Ectophial route require only Morytania access (Priest in Peril), not A Taste of Hope.
+
+**Why it stands:** `RequirementsChecker.checkRequirementsDetail` treats `requirements.quests` as a **hard FINISHED accessibility gate** (`src/main/java/com/collectionloghelper/data/RequirementsChecker.java:312-321`, marks source inaccessible at 84-90). A player with Priest in Peril but not A Taste of Hope can still enter ToB (Slepe/Andras route), so the current gate hides an accessible source. The project's own convention confirms this: every other Morytania source gates on `PRIEST_IN_PERIL`, and ToB's own travel waypoint already carries `PRIEST_IN_PERIL` while the top-level gate contradicts it. The A Taste of Hope convenience (Drakan's medallion) is already preserved as a `conditionalAlternative`, so correcting the gate loses no information.
+
+**Skeptic:** STANDS — high. Ran all refutation vectors (multi-source / variant / account-type / staleness via `wiki_updates` count=0 / requirement-nuance); none rescued the value.
+
+---
+
+## F2 — Drakan's medallion → Ver Sinhaza waypoint requires the wrong quest (Low) — STANDS
+
+**Source:** `Theatre of Blood`, waypoint "Drakan's medallion to Ver Sinhaza" (drop_rates.json:6646; requirement at :6652).
+**Data:** `requirements.quests = ["SINS_OF_THE_FATHER"]`.
+**Should be:** `["A_TASTE_OF_HOPE"]`.
+
+**Raw receipt — `wiki_lookup` "Drakan's medallion":**
+> "Drakan's medallion is a reward from the quest **A Taste of Hope**. It allows unlimited teleportation to **Ver Sinhaza**, **Darkmeyer (after completion of Sins of the Father)**, and the Sisterhood Sanctuary under Slepe..."
+
+**Why it stands:** The "after completion of Sins of the Father" parenthetical attaches to the **Darkmeyer** destination only. The Ver Sinhaza teleport is available immediately on obtaining the medallion (i.e. completing A Taste of Hope). The file itself already distinguishes the two gates correctly for the Darkmeyer waypoints (line 32387), so this is an isolated wrong-quest gate, not a convention. Blast radius is low (worst case the plugin suggests the slower Canifis-walk fallback for AToH-but-not-SotF accounts; it never routes a player somewhere they cannot go). Note: `Theatre of Blood (Hard Mode)` has **no** `waypoints` array, so this finding is confined to the regular source.
+
+**Skeptic:** STANDS — low.
+
+---
+
+## F3 — Theatre of Blood cache_ids name mismatch (id correct) (Low) — tool receipt
+
+**Raw receipt — `validate_drop_rates --check cache_ids --source_name "Theatre of Blood"`:**
+> [Theatre of Blood] [cache_ids] itemId 22486 name mismatch: data "Scythe of vitur" vs cache "Scythe of vitur (uncharged)" — verify the canonical id
+> [Theatre of Blood] [cache_ids] itemId 22481 name mismatch: data "Sanguinesti staff" vs cache "Sanguinesti staff (uncharged)" — verify the canonical id
+
+**Assessment:** The **ids are cache-confirmed correct** — 22486 / 22481 are the uncharged variants the collection log actually tracks. Only the stored display-name string is off (missing "(uncharged)"). This is internally inconsistent: the `Theatre of Blood (Hard Mode)` source already names the same ids "Scythe of vitur (uncharged)" / "Sanguinesti staff (uncharged)" and passes clean. No id change needed; cosmetic name string only. (Deterministic tool output — no domain-skeptic pass required.)
+
+---
+
+## F4 — Tombs of Amascut cache_ids name mismatch (id correct) (Low) — tool receipt
+
+**Raw receipt — `validate_drop_rates --check cache_ids --source_name "Tombs of Amascut"`:**
+> [Tombs of Amascut] [cache_ids] itemId 27277 name mismatch: data "Tumeken's shadow" vs cache "Tumeken's shadow (uncharged)" — verify the canonical id
+> [Tombs of Amascut (300 Invocation)] [cache_ids] itemId 27277 name mismatch: data "Tumeken's shadow" vs cache "Tumeken's shadow (uncharged)"
+> [Tombs of Amascut (500 Invocation)] [cache_ids] itemId 27277 name mismatch: data "Tumeken's shadow" vs cache "Tumeken's shadow (uncharged)"
+
+**Assessment:** id 27277 is **cache-confirmed correct** (the uncharged shadow is the clog-tracked drop). Only the display-name string differs (missing "(uncharged)"). Cosmetic name string only across all three ToA variants; no id change needed. (Deterministic tool output — no domain-skeptic pass required.)
+
+---
+
+## Checks that passed (no findings)
+
+- **cache_ids** — Chambers of Xeric, Chambers of Xeric (Challenge Mode): clean. ToA family: all ids valid (only the 27277 name string flagged, F4). ToB family: all ids valid (only 22486/22481 name strings flagged, F3). Drop rates, pet/independent flags, `requiresPrevious` chains, and `mutuallyExclusiveSources` pairings all consistent.
+- **Arrival coords (`travel_path_verify` + `coordinate_helper identify`):** all RAIDS coords in-bounds and on the correct plane. CoX (1233,3573)=Chambers of Xeric center; ToB (3650,3218)=Ver Sinhaza (ToB) center; ToA (3234,2784)=Necropolis (58 tiles from Sophanem). `travel_path_verify` reported zero RAIDS findings (its out-of-bounds hits were all in non-RAIDS sources).
+- **Requirement gates (other):** ToA / ToA 300 / ToA 500 `requirements.quests = ["BENEATH_CURSED_SANDS"]` — correct (hard gate to access the Tombs). CoX / CoX CM no quest gate — correct.
+- **Fairy-ring / travel direction:** ToA guidance "fairy ring AKP and run south" — AKP lands north of the Necropolis, so running south to the entrance is the correct direction. (`travel_path_verify` v1 does not yet semantically cross-check fairy-ring codes; verified by direction consistency, no contradiction found.)
+- **Travel tips:** CoX (Xeric's talisman), ToB (Drakan's medallion), ToA (Pharaoh's sceptre Jaltevas) all consistent with wiki travel methods.
+
+---
+
+## Recommended fixes (for a separate data-edit PR — NOT applied here)
+
+1. F1: set `requirements.quests` to `["PRIEST_IN_PERIL"]` for both Theatre of Blood and Theatre of Blood (Hard Mode).
+2. F2: set the "Drakan's medallion to Ver Sinhaza" waypoint `requirements.quests` to `["A_TASTE_OF_HOPE"]`.
+3. F3/F4: append "(uncharged)" to the data `name` strings for 22486, 22481 (ToB) and 27277 (ToA ×3) to match the cache canonical names and the existing Hard Mode source. Ids are correct — no id change.

--- a/docs/verify/findings-SKILLING.md
+++ b/docs/verify/findings-SKILLING.md
@@ -1,0 +1,111 @@
+# Data-verification findings — SKILLING category
+
+Scope: all 17 `SKILLING` sources in
+`src/main/resources/com/collectionloghelper/drop_rates.json`.
+
+Method:
+- **IDs** — `validate_drop_rates --check cache_ids --source_name "<source>"` per source.
+  The abextm game cache is the sole id authority; ids were not adjudicated against
+  Temple/wiki.
+- **Judgment** (requirements/quest+skill+diary gates, fairy-ring codes, arrival coords,
+  travel direction) — only logged with a cited raw receipt, then passed through the
+  `domain-skeptic` agent; only verdicts that **STAND** are recorded below.
+- `resource_health` confirmed green (osrs-wiki, temple-osrs, prices, WOM, runelite-ids,
+  mejrs all 200) before the run.
+- `drop_rates.json` was **not** edited. Findings only.
+
+Sources reviewed: Aerial Fishing, Deep Sea Fishing, Colossal Wyrm Agility, Rooftop Agility,
+Motherlode Mine, Shooting Stars, Thieving (Seed Stalls), Black Chinchompas,
+Woodcutting (Teak Trees), Mining (Gemstone Rocks), Fishing (Swordfish),
+Runecrafting (Fire Runes), Farming (Fruit Trees), Underwater Crabs, Cutting Squid,
+Prifddinas Rabbit, Pickpocketing Darkmeyer Vyre.
+
+---
+
+## Findings (STANDS)
+
+### 1. Cutting Squid — requirements gate under-specified  — severity: high
+
+- **Source:** `Cutting Squid` (SKILLING), item `Squid beak` (itemId 31572).
+- **Data:** `requirements` block at lines 32072–32077 —
+  `{ "skills": [ { "skill": "SAILING", "level": 45 } ] }`. No Fishing requirement.
+  Guidance prose at line 32030 also states "Sailing level 45 required."
+- **Receipt** (OSRS Wiki, https://oldschool.runescape.wiki/w/Raw_swordtip_squid):
+  > "Raw swordtip squid is a fish caught by lantern harpooning, requiring level 52 Fishing
+  > alongside a lantern and harpoon. … the minimum Sailing level to catch them is 47, the
+  > level required to dock at the Onyx Crest."
+
+  Corroborating (https://oldschool.runescape.wiki/w/Lantern_harpooning):
+  > "Lantern harpooning is a Fishing activity released with Sailing, requiring at least
+  > 47 Sailing and 52 Fishing."
+- **Why it stands:** Squid beak is obtained only by cutting squid, and squid are caught
+  only via lantern harpooning. The universal activity floor is **Sailing 47 + Fishing 52**.
+  The data's Sailing 45 is below the true gate, and the Fishing 52 requirement is absent —
+  so the source is reachable in-data at Sailing 45 / 0 Fishing, which no real account can do.
+  Account-type-invariant; wiki page unchanged since 2025-06-01 (not staleness). Item id is
+  cache-confirmed correct and not in dispute.
+- **domain-skeptic:** STANDS (high). Both prongs survived every refutation vector.
+- **Suggested fix (not applied):** Sailing 45 → 47, and add `{ "skill": "FISHING",
+  "level": 52 }`. Update the guidance prose at line 32030 accordingly.
+
+### 2. Deep Sea Fishing — Fishing gate off by one  — severity: low
+
+- **Source:** `Deep Sea Fishing` (SKILLING), trophy fish Giant blue krill (31408),
+  Golden haddock (31412), Orangefin (31416), Huge halibut (31420), Purplefin (31424),
+  Swift marlin (31428).
+- **Data:** `requirements` block at lines 20644–20653 —
+  `{ "skills": [ { "skill": "FISHING", "level": 68 }, { "skill": "SAILING", "level": 1 } ] }`.
+  Prose at line 20604 (travelTip) and line 20607 (guidance) also say "68 Fishing".
+- **Receipt** (OSRS Wiki, https://oldschool.runescape.wiki/w/Deep_sea_trawling shoals
+  table, and the Giant krill shoal entry): the lowest-tier shoal, the **Giant krill shoal**
+  (source of Giant blue krill), requires **Fishing 69**. No shoal is listed at Fishing 68.
+  Higher trophies: Haddock 73, Yellowfin/Orangefin 79, Halibut 83, Bluefin/Purplefin 87,
+  Marlin 91.
+- **Why it stands:** The lowest obtainable trophy needs Fishing 69; the lowest shoal in the
+  activity *is* the trophy source, so there is no sub-69 entry point. The project convention
+  (e.g. the adjacent Pyramid Plunder source) gates on the lowest level that yields a clog
+  item, not an "activity-start" level. The gate of 68 corresponds to no obtainable content.
+  Severity low: only affects the narrow Fishing-68 boundary; the six trophy ids and drop
+  rates are correct. (Sailing 1 was **not** flagged — no contradicting access-level receipt
+  found; wiki documents no Sailing minimum for area access.)
+- **domain-skeptic:** STANDS (low).
+- **Suggested fix (not applied):** Fishing 68 → 69 in the requirements block; correct the
+  prose at lines 20604 and 20607 to "69 Fishing".
+
+---
+
+## Reviewed — no finding
+
+### ID checks (cache_ids)
+All 17 sources resolved every item/NPC/object id against the abextm cache. Two
+**name-mismatch** notes were returned by the validator; both are deliberate display labels,
+not id errors (ids are cache-confirmed), so neither is logged as a finding:
+
+- **Colossal Wyrm Agility** — ids 30048/30051/30054/30057/30060 carry a "(Varlamore)" suffix
+  ("Graceful cape (Varlamore)" etc.) vs cache "Graceful cape". The suffix disambiguates the
+  Varlamore graceful recolour from the Rooftop graceful set (which shares the base names at
+  ids 11852 etc.). Ids correct.
+- **Shooting Stars** — id 25539 stored as "Celestial ring" vs cache "Celestial ring
+  (uncharged)". Id correct; the abextm cache is the sole id authority and is not adjudicated
+  against the name suffix.
+
+### Judgment checks
+- **No SKILLING source has fairy-ring codes or out-of-bounds coordinates.**
+  `travel_path_verify` scanned all 808 steps / 225 sources; the only coord-out-of-bounds
+  findings are in non-SKILLING sources (Miscellaneous, Shellbane Gryphon, Treasure Trails).
+- **Requirement gates verified as correct** (no contradicting receipt):
+  - Aerial Fishing — Fishing 43 + Hunter 35 (wiki: "requiring 35 Hunter and 43 Fishing"). ✓
+  - Colossal Wyrm Agility — Children of the Sun + Agility 50. ✓
+  - Rooftop Agility — Agility 10. ✓
+  - Motherlode Mine — Mining 30. ✓
+  - Shooting Stars — Mining 10. ✓
+  - Thieving (Seed Stalls) — Thieving 27. ✓
+  - Black Chinchompas — Hunter 73. ✓
+  - Woodcutting (Teak Trees) — Woodcutting 35. ✓
+  - Mining (Gemstone Rocks) — Shilo Village + Mining 40. ✓
+  - Fishing (Swordfish) — Fishing 50. ✓
+  - Runecrafting (Fire Runes) — Runecraft 14. ✓
+  - Farming (Fruit Trees) — Farming 27. ✓
+  - Underwater Crabs — Recipe for Disaster (Pirate Pete subquest). ✓
+  - Prifddinas Rabbit — Song of the Elves. ✓
+  - Pickpocketing Darkmeyer Vyre — Sins of the Father + Thieving 82. ✓

--- a/docs/verify/findings-SLAYER.md
+++ b/docs/verify/findings-SLAYER.md
@@ -1,0 +1,112 @@
+# SLAYER source verification
+
+Verification of every `SLAYER` source in
+`src/main/resources/com/collectionloghelper/drop_rates.json`.
+
+- **Date:** 2026-06-07
+- **Sources checked:** 45
+- **Tooling:** `runelite-dev` MCP (`resource_health`, `validate_drop_rates --check cache_ids`,
+  `travel_path_verify`, `wiki_lookup`), OSRS Wiki receipts, `domain-skeptic` agent gating.
+- **MCP health at start:** all sources `ok` (osrs-wiki, temple-osrs, runelite-ids, etc.).
+- **Scope rule:** IDs adjudicated against the abextm cache only; judgment findings logged
+  only with a cited raw receipt and kept only if they survive the `domain-skeptic` pass.
+- **Not edited:** `drop_rates.json` was not modified (verification only).
+
+## Summary
+
+| Check | Result |
+|-------|--------|
+| Item / NPC IDs (`cache_ids`) | ✅ All 45 sources clean — zero SLAYER entries in the 162 cache-id findings (all 162 are non-SLAYER name-variant cosmetics). |
+| Coordinate bounds (`travel_path_verify`) | ✅ Clean for SLAYER. (The one out-of-bounds slayer-like hit, *Shellbane Gryphon* `13993,9901`, is category **BOSSES** — out of scope here.) |
+| Requirements (skill / quest / Sailing gates) | ✅ All verified or defensibly modeled (see notes). |
+| Fairy-ring codes & travel direction | ⚠️ 2 findings (Terror Dog, Spiritual Mage) — both **STAND**. |
+
+**Net: 2 findings, both low severity, both in guidance travel-route text (not IDs, rates, or coords).**
+
+---
+
+## Findings (STANDS)
+
+### 1. Terror Dog — wrong fairy-ring code + bearing in Travel step
+
+- **Source:** `Terror Dog` (npc 6474), guidance Travel step, arrival tile `(3414,3232,0)`.
+- **Text:** *"…Alternatively, use fairy ring AJR to Fremennik Province and run east to the
+  Abandoned Mine entrance."* (source-level `travelTip` repeats *"fairy ring AJR -> run east to Abandoned Mine"*).
+- **Receipt:** OSRS Wiki *Fairy ring* — `AJR` = **"Slayer cave south-east of Rellekka"**
+  (Fremennik Province, ~`2700,3700`). The Abandoned Mine entrance is `~3416,3232` (Mort'ton),
+  ~700 tiles south-east across water. You cannot "run east" from AJR to reach it.
+- **Correct route (per Wiki *Abandoned Mine* / *Tarn's Lair*):** fairy ring **BIQ** → cross the
+  River Salve shortcut (50 Agility) → run **south**.
+- **domain-skeptic verdict:** **STANDS — low.** A fairy-ring route *does* exist (BIQ + Salve +
+  south), so the defect is a **wrong code and wrong bearing**, not a nonexistent route. The
+  primary route in the same step (Slayer ring → Tarn's Lair) is correct and independently
+  confirmed, so the recommendation still functions.
+- **Suggested fix (data owner):** replace the AJR clause with "fairy ring **BIQ**, cross the Salve
+  shortcut (50 Agility) and run **south**," or drop the fairy-ring alternative entirely.
+
+### 2. Spiritual Mage — invalid fairy-ring route to the God Wars Dungeon
+
+- **Source:** `Spiritual Mage` (npc 2212), guidance Travel step `description`, arrival tile
+  `(2844,5280,plane 2)` (GWD main chamber).
+- **Text:** *"Travel to the God Wars Dungeon (fairy ring AJQ then south, or Trollheim teleport)".*
+- **Receipt:** OSRS Wiki *Fairy ring* — `AJQ` = **"Cave south of Dorgesh-Kaan"** (central Misthalin
+  underground). OSRS Wiki *God Wars Dungeon* access lists only "north of Trollheim … Trollheim
+  Teleport … or teleport to Burthorpe"; there is **no fairy ring** serving the GWD. AJQ lands
+  ~1,800 tiles south; running south moves further from the far-north GWD.
+- **domain-skeptic verdict:** **STANDS — low.** No OSRS mechanic links the Dorgesh-Kaan cave to the
+  GWD. The arrival tile and the source `travelTip` ("Trollheim teleport -> GWD") are correct; only
+  the parenthetical fairy-ring clause is bad.
+- **Suggested fix (data owner):** drop the "fairy ring AJQ then south, or " clause, leaving
+  *"Travel to the God Wars Dungeon (Trollheim teleport)"*, matching the already-correct `travelTip`.
+
+---
+
+## Verified correct (no finding)
+
+### IDs
+All 45 SLAYER sources pass `validate_drop_rates --check cache_ids`. The full-file run surfaced 162
+cache-id findings; **none** are SLAYER (every one is a non-SLAYER charged/uncharged or coloured
+name variant). New high-id NPCs are all cache-confirmed: Gryphon 14857, Custodian Stalker 14704,
+Lava Strykewyrm 15500, Aquanite 15497, Earthen Nagua 14420, Frost Nagua 13788, Araxyte 13667.
+Per project rule, Unsired (25624) is correct and was not flagged (not in SLAYER anyway).
+
+### Requirements / gates (receipted)
+- **Naguas** — Sulphur / Frost / Earthen Nagua all **Slayer 48**, "Lesser Nagua" category (Wiki
+  infoboxes). Matches data. Frost Nagua drop rates also confirmed: Glacial temotli 1/500, Frozen
+  tear 1/10, Pendant of ates (inert) 1/100.
+- **Gryphon** — **Slayer 51** (Wiki), npc 14857; Horn of plenty (empty) 1/2500 confirmed. Data adds
+  Troubled Tortugans quest (Sailing access to Great Conch) — plausible, no contradicting receipt.
+- **Lava Strykewyrm** — **Slayer 62 + Sailing 60** confirmed verbatim (Wiki: "Sailing Level: 60
+  (required to reach the location)" — Charred Island/Charred Dungeon). Matches data exactly.
+- **Aquanite** — **Slayer 78 + Sailing 73** confirmed verbatim (Wiki: "Sailing Level: 73 (to access
+  Ynysdail)"). Matches data exactly.
+- **Custodian Stalker** — Wiki: "fought after completion of the Shadows of Custodia quest." Matches
+  data (Slayer 76 + SHADOWS_OF_CUSTODIA).
+- **Araxyte** — **Slayer 92** (Wiki). Matches data.
+- **Spiritual Mage / Spiritual Mage (Zarosian)** — **Slayer 83** (Wiki). Matches data; Zarosian
+  variant correctly notes frozen key for the Ancient Prison.
+- **Mogre** — **Slayer 32** (Wiki), npc 2592; Mudskipper hat 5/128, Flippers 2/128 confirmed.
+- **Vyrewatch Sentinel** — data lists only SINS_OF_THE_FATHER (no Slayer level). Wiki confirms the
+  Slayer 38 applies **only to task assignment**, not to attacking ("can be fought after completing
+  Sins of the Father"). Data's quest-only gate is correct — **not a finding**.
+- Classic gates spot-consistent with known values: Crawling Hand 5 … Hydra 95; quest gates
+  (Monkey Madness II, While Guthix Sleeps, Haunted Mine, Olaf's Quest, Cabin Fever, Bone Voyage,
+  The Fremennik Exiles, The Path of Glouphrie, Song of the Elves) all match.
+
+### Fairy-ring codes verified against the canonical Wiki map (correct)
+| Code | Wiki destination | Used by | Verdict |
+|------|------------------|---------|---------|
+| DJR | Chasm of Fire (Kebos) | Lizardman shaman → Canyon | ✅ |
+| AJR | Slayer cave SE of Rellekka | Cave Crawler, Rockslug, Cockatrice, Pyrefiend, Basilisk, Jelly, Turoth, Kurask (Fremennik dungeon) | ✅ |
+| CKS | Canifis | Infernal Mage, Bloodveld, Aberrant Spectre, Gargoyle, Nechryael (Slayer Tower) | ✅ |
+| DKS | Polar/Snowy Hunter area | Brine Rat (cavern NE of Rellekka) | ✅ |
+| CJQ | The Great Conch | Gryphon | ✅ |
+| CIR | South of Mount Karuulm | Wyrm, Drake, Hydra (Karuulm dungeon) | ✅ |
+| AIQ | Mudskipper Point | Skeletal Wyvern (Asgarnian Ice Dungeon) | ✅ |
+| AIS | Auburn Valley | Custodian Stalker (Stalker Den) | ✅ |
+| AKQ | Piscatoris Hunter area | Cave Kraken (Kraken Cove) | ✅ |
+| BKP | Chompy Marsh S of Castle Wars | Smoke Devil (Smoke Devil Dungeon) | ✅ |
+| AJQ | Cave south of Dorgesh-Kaan | Spiritual Mage | ❌ Finding #2 |
+
+(Vyrewatch Sentinel uses Drakan's medallion → Darkmeyer, not a fairy ring — "BIS" in its text is
+"best-in-slot", a false positive.)


### PR DESCRIPTION
Clean consolidation of the parallel per-category verification into `docs/verify/`, off master - supersedes the 6 stacked `verify/*` branches (#745-#750), which each carried unrelated diffs (CollectionLogSource.java, guidance-backlog) and all touched the shared `data-verification-log.md`.

## Contents
- 6 authoritative `findings-<CATEGORY>.md` (each from its own session) + a README indexing the fix backlog.
- **No `drop_rates.json` edits** - verification only; fixes are a separate reviewed step.

## What verification found
- **IDs: clean** across all 225 sources (0 wrong/missing per `cache_ids`; the abextm cache is the id authority).
- **Real semantic bugs** (all `STANDS`, cited, domain-skeptic-vetted): fabricated requirements (8 Desert Treasure II skill gates, Brimhaven `AGILITY 40`), copy/paste-wrong recipe item ids (Creature Creation: Raw chicken -> Feather, etc.), wrong fairy-ring codes (Araxxor, Terror Dog, 3 MINIGAMES), wrong ToB quest gates.

The auto-grab's weakness is **inventing requirements and copy/pasting recipes**, not ids - exactly what verification surfaced.

## After merge
Close #745-#750 in favor of this. Then the fix loop runs on the README's backlog, each fix gated by `validate_drop_rates --check cache_ids` + the Unsired guard.