### PR TITLE
docs(verify): TempleOSRS completeness findings (3 missing clog items)

### DIFF
--- a/docs/verify/findings-COMPLETENESS.md
+++ b/docs/verify/findings-COMPLETENESS.md
@@ -1,0 +1,42 @@
+# Data-verification findings - COMPLETENESS (TempleOSRS clog membership)
+
+Bulk TempleOSRS canonical clog sweep across all 225 sources (id->name `items.php`,
+source->item `categories.php`). This is the one check `cache_ids` cannot do: it finds clog
+items that are **missing** from `drop_rates.json` entirely (a coverage hole the efficiency
+calc can never route a player to). IDs of items we *do* carry are clean (0 wrong per cache_ids).
+
+**Result: 0 wrong ids, 3 missing-item (completeness) findings - all `STANDS`, with receipts.**
+
+### Giant Mole - clog items (completeness) - high
+- check: TempleOSRS canonical clog sweep (2026-06-07), `temple_lookup` clog dimension
+- ours: Giant Mole lists 3 clog items - Baby mole (12646), Mole claw (7416), Mole skin (7418)
+- authoritative: TempleOSRS `giant_mole` lists 4 -> `[12646, 7418, 7416, 33382]`. Receipt
+  (items.php): `33382 -> "Immaculate mole skin"`. Item is absent from our entire dataset.
+- action: add Immaculate mole skin (id 33382) to the Giant Mole source. Giant Mole is its
+  only obtainable source, so this is a true coverage hole (efficiency calc can never route
+  the player here for it).
+- status: open
+
+### Lost Schematics - clog items (completeness) - high
+- check: TempleOSRS canonical clog sweep (2026-06-07), `temple_lookup` clog dimension
+- ours: Lost Schematics lists 11 schematics (32401-32410, 33143)
+- authoritative: TempleOSRS `lost_schematics` lists 12; we are missing one. Receipt
+  (items.php): `33423 -> "Bosun's workbench schematic"`; categories.php `lost_schematics`
+  contains 33423. Item is absent from our entire dataset.
+- action: add Bosun's workbench schematic (id 33423) to the Lost Schematics source.
+- status: open
+
+### Slayer (Mystic (dark) set) - clog items (completeness) - high
+- check: TempleOSRS canonical clog sweep (2026-06-07), `temple_lookup` clog dimension
+- ours: we list 4 of the 5 Mystic (dark) pieces, split across slayer sources -
+  Mystic hat (dark) 4099 + Mystic boots (dark) 4107 (Infernal Mage),
+  Mystic robe bottom (dark) 4103 (Aberrant Spectre), Mystic robe top (dark) 4101 (Gargoyle).
+  Mystic gloves (dark) is on no source.
+- authoritative: TempleOSRS clog item `4105 -> "Mystic gloves (dark)"` (items.php); present in
+  the `slayer` category set. Item is absent from our entire dataset - the lone missing piece
+  of a set we otherwise carry.
+- action: add Mystic gloves (dark) (id 4105). Placement is a judgment call (which slayer
+  monster's drop table) - the per-source loop should decide; the existing set pieces sit on
+  Infernal Mage / Aberrant Spectre / Gargoyle.
+- status: open
+


### PR DESCRIPTION
Preserves the unique value of the temple-sweep without its regressive diff.

**Why not just merge #744:** that branch predates the #751 consolidation, so its diff *deletes* all the `docs/verify/findings-*.md` + README that #751 added. Merging it would regress the consolidation. This PR instead extracts the 3 findings cleanly off current master.

**The 3 findings** (completeness - the one check `cache_ids` can't do, since they're *missing* items where TempleOSRS clog membership is authority; all `STANDS` with `items.php`/`categories.php` receipts):
- Giant Mole missing **Immaculate mole skin (33382)** - its only source (a true coverage hole)
- Lost Schematics missing **Bosun's workbench schematic (33423)**
- **Mystic gloves (dark) (4105)** missing - lone piece of a set we otherwise carry (slayer placement TBD)

IDs of items we *do* carry are clean (0 wrong). **Close #744** in favor of this.