### PR TITLE
fix(data): entrance steps complete on the inside, not surface proximity (#806)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -4616,8 +4616,14 @@
         "requiredItemIds": [
           1506
         ],
-        "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 10,
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionZone": [
+          2350,
+          9400,
+          2432,
+          9472,
+          0
+        ],
         "section": "Travel"
       },
       {
@@ -24261,8 +24267,14 @@
         "worldPlane": 0,
         "objectId": 882,
         "objectInteractAction": "Climb-down",
-        "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 10,
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionZone": [
+          3225,
+          9850,
+          3325,
+          9890,
+          0
+        ],
         "section": "Travel"
       },
       {

--- a/src/test/java/com/collectionloghelper/data/DropRateDatabaseTest.java
+++ b/src/test/java/com/collectionloghelper/data/DropRateDatabaseTest.java
@@ -765,4 +765,74 @@ public class DropRateDatabaseTest
 				zone.contains(new WorldPoint(surface.getX(), surface.getY(), 2)),"Zone must not match plane 2 at surface for " + name);
 		}
 	}
+
+	/**
+	 * Regression test for #806: dungeon-entrance steps (an entrance object the
+	 * player climbs/enters) must complete on the INSIDE of the destination, not
+	 * on surface proximity. The live bug: Thermonuclear step 2's
+	 * ARRIVE_AT_TILE r=10 auto-completed on the SURFACE while the player was
+	 * still outside the cave, so the entrance glow vanished in a narrow
+	 * proximity band (Scurrius's manhole step could even insta-complete,
+	 * because the preceding travel step ends within its radius).
+	 *
+	 * <p>Each case carries the source name, the entrance step index, the
+	 * surface entrance coord that must NOT complete the step, the underground
+	 * landing coord, and the next step's coord (both must be inside the zone so
+	 * entry always completes the step).
+	 */
+	@Test
+	public void regression_806_entranceSteps_completeOnInsideNotSurfaceProximity()
+	{
+		Object[][] cases = new Object[][]
+		{
+			// { name, stepIndex, surfaceEntrance, undergroundLanding, nextStepCoord }
+			{"Thermonuclear smoke devil", 1, new WorldPoint(2412, 3061, 0), new WorldPoint(2411, 9461, 0), new WorldPoint(2379, 9452, 0)},
+			{"Scurrius",                  2, new WorldPoint(3237, 3458, 0), new WorldPoint(3237, 9858, 0), new WorldPoint(3299, 9867, 0)},
+		};
+
+		for (Object[] tc : cases)
+		{
+			String name = (String) tc[0];
+			int stepIndex = (Integer) tc[1];
+			WorldPoint surface = (WorldPoint) tc[2];
+			WorldPoint landing = (WorldPoint) tc[3];
+			WorldPoint nextStep = (WorldPoint) tc[4];
+
+			CollectionLogSource source = null;
+			for (CollectionLogSource s : database.getAllSources())
+			{
+				if (name.equals(s.getName()))
+				{
+					source = s;
+					break;
+				}
+			}
+			assertNotNull(source, "Source must exist in drop_rates.json: " + name);
+
+			List<GuidanceStep> steps = source.getGuidanceSteps();
+			assertNotNull(steps, "Source must have guidance steps: " + name);
+			assertTrue(steps.size() > stepIndex, name + " must have a step " + stepIndex);
+
+			GuidanceStep entranceStep = steps.get(stepIndex);
+			assertTrue(entranceStep.getObjectId() > 0,
+				"Entrance step must keep its entrance object target: " + name);
+			assertEquals(
+				CompletionCondition.ARRIVE_AT_ZONE, entranceStep.getCompletionCondition(),
+				"Entrance step must complete by zone, not surface proximity (#806): " + name);
+
+			Zone zone = entranceStep.getZone();
+			assertNotNull(zone, "Entrance step must declare a completionZone: " + name);
+
+			// The #806 bug: standing at the surface entrance must NOT complete the step.
+			assertFalse(zone.contains(surface),
+				"Surface entrance " + surface + " must be OUTSIDE the completion zone for " + name);
+
+			// Entering must always complete it: the landing tile and the next step's
+			// destination are both inside.
+			assertTrue(zone.contains(landing),
+				"Underground landing " + landing + " must be inside the zone for " + name);
+			assertTrue(zone.contains(nextStep),
+				"Next step coord " + nextStep + " must be inside the zone for " + name);
+		}
+	}
 }


### PR DESCRIPTION
Fixes #806.

## Problem (operator-observed 2026-06-10)

The Smoke Devil Dungeon entrance highlight (Thermonuclear step 2, obj 30176) only rendered in a narrow band: inside the step-1 travel zone but more than 10 tiles from the entrance. Closer than that, the step's `ARRIVE_AT_TILE` r=10 auto-completed **on the surface** — the entrance glow vanished while the player was still outside the cave.

## Corpus audit

Scanned for the class: entrance object + `ARRIVE_AT_TILE` completion + next step underground or on another plane. Exactly **two** instances corpus-wide, both fixed here (one source per commit was waived since both land in the same logical fix; they share a commit but are separately pinned by the test):

| source | step | old | new |
|---|---|---|---|
| Thermonuclear smoke devil | step[1] | ARRIVE_AT_TILE r=10 (surface) | ARRIVE_AT_ZONE `[2350,9400,2432,9472,0]` (cave interior) |
| Scurrius | step[2] | ARRIVE_AT_TILE r=10 (surface) | ARRIVE_AT_ZONE `[3225,9850,3325,9890,0]` (sewers corridor) |

The Scurrius case was strictly worse: the preceding travel step ends within the manhole step's r=10, so the entrance step could **insta-complete** on the surface and never show its highlight at all.

Both steps keep their entrance object target, so the glow persists from the moment the step becomes current until the player actually transitions inside (the operator-requested Shades-style behaviour). `isStepAlreadySatisfied(ARRIVE_AT_ZONE)` also means mid-dungeon activations now skip the entrance step correctly.

## Test

`regression_806_entranceSteps_completeOnInsideNotSurfaceProximity` in `DropRateDatabaseTest` (modeled on the #555 zone-migration test): asserts ARRIVE_AT_ZONE, the surface entrance coord OUTSIDE the zone (the live bug), the underground landing + next-step coords inside, and the entrance object retained. Verified failing pre-fix.

`validate_drop_rates`, `guidance_lint`, `data_ascii_lint`: no new findings (remaining warnings on these sources are the pre-existing corpus-wide bank-return-last-step class). `./gradlew build test` green locally; CI is the authoritative gate for data changes.