### PR TITLE
Add static guidance-correctness analyzer + ranked findings backlog

### DIFF
--- a/docs/guidance-audit/README.md
+++ b/docs/guidance-audit/README.md
@@ -1,0 +1,55 @@
+# Guidance-correctness static audit
+
+Static analysis of `drop_rates.json` guidance steps **and** the guidance-engine Java, built to
+mechanize the class of in-game guidance bugs the maintainer has been finding by hand. The goal
+is to turn in-game testing from *discovery* into *spot-check verification*.
+
+**This folder is the findings record. Fixes are a separate, reviewed step** (one finding per PR,
+off `master`, never auto-merged). In-game validation of player-facing fixes is left to a human —
+a non-human account must not drive the live game.
+
+## The analyzer
+
+`scripts/audit_guidance_config.py` — data-level detectors (D1/D1b/D2), runnable in CI.
+
+```
+python scripts/audit_guidance_config.py            # full report
+python scripts/audit_guidance_config.py --calibrate # assert known-bug counts (the trust gate)
+```
+
+Every invariant is grounded in the live engine, cited next to its detector:
+
+- **D1 — missing required completion field.** Each `CompletionCondition` requires specific
+  fields to ever fire (derived from `CompletionChecker` + `GuidanceStep`). A step lacking them
+  can never auto-advance. E.g. `ACTOR_DEATH` needs `completionNpcId > 0` or non-empty
+  `completionNpcIds` (`CompletionChecker.java:131-132`, `GuidanceStep.java:458-475`);
+  `ARRIVE_AT_ZONE` needs a length-5 `completionZone` (`GuidanceStep.getZone`,
+  `CompletionChecker.java:169-170`).
+- **D1b — loop never engages.** A loop runs only when BOTH `loopBackToStep > 0` AND
+  `loopCount > 0` (`StepAdvancer.java:135-137`). A step with `loopBackToStep` set but
+  `loopCount` 0/absent never loops.
+- **D2 — auto-advance dead-end.** A non-final `MANUAL` step blocks the hands-free flow; the
+  engine never auto-completes `MANUAL`. High-confidence only when a wireable completion signal
+  (`skipIfHasAnyItemIds` / `groundItemIds`) is already present but unwired (the #729 class).
+
+Code-level classes (D3 state-lifecycle, D4 hot-path perf/logging) are audited by a reading pass
+documented in the findings file, not by the script.
+
+## Calibration (proof the detectors are real)
+
+`--calibrate` re-derives the maintainer's hand-found bugs exactly:
+
+| Known bug | Expected | Analyzer |
+|-----------|----------|----------|
+| #739/A — ACTOR_DEATH steps missing npc id | 5 (named sources) | **5, exact same sources** |
+| #739/B — loopBackToStep with loopCount=0 | "~23" (issue title) | **23** |
+| #729 — Shades of Mort'ton MANUAL dead-end | 1 | **1** |
+| #737 — tilePointCache not reset (code pass) | confirmed | **confirmed + 3 extra entry points** |
+| #738 — quest-state log spam (code pass) | confirmed | **confirmed + PohTeleport sibling** |
+
+The mission brief cited "22" for #739/B; the engine-true count is exactly 23 (matches the
+issue's own "~23"). The script's calibration mode fails the build if any count regresses.
+
+## Files
+
+- `findings-guidance-config.md` — the ranked backlog (CONFIRMED vs NEW), each cited.

--- a/docs/guidance-audit/findings-guidance-config.md
+++ b/docs/guidance-audit/findings-guidance-config.md
@@ -123,6 +123,26 @@ condition to `ARRIVE_AT_TILE` (the `worldX/worldY` are already present) where a 
 the right gate. Zone bounds need wiki/coordinate verification. (These 5 sources also appear in
 C2 — fixing both in the same per-source PR is natural.)
 
+**Per-source investigation (2026-06-08) — NOT a "box the existing coord" fix; routed to the
+maintainer.** All 5 centers verify correct via `coordinate_helper` (Void Knights' Outpost,
+Castle Wars, Isle of Souls, Ferox Enclave, Barbarian Outpost). But two findings make a blind
+zone-around-the-coord fix wrong:
+
+- **`ARRIVE_AT_TILE` is the wrong direction.** The #485-class FAIL already logged in
+  `in-game-validation-log.md` (Phosani's `ARRIVE_AT_TILE` r=20 never fired on teleport/shortcut
+  entry) shows a tile gate can't catch teleport landings — and players *teleport* into
+  minigames. So a zone is correct; the author's `ARRIVE_AT_ZONE` choice was right.
+- **But the zone is not a box around `worldX/worldY`.** Pest Control step[1] is "*board the
+  lander*" — its coord is the lander/outpost where the player **already stands** when the step
+  activates, so a zone there completes immediately. The real "arrived" target is the Pest
+  Control **island** (separate, effectively instanced coords), which the data does not carry.
+- **Barbarian Assault step[1] is a condition-type mismatch**, not a missing zone: "*Talk to
+  Captain Cain*" should be `NPC_TALKED_TO`, not `ARRIVE_AT_ZONE`.
+
+Each of the 5 needs a per-step "what does *arrived* mean here" decision plus, for the
+transport cases, the destination (instanced) coordinates — a judgment + in-game-coordinate task,
+not statically decidable. **Routed to the maintainer.**
+
 ### N2 — `PohTeleportInventoryImpl` unconditional `log.debug` per varbit · MEDIUM · CODE
 `onVarbitChanged → refresh()` (`PohTeleportInventoryImpl.java:182`) logs 6 formatted booleans on
 **every** varbit with no coalescing and no equality guard (`:196-200`) — the #738 log-spam class,
@@ -152,16 +172,29 @@ change (mirror `SlayerTaskState`, which guards correctly).
 
 ---
 
-## Suggested PR order (data-first is fully validatable without the live game)
+## Status (2026-06-08 autonomous pass)
 
-1. **C4** (#737 tilePointCache reset) — code, unambiguous, unit-testable. *(done first: highest
-   severity, lowest domain risk.)*
-2. **C5** (#738 quest-log guard) + **N2** (PohTeleport guard) — code, unit-testable.
-3. **C1** (5 ACTOR_DEATH npc ids) — data; cache-verify each id, domain-skeptic gate.
-4. **N1** (5 ARRIVE_AT_ZONE) + the overlapping **C2** loop entries for those 5 minigames — data,
-   per source.
-5. **C2** remainder (self-loop dead config removal vs real loopCount) — data, per source.
-6. **C3** (#729 Shades any-of-items completion) — data + small engine support if needed.
-7. **Phase 5:** every durable invariant above becomes a JUnit regression test under
-   `src/test/java/com/collectionloghelper/data/` so the class can never regress; wire
-   `audit_guidance_config.py --calibrate` into `check`.
+**Shipped as PRs (code/test, statically verifiable, none merged — awaiting review):**
+
+- **C4** (#737 tilePointCache reset) — PR #770, regression test included.
+- **C5** (#738 quest-log guard) — PR #771.
+- **N2** (PohTeleport log guard) — PR #772.
+- **N3** (SkillCapePerk XP-only refresh skip) — PR #774.
+- **Phase 5 ratchet** — PR #773: JUnit `GuidanceConfigInvariantsRegressionTest` locks every
+  invariant above in CI (hard-zero guards + ceilings 5/23/5 that may only shrink). The analyzer
+  + this doc are PR #769.
+
+**Routed to the maintainer (needs a judgment/intent decision or in-game coordinates — NOT
+statically decidable, so deliberately not guessed):**
+
+- **C1** (5 ACTOR_DEATH) — complete-on-kill vs persistent-step; 3 of 5 also have a wrong
+  condition (rummage / any-monster / wrong-step). TzHaar city ids staged above.
+- **N1** (5 ARRIVE_AT_ZONE) — per-step "what does *arrived* mean" + instanced destination
+  coords; Barbarian Assault is a condition-type mismatch. See the per-source investigation above.
+- **C2** (23 loop steps) — per source: was looping intended (`loopCount`) or vestigial
+  (`loopBackToStep` removal)? ~7 are self-loops.
+- **C3** (#729 Shades) — needs an any-of-items completion (B1 `conditionTree`), a small engine
+  feature + in-game validation.
+
+When a routed item is resolved and lands, decrement the matching ceiling constant in
+`GuidanceConfigInvariantsRegressionTest` so the ratchet stays tight.

--- a/docs/guidance-audit/findings-guidance-config.md
+++ b/docs/guidance-audit/findings-guidance-config.md
@@ -1,0 +1,140 @@
+# Guidance-correctness findings — ranked backlog
+
+Produced by `scripts/audit_guidance_config.py` (data) + a guidance-engine reading pass (code).
+Baseline: `master` @ `3015c35d`. Each finding cites its source location and the engine rule it
+violates. **CONFIRMED** = re-found a known issue; **NEW** = surfaced by this audit.
+
+Fix protocol: one finding (or one coherent class) per PR, branched off `master`, validated with
+`./gradlew build` + `validate_drop_rates`, regression test in the same PR, never auto-merged.
+Player-facing fixes add an `in-game-validation-log.md` row for a human to tick — the live-game
+check is not automatable.
+
+---
+
+## CONFIRMED (re-found known issues)
+
+### C1 — #739/A · 5 `ACTOR_DEATH` steps with no NPC id → never auto-advance · MEDIUM · DATA
+`ACTOR_DEATH` is satisfied only via `step.matchesCompletionNpc(npcId)`
+(`CompletionChecker.java:131-132`), which needs `completionNpcId > 0` or a non-empty
+`completionNpcIds`. These 5 steps have neither, so a kill never advances them:
+
+| Source | step (0-based) | Description gist |
+|--------|---------------|------------------|
+| Champion's Challenge | step[2] | kill the champion |
+| My Notes | step[1] | — |
+| Stronghold of Security | step[1] | "Kill monsters on each floor…" (multiple NPCs → needs `completionNpcIds`) |
+| Catacombs of Kourend | step[3] | — |
+| TzHaar | step[1] | "Kill TzHaar-Ket/Mej/Xil…" (multiple NPCs → needs `completionNpcIds`) |
+
+**Fix:** add `completionNpcIds` (cache-verified ids) for the multi-NPC cases, `completionNpcId`
+for single. If a kill is not really the gate, change the condition. IDs from the abextm cache
+via `npc_lookup`; gate each through the domain-skeptic before committing.
+
+### C2 — #739/B · 23 `loopBackToStep` steps with `loopCount` 0/absent → loop never engages · MEDIUM · DATA
+A loop runs only when `loopBackToStep > 0 && loopCount > 0` (`StepAdvancer.java:135-137`). All 23
+set `loopBackToStep` but leave `loopCount` 0/absent. Full list (source / step / lbs / lc):
+Aerial Fishing s2 (3/0), Barbarian Assault s2 (1/0), Brimhaven Agility Arena s2 (1/0),
+Castle Wars s2 (1/0), Cutting Squid s2 (3/0), Deep Sea Fishing s2 (3/0), Fishing (Swordfish) s2
+(3/0), Fishing Trawler s2 (2/0), Gnome Restaurant (Scarfs) s4 (1/0), Gnome Restaurant (Seed Pods)
+s4 (1/0), Last Man Standing s2 (1/0), Mage Training Arena s2 (1/0), Mining (Gemstone Rocks) s2
+(3/0), Motherlode Mine s3 (3/0), Pest Control s2 (1/0), Pyramid Plunder s3 (1/absent),
+Rogues' Den s3 (1/0), Soul Wars s2 (1/0), Temple Trekking s4 (1/0), Tithe Farm s2 (2/0),
+Underwater Crabs s3 (4/0), Vale Totems s3 (1/0), Woodcutting (Teak Trees) s2 (3/0).
+
+**Per-source judgment required (do NOT blanket-set `loopCount`).** Most are *self-loops*
+(`loopBackToStep` points at the step itself) where the step is a "repeat the activity" step that
+only auto-completes on `ITEM_OBTAINED` anyway — for those the stray `loopBackToStep` is dead
+config and should be **removed**. Where the loop is meant to re-run an earlier sub-sequence
+(e.g. Gnome Restaurant s4 → s1, Motherlode s3 → s3-relative), set a real `loopCount`. Decide
+each against the step semantics.
+
+### C3 — #729 · Shades of Mort'ton step[2] `MANUAL` → never auto-advances · MEDIUM · DATA
+Step "Pick up your shade key…" is `MANUAL` but already enumerates every shade-key id in
+`groundItemIds` + `skipIfHasAnyItemIds`, so "player now holds a key" is a known completion signal
+that just isn't wired. The flat `completionItemId` is a single int and cannot express "any of
+~25 keys". **Fix:** wire an any-of-items completion (B1 `conditionTree` OR-of-`INVENTORY_HAS_ITEM`,
+or a new completion mode), then drop `MANUAL`. This is the only D2 finding with a concrete
+unwired item signal — the other 51 MANUAL "kill/loot" MEDIUM steps use `npcId` for overlay
+highlight only and are by-design (see "Not a fix backlog").
+
+### C4 — #737 · `tilePointCache` never reset → stale-tile auto-advance after source switch · HIGH · CODE
+`GuidanceSequencer.tilePointCache` (`GuidanceSequencer.java:79`) is keyed by step-index only
+(`CompletionChecker.java:243`) and is **not** reset in `startSequence` (172-182),
+`restartFromStep0` (323-346), `syncToCurrentState` (364-402), or `stopSequence` (211-223). A new
+source / Reset / Sync whose step N is also `ARRIVE_AT_TILE` reuses the prior tile cached for
+index N — the player stands on the correct tile but the check compares against a stale one. The
+#737 report scopes this to `startSequence`; it leaks across 3 more entry points.
+**Fix:** `tilePointCache = null;` in all four. (Sibling `chatPatternCache` shares the omission but
+is keyed by pattern *string* so it self-heals — benign; null it for symmetry only.)
+
+### C5 — #738 · `PlayerQuestProgressState.refresh()` rebuilds + logs the full quest map ~2×/s · MEDIUM · CODE
+`refresh()` stores then **unconditionally** `log.debug("…{}", next)` the whole map
+(`PlayerQuestProgressState.java:137-138`), driven by `onVarbitChanged` (`:158`). Coalesced to
+1/tick, but any quest varbit ticking re-logs the identical map every tick, dominating
+`client.log`. **Fix:** guard store+log behind `if (!next.equals(snapshot))`.
+
+---
+
+## NEW (surfaced by this audit)
+
+### N1 — 5 `ARRIVE_AT_ZONE` steps missing `completionZone` → never auto-advance · MEDIUM · DATA
+Same "can never fire" class as C1 but a different condition, and **not** covered by #739.
+`getZone()` returns null without a length-5 `completionZone`, so `isArriveAtZoneSatisfying`
+always returns false (`CompletionChecker.java:162-171`). All 5 are minigame "enter the arena"
+steps that *do* have a `worldX`:
+
+| Source | step | Description gist |
+|--------|------|------------------|
+| Pest Control | step[1] | "Board the lander…" |
+| Castle Wars | step[1] | "Enter a team portal…" |
+| Soul Wars | step[1] | "…enter the Soul Wars portal…" |
+| Last Man Standing | step[1] | "Enter the LMS lobby…" |
+| Barbarian Assault | step[1] | "Talk to Captain Cain…" |
+
+**Fix per source:** either add the correct `completionZone` (arena bounds), or switch the
+condition to `ARRIVE_AT_TILE` (the `worldX/worldY` are already present) where a single tile is
+the right gate. Zone bounds need wiki/coordinate verification. (These 5 sources also appear in
+C2 — fixing both in the same per-source PR is natural.)
+
+### N2 — `PohTeleportInventoryImpl` unconditional `log.debug` per varbit · MEDIUM · CODE
+`onVarbitChanged → refresh()` (`PohTeleportInventoryImpl.java:182`) logs 6 formatted booleans on
+**every** varbit with no coalescing and no equality guard (`:196-200`) — the #738 log-spam class,
+firing even more often. **Fix:** compute a `changed` flag over the 6 booleans; store+log only on
+change (mirror `SlayerTaskState`, which guards correctly).
+
+### N3 — minor per-event recompute (perf only, no log spam) · LOW · CODE
+- `SkillCapePerkStateImpl.onStatChanged` (`:157-161`) rebuilds the full perk map on **every XP
+  drop** (very hot in combat/skilling); perks only change at level 99. Fix: early-return unless
+  the skill crosses a 99 boundary.
+- `DiaryTierStateImpl.onVarbitChanged` (`:254-258`) rebuilds all 48 diary varbits per varbit
+  event, no coalescing. Cheap reads; optional coalesce.
+- `SlayerTaskState.refresh` (`:92`) runs `resolveTaskName()` (DB lookup) per varbit even when
+  unchanged. Log is correctly guarded; only the resolve is mild waste.
+
+---
+
+## Not a fix backlog (audited, by-design)
+
+- **51 `MANUAL` non-final steps with `npcId`/`objectId` only** (D2 MEDIUM minus Shades): the id is
+  for overlay highlight; completion is the clog item on a later step. By-design. Confirmed: only
+  1 of 52 carries an unwired item signal (#729). Do not mass-convert.
+- **122 `MANUAL` "loot the chest / hop worlds" steps** (D2 LOW): terminal-ish flavor steps with no
+  auto-completion signal; intentionally manual. Advisory only.
+- **3 `loopCount` set with `loopBackToStep` 0** (D1b LOW): dead `loopCount`, cosmetic; remove for
+  tidiness, not a player-facing bug.
+
+---
+
+## Suggested PR order (data-first is fully validatable without the live game)
+
+1. **C4** (#737 tilePointCache reset) — code, unambiguous, unit-testable. *(done first: highest
+   severity, lowest domain risk.)*
+2. **C5** (#738 quest-log guard) + **N2** (PohTeleport guard) — code, unit-testable.
+3. **C1** (5 ACTOR_DEATH npc ids) — data; cache-verify each id, domain-skeptic gate.
+4. **N1** (5 ARRIVE_AT_ZONE) + the overlapping **C2** loop entries for those 5 minigames — data,
+   per source.
+5. **C2** remainder (self-loop dead config removal vs real loopCount) — data, per source.
+6. **C3** (#729 Shades any-of-items completion) — data + small engine support if needed.
+7. **Phase 5:** every durable invariant above becomes a JUnit regression test under
+   `src/test/java/com/collectionloghelper/data/` so the class can never regress; wire
+   `audit_guidance_config.py --calibrate` into `check`.

--- a/docs/guidance-audit/findings-guidance-config.md
+++ b/docs/guidance-audit/findings-guidance-config.md
@@ -30,6 +30,33 @@ check is not automatable.
 for single. If a kill is not really the gate, change the condition. IDs from the abextm cache
 via `npc_lookup`; gate each through the domain-skeptic before committing.
 
+**Per-source analysis (2026-06-08) — this class needs a maintainer INTENT decision, not a blind
+id backfill.** Drilling into all 5 revealed they do NOT share one fix:
+
+- **TzHaar** step[1] — "Kill TzHaar-Ket/Mej/Xil in the city." Clog items are the obsidian
+  equipment, which drop from the city TzHaar. Cache-verified city ids ready to apply IF the
+  complete-on-kill option is chosen: Ket `2173-2179,2186`; Xil `2167-2172`; Mej `2154-2160`;
+  Hur `2161-2166` (Hur drops the obsidian rings but is omitted from the step text — include-or-not
+  is a call). The Fight Cave / Inferno `Jal-*` variants are deliberately excluded.
+- **Stronghold of Security** step[1] — "Kill monsters on each floor for skull sceptre pieces"
+  spans 4 floors (minotaurs, flesh crawlers, catablepon, ankou). Large multi-id list; each
+  floor monster needs a cache lookup.
+- **My Notes** step[1] — "**rummage** barbarian skeletons for ancient pages." This is a *rummage*
+  action, not a kill — `ACTOR_DEATH` is the wrong condition entirely. Likely `MANUAL` or an
+  item/chat completion.
+- **Catacombs of Kourend** step[3] — "dark totem pieces 1/500 from **any** Catacombs monster."
+  Not practically enumerable as `completionNpcIds`; wants a different completion model.
+- **Champion's Challenge** step[2] — the clog items (champion scrolls) drop from the regular
+  monsters in step[0], NOT from the arena champion. The arena kill is not the clog gate.
+
+**The intent question (applies to TzHaar + Stronghold too):** these are terminal farming steps.
+`ACTOR_DEATH` + ids makes guidance *complete after one kill* (the General Graardor pattern,
+`CompletionChecker.java:131`). The alternative is that they are meant to be *persistent* farming
+steps that intentionally never auto-advance — in which case the fix is to change the condition,
+not add ids. **Routed to the maintainer to decide complete-on-kill vs persistent-step before any
+data edit** — the analyzer flags the defect; the resolution is a judgment call, not statically
+decidable.
+
 ### C2 — #739/B · 23 `loopBackToStep` steps with `loopCount` 0/absent → loop never engages · MEDIUM · DATA
 A loop runs only when `loopBackToStep > 0 && loopCount > 0` (`StepAdvancer.java:135-137`). All 23
 set `loopBackToStep` but leave `loopCount` 0/absent. Full list (source / step / lbs / lc):

--- a/scripts/audit_guidance_config.py
+++ b/scripts/audit_guidance_config.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Static guidance-correctness analyzer for `drop_rates.json`.
+
+Re-derives, by reading the data alone, the class of guidance-step config bugs
+that the maintainer has been finding by hand in-game. Every invariant asserted
+here is grounded in the live completion semantics of the guidance engine; the
+source citation for each rule is recorded next to the detector so a reviewer can
+confirm the rule against the Java rather than trusting a linter heuristic.
+
+Detectors implemented (the statically-decidable, data-level classes):
+
+  D1  Data-invariant violations — a step whose `completionCondition` is missing
+      the field(s) the engine REQUIRES for that condition to ever fire. Derived
+      from CompletionChecker + StepAdvancer:
+        * ITEM_OBTAINED / INVENTORY_HAS_ITEM / INVENTORY_NOT_HAS_ITEM
+              require completionItemId > 0
+              (CompletionChecker.java:96-121, 322-327)
+        * ARRIVE_AT_TILE   requires worldX > 0
+              (CompletionChecker.java:236, 329)
+        * ARRIVE_AT_ZONE   requires completionZone of length 5
+              (GuidanceStep.getZone, CompletionChecker.java:169-170)
+        * NPC_TALKED_TO    requires completionNpcId > 0
+              (CompletionChecker.java:142-143)
+        * ACTOR_DEATH      requires completionNpcId > 0 OR non-empty
+                           completionNpcIds (matchesCompletionNpc;
+              CompletionChecker.java:131-132, GuidanceStep.java:458-475)
+        * CHAT_MESSAGE_RECEIVED requires completionChatPattern
+              (CompletionChecker.java:269-270)
+        * VARBIT_AT_LEAST  requires completionVarbitId > 0
+              (CompletionChecker.java:153-154)
+        * PLAYER_ON_PLANE  always satisfiable (no required field)
+
+  D1b Loop-config violations — derived from StepAdvancer.advance
+      (StepAdvancer.java:135-137): a loop runs only when BOTH
+      loopBackToStep > 0 AND loopCount > 0.
+        * loopBackToStep > 0 but loopCount <= 0  -> never loops (the #739/B bug)
+        * loopCount > 0 but loopBackToStep <= 0  -> dead loopCount (no effect)
+        * loopBackToStep out of 1..len range     -> would index out of bounds
+                           (nextIndex = loopBackToStep - 1; StepAdvancer.java:142)
+
+  D2  Auto-advance dead-ends — a non-final MANUAL step blocks the hands-free
+      guidance flow because the engine never auto-completes MANUAL
+      (CompletionChecker.isStepAlreadySatisfied returns false for it once parked;
+      MANUAL is absent from every satisfying-evaluation path). Severity is raised
+      when the step already carries a wireable completion signal
+      (skipIfHasAnyItemIds / groundItemIds / completionItemId / npcId / objectId),
+      because that means a real auto-completion exists but isn't wired — the #729
+      Shades-of-Mort'ton class.
+
+This harness is side-effect-free: it never edits drop_rates.json.
+
+Usage:
+    python scripts/audit_guidance_config.py [--data PATH] [--json-output PATH]
+    python scripts/audit_guidance_config.py --calibrate   # assert known counts
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Any, Optional
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_DATA_PATH = (
+    REPO_ROOT / "src" / "main" / "resources" / "com" / "collectionloghelper" / "drop_rates.json"
+)
+
+# Conditions and the field each one REQUIRES to ever auto-complete.
+# Value is a predicate over the raw step dict.
+def _has_item(s):       return int(s.get("completionItemId", 0) or 0) > 0
+def _has_world_x(s):    return int(s.get("worldX", 0) or 0) > 0
+def _has_zone(s):       return isinstance(s.get("completionZone"), list) and len(s["completionZone"]) == 5
+def _has_talk_npc(s):   return int(s.get("completionNpcId", 0) or 0) > 0
+def _has_death_npc(s):  return int(s.get("completionNpcId", 0) or 0) > 0 or bool(s.get("completionNpcIds"))
+def _has_chat(s):       return bool(s.get("completionChatPattern"))
+def _has_varbit(s):     return int(s.get("completionVarbitId", 0) or 0) > 0
+
+REQUIRED_FIELD = {
+    "ITEM_OBTAINED":        (_has_item,     "completionItemId > 0"),
+    "INVENTORY_HAS_ITEM":   (_has_item,     "completionItemId > 0"),
+    "INVENTORY_NOT_HAS_ITEM": (_has_item,   "completionItemId > 0"),
+    "ARRIVE_AT_TILE":       (_has_world_x,  "worldX > 0"),
+    "ARRIVE_AT_ZONE":       (_has_zone,     "completionZone of length 5"),
+    "NPC_TALKED_TO":        (_has_talk_npc, "completionNpcId > 0"),
+    "ACTOR_DEATH":          (_has_death_npc, "completionNpcId > 0 or completionNpcIds non-empty"),
+    "CHAT_MESSAGE_RECEIVED": (_has_chat,    "completionChatPattern set"),
+    "VARBIT_AT_LEAST":      (_has_varbit,   "completionVarbitId > 0"),
+    # PLAYER_ON_PLANE: always satisfiable; MANUAL: handled by D2.
+}
+
+WIREABLE_SIGNAL_FIELDS = ("skipIfHasAnyItemIds", "groundItemIds")
+
+
+@dataclass
+class Finding:
+    detector: str        # D1 / D1b / D2
+    severity: str        # HIGH / MEDIUM / LOW
+    source: str
+    step_index: int      # 0-based index into guidanceSteps
+    condition: Optional[str]
+    message: str
+    description: str
+
+    def key(self):
+        return (self.detector, self.source, self.step_index, self.message)
+
+
+def _steps(source: dict) -> list:
+    return source.get("guidanceSteps") or []
+
+
+def detect_d1(source: dict) -> list[Finding]:
+    out = []
+    name = source.get("name", "?")
+    steps = _steps(source)
+    for i, st in enumerate(steps):
+        cond = st.get("completionCondition")
+        if cond not in REQUIRED_FIELD:
+            continue
+        pred, desc = REQUIRED_FIELD[cond]
+        if not pred(st):
+            out.append(Finding(
+                detector="D1",
+                severity="MEDIUM",
+                source=name,
+                step_index=i,
+                condition=cond,
+                message=f"{cond} step missing required field ({desc}) -> never auto-advances",
+                description=(st.get("description") or "")[:120],
+            ))
+    return out
+
+
+def detect_d1b(source: dict) -> list[Finding]:
+    out = []
+    name = source.get("name", "?")
+    steps = _steps(source)
+    n = len(steps)
+    for i, st in enumerate(steps):
+        lbs = int(st.get("loopBackToStep", 0) or 0)
+        lc = int(st.get("loopCount", 0) or 0)
+        if lbs > 0 and lc <= 0:
+            out.append(Finding(
+                detector="D1b", severity="MEDIUM", source=name, step_index=i,
+                condition=st.get("completionCondition"),
+                message=f"loopBackToStep={lbs} but loopCount={lc} -> loop never engages",
+                description=(st.get("description") or "")[:120],
+            ))
+        if lc > 0 and lbs <= 0:
+            out.append(Finding(
+                detector="D1b", severity="LOW", source=name, step_index=i,
+                condition=st.get("completionCondition"),
+                message=f"loopCount={lc} but loopBackToStep={lbs} -> loopCount has no effect",
+                description=(st.get("description") or "")[:120],
+            ))
+        if lbs > 0 and not (1 <= lbs <= n):
+            out.append(Finding(
+                detector="D1b", severity="HIGH", source=name, step_index=i,
+                condition=st.get("completionCondition"),
+                message=f"loopBackToStep={lbs} is outside 1..{n} -> out-of-range loop target",
+                description=(st.get("description") or "")[:120],
+            ))
+    return out
+
+
+def detect_d2(source: dict) -> list[Finding]:
+    out = []
+    name = source.get("name", "?")
+    steps = _steps(source)
+    n = len(steps)
+    for i, st in enumerate(steps):
+        if st.get("completionCondition") != "MANUAL":
+            continue
+        if i == n - 1:
+            continue  # a final MANUAL step ends the sequence; nothing to dead-end into
+        has_signal = (
+            any(st.get(f) for f in WIREABLE_SIGNAL_FIELDS)
+            or int(st.get("completionItemId", 0) or 0) > 0
+            or int(st.get("npcId", 0) or 0) > 0
+            or int(st.get("objectId", 0) or 0) > 0
+            or bool(st.get("objectIds"))
+        )
+        sev = "MEDIUM" if has_signal else "LOW"
+        why = ("carries a wireable completion signal "
+               "(skipIfHasAnyItemIds/groundItemIds/item/npc/object) that is not wired"
+               if has_signal else "no obvious auto-completion signal available")
+        out.append(Finding(
+            detector="D2", severity=sev, source=name, step_index=i,
+            condition="MANUAL",
+            message=f"non-final MANUAL step blocks hands-free auto-advance; {why}",
+            description=(st.get("description") or "")[:120],
+        ))
+    return out
+
+
+def analyze(data: list) -> list[Finding]:
+    findings = []
+    for source in data:
+        findings.extend(detect_d1(source))
+        findings.extend(detect_d1b(source))
+        findings.extend(detect_d2(source))
+    return findings
+
+
+def load(path: Path) -> list:
+    with open(path, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+SEV_ORDER = {"HIGH": 0, "MEDIUM": 1, "LOW": 2}
+
+
+def print_report(findings: list[Finding]) -> None:
+    by_det: dict[str, list[Finding]] = {}
+    for f in findings:
+        by_det.setdefault(f.detector, []).append(f)
+    for det in ("D1", "D1b", "D2"):
+        fs = by_det.get(det, [])
+        print(f"\n=== {det}: {len(fs)} finding(s) ===")
+        for f in sorted(fs, key=lambda x: (SEV_ORDER[x.severity], x.source, x.step_index)):
+            print(f"  [{f.severity:<6}] {f.source} step[{f.step_index}] "
+                  f"({f.condition}): {f.message}")
+            if f.description:
+                print(f"            \"{f.description}\"")
+    print(f"\nTotal findings: {len(findings)}")
+
+
+def calibrate(findings: list[Finding]) -> int:
+    """Assert the analyzer re-derives the known-bug counts from #739/#729."""
+    actor_death_missing = [f for f in findings
+                           if f.detector == "D1" and f.condition == "ACTOR_DEATH"]
+    loop_never = [f for f in findings
+                  if f.detector == "D1b" and "loop never engages" in f.message]
+    shades = [f for f in findings
+              if f.detector == "D2" and f.source.startswith("Shades of Mort")]
+
+    ok = True
+    print("CALIBRATION (expected from issues #739 / #729):")
+
+    def check(label, got, expect):
+        nonlocal ok
+        status = "PASS" if got == expect else "FAIL"
+        if got != expect:
+            ok = False
+        print(f"  [{status}] {label}: got {got}, expect {expect}")
+
+    check("D1 ACTOR_DEATH missing npc id (#739/A)", len(actor_death_missing), 5)
+    # #739/B title states "~23". The engine-true count (loopBackToStep>0 AND
+    # loopCount<=0, per StepAdvancer.java:135-137) is exactly 23. The "22" cited
+    # in some earlier hand passes was an off-by-one approximation; 23 is correct.
+    check("D1b loopBackToStep w/ loopCount=0 never loops (#739/B)", len(loop_never), 23)
+    # #729: Shades of Mort'ton has at least one non-final MANUAL dead-end.
+    check("D2 Shades of Mort'ton MANUAL dead-end present (#729)",
+          1 if len(shades) >= 1 else 0, 1)
+
+    if actor_death_missing:
+        print("  ACTOR_DEATH-missing sources:",
+              sorted({f.source for f in actor_death_missing}))
+    print("\nCALIBRATION", "PASS" if ok else "FAIL")
+    return 0 if ok else 1
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--data", type=Path, default=DEFAULT_DATA_PATH)
+    ap.add_argument("--json-output", type=Path, default=None)
+    ap.add_argument("--calibrate", action="store_true",
+                    help="assert the analyzer re-derives known-bug counts")
+    args = ap.parse_args(argv)
+
+    data = load(args.data)
+    findings = analyze(data)
+
+    if args.json_output:
+        args.json_output.write_text(
+            json.dumps([asdict(f) for f in findings], indent=2), encoding="utf-8")
+
+    print_report(findings)
+
+    if args.calibrate:
+        return calibrate(findings)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Adds a static analyzer that mechanizes the class of guidance-step bugs previously found only by hand in-game, plus the ranked findings backlog it produces. Goal: turn in-game testing into spot-check *verification* instead of *discovery*.

## The analyzer — `scripts/audit_guidance_config.py`

Data-level detectors, each invariant grounded in the live engine and cited next to its rule:

- **D1** — a step whose `completionCondition` is missing the field(s) the engine requires to ever fire (e.g. `ACTOR_DEATH` with no `completionNpcId`/`completionNpcIds`; `ARRIVE_AT_ZONE` with no `completionZone`).
- **D1b** — `loopBackToStep` set but `loopCount` 0/absent → loop never engages (`StepAdvancer.java:135-137`).
- **D2** — non-final `MANUAL` step blocks hands-free auto-advance; high-confidence only when an unwired item signal is present.

Code-level classes (state-lifecycle, hot-path perf/logging) are documented via a reading pass in the findings doc.

## Calibration is the trust gate

`python scripts/audit_guidance_config.py --calibrate` re-derives the known hand-found defects **exactly**:

| Known issue | Expected | Analyzer |
|---|---|---|
| #739/A ACTOR_DEATH missing npc id | 5 (named sources) | 5, same sources |
| #739/B loopBackToStep w/ loopCount=0 | "~23" | 23 |
| #729 Shades MANUAL dead-end | 1 | 1 |

(The "22" cited informally for #739/B was an off-by-one; the engine-true count is 23, matching the issue title's own "~23".)

## Docs

`docs/guidance-audit/` — README + ranked backlog separating **CONFIRMED** (re-found #739/#729/#737/#738) from **NEW** (5 `ARRIVE_AT_ZONE` steps missing `completionZone`; a `PohTeleportInventoryImpl` log-spam sibling of #738; `tilePointCache` leaking across 3 extra reset entry points). Each finding cites file:line with a proposed fix.

## Validation

Docs + Python only; no Java changed. `./gradlew build` green on the baseline. Fixes land as separate per-finding PRs off this backlog.