### PR TITLE
fix(data): correct Theatre of Blood quest gates

### DIFF
--- a/docs/verify/findings-RAIDS.md
+++ b/docs/verify/findings-RAIDS.md
@@ -45,6 +45,8 @@ Chambers of Xeric and Chambers of Xeric (Challenge Mode) passed all checks with 
 
 **Skeptic:** STANDS — high. Ran all refutation vectors (multi-source / variant / account-type / staleness via `wiki_updates` count=0 / requirement-nuance); none rescued the value.
 
+**status:** resolved 2026-06-07 (set `requirements.quests` to `["PRIEST_IN_PERIL"]` on Theatre of Blood and Theatre of Blood (Hard Mode); `lintDropRates build` green).
+
 ---
 
 ## F2 — Drakan's medallion → Ver Sinhaza waypoint requires the wrong quest (Low) — STANDS
@@ -59,6 +61,8 @@ Chambers of Xeric and Chambers of Xeric (Challenge Mode) passed all checks with 
 **Why it stands:** The "after completion of Sins of the Father" parenthetical attaches to the **Darkmeyer** destination only. The Ver Sinhaza teleport is available immediately on obtaining the medallion (i.e. completing A Taste of Hope). The file itself already distinguishes the two gates correctly for the Darkmeyer waypoints (line 32387), so this is an isolated wrong-quest gate, not a convention. Blast radius is low (worst case the plugin suggests the slower Canifis-walk fallback for AToH-but-not-SotF accounts; it never routes a player somewhere they cannot go). Note: `Theatre of Blood (Hard Mode)` has **no** `waypoints` array, so this finding is confined to the regular source.
 
 **Skeptic:** STANDS — low.
+
+**status:** resolved 2026-06-07 (set the "Drakan's medallion to Ver Sinhaza" waypoint `requirements.quests` to `["A_TASTE_OF_HOPE"]`; `lintDropRates build` green).
 
 ---
 

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -6513,7 +6513,7 @@
     "killTimeSeconds": 1200,
     "requirements": {
       "quests": [
-        "A_TASTE_OF_HOPE"
+        "PRIEST_IN_PERIL"
       ]
     },
     "items": [
@@ -6649,7 +6649,7 @@
         "worldPlane": 0,
         "requirements": {
           "quests": [
-            "SINS_OF_THE_FATHER"
+            "A_TASTE_OF_HOPE"
           ]
         }
       },
@@ -6738,7 +6738,7 @@
     "ironKillTimeSeconds": 1620,
     "requirements": {
       "quests": [
-        "A_TASTE_OF_HOPE"
+        "PRIEST_IN_PERIL"
       ]
     },
     "items": [


### PR DESCRIPTION
## What

Two STANDS findings on the Theatre of Blood quest gates:

1. **Over-strict access gate (F1, high).** ToB and ToB (Hard Mode) gated on `A_TASTE_OF_HOPE`, but the only hard requirement is **Priest in Peril** (Morytania access). A player with Priest in Peril can enter ToB via the Slepe/Andras route without A Taste of Hope, so the gate hid an accessible source. (`requirements.quests` is a hard accessibility gate in `RequirementsChecker`.)
2. **Wrong waypoint quest (F2, low).** The "Drakan's medallion to Ver Sinhaza" waypoint required `SINS_OF_THE_FATHER`, but the medallion's **Ver Sinhaza** teleport unlocks on completing **A Taste of Hope** - the Sins of the Father gate applies only to the *Darkmeyer* destination.

## Change

- ToB + ToB (Hard Mode) top-level `requirements.quests` -> `["PRIEST_IN_PERIL"]`. (The A Taste of Hope / Drakan's medallion convenience is already preserved as a `conditionalAlternative`, so no information is lost.)
- "Drakan's medallion to Ver Sinhaza" waypoint `requirements.quests` -> `["A_TASTE_OF_HOPE"]`.

## Verification

- `validate_drop_rates` - passed (both ToB sources), no issues.
- `./gradlew lintDropRates build` - **BUILD SUCCESSFUL** (enum strings resolve).

## Receipts

`docs/verify/findings-RAIDS.md` **F1** + **F2** - wiki Theatre of Blood / Ver Sinhaza / Drakan's medallion pages (fetched 2026-06-07); domain-skeptic STANDS.
