### PR TITLE
fix(data): remove invalid Spiritual Mage fairy-ring route to the GWD

### DIFF
--- a/docs/verify/findings-SLAYER.md
+++ b/docs/verify/findings-SLAYER.md
@@ -58,6 +58,7 @@ Verification of every `SLAYER` source in
   the parenthetical fairy-ring clause is bad.
 - **Suggested fix (data owner):** drop the "fairy ring AJQ then south, or " clause, leaving
   *"Travel to the God Wars Dungeon (Trollheim teleport)"*, matching the already-correct `travelTip`.
+- **status:** resolved 2026-06-07 (struck the AJQ clause; left "Travel to the God Wars Dungeon (Trollheim teleport)"; `lintDropRates build` green).
 
 ---
 

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -12571,7 +12571,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to the God Wars Dungeon (fairy ring AJQ then south, or Trollheim teleport)",
+        "description": "Travel to the God Wars Dungeon (Trollheim teleport)",
         "worldX": 2844,
         "worldY": 5280,
         "worldPlane": 2,


### PR DESCRIPTION
## What

The Spiritual Mage travel step offered "**fairy ring AJQ** then south" to reach the God Wars Dungeon. `AJQ` is the cave south of Dorgesh-Kaan (central Misthalin underground) - ~1,800 tiles south of the far-north GWD - and no fairy ring serves the GWD.

## Change

Strike the `fairy ring AJQ then south, or ` clause, leaving "Travel to the God Wars Dungeon (Trollheim teleport)" - matching the source's already-correct `travelTip`.

## Verification

- `validate_drop_rates` - passed, no issues.
- `./gradlew lintDropRates build` - **BUILD SUCCESSFUL**.

## Receipts

`docs/verify/findings-SLAYER.md` #2 - wiki Fairy ring + God Wars Dungeon pages (fetched 2026-06-07); domain-skeptic STANDS (low).
