### PR TITLE
fix(data): correct Terror Dog fairy-ring route AJR -> BIQ

### DIFF
--- a/docs/verify/findings-SLAYER.md
+++ b/docs/verify/findings-SLAYER.md
@@ -43,6 +43,7 @@ Verification of every `SLAYER` source in
   confirmed, so the recommendation still functions.
 - **Suggested fix (data owner):** replace the AJR clause with "fairy ring **BIQ**, cross the Salve
   shortcut (50 Agility) and run **south**," or drop the fairy-ring alternative entirely.
+- **status:** resolved 2026-06-07 (swapped AJR -> BIQ + Salve shortcut (50 Agility) + run south in all 3 Terror Dog strings; the Slayer-ring route is unchanged; `lintDropRates build` green).
 
 ### 2. Spiritual Mage — invalid fairy-ring route to the God Wars Dungeon
 

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -10611,7 +10611,7 @@
       }
     ],
     "locationDescription": "Tarn's Lair, Abandoned Mine (requires Haunted Mine quest)",
-    "travelTip": "Slayer ring -> Tarn's Lair (fastest), or fairy ring AJR -> run east to Abandoned Mine",
+    "travelTip": "Slayer ring -> Tarn's Lair (fastest), or fairy ring BIQ -> Salve shortcut (50 Agility) -> run south to Abandoned Mine",
     "npcId": 6474,
     "interactAction": "Attack",
     "guidanceSteps": [
@@ -10625,13 +10625,13 @@
         "section": "Bank"
       },
       {
-        "description": "Teleport to Tarn's Lair using a Slayer ring (fastest direct teleport). Alternatively, use fairy ring AJR to Fremennik Province and run east to the Abandoned Mine entrance",
+        "description": "Teleport to Tarn's Lair using a Slayer ring (fastest direct teleport). Alternatively, use fairy ring BIQ, cross the Salve shortcut (50 Agility), and run south to the Abandoned Mine entrance",
         "worldX": 3414,
         "worldY": 3232,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
-        "travelTip": "Slayer ring -> Tarn's Lair, or fairy ring AJR -> run east to Abandoned Mine entrance",
+        "travelTip": "Slayer ring -> Tarn's Lair, or fairy ring BIQ -> Salve shortcut (50 Agility) -> run south to Abandoned Mine entrance",
         "section": "Travel"
       },
       {


### PR DESCRIPTION
## What

The Terror Dog travel guidance cited **fairy ring AJR** ("run east to the Abandoned Mine"). `AJR` is the Slayer cave south-east of Rellekka (Fremennik Province) - ~700 tiles north-west of the Abandoned Mine, across water. You cannot "run east" from AJR to reach it.

The correct fairy-ring route (per the wiki Abandoned Mine / Tarn's Lair pages) is **BIQ -> cross the River Salve shortcut (50 Agility) -> run south**.

## Change

Swap the code and bearing in all three Terror Dog strings (source `travelTip`, step description, step `travelTip`). The primary `Slayer ring -> Tarn's Lair` route (independently correct) is unchanged.

## Verification

- `validate_drop_rates` - passed, no issues.
- `./gradlew lintDropRates build` - **BUILD SUCCESSFUL**.

## Receipts

`docs/verify/findings-SLAYER.md` #1 - wiki Fairy ring + Abandoned Mine/Tarn's Lair pages (fetched 2026-06-07); domain-skeptic STANDS (low).
