### PR TITLE
fix(data): Castle Wars Lanthus shop step npcId 1295 -> 11650 (#805)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -17019,7 +17019,7 @@
         "worldX": 2440,
         "worldY": 3089,
         "worldPlane": 0,
-        "npcId": 1295,
+        "npcId": 11650,
         "interactAction": "Trade",
         "completionCondition": "MANUAL"
       }


### PR DESCRIPTION
Fixes #805.

One-line data fix: the Castle Wars reward-shop guidance step (step 4/4) declared `npcId: 1295`, which the abextm cache resolves to **"Mort'ton local"**. Lanthus is **11650**. The overlay hunted a Mort'ton villager in the Castle Wars lobby and never rendered a highlight (operator-observed 2026-06-10).

## Receipts

- `npc_lookup("Lanthus")` → abextm cache: **11650** ("Lanthus", Castle Wars)
- `npc_lookup(1295)` → abextm cache: **"Mort'ton local"**; only referenced by the Castle Wars guidance step
- `validate_drop_rates` (all + cache_ids), `guidance_lint`, `data_ascii_lint` — all green
- `./gradlew build` green locally; CI is the authoritative gate for data changes

## Scope

The class-level fix (corpus-wide guidance-step npcId/objectId cache cross-check wired into the lint gate) is tracked toolkit-side as runelite-dev-toolkit#49 and has not landed yet — per the fix-at-the-right-layer rule, this PR fixes only the receipted Lanthus instance.