### PR TITLE
feat(data): add Twisted Banshee source for Mystic gloves (dark)

### DIFF
--- a/docs/verify/findings-COMPLETENESS.md
+++ b/docs/verify/findings-COMPLETENESS.md
@@ -38,5 +38,9 @@ calc can never route a player to). IDs of items we *do* carry are clean (0 wrong
 - action: add Mystic gloves (dark) (id 4105). Placement is a judgment call (which slayer
   monster's drop table) - the per-source loop should decide; the existing set pieces sit on
   Infernal Mage / Aberrant Spectre / Gargoyle.
-- status: open
+- status: resolved 2026-06-08 (placement decided with data owner: the gloves drop ONLY from
+  Banshees - none of the existing dark-mystic sources actually drop them - so added a new
+  `Twisted Banshee` SLAYER source (npc 7272, Catacombs of Kourend, Slayer 15) carrying the
+  gloves at 1/256. npcId/rate/slayer-level confirmed via npc_lookup + wiki_lookup; id 4105
+  cache-confirmed; `lintDropRates build` green).
 

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -12109,6 +12109,68 @@
     ]
   },
   {
+    "name": "Twisted Banshee",
+    "category": "SLAYER",
+    "worldX": 1612,
+    "worldY": 9994,
+    "worldPlane": 0,
+    "killTimeSeconds": 6,
+    "afkLevel": 2,
+    "requirements": {
+      "skills": [
+        {
+          "skill": "SLAYER",
+          "level": 15
+        }
+      ]
+    },
+    "items": [
+      {
+        "itemId": 4105,
+        "name": "Mystic gloves (dark)",
+        "dropRate": 0.003906,
+        "isPet": false,
+        "wikiPage": "Mystic_gloves_(dark)"
+      }
+    ],
+    "locationDescription": "Catacombs of Kourend",
+    "travelTip": "Xeric's talisman -> Xeric's Heart, or fairy ring CIS -> Kourend Castle then descend into the Catacombs",
+    "npcId": 7272,
+    "interactAction": "Attack",
+    "guidanceSteps": [
+      {
+        "description": "Travel to the Catacombs of Kourend. Bring earmuffs or a slayer helmet (mandatory for Banshees) plus combat gear.",
+        "worldX": 1664,
+        "worldY": 10050,
+        "worldPlane": 0,
+        "completionCondition": "ARRIVE_AT_TILE",
+        "completionDistance": 20,
+        "travelTip": "Xeric's talisman -> Xeric's Heart, or fairy ring CIS -> Kourend Castle then descend",
+        "section": "Travel"
+      },
+      {
+        "description": "Find the Twisted Banshees in the Catacombs of Kourend. Earmuffs or a slayer helmet are required or they hit hard.",
+        "worldX": 1612,
+        "worldY": 9994,
+        "worldPlane": 0,
+        "completionCondition": "ARRIVE_AT_TILE",
+        "completionDistance": 15,
+        "section": "Travel"
+      },
+      {
+        "description": "Kill Twisted Banshees (15 Slayer, Banshees category). Mystic gloves (dark) drop at 1/256.",
+        "worldX": 1612,
+        "worldY": 9994,
+        "worldPlane": 0,
+        "npcId": 7272,
+        "interactAction": "Attack",
+        "completionCondition": "ACTOR_DEATH",
+        "completionNpcId": 7272,
+        "section": "Combat"
+      }
+    ]
+  },
+  {
     "name": "Gargoyle",
     "category": "SLAYER",
     "worldX": 3429,


### PR DESCRIPTION
## What

**Mystic gloves (dark)** (`4105`) was the lone dark-mystic collection-log piece absent from the entire dataset. The other four pieces sit on Infernal Mage / Aberrant Spectre / Gargoyle - but **none of those actually drop the gloves**. Per the OSRS drop data, Mystic gloves (dark) drop only from **Banshees**, which the plugin did not track as a source.

## Change

Add a new **Twisted Banshee** SLAYER source:
- npc **7272**, Catacombs of Kourend (~`1612,9994,0`), **Slayer 15**, Banshees category.
- Clog item: Mystic gloves (dark) `4105` at **1/256** (`dropRate` 0.003906).
- Guidance: travel to the Catacombs (Xeric's talisman / fairy ring CIS), earmuffs or slayer helmet required (prose, matching the Aberrant Spectre source convention). Last step is `ACTOR_DEATH`.

Twisted Banshee is the standard efficient gloves source (vs Banshee lvl 23 / Screaming variants); the user greenlit adding it as a new source rather than mis-attaching the gloves to a source that doesn't drop them.

## Verification

- `npc_lookup` Twisted Banshee -> npc 7272, Slayer level 15, Banshees category.
- `wiki_lookup` Twisted Banshee -> "Mystic gloves (dark) | qty: 1 | rarity: 1/256".
- `npc_spawns` 7272 -> Catacombs of Kourend spawns.
- `cross_check_ids` 4105 -> matches abextm cache.
- `validate_drop_rates` + `data_ascii_lint` clean; `./gradlew lintDropRates build` - **BUILD SUCCESSFUL**.

## Receipts

`docs/verify/findings-COMPLETENESS.md` - TempleOSRS clog sweep flagged 4105 missing; placement sourced from wiki/npc lookups above.
