### PR TITLE
fix(data): correct Cutting Squid requirement gate (Sailing 47 + Fishing 52)

### DIFF
--- a/docs/verify/findings-SKILLING.md
+++ b/docs/verify/findings-SKILLING.md
@@ -47,6 +47,7 @@ Prifddinas Rabbit, Pickpocketing Darkmeyer Vyre.
 - **domain-skeptic:** STANDS (high). Both prongs survived every refutation vector.
 - **Suggested fix (not applied):** Sailing 45 → 47, and add `{ "skill": "FISHING",
   "level": 52 }`. Update the guidance prose at line 32030 accordingly.
+- **status:** resolved 2026-06-07 (Sailing 45->47 and added Fishing 52; prose updated to "Sailing 47 and Fishing 52 required (lantern harpooning)"; `lintDropRates build` green).
 
 ### 2. Deep Sea Fishing — Fishing gate off by one  — severity: low
 

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -32027,7 +32027,7 @@
     "travelTip": "Port Piscarilius sailing dock -> sail to squid fishing spots",
     "guidanceSteps": [
       {
-        "description": "Bank for squid cutting. Bring a knife for hand-cutting (most beak rolls per squid) or use the boat chum station for faster throughput. Jumbo squid give 1/512 per cut; swordtip squid give 1/1024. Sailing level 45 required. Spirit flakes or rada's blessing can double catches.",
+        "description": "Bank for squid cutting. Bring a knife for hand-cutting (most beak rolls per squid) or use the boat chum station for faster throughput. Jumbo squid give 1/512 per cut; swordtip squid give 1/1024. Sailing 47 and Fishing 52 required (lantern harpooning). Spirit flakes or rada's blessing can double catches.",
         "worldX": 1824,
         "worldY": 3691,
         "worldPlane": 0,
@@ -32073,7 +32073,11 @@
       "skills": [
         {
           "skill": "SAILING",
-          "level": 45
+          "level": 47
+        },
+        {
+          "skill": "FISHING",
+          "level": 52
         }
       ]
     }


### PR DESCRIPTION
## What

Squid beak is obtained only by cutting squid, and squid are caught only via **lantern harpooning** - a Fishing activity requiring **Sailing 47** (to dock at the Onyx Crest) and **Fishing 52**. The data gated only on **Sailing 45** with no Fishing requirement, so the source was reachable in-data at Sailing 45 / 0 Fishing - which no real account can achieve (the source was *under*-gated, not over-gated).

## Change

- `requirements.skills`: Sailing 45 -> 47; add Fishing 52.
- Guidance prose: "Sailing level 45 required" -> "Sailing 47 and Fishing 52 required (lantern harpooning)".

## Verification

- `validate_drop_rates` - clean (one pre-existing unrelated guidance-step note).
- `./gradlew lintDropRates build` - **BUILD SUCCESSFUL** (enum strings resolve).

## Receipts

`docs/verify/findings-SKILLING.md` #1 - wiki Raw swordtip squid + Lantern harpooning pages (fetched 2026-06-07): "requiring level 52 Fishing ... the minimum Sailing level to catch them is 47". domain-skeptic STANDS (high).
