### PR TITLE
fix(data): remove invalid Araxxor fairy-ring CLS travel hint

### DIFF
--- a/docs/verify/findings-BOSSES.md
+++ b/docs/verify/findings-BOSSES.md
@@ -135,7 +135,7 @@ cache-confirmed and was not flagged.
   - `wiki_updates` (Araxxor): `count: 0` since 2024-08-01 → not staleness drift.
 - **domain-skeptic:** STANDS. Vectors failed: `CLS` is not in/near Morytania; no fairy ring serves the Araxyte cave; even the nearest Morytania code `CKS` (Canifis) does not reach it, so the fix is to **strike the fairy-ring claim**, not swap `CLS`→`CKS` while keeping "fastest unquested route."
 - **action (for the separate fix PR):** remove the `fairy ring CLS` clause from all three strings; keep the Drakan's medallion → Darkmeyer route.
-- **status:** open
+- **status:** resolved 2026-06-07 (struck the `fairy ring CLS` clause from all 3 Araxxor strings; kept the Drakan's medallion route; `lintDropRates build` green)
 
 ---
 

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -9314,7 +9314,7 @@
       }
     ],
     "locationDescription": "Morytania Spider Cave",
-    "travelTip": "Drakan's medallion -> Darkmeyer, or fairy ring CLS",
+    "travelTip": "Drakan's medallion -> Darkmeyer",
     "npcId": 13668,
     "interactAction": "Attack",
     "guidanceSteps": [
@@ -9333,13 +9333,13 @@
         "section": "Bank"
       },
       {
-        "description": "Travel to the Araxyte Cave in north-east Morytania. Drakan's medallion to Darkmeyer then run east, or fairy ring CLS for the fastest unquested route",
+        "description": "Travel to the Araxyte Cave in north-east Morytania. Drakan's medallion to Darkmeyer then run east",
         "worldX": 3686,
         "worldY": 3426,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
-        "travelTip": "Drakan's medallion -> Darkmeyer -> run east, or fairy ring CLS",
+        "travelTip": "Drakan's medallion -> Darkmeyer -> run east",
         "section": "Travel"
       },
       {


### PR DESCRIPTION
## What

The Araxxor travel guidance cited **fairy ring CLS** as the route to the Araxyte cave in NE Morytania, in three places (source `travelTip`, step description, step `travelTip`).

`CLS` actually lands at the **Yanille Chain in Kandarin** — the opposite side of the map. No fairy ring serves the Araxyte cave; even Morytania's own code (`CKS` → Canifis) does not reach it. The canonical route is **Drakan's medallion → Darkmeyer**.

## Change

Strike the `, or fairy ring CLS` clause from all three strings; keep the Drakan's medallion → Darkmeyer route (already present and correct).

## Verification

- `validate_drop_rates` (schema) — clean (one pre-existing unrelated guidance-step note).
- `data_ascii_lint` — 0 violations.
- `./gradlew lintDropRates build` — **BUILD SUCCESSFUL**.

## Receipts

`docs/verify/findings-BOSSES.md` finding **F2** — OSRS Wiki fairy-ring table (`CLS` = Yanille Chain) + Araxxor page (no fairy-ring route), fetched 2026-06-07; domain-skeptic STANDS.
