### PR TITLE
fix(data): add missing Immaculate mole skin to Giant Mole

### DIFF
--- a/docs/verify/findings-COMPLETENESS.md
+++ b/docs/verify/findings-COMPLETENESS.md
@@ -15,7 +15,7 @@ calc can never route a player to). IDs of items we *do* carry are clean (0 wrong
 - action: add Immaculate mole skin (id 33382) to the Giant Mole source. Giant Mole is its
   only obtainable source, so this is a true coverage hole (efficiency calc can never route
   the player here for it).
-- status: open
+- status: resolved 2026-06-07 (added Immaculate mole skin 33382, dropRate 0.02 (wiki 1/50), wikiPage Immaculate_mole_skin; id cache-confirmed; `lintDropRates build` green)
 
 ### Lost Schematics - clog items (completeness) - high
 - check: TempleOSRS canonical clog sweep (2026-06-07), `temple_lookup` clog dimension

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -3943,6 +3943,13 @@
         "isPet": false,
         "wikiPage": "Mole_skin",
         "milestoneKills": 1
+      },
+      {
+        "itemId": 33382,
+        "name": "Immaculate mole skin",
+        "dropRate": 0.02,
+        "isPet": false,
+        "wikiPage": "Immaculate_mole_skin"
       }
     ],
     "locationDescription": "Falador Park",


### PR DESCRIPTION
## What

A TempleOSRS canonical clog sweep found Giant Mole carries **4** collection-log items, but the dataset listed only 3 - **Immaculate mole skin (33382)** was missing from the entire dataset. Giant Mole is its only obtainable source, so the efficiency calc could never route a player to it (a true coverage hole).

## Change

Add Immaculate mole skin to the Giant Mole `items`:
- `itemId` 33382, `dropRate` 0.02 (wiki rarity **1/50**), `wikiPage` `Immaculate_mole_skin`.

## Verification

- `cross_check_ids` - 33382 resolves in the abextm cache (match).
- `wiki_lookup` "Giant Mole" - "Immaculate mole skin | qty: 1 | rarity: 1/50".
- `validate_drop_rates` - passed, no issues.
- `./gradlew lintDropRates build` - **BUILD SUCCESSFUL**.

## Receipts

`docs/verify/findings-COMPLETENESS.md` - TempleOSRS clog membership sweep (`giant_mole` -> `[12646, 7418, 7416, 33382]`) + wiki drop rate (fetched 2026-06-07).
