### PR TITLE
fix(data): remove fabricated skill requirements from 8 Desert Treasure II bosses

### DIFF
--- a/docs/verify/findings-BOSSES.md
+++ b/docs/verify/findings-BOSSES.md
@@ -119,7 +119,7 @@ cache-confirmed and was not flagged.
 - **domain-skeptic:** STANDS ×2 (The Whisperer adjudicated separately; Duke/Leviathan/Vardorvis adjudicated together, per-source STANDS). Refutation vectors worked and failed: no hidden area/fight skill gate; Duke's vent-mining imposes no Mining level; Awakened adds only the orb (so a *higher* level for the identical encounter is incoherent); the wiki's only efficiency suggestions are unrelated (e.g. Magic 90+/Prayer 77+ for Augury) and live in no "requirement."
 - **why it matters:** `requirements.skills` is the field the plugin uses to gate/lock a source. A DT2-complete account below the listed level can fight these bosses but would be wrongly locked out of the source. Same schema shape that, for General Graardor, correctly encodes the real Strength-70 GWD gate — so this is a functional defect, not a cosmetic note.
 - **action (for the separate fix PR):** remove the `skills` array from `requirements` on all 8 entries; **keep** `quests: ["DESERT_TREASURE_II__THE_FALLEN_EMPIRE"]`.
-- **status:** open
+- **status:** resolved 2026-06-07 (removed `skills` from all 8 DT2 entries; updated `Dt2DeepGuidanceAuditTest` to assert the DT2 quest gate instead of the fabricated skill gate; `lintDropRates build` green)
 
 ### F2 — Araxxor: travel guidance cites fairy ring `CLS`, which lands in Kandarin (Yanille), not Morytania — high
 - **Source:** Araxxor (npcId 13668).

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -1640,12 +1640,6 @@
     "requirements": {
       "quests": [
         "DESERT_TREASURE_II__THE_FALLEN_EMPIRE"
-      ],
-      "skills": [
-        {
-          "skill": "MINING",
-          "level": 65
-        }
       ]
     },
     "items": [
@@ -1800,12 +1794,6 @@
     "requirements": {
       "quests": [
         "DESERT_TREASURE_II__THE_FALLEN_EMPIRE"
-      ],
-      "skills": [
-        {
-          "skill": "RANGED",
-          "level": 70
-        }
       ]
     },
     "items": [
@@ -1958,12 +1946,6 @@
     "requirements": {
       "quests": [
         "DESERT_TREASURE_II__THE_FALLEN_EMPIRE"
-      ],
-      "skills": [
-        {
-          "skill": "RANGED",
-          "level": 75
-        }
       ]
     },
     "items": [
@@ -2127,12 +2109,6 @@
     "requirements": {
       "quests": [
         "DESERT_TREASURE_II__THE_FALLEN_EMPIRE"
-      ],
-      "skills": [
-        {
-          "skill": "ATTACK",
-          "level": 70
-        }
       ]
     },
     "items": [
@@ -2286,12 +2262,6 @@
     "requirements": {
       "quests": [
         "DESERT_TREASURE_II__THE_FALLEN_EMPIRE"
-      ],
-      "skills": [
-        {
-          "skill": "MINING",
-          "level": 65
-        }
       ]
     },
     "items": [
@@ -2486,12 +2456,6 @@
     "requirements": {
       "quests": [
         "DESERT_TREASURE_II__THE_FALLEN_EMPIRE"
-      ],
-      "skills": [
-        {
-          "skill": "RANGED",
-          "level": 75
-        }
       ]
     },
     "items": [
@@ -2682,12 +2646,6 @@
     "requirements": {
       "quests": [
         "DESERT_TREASURE_II__THE_FALLEN_EMPIRE"
-      ],
-      "skills": [
-        {
-          "skill": "RANGED",
-          "level": 80
-        }
       ]
     },
     "items": [
@@ -2886,12 +2844,6 @@
     "requirements": {
       "quests": [
         "DESERT_TREASURE_II__THE_FALLEN_EMPIRE"
-      ],
-      "skills": [
-        {
-          "skill": "ATTACK",
-          "level": 75
-        }
       ]
     },
     "items": [

--- a/src/test/java/com/collectionloghelper/data/Dt2DeepGuidanceAuditTest.java
+++ b/src/test/java/com/collectionloghelper/data/Dt2DeepGuidanceAuditTest.java
@@ -25,8 +25,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * D2 batch 2 audit guard — asserts the four DT2 awakened-style boss sources exist
- * by name, each carries at least three guidance steps after the deep-guidance pass,
- * and each declares a source-level skill requirement.
+ * by name and each carries at least three guidance steps after the deep-guidance pass.
+ * DT2 bosses are gated only by the Desert Treasure II quest; they carry no skill-level
+ * access requirement (the wiki lists none), so no skill requirement is asserted here.
  */
 public class Dt2DeepGuidanceAuditTest
 {
@@ -67,10 +68,11 @@ public class Dt2DeepGuidanceAuditTest
 			assertTrue(source.getGuidanceSteps().size() >= 3,
 				name + " has fewer than 3 guidance steps");
 			assertNotNull(source.getRequirements(), name + " has no source-level requirements");
-			assertNotNull(source.getRequirements().getSkills(),
-				name + " has no source-level skill requirements");
-			assertTrue(!source.getRequirements().getSkills().isEmpty(),
-				name + " source-level skill requirements list is empty");
+			assertNotNull(source.getRequirements().getQuests(),
+				name + " has no source-level quest requirements");
+			assertTrue(source.getRequirements().getQuests().stream()
+					.anyMatch(q -> q.startsWith("DESERT_TREASURE_II")),
+				name + " is not gated on the Desert Treasure II quest");
 		}
 	}
 }


### PR DESCRIPTION
## What

The auto-grabbed data placed hard skill-level access gates on the 8 Desert Treasure II bosses:

| Source | Fabricated gate |
|--------|-----------------|
| Duke Sucellus / (Awakened) | MINING 65 |
| The Leviathan | RANGED 70 |
| The Leviathan (Awakened) | RANGED 75 |
| The Whisperer | RANGED 75 |
| The Whisperer (Awakened) | RANGED 80 |
| Vardorvis | ATTACK 70 |
| Vardorvis (Awakened) | ATTACK 75 |

The OSRS Wiki lists **no** skill-level requirement for any of these bosses. The only access gate is the **Desert Treasure II - The Fallen Empire** quest. Because `requirements.skills` is treated as a hard accessibility gate, a DT2-complete account below the invented level is wrongly locked out of the source.

## Change

- Remove the `skills` array from all 8 DT2 source entries in `drop_rates.json`; keep `quests: ["DESERT_TREASURE_II__THE_FALLEN_EMPIRE"]`.
- Update `Dt2DeepGuidanceAuditTest` — it had codified the fabricated requirement (asserting a non-empty skills list). It now asserts the correct invariant: each DT2 source is gated on the Desert Treasure II quest.

## Verification

- `validate_drop_rates` (schema) clean for the affected sources.
- `./gradlew lintDropRates build` — **BUILD SUCCESSFUL** (full test suite green).
- `python scripts/audit_drop_rates.py --category BOSSES` — exit 0.

## Receipts

`docs/verify/findings-BOSSES.md` finding **F1** — cited raw wiki fetches (2026-06-07) for each boss confirming no skill requirement; domain-skeptic STANDS (both passes).
