### PR TITLE
fix(data): correct Deep Sea Fishing gate Fishing 68 -> 69

### DIFF
--- a/docs/verify/findings-SKILLING.md
+++ b/docs/verify/findings-SKILLING.md
@@ -71,6 +71,7 @@ Prifddinas Rabbit, Pickpocketing Darkmeyer Vyre.
 - **domain-skeptic:** STANDS (low).
 - **Suggested fix (not applied):** Fishing 68 → 69 in the requirements block; correct the
   prose at lines 20604 and 20607 to "69 Fishing".
+- **status:** resolved 2026-06-07 (Fishing 68->69 in requirements + both prose strings; Sailing 1 left as-is; `lintDropRates build` green).
 
 ---
 

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -20601,10 +20601,10 @@
       }
     ],
     "locationDescription": "Deep sea fishing shoals",
-    "travelTip": "Port Roberts dock -> sail to trawling shoal (68 Fishing + Sailing required)",
+    "travelTip": "Port Roberts dock -> sail to trawling shoal (69 Fishing + Sailing required)",
     "guidanceSteps": [
       {
-        "description": "Bank for deep sea trawling. Bring a trawling net (from Netmaster or Sailing shops), stamina potions, and food. 68 Fishing and basic Sailing required. Speak to Netmaster Kellan at the Rolling Tide pub in Port Roberts for an introduction.",
+        "description": "Bank for deep sea trawling. Bring a trawling net (from Netmaster or Sailing shops), stamina potions, and food. 69 Fishing and basic Sailing required. Speak to Netmaster Kellan at the Rolling Tide pub in Port Roberts for an introduction.",
         "worldX": 1565,
         "worldY": 3420,
         "worldPlane": 0,
@@ -20645,7 +20645,7 @@
       "skills": [
         {
           "skill": "FISHING",
-          "level": 68
+          "level": 69
         },
         {
           "skill": "SAILING",


### PR DESCRIPTION
## What

The lowest-tier Deep Sea trawling shoal - the **Giant krill shoal** (source of the Giant blue krill trophy) - requires **Fishing 69**. No shoal is listed at Fishing 68, so the gate of `68` corresponds to no obtainable content (the lowest shoal *is* the lowest trophy source).

## Change

Per the project convention of gating on the lowest level that yields a clog item:
- `requirements.skills` Fishing 68 -> 69 (Sailing 1 left as-is - no contradicting access-level receipt).
- Prose (travelTip + guidance) "68 Fishing" -> "69 Fishing".

The six trophy ids and drop rates are unchanged. The Swordfish source's separate "68 Fishing" (Fishing Guild) references are correct and untouched.

## Verification

- `validate_drop_rates` - clean (one pre-existing unrelated guidance-step note).
- `./gradlew lintDropRates build` - **BUILD SUCCESSFUL**.

## Receipts

`docs/verify/findings-SKILLING.md` #2 - wiki Deep sea trawling shoals table (fetched 2026-06-07): Giant krill shoal = Fishing 69. domain-skeptic STANDS (low).
