### PR TITLE
fix(player): skip SkillCapePerk refresh on XP-only StatChanged events (N3)

### DIFF
--- a/src/main/java/com/collectionloghelper/player/SkillCapePerkStateImpl.java
+++ b/src/main/java/com/collectionloghelper/player/SkillCapePerkStateImpl.java
@@ -81,6 +81,13 @@ public class SkillCapePerkStateImpl implements SkillCapePerkState
 	 */
 	private volatile Map<SkillCapePerk, Boolean> cache;
 
+	/**
+	 * Last-seen real (unboosted) level per skill, used to suppress redundant
+	 * refreshes on XP-only {@link StatChanged} events. Accessed only on the client
+	 * thread, so no synchronization is needed.
+	 */
+	private final Map<Skill, Integer> lastRealLevel = new EnumMap<>(Skill.class);
+
 	@Inject
 	SkillCapePerkStateImpl(Client client)
 	{
@@ -150,13 +157,22 @@ public class SkillCapePerkStateImpl implements SkillCapePerkState
 	 *
 	 * <p>Hitting level 99 in any skill unlocks a new cape perk, so a stat-level
 	 * change can flip {@link #hasPerkAvailable(SkillCapePerk)} from {@code false}
-	 * to {@code true}. {@link StatChanged} fires per-skill on level changes
-	 * (and at login bootstrap) — frequency is low enough that the {@code O(n)}
-	 * cape scan (n &lt;= number of perks) is acceptable without filtering.
+	 * to {@code true}. {@link StatChanged}, however, fires on every XP drop — not
+	 * just on level-ups — so it can arrive many times per second while training.
+	 * The perk fallback depends only on the real level, so a refresh is skipped
+	 * unless the changed skill's real level actually moved.
 	 */
 	@Subscribe
 	public void onStatChanged(StatChanged event)
 	{
+		Skill skill = event.getSkill();
+		int level = event.getLevel();
+		Integer previous = lastRealLevel.put(skill, level);
+		if (previous != null && previous == level)
+		{
+			// XP-only change at the same real level — perk availability cannot change.
+			return;
+		}
 		refresh();
 	}
 
@@ -165,6 +181,7 @@ public class SkillCapePerkStateImpl implements SkillCapePerkState
 	public void reset()
 	{
 		cache = buildEmptyCache();
+		lastRealLevel.clear();
 		log.debug("SkillCapePerkState reset");
 	}
 

--- a/src/test/java/com/collectionloghelper/player/SkillCapePerkStateImplSubscribeTest.java
+++ b/src/test/java/com/collectionloghelper/player/SkillCapePerkStateImplSubscribeTest.java
@@ -122,4 +122,32 @@ public class SkillCapePerkStateImplSubscribeTest
 		assertTrue(detector.hasPerkAvailable(SkillCapePerk.MAGIC_SPELLBOOK_SWAP));
 	}
 
+	@Test
+	public void onStatChanged_sameLevelXpOnly_doesNotRefreshAgain()
+	{
+		when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(null);
+		when(client.getRealSkillLevel(any(Skill.class))).thenReturn(50);
+
+		// First event at level 50 refreshes; the second is an XP-only drop at the
+		// same real level and must be skipped (StatChanged fires on every XP gain).
+		detector.onStatChanged(new StatChanged(Skill.ATTACK, 100_000, 50, 50));
+		detector.onStatChanged(new StatChanged(Skill.ATTACK, 100_500, 50, 50));
+
+		// One refresh -> one equipment read.
+		verify(client, times(1)).getItemContainer(InventoryID.EQUIPMENT);
+	}
+
+	@Test
+	public void onStatChanged_levelChange_refreshesAgain()
+	{
+		when(client.getItemContainer(InventoryID.EQUIPMENT)).thenReturn(null);
+		when(client.getRealSkillLevel(any(Skill.class))).thenReturn(50);
+
+		// A genuine level change can unlock a cape perk, so it must refresh.
+		detector.onStatChanged(new StatChanged(Skill.ATTACK, 100_000, 50, 50));
+		detector.onStatChanged(new StatChanged(Skill.ATTACK, 110_000, 51, 51));
+
+		verify(client, times(2)).getItemContainer(InventoryID.EQUIPMENT);
+	}
+
 }


### PR DESCRIPTION
Hot-path perf finding N3 from the guidance-correctness audit (`docs/guidance-audit/`).

## Problem

`StatChanged` fires on **every XP drop**, not just on level-ups (the prior code comment claimed otherwise). So `SkillCapePerkStateImpl.onStatChanged` rebuilt the full perk-availability map — an equipment-container read plus a per-perk scan — many times per second while training or in combat. The owned-status fallback depends only on the real skill *level*, so the rebuild is wasted on every XP-only event.

## Fix

Cache the last-seen real level per skill; `onStatChanged` refreshes only when the changed skill's real level actually moved. `reset()` clears the cache so a re-login re-bootstraps one refresh per skill. Equipped-cape changes are unaffected — those are handled by `onItemContainerChanged`.

## Test

Extends `SkillCapePerkStateImplSubscribeTest`: an XP-only event at the same level does **not** trigger a second refresh; a genuine level change does. (Refreshes counted via the per-refresh equipment read.)

## Validation

`./gradlew build` green (full suite). No data changed; perf/wasted-work fix with no behaviour change to `hasPerkAvailable`, so no in-game validation row required.