### PR TITLE
fix(data): correct Creature Creation (Newtroost) recipe ingredients

### DIFF
--- a/docs/verify/findings-OTHER.md
+++ b/docs/verify/findings-OTHER.md
@@ -71,6 +71,7 @@ coverage) and is reported under the Newtroost finding.
   surfaced the 219→Grimy torstol id error.
 - **Suggested fix (not applied):** `requiredItemIds` `[2138, 219]` → `[221, 314]`; both
   step descriptions "raw chicken and eye of newt" → "eye of newt and feather".
+- **status:** resolved 2026-06-07 (ids swapped to `[221, 314]`, both descriptions updated; new ids cache-confirmed via `cross_check_ids`; `lintDropRates build` green).
 
 ### 2. Creature Creation (Frogeel) — wrong creation ingredients (cross-creature copy/paste)  — severity: high
 

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -22844,20 +22844,20 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to the Tower of Life dungeon (fairy ring DJP), south of Ardougne. Bring raw chicken and eye of newt as ingredients.",
+        "description": "Travel to the Tower of Life dungeon (fairy ring DJP), south of Ardougne. Bring eye of newt and feather as ingredients.",
         "worldX": 2639,
         "worldY": 3218,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
         "requiredItemIds": [
-          2138,
-          219
+          221,
+          314
         ],
         "section": "Travel"
       },
       {
-        "description": "Place raw chicken and eye of newt on the Altar of Life to create a Newtroost, then kill it. Use Protect from Melee if food is running low.",
+        "description": "Place eye of newt and feather on the Altar of Life to create a Newtroost, then kill it. Use Protect from Melee if food is running low.",
         "worldX": 2639,
         "worldY": 3218,
         "worldPlane": 0,


### PR DESCRIPTION
## What

The Creature Creation (Newtroost) guidance listed the wrong ingredients:
- `requiredItemIds` `[2138, 219]` — `2138` = Raw chicken (a *Swordchick* ingredient), `219` = **Grimy torstol** (not eye of newt at all).
- Step descriptions said "raw chicken and eye of newt".

The wiki recipe is **Eye of newt + Feather**, which also matches the source's own `locationDescription` ("Eye of newt + Feather").

## Change

- `requiredItemIds` → `[221, 314]` (Eye of newt, Feather).
- Both step descriptions → "eye of newt and feather".

## Verification

- `cross_check_ids` — 221/314 resolve in the abextm cache (match).
- `validate_drop_rates` — passed, no issues.
- `./gradlew lintDropRates build` — **BUILD SUCCESSFUL**.

## Receipts

`docs/verify/findings-OTHER.md` #1 — wiki Creature Creation recipe table (fetched 2026-06-07); domain-skeptic STANDS (high).
