### PR TITLE
fix(overlay): render the collection-log book marker on NPC guidance targets (#802)

### DIFF
--- a/src/main/java/com/collectionloghelper/overlay/GuidanceOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/GuidanceOverlay.java
@@ -48,6 +48,7 @@ import net.runelite.api.Player;
 import net.runelite.api.Point;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPanel;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -78,6 +79,9 @@ public class GuidanceOverlay extends OverlayPanel
 	private final Client client;
 	private final CollectionLogHelperConfig config;
 
+	/** Shared floating collection-log book marker, drawn above NPC targets (#802). */
+	private final GuidanceTargetMarker targetMarker;
+
 	@Inject
 	private TooltipManager tooltipManager;
 
@@ -104,10 +108,11 @@ public class GuidanceOverlay extends OverlayPanel
 	private volatile String cachedNpcLabel;
 
 	@Inject
-	private GuidanceOverlay(Client client, CollectionLogHelperConfig config)
+	private GuidanceOverlay(Client client, CollectionLogHelperConfig config, ItemManager itemManager)
 	{
 		this.client = client;
 		this.config = config;
+		this.targetMarker = new GuidanceTargetMarker(itemManager);
 		setPosition(OverlayPosition.TOP_LEFT);
 		setLayer(OverlayLayer.ABOVE_SCENE);
 		setMovable(true);
@@ -320,6 +325,8 @@ public class GuidanceOverlay extends OverlayPanel
 			}
 		}
 
+		drawTargetMarker(graphics, npc);
+
 		// Draw downward-pointing arrow above the NPC (reuse hull from HULL case if available)
 		Shape arrowHull = npc.getConvexHull();
 		if (arrowHull != null)
@@ -355,6 +362,25 @@ public class GuidanceOverlay extends OverlayPanel
 				renderOutlinedText(graphics, textPoint, label, overlayColor);
 			}
 		}
+	}
+
+	/**
+	 * Draws the floating collection-log marker above the NPC, same float-above
+	 * pattern as the object and ground-item overlays (#802). The z-offset is
+	 * {@code getLogicalHeight()}-relative (local height units) so the marker
+	 * clears the model and the action label, which renders at
+	 * {@code logicalHeight + ARROW_HEIGHT + ARROW_GAP + 40}. No-op when the
+	 * config toggle is off. The shared marker caches its sprite/glyph, so the
+	 * render path allocates nothing per frame.
+	 */
+	private void drawTargetMarker(Graphics2D graphics, NPC npc)
+	{
+		if (!config.showGuidanceTargetMarker())
+		{
+			return;
+		}
+		targetMarker.draw(graphics, client, npc.getLocalLocation(),
+			npc.getLogicalHeight() + ARROW_HEIGHT + ARROW_GAP + 90);
 	}
 
 	/**

--- a/src/main/java/com/collectionloghelper/overlay/GuidanceTargetMarker.java
+++ b/src/main/java/com/collectionloghelper/overlay/GuidanceTargetMarker.java
@@ -58,7 +58,13 @@ final class GuidanceTargetMarker
 	/** Glyph canvas size in pixels - large enough to be legible as a small book. */
 	private static final int SIZE = 26;
 
-	/** Pixels to lift the marker above the target's canvas point so it floats clear. */
+	/**
+	 * Default z-offset lifting the marker above the target, in LOCAL HEIGHT
+	 * UNITS (the {@code zOffset} of
+	 * {@link Perspective#getCanvasImageLocation}), not screen pixels. Suits
+	 * ground-anchored targets (objects, ground items); entity targets must pass
+	 * a {@code getLogicalHeight()}-relative offset instead (#802).
+	 */
 	private static final int HEIGHT_OFFSET = 80;
 
 	private static final Color BOOK_FILL = new Color(0xE8, 0xC4, 0x6A);
@@ -92,12 +98,23 @@ final class GuidanceTargetMarker
 	 */
 	void draw(Graphics2D graphics, Client client, LocalPoint localPoint)
 	{
+		draw(graphics, client, localPoint, HEIGHT_OFFSET);
+	}
+
+	/**
+	 * As {@link #draw(Graphics2D, Client, LocalPoint)} but with an explicit
+	 * z-offset in local height units — entity targets pass their
+	 * {@code getLogicalHeight()} plus clearance so the marker floats above the
+	 * model instead of blitting into it (#802).
+	 */
+	void draw(Graphics2D graphics, Client client, LocalPoint localPoint, int zOffset)
+	{
 		if (localPoint == null)
 		{
 			return;
 		}
 		BufferedImage image = resolveImage();
-		Point canvasPoint = Perspective.getCanvasImageLocation(client, localPoint, image, HEIGHT_OFFSET);
+		Point canvasPoint = Perspective.getCanvasImageLocation(client, localPoint, image, zOffset);
 		if (canvasPoint != null)
 		{
 			graphics.drawImage(image, canvasPoint.getX(), canvasPoint.getY(), null);

--- a/src/test/java/com/collectionloghelper/overlay/GuidanceTargetMarkerTest.java
+++ b/src/test/java/com/collectionloghelper/overlay/GuidanceTargetMarkerTest.java
@@ -52,7 +52,9 @@ import static org.mockito.Mockito.verify;
  * glyph rasterised once at construction while the async sprite loads (or when no
  * {@link ItemManager} is available). The in-world projection cannot be exercised
  * headless, so these tests confirm the glyph builds, the sprite is preferred once
- * resolved, null local points are no-ops, and both overlays hold a marker.
+ * resolved, null local points are no-ops, and all three highlight overlays
+ * (object, ground-item, and the NPC path in {@code GuidanceOverlay}) hold a
+ * marker.
  */
 public class GuidanceTargetMarkerTest
 {
@@ -136,6 +138,23 @@ public class GuidanceTargetMarkerTest
 		GroundItemHighlightOverlay overlay = ctor.newInstance(client, config, itemManager);
 
 		assertNotNull(readMarker(overlay), "ground-item overlay should hold a target marker");
+	}
+
+	@Test
+	public void guidanceOverlayHoldsMarkerInstance() throws Exception
+	{
+		// #802: NPC kill/talk targets must get the same floating book marker as
+		// objects and ground items. The NPC highlight lives in GuidanceOverlay.
+		Client client = mock(Client.class);
+		CollectionLogHelperConfig config = mock(CollectionLogHelperConfig.class);
+		ItemManager itemManager = mock(ItemManager.class);
+
+		Constructor<GuidanceOverlay> ctor = GuidanceOverlay.class.getDeclaredConstructor(
+			Client.class, CollectionLogHelperConfig.class, ItemManager.class);
+		ctor.setAccessible(true);
+		GuidanceOverlay overlay = ctor.newInstance(client, config, itemManager);
+
+		assertNotNull(readMarker(overlay), "guidance (NPC) overlay should hold a target marker");
 	}
 
 	private static BufferedImage resolveImage(GuidanceTargetMarker marker)


### PR DESCRIPTION
Fixes #802.

## Problem (operator-observed 2026-06-10)

Object targets render the outline glow PLUS the floating collection-log book sprite; NPC targets rendered only the glow. `GuidanceTargetMarker` (the #720 shared marker) was instantiated only by `ObjectHighlightOverlay` and `GroundItemHighlightOverlay` — the NPC highlight path in `GuidanceOverlay.renderNpcHighlight` never drew it.

## Fix

- `GuidanceOverlay` constructs the shared marker (`ItemManager` constructor-injected, matching the sibling overlays) and draws it from `renderNpcHighlight` via the same `drawTargetMarker` guard-clause helper, gated on `showGuidanceTargetMarker()`.
- **Unit fix surfaced in review:** the marker's fixed z-offset (80) is in *local height units*, not pixels — fine for ground-anchored targets, but it would blit into an NPC model at torso height. A new `draw` overload takes an explicit z-offset; the NPC path passes `getLogicalHeight() + ARROW_HEIGHT + ARROW_GAP + 90` so the marker clears the model, the arrow, and the action label (which renders at `logicalHeight + ARROW_HEIGHT + ARROW_GAP + 40`). The mislabeled javadoc is corrected.
- Render hot path allocates nothing per frame (sprite/glyph cached by the shared class).

## Test

`guidanceOverlayHoldsMarkerInstance` in `GuidanceTargetMarkerTest` (the file's established reflection pattern), verified failing pre-wiring. `./gradlew build test` green (full suite); toolkit `overlay_lint` shows only pre-existing findings in other files.

## Deferred

In-game visual confirm via the actuation seam (`region_capture`, title-bar crop per the toolkit privacy lesson) requires a logged-in dev client (manual login only) — it is the **first checklist row of the planned re-validation session**, specifically verifying the NPC marker offset on a tall and a short NPC.