### PR TITLE
fix(data): add missing Bosun's workbench schematic to Lost Schematics

### DIFF
--- a/docs/verify/findings-COMPLETENESS.md
+++ b/docs/verify/findings-COMPLETENESS.md
@@ -24,7 +24,7 @@ calc can never route a player to). IDs of items we *do* carry are clean (0 wrong
   (items.php): `33423 -> "Bosun's workbench schematic"`; categories.php `lost_schematics`
   contains 33423. Item is absent from our entire dataset.
 - action: add Bosun's workbench schematic (id 33423) to the Lost Schematics source.
-- status: open
+- status: resolved 2026-06-07 (added Bosun's workbench schematic 33423 matching the other 11 schematics' convention - dropRate 1.0, pointCost 1, independent true; id cache-confirmed; `lintDropRates build` green)
 
 ### Slayer (Mystic (dark) set) - clog items (completeness) - high
 - check: TempleOSRS canonical clog sweep (2026-06-07), `temple_lookup` clog dimension

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -19725,6 +19725,15 @@
         "wikiPage": "Ballistic_attractor_schematic",
         "pointCost": 1,
         "independent": true
+      },
+      {
+        "itemId": 33423,
+        "name": "Bosun's workbench schematic",
+        "dropRate": 1.0,
+        "isPet": false,
+        "wikiPage": "Bosun%27s_workbench_schematic",
+        "pointCost": 1,
+        "independent": true
       }
     ],
     "locationDescription": "Various islands discovered through Sailing",


### PR DESCRIPTION
## What

A TempleOSRS canonical clog sweep found Lost Schematics carries **12** collection-log items, but the dataset listed only 11 - **Bosun's workbench schematic (33423)** was missing from the entire dataset.

## Change

Add Bosun's workbench schematic to the Lost Schematics `items`, matching the convention of the other 11 schematics (`dropRate` 1.0, `pointCost` 1, `independent` true), `wikiPage` `Bosun%27s_workbench_schematic`.

## Verification

- `cross_check_ids` - 33423 resolves in the abextm cache (match).
- `validate_drop_rates` - passed, no issues.
- `./gradlew lintDropRates build` - **BUILD SUCCESSFUL**.

## Receipts

`docs/verify/findings-COMPLETENESS.md` - TempleOSRS clog membership sweep (`categories.php lost_schematics` contains 33423; `items.php` 33423 -> "Bosun's workbench schematic"), fetched 2026-06-07.
