### PR TITLE
fix(data): correct Fishing Trawler fairy-ring code BKP -> DJP

### DIFF
--- a/docs/verify/findings-MINIGAMES.md
+++ b/docs/verify/findings-MINIGAMES.md
@@ -121,6 +121,7 @@ cache-confirmed and was not flagged.
   from Khazard. The correct code is `DJP`.
 - **domain-skeptic:** `STANDS` (low) — route shape is right, only the code letters are wrong; does not
   hide the source or affect ids.
+- **status:** resolved 2026-06-07 (swapped `BKP` -> `DJP` in all 3 Fishing Trawler strings; smoke-devil `BKP` left untouched; `lintDropRates build` green).
 
 ## Considered & not logged
 

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -16196,7 +16196,7 @@
       }
     ],
     "locationDescription": "Fishing Trawler, Port Khazard",
-    "travelTip": "Minigame tele -> Fishing Trawler, or fairy ring BKP -> Port Khazard",
+    "travelTip": "Minigame tele -> Fishing Trawler, or fairy ring DJP -> Port Khazard",
     "requirements": {
       "skills": [
         {
@@ -16207,13 +16207,13 @@
     },
     "guidanceSteps": [
       {
-        "description": "Travel to Port Khazard. Use the Minigame Grouping teleport (Fishing Trawler) for the fastest route, or fairy ring BKP then run south. Bring bailing buckets and rope for repairs",
+        "description": "Travel to Port Khazard. Use the Minigame Grouping teleport (Fishing Trawler) for the fastest route, or fairy ring DJP then run south. Bring bailing buckets and rope for repairs",
         "worldX": 2661,
         "worldY": 3164,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
-        "travelTip": "Minigame tele -> Fishing Trawler, or fairy ring BKP -> run south",
+        "travelTip": "Minigame tele -> Fishing Trawler, or fairy ring DJP -> run south",
         "requiredItemIds": [
           1925,
           954


### PR DESCRIPTION
## What

The Fishing Trawler travel guidance cited **fairy ring BKP**, which lands in Feldip Hills (Chompy Marsh, south of Castle Wars) - far south of Port Khazard. The Fishing Trawler wiki page lists **DJP** (by the Tower of Life, just north of Port Khazard, then run south).

A fairy-ring-then-south route is legitimate; only the code letters were wrong.

## Change

Swap `BKP` -> `DJP` in all three Fishing Trawler strings (source `travelTip`, step description, step `travelTip`). The smoke-devil dungeon's `BKP` routes (which are correct) are left untouched.

## Verification

- `validate_drop_rates` - clean (one pre-existing unrelated guidance-step note).
- `./gradlew lintDropRates build` - **BUILD SUCCESSFUL**.

## Receipts

`docs/verify/findings-MINIGAMES.md` **F4** - wiki Fishing Trawler page + fairy-ring table (fetched 2026-06-07); domain-skeptic STANDS.
