### PR TITLE
fix(guidance): capture completed source before deactivation so auto-advance can re-loop a drop-less grind (#801)

### DIFF
--- a/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
@@ -264,8 +264,7 @@ public class CollectionLogHelperPlugin extends Plugin
 			this::markPanelRebuildAndRankedDirty,
 			this::getRankedSources,
 			this::activateGuidance,
-			guidance.getGuidanceSequencer()::wasTargetSlotUnlocked,
-			guidance.getGuidanceSequencer()::getActiveSource);
+			guidance.getGuidanceSequencer()::wasTargetSlotUnlocked);
 		guidance.getGuidanceCoordinator().setOnSequenceCompleteCallback(
 			collectionStateChangeHandler::handleSequenceComplete);
 		// Wire coordinator into resolver (post-construction, avoids circular injection)

--- a/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceOverlayCoordinator.java
@@ -55,6 +55,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -188,9 +189,12 @@ public class GuidanceOverlayCoordinator
 	/**
 	 * Optional callback invoked after a guidance sequence completes and overlays
 	 * are cleared. Used by the plugin for auto-advance and panel rebuild logic.
+	 * Receives the source whose sequence just completed — captured BEFORE
+	 * deactivation, because deactivating stops the sequencer and nulls its
+	 * active source (#801).
 	 */
 	@Setter
-	private Runnable onSequenceCompleteCallback;
+	private Consumer<CollectionLogSource> onSequenceCompleteCallback;
 
 	@Inject
 	GuidanceOverlayCoordinator(
@@ -667,13 +671,16 @@ public class GuidanceOverlayCoordinator
 	 */
 	private void onSequenceComplete()
 	{
-		String sourceName = guidanceSequencer.getActiveSource() != null
-			? guidanceSequencer.getActiveSource().getName() : "unknown";
+		// Capture BEFORE deactivateGuidance(): deactivation stops the sequencer
+		// and nulls its active source, which is exactly how the not-unlocked
+		// re-activate guard lost its source context live (#801).
+		CollectionLogSource completedSource = guidanceSequencer.getActiveSource();
+		String sourceName = completedSource != null ? completedSource.getName() : "unknown";
 		deactivateGuidance();
 		log.debug("Guidance sequence complete for {}", sourceName);
 		if (onSequenceCompleteCallback != null)
 		{
-			onSequenceCompleteCallback.run();
+			onSequenceCompleteCallback.accept(completedSource);
 		}
 	}
 

--- a/src/main/java/com/collectionloghelper/lifecycle/CollectionStateChangeHandler.java
+++ b/src/main/java/com/collectionloghelper/lifecycle/CollectionStateChangeHandler.java
@@ -25,7 +25,9 @@
 package com.collectionloghelper.lifecycle;
 
 import com.collectionloghelper.CollectionLogHelperConfig;
+import com.collectionloghelper.data.CollectionLogItem;
 import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.data.PlayerCollectionState;
 import com.collectionloghelper.di.DataModule;
 import com.collectionloghelper.di.EfficiencyModule;
 import com.collectionloghelper.di.GuidanceModule;
@@ -35,6 +37,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
@@ -46,7 +49,7 @@ import net.runelite.client.RuneLite;
  * lived inline in {@link com.collectionloghelper.CollectionLogHelperPlugin}:
  *
  * <ol>
- *   <li>{@link #handleSequenceComplete()} -- callback invoked by
+ *   <li>{@link #handleSequenceComplete(CollectionLogSource)} -- callback invoked by
  *       {@code GuidanceOverlayCoordinator} when an active guidance sequence
  *       finishes.  Flags a panel rebuild and ranked-source recompute, and
  *       auto-activates guidance for the next top efficiency pick when
@@ -62,7 +65,7 @@ import net.runelite.client.RuneLite;
  *       per-character data manager has not resolved a player name yet.</li>
  * </ol>
  *
- * <p>The plugin wires three narrow callbacks once in {@code startUp()}:
+ * <p>The plugin wires four narrow callbacks once in {@code startUp()}:
  * <ul>
  *   <li>{@code onSequenceCompleteFlags} -- toggles {@code pendingPanelRebuild}
  *       and {@code rankedSourcesDirty} on the plugin.</li>
@@ -74,7 +77,7 @@ import net.runelite.client.RuneLite;
  *       wrap stays in one place.</li>
  * </ul>
  *
- * <p>Performance: {@link #handleSequenceComplete()} only fires when a guidance
+ * <p>Performance: {@link #handleSequenceComplete(CollectionLogSource)} only fires when a guidance
  * sequence completes (rare, user-driven).  Allocation discipline still holds
  * on guard-fail paths -- when auto-advance is disabled the method returns
  * after the flag callback with no allocations (see #527 / #523 lessons).
@@ -101,12 +104,6 @@ public class CollectionStateChangeHandler
 	 * {@link com.collectionloghelper.guidance.GuidanceSequencer#wasTargetSlotUnlocked()}.
 	 */
 	private Supplier<Boolean> targetSlotUnlockedSupplier;
-	/**
-	 * Returns the currently active {@link CollectionLogSource}, or {@code null}
-	 * when no guidance is active.  Wired to
-	 * {@link com.collectionloghelper.guidance.GuidanceSequencer#getActiveSource()}.
-	 */
-	private Supplier<CollectionLogSource> activeSourceSupplier;
 
 	@Inject
 	public CollectionStateChangeHandler(
@@ -133,14 +130,12 @@ public class CollectionStateChangeHandler
 		Runnable onSequenceCompleteFlags,
 		Supplier<List<ScoredItem>> rankedSourcesSupplier,
 		BiConsumer<CollectionLogSource, Integer> activateGuidanceCallback,
-		Supplier<Boolean> targetSlotUnlockedSupplier,
-		Supplier<CollectionLogSource> activeSourceSupplier)
+		Supplier<Boolean> targetSlotUnlockedSupplier)
 	{
 		this.onSequenceCompleteFlags = onSequenceCompleteFlags;
 		this.rankedSourcesSupplier = rankedSourcesSupplier;
 		this.activateGuidanceCallback = activateGuidanceCallback;
 		this.targetSlotUnlockedSupplier = targetSlotUnlockedSupplier;
-		this.activeSourceSupplier = activeSourceSupplier;
 	}
 
 	/**
@@ -148,19 +143,30 @@ public class CollectionStateChangeHandler
 	 * sequence completes.  Flags a panel rebuild and ranked-source recompute.
 	 *
 	 * <p>Auto-advance (when {@link CollectionLogHelperConfig#autoAdvanceGuidance()}
-	 * is enabled) now gates on whether the active source's target collection-log
+	 * is enabled) gates on whether the completed source's target collection-log
 	 * slot actually unlocked during the sequence:
 	 * <ul>
 	 *   <li>Slot unlocked → advance to the next top efficiency pick as before.</li>
-	 *   <li>Slot NOT unlocked → re-activate guidance on the same source so the
-	 *       player loops (e.g., repeated boss kills) until the drop arrives.</li>
+	 *   <li>Slot NOT unlocked and the source still has missing items →
+	 *       re-activate guidance on the same source so the player loops
+	 *       (e.g., repeated boss kills) until the drop arrives.</li>
+	 *   <li>Slot NOT unlocked but every item is already obtained → advance; a
+	 *       fully-obtained source can only ever complete drop-less, so
+	 *       re-activating it would loop forever (#801, live Castle Wars case).</li>
 	 * </ul>
 	 *
 	 * <p>This prevents the plugin from abandoning a source mid-grind just because
 	 * the player completed the last guidance step (e.g., "kill boss") without
 	 * receiving the target item.
+	 *
+	 * @param completedSource the source whose sequence just completed, captured
+	 *                        by the coordinator BEFORE deactivation — by callback
+	 *                        time the sequencer's own active source is already
+	 *                        null (#801). May be {@code null} when no source
+	 *                        context exists, in which case auto-advance falls
+	 *                        through to the ranked pick.
 	 */
-	public void handleSequenceComplete()
+	public void handleSequenceComplete(@Nullable CollectionLogSource completedSource)
 	{
 		if (onSequenceCompleteFlags != null)
 		{
@@ -178,20 +184,20 @@ public class CollectionStateChangeHandler
 		boolean slotUnlocked = targetSlotUnlockedSupplier != null
 			&& Boolean.TRUE.equals(targetSlotUnlockedSupplier.get());
 
-		if (!slotUnlocked)
+		if (!slotUnlocked && completedSource != null)
 		{
-			// Target slot did not unlock — loop back on the same source.
-			CollectionLogSource currentSource = activeSourceSupplier != null
-				? activeSourceSupplier.get()
-				: null;
-			if (currentSource != null)
+			if (hasMissingItems(completedSource))
 			{
+				// Target slot did not unlock — loop back on the same source.
 				log.debug("Sequence complete but target slot not unlocked for {} — re-activating",
-					currentSource.getName());
-				activateGuidanceCallback.accept(currentSource, null);
+					completedSource.getName());
+				activateGuidanceCallback.accept(completedSource, null);
 				return;
 			}
-			// No active source context available — fall through to normal advance.
+			// Every item already obtained: this source can only ever complete
+			// drop-less. Fall through to the ranked advance instead of looping.
+			log.debug("Sequence complete for {} with no missing items — advancing",
+				completedSource.getName());
 		}
 
 		if (rankedSourcesSupplier == null)
@@ -213,6 +219,29 @@ public class CollectionStateChangeHandler
 					: null;
 				activateGuidanceCallback.accept(topPick.getSource(), targetItemId);
 			});
+	}
+
+	/**
+	 * Returns true when the source still has at least one unobtained
+	 * collection-log item. Guards the not-unlocked re-activation loop: a
+	 * fully-obtained source must advance, never re-loop (#801).
+	 */
+	private boolean hasMissingItems(CollectionLogSource source)
+	{
+		List<CollectionLogItem> items = source.getItems();
+		if (items == null)
+		{
+			return false;
+		}
+		PlayerCollectionState collectionState = data.getCollectionState();
+		for (CollectionLogItem item : items)
+		{
+			if (!collectionState.isItemObtained(item.getItemId()))
+			{
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**

--- a/src/test/java/com/collectionloghelper/OnSequenceCompletePerItemTest.java
+++ b/src/test/java/com/collectionloghelper/OnSequenceCompletePerItemTest.java
@@ -103,8 +103,7 @@ public class OnSequenceCompletePerItemTest
 			() -> { /* flag toggle no-op for this test */ },
 			() -> rankedSources,
 			activateGuidanceCallback,
-			() -> true,   // slot unlocked — these tests verify advance-to-next behaviour
-			() -> null);
+			() -> true);   // slot unlocked — these tests verify advance-to-next behaviour
 		when(config.autoAdvanceGuidance()).thenReturn(true);
 	}
 
@@ -122,7 +121,7 @@ public class OnSequenceCompletePerItemTest
 		ScoredItem topPick = new ScoredItem(source, 100.0, 1, "Best", false, 100.0, bestItem, 100.0);
 		rankedSources = Collections.singletonList(topPick);
 
-		handler.handleSequenceComplete();
+		handler.handleSequenceComplete(null);
 
 		ArgumentCaptor<Integer> itemIdCaptor = ArgumentCaptor.forClass(Integer.class);
 		verify(activateGuidanceCallback).accept(eq(source), itemIdCaptor.capture());
@@ -142,7 +141,7 @@ public class OnSequenceCompletePerItemTest
 		ScoredItem topPick = new ScoredItem(source, 50.0, 2, "Some reason", false, 50.0, null, 0.0);
 		rankedSources = Collections.singletonList(topPick);
 
-		handler.handleSequenceComplete();
+		handler.handleSequenceComplete(null);
 
 		verify(activateGuidanceCallback).accept(eq(source), isNull());
 	}

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequenceCompleteOrderingTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequenceCompleteOrderingTest.java
@@ -1,0 +1,342 @@
+/*
+ * Copyright (c) 2026, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.guidance;
+
+import com.collectionloghelper.CollectionLogHelperConfig;
+import com.collectionloghelper.data.CollectionLogCategory;
+import com.collectionloghelper.data.CollectionLogItem;
+import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.data.CompletionCondition;
+import com.collectionloghelper.data.GuidanceStep;
+import com.collectionloghelper.data.PlayerCollectionState;
+import com.collectionloghelper.data.PlayerInventoryState;
+import com.collectionloghelper.data.PlayerTravelCapabilities;
+import com.collectionloghelper.data.RequirementsChecker;
+import com.collectionloghelper.di.DataModule;
+import com.collectionloghelper.di.EfficiencyModule;
+import com.collectionloghelper.di.GuidanceModule;
+import com.collectionloghelper.efficiency.ScoredItem;
+import com.collectionloghelper.lifecycle.CollectionStateChangeHandler;
+import com.collectionloghelper.overlay.DialogHighlightOverlay;
+import com.collectionloghelper.overlay.GroundItemHighlightOverlay;
+import com.collectionloghelper.overlay.GuidanceMinimapOverlay;
+import com.collectionloghelper.overlay.GuidanceOverlay;
+import com.collectionloghelper.overlay.ItemHighlightOverlay;
+import com.collectionloghelper.overlay.ObjectHighlightOverlay;
+import com.collectionloghelper.overlay.WidgetHighlightOverlay;
+import com.collectionloghelper.overlay.WorldMapDestinationOverlay;
+import com.collectionloghelper.overlay.WorldMapRouteOverlay;
+import java.lang.reflect.Constructor;
+import java.util.Collections;
+import java.util.List;
+import net.runelite.api.Client;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.eventbus.EventBus;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
+import net.runelite.client.ui.overlay.worldmap.WorldMapPointManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression tests for #801: auto-advance must not abandon a drop-less grind.
+ *
+ * <p>The live failure: {@code GuidanceOverlayCoordinator.onSequenceComplete}
+ * deactivates guidance (which stops the sequencer and nulls its active source)
+ * BEFORE invoking the completion callback, so the handler's not-unlocked
+ * re-activate guard saw a null source and fell through to ranked advance.
+ *
+ * <p>The original unit test missed this because it hand-wired the handler's
+ * active-source supplier with a non-null source. These tests drive the REAL
+ * integration ordering instead: a real {@link GuidanceSequencer}, a real
+ * {@link OverlayDeactivator} (so deactivation really stops the sequencer), a
+ * real {@link GuidanceOverlayCoordinator}, and a real
+ * {@link CollectionStateChangeHandler} wired exactly like
+ * {@code CollectionLogHelperPlugin.startUp()} — then complete a sequence via
+ * the sequencer and observe which source gets (re-)activated.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class GuidanceSequenceCompleteOrderingTest
+{
+	// Sequencer collaborators
+	@Mock private PlayerInventoryState inventoryState;
+	@Mock private PlayerCollectionState collectionState;
+	@Mock private RequirementsChecker requirementsChecker;
+
+	// Coordinator collaborators (all mocked except sequencer + deactivator)
+	@Mock private Client client;
+	@Mock private ClientThread clientThread;
+	@Mock private EventBus eventBus;
+	@Mock private CollectionLogHelperConfig config;
+	@Mock private PlayerTravelCapabilities travelCapabilities;
+	@Mock private PlayerInventoryState playerInventoryState;
+	@Mock private ItemManager itemManager;
+	@Mock private RequiredItemResolver requiredItemResolver;
+	@Mock private WorldMapPointManager worldMapPointManager;
+	@Mock private InfoBoxManager infoBoxManager;
+	@Mock private GuidanceOverlay guidanceOverlay;
+	@Mock private GuidanceMinimapOverlay guidanceMinimapOverlay;
+	@Mock private DialogHighlightOverlay dialogHighlightOverlay;
+	@Mock private ObjectHighlightOverlay objectHighlightOverlay;
+	@Mock private ItemHighlightOverlay itemHighlightOverlay;
+	@Mock private WorldMapRouteOverlay worldMapRouteOverlay;
+	@Mock private WorldMapDestinationOverlay worldMapDestinationOverlay;
+	@Mock private GroundItemHighlightOverlay groundItemHighlightOverlay;
+	@Mock private WidgetHighlightOverlay widgetHighlightOverlay;
+	@Mock private OverlayStepApplier overlayStepApplier;
+	@Mock private OverlaySourceApplier overlaySourceApplier;
+	@Mock private WorldMapController worldMapController;
+	@Mock private DynamicTargetManager dynamicTargetManager;
+	@Mock private NpcTrackerHelper npcTrackerHelper;
+	@Mock private StepChangeHandler stepChangeHandler;
+	@Mock private DynamicItemObjectTierResolver dynamicItemObjectTierResolver;
+
+	// Handler collaborators
+	@Mock private DataModule dataModule;
+	@Mock private EfficiencyModule efficiencyModule;
+	@Mock private GuidanceModule guidanceModule;
+	@Mock
+	@SuppressWarnings("unchecked")
+	private java.util.function.BiConsumer<CollectionLogSource, Integer> activateGuidanceCallback;
+
+	private GuidanceSequencer sequencer;
+	private GuidanceOverlayCoordinator coordinator;
+	private CollectionStateChangeHandler handler;
+
+	private CollectionLogSource giantMole;
+	private CollectionLogSource narwhal;
+	private List<ScoredItem> rankedSources;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		// Real sequencer: stopSequence() genuinely nulls the active source,
+		// which is the heart of the #801 ordering bug.
+		Constructor<GuidanceSequencer> seqCtor = GuidanceSequencer.class.getDeclaredConstructor(
+			PlayerInventoryState.class, PlayerCollectionState.class, RequirementsChecker.class,
+			com.collectionloghelper.guidance.bosses.BossGuidanceRegistry.class);
+		seqCtor.setAccessible(true);
+		sequencer = seqCtor.newInstance(inventoryState, collectionState, requirementsChecker, null);
+
+		when(inventoryState.hasItem(anyInt())).thenReturn(false);
+		when(inventoryState.hasAllItems(any())).thenReturn(true);
+		when(collectionState.isItemObtained(anyInt())).thenReturn(false);
+
+		// Real deactivator wired to the REAL sequencer — deactivateGuidance()
+		// must actually stop the sequence, as it does live.
+		OverlayDeactivator overlayDeactivator = new OverlayDeactivator(
+			client, clientThread, eventBus, config,
+			worldMapPointManager, infoBoxManager,
+			guidanceOverlay, guidanceMinimapOverlay, dialogHighlightOverlay,
+			objectHighlightOverlay, itemHighlightOverlay,
+			worldMapRouteOverlay, worldMapDestinationOverlay,
+			groundItemHighlightOverlay, widgetHighlightOverlay,
+			npcTrackerHelper, sequencer);
+
+		Constructor<GuidanceOverlayCoordinator> ctor =
+			GuidanceOverlayCoordinator.class.getDeclaredConstructor(
+				Client.class, ClientThread.class, EventBus.class, CollectionLogHelperConfig.class,
+				GuidanceSequencer.class, RequirementsChecker.class, PlayerTravelCapabilities.class,
+				PlayerInventoryState.class, ItemManager.class, RequiredItemResolver.class,
+				WorldMapPointManager.class, InfoBoxManager.class, GuidanceOverlay.class,
+				GuidanceMinimapOverlay.class, DialogHighlightOverlay.class, ObjectHighlightOverlay.class,
+				ItemHighlightOverlay.class, WorldMapRouteOverlay.class, WorldMapDestinationOverlay.class,
+				GroundItemHighlightOverlay.class, WidgetHighlightOverlay.class, OverlayStepApplier.class,
+				OverlaySourceApplier.class, OverlayDeactivator.class, WorldMapController.class,
+				DynamicTargetManager.class, NpcTrackerHelper.class, StepChangeHandler.class,
+				DynamicItemObjectTierResolver.class);
+		ctor.setAccessible(true);
+		coordinator = ctor.newInstance(
+			client, clientThread, eventBus, config,
+			sequencer, requirementsChecker, travelCapabilities,
+			playerInventoryState, itemManager, requiredItemResolver,
+			worldMapPointManager, infoBoxManager,
+			guidanceOverlay, guidanceMinimapOverlay, dialogHighlightOverlay,
+			objectHighlightOverlay, itemHighlightOverlay,
+			worldMapRouteOverlay, worldMapDestinationOverlay,
+			groundItemHighlightOverlay, widgetHighlightOverlay,
+			overlayStepApplier, overlaySourceApplier, overlayDeactivator,
+			worldMapController, dynamicTargetManager, npcTrackerHelper, stepChangeHandler,
+			dynamicItemObjectTierResolver);
+
+		// Stub the mocked collaborators the activation/step path threads results from.
+		when(overlayStepApplier.apply(any(), anyString(), any(), any(), any(), any(), any()))
+			.thenReturn(new OverlayStepApplier.Result(-1, null));
+		when(dynamicItemObjectTierResolver.resolve(any()))
+			.thenReturn(DynamicItemObjectTierResolver.Result.EMPTY);
+		when(requirementsChecker.getUnmetRequirements(anyString()))
+			.thenReturn(Collections.emptyList());
+
+		// Real handler, wired exactly like CollectionLogHelperPlugin.startUp().
+		handler = new CollectionStateChangeHandler(
+			client, config, dataModule, efficiencyModule, guidanceModule);
+		when(dataModule.getCollectionState()).thenReturn(collectionState);
+		when(config.autoAdvanceGuidance()).thenReturn(true);
+
+		narwhal = mock(CollectionLogSource.class);
+		when(narwhal.getName()).thenReturn("Narwhal");
+		rankedSources = Collections.singletonList(
+			new ScoredItem(narwhal, 50.0, 1, "next pick", false, 50.0, null, 50.0));
+
+		handler.setCallbacks(
+			() -> { /* panel rebuild flags — not under test */ },
+			() -> rankedSources,
+			activateGuidanceCallback,
+			sequencer::wasTargetSlotUnlocked);
+		coordinator.setOnSequenceCompleteCallback(handler::handleSequenceComplete);
+
+		giantMole = mock(CollectionLogSource.class);
+		when(giantMole.getName()).thenReturn("Giant Mole");
+		when(giantMole.getCategory()).thenReturn(CollectionLogCategory.BOSSES);
+		when(giantMole.getGuidanceHelperKey()).thenReturn(null);
+		when(giantMole.getGuidanceSteps()).thenReturn(
+			Collections.singletonList(manualKillStep()));
+		when(giantMole.getItems()).thenReturn(Collections.singletonList(
+			new CollectionLogItem(7418, "Mole claw", 1.0 / 25, false, null, 0, 0, false, false)));
+	}
+
+	private static GuidanceStep manualKillStep()
+	{
+		return new GuidanceStep(
+			"Kill the Giant Mole",
+			null,           // perItemStepDescription
+			0, 0, 0,        // worldX, worldY, worldPlane
+			0, null, null, null,  // npcId, perItemNpcId, interactAction, dialogOptions
+			null, null,     // travelTip, requiredItemIds
+			null,           // perItemRequiredItemIds
+			null,           // recommendedItemIds
+			null,           // perItemRecommendedItemIds
+			CompletionCondition.MANUAL,
+			0, 0, 0, 0,     // completionItemId, completionItemCount, completionDistance, completionNpcId
+			null,           // completionNpcIds
+			null,           // worldMessage
+			0, null, null,  // objectId, objectIds, objectInteractAction
+			null, null,     // highlightItemIds, groundItemIds
+			null,           // completionChatPattern
+			0, 0,           // completionVarbitId, completionVarbitValue
+			false,          // useItemOnObject
+			0,              // objectMaxDistance
+			null,           // objectFilterTiles
+			null,           // highlightWidgetIds
+			0, 0,           // loopBackToStep, loopCount
+			null,           // skipIfHasAnyItemIds
+			null,           // dynamicItemObjectTiers
+			null,           // completionZone
+			null,           // conditionalAlternatives
+			null,           // section
+			null,           // waypoints
+			null,           // dynamicTargetEvaluator
+			null,           // conditionTree
+			null,           // perItemStepPriority
+			null,           // activityObtainableItemIds
+			null            // restockIfMissingAllItemIds (#719)
+		);
+	}
+
+	/** Activates guidance and completes the single manual step like a live boss kill. */
+	private void activateAndCompleteSequence()
+	{
+		coordinator.activateGuidance(giantMole, null, null);
+		assertTrue(sequencer.isActive(), "sequence should be active on the manual kill step");
+
+		// Completing the final step fires sequence-complete through the REAL
+		// chain: coordinator.onSequenceComplete -> deactivateGuidance ->
+		// OverlayDeactivator.deactivate -> sequencer.stopSequence -> callback.
+		sequencer.advanceStep();
+
+		assertFalse(sequencer.isActive(), "sequence must be stopped after completion");
+		assertNull(sequencer.getActiveSource(),
+			"the live bug precondition: the sequencer source is gone by callback time");
+	}
+
+	/**
+	 * The #801 live repro: a boss kill completes the sequence with no drop
+	 * (target slot not unlocked) and the source still has missing items.
+	 * Auto-advance must re-activate the SAME source — not roll to the next
+	 * ranked pick.
+	 */
+	@Test
+	public void dropLessCompletion_reActivatesCompletedSource()
+	{
+		activateAndCompleteSequence();
+
+		verify(activateGuidanceCallback).accept(giantMole, null);
+		verify(activateGuidanceCallback, never()).accept(narwhal, null);
+	}
+
+	/**
+	 * The live Castle Wars case: a source whose items are ALL obtained can
+	 * only ever complete drop-less. Re-activating would loop forever — it must
+	 * advance to the next ranked pick instead.
+	 */
+	@Test
+	public void fullyObtainedSource_advancesInsteadOfRelooping()
+	{
+		when(collectionState.isItemObtained(anyInt())).thenReturn(true);
+
+		activateAndCompleteSequence();
+
+		verify(activateGuidanceCallback, never()).accept(giantMole, null);
+		verify(activateGuidanceCallback).accept(narwhal, null);
+	}
+
+	/**
+	 * When the target slot unlocked during the sequence, the pre-#801 advance
+	 * behaviour is preserved: move on to the next ranked pick.
+	 */
+	@Test
+	public void slotUnlocked_advancesToNextRankedPick() throws Exception
+	{
+		coordinator.activateGuidance(giantMole, null, null);
+		assertTrue(sequencer.isActive());
+
+		// Mark the target slot unlocked the way the live path does before completion.
+		java.lang.reflect.Field f = GuidanceSequencer.class.getDeclaredField("targetSlotUnlocked");
+		f.setAccessible(true);
+		f.setBoolean(sequencer, true);
+
+		sequencer.advanceStep();
+
+		verify(activateGuidanceCallback).accept(narwhal, null);
+		verify(activateGuidanceCallback, never()).accept(giantMole, null);
+	}
+}

--- a/src/test/java/com/collectionloghelper/lifecycle/CollectionStateChangeHandlerTest.java
+++ b/src/test/java/com/collectionloghelper/lifecycle/CollectionStateChangeHandlerTest.java
@@ -103,8 +103,7 @@ public class CollectionStateChangeHandlerTest
 			() -> flagsCalled = true,
 			Collections::emptyList,
 			activateGuidanceCallback,
-			() -> true,   // slot unlocked by default so existing advance tests still pass
-			() -> null);
+			() -> true);   // slot unlocked by default so existing advance tests still pass
 	}
 
 	// ── handleSequenceComplete ────────────────────────────────────────────────
@@ -113,7 +112,7 @@ public class CollectionStateChangeHandlerTest
 	public void handleSequenceComplete_alwaysFiresFlagCallback()
 	{
 		when(config.autoAdvanceGuidance()).thenReturn(false);
-		handler.handleSequenceComplete();
+		handler.handleSequenceComplete(null);
 		assertTrue( flagsCalled,"flag callback must always fire so the panel rebuilds");
 	}
 
@@ -121,7 +120,7 @@ public class CollectionStateChangeHandlerTest
 	public void handleSequenceComplete_autoAdvanceDisabled_doesNotActivate()
 	{
 		when(config.autoAdvanceGuidance()).thenReturn(false);
-		handler.handleSequenceComplete();
+		handler.handleSequenceComplete(null);
 		verifyNoInteractions(activateGuidanceCallback);
 	}
 
@@ -130,7 +129,7 @@ public class CollectionStateChangeHandlerTest
 	{
 		when(config.autoAdvanceGuidance()).thenReturn(true);
 		// supplier already returns Collections.emptyList()
-		handler.handleSequenceComplete();
+		handler.handleSequenceComplete(null);
 		verifyNoInteractions(activateGuidanceCallback);
 		assertTrue(flagsCalled);
 	}
@@ -147,9 +146,8 @@ public class CollectionStateChangeHandlerTest
 			() -> flagsCalled = true,
 			() -> java.util.Arrays.asList(locked, unlocked),
 			activateGuidanceCallback,
-			() -> true,
-			() -> null);
-		handler.handleSequenceComplete();
+			() -> true);
+		handler.handleSequenceComplete(null);
 		verify(activateGuidanceCallback).accept(unlockedSource, null);
 		verify(activateGuidanceCallback, never()).accept(lockedSource, null);
 	}
@@ -162,9 +160,8 @@ public class CollectionStateChangeHandlerTest
 			() -> flagsCalled = true,
 			() -> null,
 			activateGuidanceCallback,
-			() -> true,
-			() -> null);
-		handler.handleSequenceComplete();
+			() -> true);
+		handler.handleSequenceComplete(null);
 		verifyNoInteractions(activateGuidanceCallback);
 	}
 
@@ -172,9 +169,9 @@ public class CollectionStateChangeHandlerTest
 	public void handleSequenceComplete_nullCallbacks_doNotNpe()
 	{
 		when(config.autoAdvanceGuidance()).thenReturn(true);
-		handler.setCallbacks(null, null, null, null, null);
+		handler.setCallbacks(null, null, null, null);
 		// Must complete without throwing
-		handler.handleSequenceComplete();
+		handler.handleSequenceComplete(null);
 	}
 
 	// ── rebuildSourcesWithMissingItems ────────────────────────────────────────
@@ -245,26 +242,52 @@ public class CollectionStateChangeHandlerTest
 	// ── slot-unlock gate (#598) ───────────────────────────────────────────────
 
 	/**
-	 * Regression: last step completes, target slot did NOT unlock.
+	 * Regression: last step completes, target slot did NOT unlock and the
+	 * source still has missing items.
 	 * Auto-advance must loop back on the same source, not advance to the next one.
 	 */
 	@Test
 	public void handleSequenceComplete_slotNotUnlocked_reActivatesSameSource()
 	{
 		when(config.autoAdvanceGuidance()).thenReturn(true);
-		CollectionLogSource activeSource = minimalSource("Active Source");
+		when(dataModule.getCollectionState()).thenReturn(collectionState);
+		when(collectionState.isItemObtained(org.mockito.ArgumentMatchers.anyInt())).thenReturn(false);
+		CollectionLogSource completedSource = sourceWithOneItem("Active Source");
 		CollectionLogSource nextSource = minimalSource("Next Source");
 		ScoredItem nextItem = new ScoredItem(nextSource, 50.0, 1, "N", false, 50.0, null, 50.0);
 		handler.setCallbacks(
 			() -> flagsCalled = true,
 			() -> java.util.Collections.singletonList(nextItem),
 			activateGuidanceCallback,
-			() -> false,              // slot did NOT unlock
-			() -> activeSource);     // active source at sequence-complete time
-		handler.handleSequenceComplete();
-		// Must re-activate the current source, not advance to nextSource
-		verify(activateGuidanceCallback).accept(activeSource, null);
+			() -> false);             // slot did NOT unlock
+		handler.handleSequenceComplete(completedSource);
+		// Must re-activate the completed source, not advance to nextSource
+		verify(activateGuidanceCallback).accept(completedSource, null);
 		verify(activateGuidanceCallback, never()).accept(nextSource, null);
+	}
+
+	/**
+	 * Regression (#801, live Castle Wars case): slot did NOT unlock but every
+	 * item of the completed source is already obtained. Re-activating would
+	 * loop forever — auto-advance must move to the next ranked source.
+	 */
+	@Test
+	public void handleSequenceComplete_slotNotUnlocked_fullyObtainedSource_advances()
+	{
+		when(config.autoAdvanceGuidance()).thenReturn(true);
+		when(dataModule.getCollectionState()).thenReturn(collectionState);
+		when(collectionState.isItemObtained(org.mockito.ArgumentMatchers.anyInt())).thenReturn(true);
+		CollectionLogSource completedSource = sourceWithOneItem("Castle Wars");
+		CollectionLogSource nextSource = minimalSource("Next Source");
+		ScoredItem nextItem = new ScoredItem(nextSource, 50.0, 1, "N", false, 50.0, null, 50.0);
+		handler.setCallbacks(
+			() -> flagsCalled = true,
+			() -> java.util.Collections.singletonList(nextItem),
+			activateGuidanceCallback,
+			() -> false);             // slot did NOT unlock
+		handler.handleSequenceComplete(completedSource);
+		verify(activateGuidanceCallback).accept(nextSource, null);
+		verify(activateGuidanceCallback, never()).accept(completedSource, null);
 	}
 
 	/**
@@ -275,19 +298,18 @@ public class CollectionStateChangeHandlerTest
 	public void handleSequenceComplete_slotUnlocked_advancesToNextSource()
 	{
 		when(config.autoAdvanceGuidance()).thenReturn(true);
-		CollectionLogSource activeSource = minimalSource("Active Source");
+		CollectionLogSource completedSource = sourceWithOneItem("Active Source");
 		CollectionLogSource nextSource = minimalSource("Next Source");
 		ScoredItem nextItem = new ScoredItem(nextSource, 50.0, 1, "N", false, 50.0, null, 50.0);
 		handler.setCallbacks(
 			() -> flagsCalled = true,
 			() -> java.util.Collections.singletonList(nextItem),
 			activateGuidanceCallback,
-			() -> true,              // slot DID unlock
-			() -> activeSource);
-		handler.handleSequenceComplete();
+			() -> true);              // slot DID unlock
+		handler.handleSequenceComplete(completedSource);
 		// Must advance to the next ranked source, not loop back
 		verify(activateGuidanceCallback).accept(nextSource, null);
-		verify(activateGuidanceCallback, never()).accept(activeSource, null);
+		verify(activateGuidanceCallback, never()).accept(completedSource, null);
 	}
 
 	// ── helpers ───────────────────────────────────────────────────────────────
@@ -305,6 +327,25 @@ public class CollectionStateChangeHandlerTest
 			null,
 			null, null, 0, null, 0,
 			Collections.emptyList()
+		, null, null, null);
+	}
+
+	/** Like {@link #minimalSource} but with one collection-log item, so the
+	 * #801 missing-items guard has something to evaluate. */
+	private static CollectionLogSource sourceWithOneItem(String name)
+	{
+		return new CollectionLogSource(
+			name,
+			CollectionLogCategory.BOSSES,
+			0, 0, 0,
+			0, 0,
+			null, null, null, 0.0,
+			null, 0, false, 0,
+			null, 0, null, null,
+			null,
+			null, null, 0, null, 0,
+			Collections.singletonList(new com.collectionloghelper.data.CollectionLogItem(
+				1234, "Test Item", 1.0 / 128, false, null, 0, 0, false, false))
 		, null, null, null);
 	}
 }


### PR DESCRIPTION
Fixes #801.

## Problem (live repro x2, 2026-06-10)

Killing Giant Mole once with no collection-log drop completed the guidance sequence and immediately rolled to the next Top Pick (Narwhal) instead of re-activating Giant Mole. `GuidanceOverlayCoordinator.onSequenceComplete` called `deactivateGuidance()` — which stops the sequencer and nulls its active source — BEFORE invoking the completion callback, so `CollectionStateChangeHandler`'s not-unlocked re-activate guard read a null source through its supplier and fell through to ranked advance.

## Fix

- The coordinator captures the completed source **before** deactivating and passes it to the callback (`Runnable` → `Consumer<CollectionLogSource>`).
- The handler takes the completed source as a parameter; the `activeSourceSupplier` is **removed** — it could only ever read null at callback time, which is exactly how the bug shipped.
- New guard: not-unlocked re-activation only fires while the source still has missing items. A fully-obtained source (live Castle Wars case) can only ever complete drop-less, so it advances instead of looping forever.

## Test

`GuidanceSequenceCompleteOrderingTest` drives the **real integration chain** — real `GuidanceSequencer`, real `OverlayDeactivator` wired to that sequencer, real `GuidanceOverlayCoordinator`, real `CollectionStateChangeHandler` wired exactly like `startUp()` — then completes a sequence via `sequencer.advanceStep()` and asserts which source gets re-activated. It also pins the live bug's precondition (`getActiveSource()` is null by callback time). Verified failing pre-fix for the live reason (callback received Narwhal, not Giant Mole). The prior hand-wired tests were updated to the new API plus a fully-obtained-advances case.

## Deferred (recorded follow-ups)

- Resume-at-kill-step on re-activation depends on #803 (kill-step area confirmability).
- Review note for #803: now that re-activation actually works, a source whose steps are ALL pre-satisfied at activation could churn activate→insta-complete→re-activate (bounded only by `clientThread.invokeLater` deferral). Not reachable for realistic kill/obtain-terminated configs; worth a cheap guard when touching this seam next.

`./gradlew build test` green locally (full suite). Java-only change — no `drop_rates.json` data touched.