### PR TITLE
docs(readme): document the collection-log search-scan actuation seam

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ Ranks every collection log source by efficiency and guides you there step-by-ste
 
 </details>
 
+## How collection-log reading works
+
+To know which items you've already obtained, the plugin briefly drives the in-game collection-log **search** mode: it calls `client.menuAction(...)` on the log's Search toggle and `client.runScript(...)`, which makes the client fire its per-item script (`4100`) once for each obtained item, then immediately switches back so the search UI doesn't visibly flash. This is a **read-only scan of your own, already-open collection log** — it does not automate gameplay, interact with the world, or transmit your log anywhere. The scan result stays on your machine.
+
+The only outbound network call is the separate **opt-in, off-by-default** TempleOSRS kill-count sync, which sends your RuneScape name to `templeosrs.com` solely to fetch per-source kill counts, and only after you enable it (the consent flag is re-checked immediately before each request).
+
+This widget-scripting technique for reading the collection log is the same one used by the established [TempleOSRS](https://templeosrs.com) and WikiSync (RuneLite's `wiki` plugin) integrations. The implementation lives in `SyncStateCoordinator#triggerSearchModeScan`.
+
 ## Building
 
 ```bash


### PR DESCRIPTION
## Document the collection-log search-scan actuation seam

Reviewer-prep: the one place the plugin *acts* rather than renders is `SyncStateCoordinator#triggerSearchModeScan`, which calls `client.menuAction(...)` + `client.runScript(...)` to drive the in-game collection-log search mode. That pattern can look suspicious at a glance, so this adds a short README section that makes it self-evidently safe and cites precedent.

The new **"How collection-log reading works"** section explains:
- The scan briefly enters the log's search mode so the client fires its per-item script (`4100`) for each obtained item, then immediately exits — a **read-only scan of the player's own, already-open collection log**.
- It automates no gameplay, doesn't interact with the world, and transmits the log nowhere; the result stays local.
- The only outbound call is the separate **opt-in, off-by-default** TempleOSRS kill-count sync (RSN → `templeosrs.com`, consent re-checked immediately before each request).
- The same widget-scripting technique is used by the established **TempleOSRS** and **WikiSync** integrations.

Docs-only (README, +8 lines). The seam's code comment already cited the precedent; this surfaces it where a reviewer will actually see it.

Not for auto-merge.
