### PR TITLE
fix(data): correct Creature Creation (Frogeel) recipe ingredients

### DIFF
--- a/docs/verify/findings-OTHER.md
+++ b/docs/verify/findings-OTHER.md
@@ -91,6 +91,7 @@ coverage) and is reported under the Newtroost finding.
 - **domain-skeptic:** STANDS (high) — survived every refutation vector.
 - **Suggested fix (not applied):** `requiredItemIds` `[377, 223]` → `[5001, 4517]`; both
   step descriptions → "raw cave eel and giant frog legs".
+- **status:** resolved 2026-06-07 (ids swapped to `[5001, 4517]`, both descriptions updated; new ids cache-confirmed; `lintDropRates build` green).
 
 ### 3. Creature Creation (Unicow) — wrong creation ingredient  — severity: low
 

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -23194,20 +23194,20 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to the Tower of Life dungeon (fairy ring DJP), south of Ardougne. Bring raw lobster and red spiders' eggs as ingredients.",
+        "description": "Travel to the Tower of Life dungeon (fairy ring DJP), south of Ardougne. Bring raw cave eel and giant frog legs as ingredients.",
         "worldX": 2639,
         "worldY": 3218,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
         "requiredItemIds": [
-          377,
-          223
+          5001,
+          4517
         ],
         "section": "Travel"
       },
       {
-        "description": "Place raw lobster and red spiders' eggs on the Altar of Life to create a Frogeel, then kill it.",
+        "description": "Place raw cave eel and giant frog legs on the Altar of Life to create a Frogeel, then kill it.",
         "worldX": 2639,
         "worldY": 3218,
         "worldPlane": 0,


### PR DESCRIPTION
## What

The Creature Creation (Frogeel) guidance listed ingredients copy/pasted from other creatures:
- `requiredItemIds` `[377, 223]` — `377` = Raw lobster (a *Jubster* ingredient), `223` = Red spiders' eggs (a *Spidine* ingredient).
- Step descriptions said "raw lobster and red spiders' eggs".

The wiki recipe is **Raw cave eel + Giant frog legs**, matching the source's own `locationDescription`.

## Change

- `requiredItemIds` → `[5001, 4517]` (Raw cave eel, Giant frog legs).
- Both step descriptions → "raw cave eel and giant frog legs".

## Verification

- `cross_check_ids` — 5001/4517 resolve in the abextm cache (match).
- `validate_drop_rates` — passed, no issues.
- `./gradlew lintDropRates build` — **BUILD SUCCESSFUL**.

## Receipts

`docs/verify/findings-OTHER.md` #2 — wiki Creature Creation recipe table (fetched 2026-06-07); domain-skeptic STANDS (high).
