### PR TITLE
fix(data): Giant Mole kill step gets an explicit lair-sized completionDistance (#803)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -3948,6 +3948,7 @@
         "npcId": 5779,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
+        "completionDistance": 60,
         "completionNpcId": 5779
       }
     ]

--- a/src/test/java/com/collectionloghelper/data/GuidanceConfigInvariantsRegressionTest.java
+++ b/src/test/java/com/collectionloghelper/data/GuidanceConfigInvariantsRegressionTest.java
@@ -62,6 +62,19 @@ public class GuidanceConfigInvariantsRegressionTest
 	private static final int ACTOR_DEATH_MISSING_NPC_CEILING = 0;   // #739/A (C1 -> MANUAL)
 	private static final int LOOP_NEVER_ENGAGES_CEILING = 8;        // #739/B: 15 earlier-target removed; 8 by-design remain (7 self-loops + Motherlode Batch-3 E4 marker)
 	private static final int ARRIVE_AT_ZONE_MISSING_ZONE_CEILING = 0; // #739 N1 resolved
+	/**
+	 * #803: ACTOR_DEATH/MANUAL steps with worldX/Y but no EXPLICIT
+	 * completionDistance or completionZone are only confirmable within the
+	 * 5-tile default radius (GuidanceStep.getCompletionDistance), so the #727
+	 * state-derived start cannot land on them from most of a boss room. Area
+	 * fields on these steps are jump-confirmation only -- the completion
+	 * trigger is unchanged. DECREMENT as the corpus audit closes steps (Giant
+	 * Mole was the first); the class detector is tracked toolkit-side
+	 * (runelite-dev-toolkit#50). Instanced-arena steps whose live coords are
+	 * unknowable are by-design members of this backlog (#775) and will stay
+	 * above zero.
+	 */
+	private static final int AREA_UNCONFIRMABLE_KILL_STEP_CEILING = 347;
 
 	private DropRateDatabase database;
 
@@ -195,6 +208,42 @@ public class GuidanceConfigInvariantsRegressionTest
 			"ARRIVE_AT_ZONE steps with no completionZone never auto-advance "
 				+ "(GuidanceStep.getZone / CompletionChecker.java:169-170); ceiling is "
 				+ ARRIVE_AT_ZONE_MISSING_ZONE_CEILING + " but found " + bad.size() + ": " + bad);
+	}
+
+	@Test
+	@DisplayName("area-unconfirmable kill/manual step backlog does not grow (#803)")
+	public void areaUnconfirmableKillStepRatchet() throws Exception
+	{
+		// getCompletionDistance() substitutes a 5-tile default, so the ratchet
+		// must read the raw field to detect a missing EXPLICIT area.
+		Field rawDistance = GuidanceStep.class.getDeclaredField("completionDistance");
+		rawDistance.setAccessible(true);
+		List<String> bad = new ArrayList<>();
+		for (CollectionLogSource source : database.getAllSources())
+		{
+			List<GuidanceStep> steps = source.getGuidanceSteps();
+			if (steps == null)
+			{
+				continue;
+			}
+			for (int i = 0; i < steps.size(); i++)
+			{
+				GuidanceStep step = steps.get(i);
+				CompletionCondition cond = step.getCompletionCondition();
+				if ((cond == CompletionCondition.ACTOR_DEATH || cond == CompletionCondition.MANUAL)
+					&& step.getWorldX() > 0
+					&& rawDistance.getInt(step) <= 0
+					&& step.getZone() == null)
+				{
+					bad.add(source.getName() + " step[" + i + "]");
+				}
+			}
+		}
+		assertTrue(bad.size() <= AREA_UNCONFIRMABLE_KILL_STEP_CEILING,
+			"ACTOR_DEATH/MANUAL steps with worldX/Y but no explicit completionDistance/zone are "
+				+ "invisible to the state-derived start beyond the 5-tile default "
+				+ "(GuidanceSequencer.playerIsConfirmablyInStepArea); ceiling is "
+				+ AREA_UNCONFIRMABLE_KILL_STEP_CEILING + " but found " + bad.size());
 	}
 
 	// ---- helper -------------------------------------------------------------


### PR DESCRIPTION
Part of #803 (does not close it — the corpus pass continues on the issue).

## Problem (operator-observed 2026-06-10)

Re-activating Giant Mole guidance while standing inside the mole lair stranded guidance on step 1/3 ("Travel to Falador Park"). The kill step at (1759,5189) declared no explicit area, and `GuidanceStep.getCompletionDistance()` substitutes a **5-tile default** — so the #727 state-derived start could only confirm the kill step within 5 tiles of its anchor. It fired when the operator stood near the mole (13:46:03) but not after the mole burrowed across the lair (13:51:07).

## Fix

`completionDistance: 60` on the kill step — sized to cover the lair from the anchor (Chebyshev radius; the lair occupies roughly x 1728–1791, y 5120–5247 in underground coordinate space, with nothing adjacent to false-positive). On an ACTOR_DEATH step this field is consumed only by `GuidanceSequencer.playerIsConfirmablyInStepArea` (jump confirmation) and the condition-gated ARRIVE_AT_TILE evaluator — **the completion trigger stays the kill** (verified in `CompletionChecker`: `isStepAlreadySatisfied` returns false for ACTOR_DEATH; `evaluateArriveAtTile` early-outs unless the condition is ARRIVE_AT_TILE).

## Ratchet

New `areaUnconfirmableKillStepRatchet` in `GuidanceConfigInvariantsRegressionTest`: ACTOR_DEATH/MANUAL steps with worldX/Y but no explicit distance/zone, ceiling **347** (was 348 pre-fix; verified failing before the data change). It reads the raw `completionDistance` field via reflection because the getter substitutes the 5-tile default. Decrement as the corpus pass closes steps.

## Corpus audit

348 steps across 223 sources share the gap (breakdown posted on #803). Per the #775 lesson, instanced-arena steps with unknowable live coords are by-design members of that backlog, and the class detector is tracked toolkit-side as runelite-dev-toolkit#50 — bulk-inventing 348 radii without per-boss verification is exactly the over-eager-edit class the CI gate exists to stop.

`validate_drop_rates` (all), `guidance_lint` (2 pre-existing INFOs only), `data_ascii_lint`, `./gradlew build test` — all green locally; CI is the authoritative gate for data changes.