### PR TITLE
fix(data): six wrong guidance-step npcIds (Lanthus class, detector corpus pass)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -17123,7 +17123,7 @@
         "worldX": 2210,
         "worldY": 2858,
         "worldPlane": 0,
-        "npcId": 8521,
+        "npcId": 10528,
         "interactAction": "Trade",
         "completionCondition": "MANUAL"
       }

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -9063,7 +9063,7 @@
         "worldX": 1794,
         "worldY": 3107,
         "worldPlane": 0,
-        "npcId": 12610,
+        "npcId": 12821,
         "interactAction": "Attack",
         "completionCondition": "CHAT_MESSAGE_RECEIVED",
         "completionChatPattern": "Your Fortis Colosseum completion count is:",

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -18535,7 +18535,7 @@
         "worldX": 1379,
         "worldY": 3634,
         "worldPlane": 0,
-        "npcId": 8523,
+        "npcId": 8521,
         "interactAction": "Trade",
         "completionCondition": "MANUAL",
         "section": "Reward"

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -28388,7 +28388,7 @@
         "worldX": 1646,
         "worldY": 3577,
         "worldPlane": 0,
-        "npcId": 7670,
+        "npcId": 7303,
         "interactAction": "Talk-to",
         "completionCondition": "MANUAL",
         "section": "Loot",

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -18279,7 +18279,7 @@
         "worldX": 2519,
         "worldY": 3571,
         "worldPlane": 0,
-        "npcId": 5258,
+        "npcId": 1656,
         "interactAction": "Talk-to",
         "completionCondition": "MANUAL"
       }

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -16071,8 +16071,8 @@
         "worldX": 1791,
         "worldY": 3504,
         "worldPlane": 0,
-        "npcId": 7638,
-        "interactAction": "Trade",
+        "npcId": 6920,
+        "interactAction": "Rewards",
         "completionCondition": "MANUAL"
       }
     ],


### PR DESCRIPTION
Six wrong guidance-step `npcId`s — the same class as the Lanthus fix (#805 / PR #809): the id exists in the game cache, so existence checks pass it silently, but it belongs to a completely different NPC than the step describes, and the overlay highlights nothing (or the wrong thing). One source per commit, cache/wiki/spawn receipts in each commit message.

Found by the new guidance-step name cross-check in the dev tooling (runelite-dev-toolkit#49, PR runelite-dev-toolkit#56), which requires a resolving step npcId's cache name to be mentioned by the step description. Each finding was confirmed through an adversarial domain-review pass before editing; two flagged steps were deliberately **not** changed after that review (Guardians of the Rift's Apprentice Cordelia anchor, Aerial Fishing step[2]'s fishing-spot target — both intentional).

| Source | Step | Was | Cache says | Now |
|---|---|---|---|---|
| Tithe Farm | 3 (Reward) | 7638 | "Shady figure" (murder-mystery quest NPC) | **6920** Farmer Gricoller (+ `interactAction` Trade→Rewards; Gricoller has no Trade entry) |
| Soul Wars | 3 (Reward) | 8521 | "Alry the Angler" (Lake Molch — copy-paste from Aerial Fishing) | **10528** Nomad |
| Barbarian Assault | 3 (Reward) | 5258 | "Duke" (no BA connection) | **1656** Commander Connad |
| Master Treasure Trails | 1 (Loot) | 7670 | "Disciple of Yama" | **7303** Watson |
| Sol Heredit | 4 (Combat) | 12610 | "Elias White" (lobby historian, no Attack option) | **12821** Sol Heredit |
| Aerial Fishing | 3 (Reward) | 8523 | "Fishing spot" (Catch-only, no Trade) | **8521** Alry the Angler |

Notes for review:
- Nomad 10529, Watson 7304, Sol Heredit 12827 are alternate transmog/phase forms of the same NPCs; the step schema holds a single highlight `npcId`, so the primary form is wired and the alternates are recorded in the commit messages.
- Loop markers on Master Treasure Trails step[1] and Aerial Fishing step[2] (`loopBackToStep`/`loopCount`, D4Batch-regression-mandated) are untouched.
- Post-fix detector run: all six warns cleared; remaining corpus warns are the known multi-form/paraphrase noise class (KQ airborne form, Bryn, Honest Jimmy, Demonic gorilla, Cordelia).
- Local `test` reported UP-TO-DATE (the known resource-caching trap) — CI is the gate that counts here, per repo policy.
