### PR TITLE
fix(data): remove fabricated Brimhaven Agility Arena gate and bad fairy ring

### DIFF
--- a/docs/verify/findings-MINIGAMES.md
+++ b/docs/verify/findings-MINIGAMES.md
@@ -86,6 +86,7 @@ cache-confirmed and was not flagged.
   rewards; the multi-source / variant / account-type vectors do not apply.
 - **Suggested fix (separate PR):** drop the gate, or model it as a soft/efficiency note (~20–40 Agility),
   not a blocking requirement.
+- **status:** resolved 2026-06-07 (removed the `requirements` block - it held only the fabricated AGILITY 40; the source has no real access gate; `lintDropRates build` green).
 
 ### Finding 2 — Brimhaven Agility Arena: wrong fairy ring code `CKR` — severity low
 
@@ -97,6 +98,7 @@ cache-confirmed and was not flagged.
   ~191 tiles **south** (`coordinate_helper` distance). The route is a long run north, not "east", and CKR
   is not a sensible Brimhaven approach.
 - **domain-skeptic:** `STANDS` (low) — travel-hint accuracy only; does not hide the source or affect ids.
+- **status:** resolved 2026-06-07 (struck the `CKR` clause from all 3 strings; kept the charter-ship route; `lintDropRates build` green).
 
 ### Finding 3 — Volcanic Mine: fabricated fairy ring `DLR` fallback — severity low
 

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -14202,24 +14202,16 @@
       }
     ],
     "locationDescription": "Brimhaven Agility Arena, east of Brimhaven",
-    "travelTip": "Fairy ring CKR -> Brimhaven, or charter ship to Brimhaven",
-    "requirements": {
-      "skills": [
-        {
-          "skill": "AGILITY",
-          "level": 40
-        }
-      ]
-    },
+    "travelTip": "Charter ship to Brimhaven",
     "guidanceSteps": [
       {
-        "description": "Travel to Brimhaven Agility Arena east of Brimhaven. Fairy ring CKR is fastest; alternatively charter ship to Brimhaven from any coastal port. Pay 200gp entrance fee to Cap'n Izzy No-Beard at the door",
+        "description": "Travel to Brimhaven Agility Arena east of Brimhaven. Charter ship to Brimhaven from any coastal port. Pay 200gp entrance fee to Cap'n Izzy No-Beard at the door",
         "worldX": 2809,
         "worldY": 3194,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
-        "travelTip": "Fairy ring CKR -> run east to arena entrance",
+        "travelTip": "Charter ship to Brimhaven -> run east to arena entrance",
         "section": "Travel"
       },
       {


### PR DESCRIPTION
## What

Two STANDS findings on **Brimhaven Agility Arena**:

1. **Fabricated `AGILITY 40` access gate.** The course has no Agility requirement to enter or to earn tickets / the clog rewards (Brimhaven Graceful recolours, Pirate's hook) - level 40 only unlocks specific obstacles. A hard gate wrongly hid a reachable source from the low-level accounts that most need the recommendation.
2. **Wrong fairy ring `CKR`.** `CKR` lands in deep south Karamja (south of Tai Bwo Wannai), ~191 tiles from the arena; the wiki lists no fairy-ring route to Brimhaven.

## Change

- Remove the `requirements` block (it contained only the fabricated `AGILITY 40`; the source has no real access gate).
- Strike the `CKR` clause from all three strings; keep the charter-ship route.

## Verification

- `validate_drop_rates` - passed, no issues.
- `./gradlew lintDropRates build` - **BUILD SUCCESSFUL**.

## Receipts

`docs/verify/findings-MINIGAMES.md` **F1** + **F2** - wiki Brimhaven Agility Arena page + fairy-ring table (fetched 2026-06-07); domain-skeptic STANDS.
