### PR TITLE
fix(data): correct Creature Creation (Unicow) recipe ingredient

### DIFF
--- a/docs/verify/findings-OTHER.md
+++ b/docs/verify/findings-OTHER.md
@@ -110,6 +110,7 @@ coverage) and is reported under the Newtroost finding.
 - **domain-skeptic:** STANDS (low) — survived every applicable refutation vector.
 - **Suggested fix (not applied):** `requiredItemIds` `[2132, 237]` → `[1739, 237]`; both
   step descriptions "raw beef and unicorn horn" → "cowhide and unicorn horn".
+- **status:** resolved 2026-06-07 (id swapped 2132->1739 (Cowhide), both descriptions updated; cache-confirmed; `lintDropRates build` green).
 
 ### 4. Pyramid Plunder — Pharaoh's sceptre source/level guidance is wrong and self-contradictory  — severity: low
 

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -22914,20 +22914,20 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to the Tower of Life dungeon (fairy ring DJP), south of Ardougne. Bring raw beef and unicorn horn as ingredients.",
+        "description": "Travel to the Tower of Life dungeon (fairy ring DJP), south of Ardougne. Bring cowhide and unicorn horn as ingredients.",
         "worldX": 2639,
         "worldY": 3218,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
         "requiredItemIds": [
-          2132,
+          1739,
           237
         ],
         "section": "Travel"
       },
       {
-        "description": "Place raw beef and unicorn horn on the Altar of Life to create a Unicow, then kill it.",
+        "description": "Place cowhide and unicorn horn on the Altar of Life to create a Unicow, then kill it.",
         "worldX": 2639,
         "worldY": 3218,
         "worldPlane": 0,


### PR DESCRIPTION
## What

The Creature Creation (Unicow) guidance listed **raw beef** (`2132`) as an ingredient, but the wiki recipe is **Cowhide + Unicorn horn** (matching the source's own `locationDescription`). Cowhide is id `1739`, not `2132`.

## Change

- `requiredItemIds` `[2132, 237]` → `[1739, 237]` (Cowhide, Unicorn horn).
- Both step descriptions "raw beef and unicorn horn" → "cowhide and unicorn horn".

## Verification

- `cross_check_ids` — 1739/237 resolve in the abextm cache (match).
- `validate_drop_rates` — passed, no issues.
- `./gradlew lintDropRates build` — **BUILD SUCCESSFUL**.

## Receipts

`docs/verify/findings-OTHER.md` #3 — wiki Creature Creation recipe table (fetched 2026-06-07); domain-skeptic STANDS (low).
