### PR TITLE
fix(data): remove invalid Volcanic Mine fairy-ring DLR fallback

### DIFF
--- a/docs/verify/findings-MINIGAMES.md
+++ b/docs/verify/findings-MINIGAMES.md
@@ -108,6 +108,7 @@ cache-confirmed and was not flagged.
 - **Why it's wrong:** there is no fairy-ring route to the Volcanic Mine; DLR lands in Tirannwn. (The
   top-level `travelTip` "Digsite pendant -> Fossil Island" is correct — only the DLR addition is wrong.)
 - **domain-skeptic:** `STANDS` (low) — misleading fallback hint; does not hide the source or affect ids.
+- **status:** resolved 2026-06-07 (struck the `DLR` clause from both strings; kept the Digsite-pendant route; `lintDropRates build` green).
 
 ### Finding 4 — Fishing Trawler: wrong fairy ring code `BKP` — severity low
 

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -15879,13 +15879,13 @@
         "section": "Bank prep"
       },
       {
-        "description": "Travel to the Fossil Island volcano in the north-east. Digsite pendant teleport goes straight to the Mushroom Forest then run north-east, or use Fairy ring DLR for the closest fairy ring fallback.",
+        "description": "Travel to the Fossil Island volcano in the north-east. Digsite pendant teleport goes straight to the Mushroom Forest then run north-east.",
         "worldX": 3815,
         "worldY": 3807,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 15,
-        "travelTip": "Digsite pendant -> Mushroom Forest + run NE, or Fairy ring DLR",
+        "travelTip": "Digsite pendant -> Mushroom Forest + run NE",
         "section": "Travel",
         "conditionalAlternatives": [
           {


### PR DESCRIPTION
## What

The Volcanic Mine guidance offered **fairy ring DLR** as a fallback route. `DLR` lands in the Poison Waste south of Isafdar (Tirannwn), and there is **no fairy-ring route** to the Volcanic Mine - Fossil Island is reached by barge.

## Change

Strike the `DLR` clause from the step description and its `travelTip`. The correct Digsite-pendant route (already present) is unchanged.

## Verification

- `validate_drop_rates` - clean (one pre-existing unrelated guidance-step note).
- `./gradlew lintDropRates build` - **BUILD SUCCESSFUL**.

## Receipts

`docs/verify/findings-MINIGAMES.md` **F3** - wiki Volcanic Mine travel section + fairy-ring table (fetched 2026-06-07); domain-skeptic STANDS.
