### PR TITLE
fix(data): #803 batch 1 - boss-room completionDistance for GWD, Cerberus, Hydra, KQ, Corp (ceiling 347 -> 338)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -166,6 +166,7 @@
         "npcId": 2215,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
+        "completionDistance": 30,
         "completionNpcId": 2215,
         "section": "Combat",
         "recommendedItemIds": [

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -1271,6 +1271,7 @@
         "npcId": 8621,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
+        "completionDistance": 20,
         "completionNpcId": 8621,
         "section": "Combat",
         "recommendedItemIds": [

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -328,14 +328,15 @@
       },
       {
         "description": "Kill Commander Zilyana. Protect from Magic, drop Bree (the ranged minion) first then Starlight, switch to Saradomin brews when Sara hits hard.",
-        "worldX": 2925,
-        "worldY": 5265,
-        "worldPlane": 2,
+        "worldX": 2897,
+        "worldY": 5269,
+        "worldPlane": 0,
         "objectId": 26504,
         "objectInteractAction": "Open",
         "npcId": 2205,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
+        "completionDistance": 30,
         "completionNpcId": 2205,
         "section": "Combat",
         "recommendedItemIds": [

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -1395,6 +1395,7 @@
         "npcId": 319,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
+        "completionDistance": 25,
         "completionNpcId": 319
       }
     ],

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -1089,6 +1089,7 @@
         "npcId": 5862,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
+        "completionDistance": 140,
         "completionNpcId": 5862,
         "section": "Combat",
         "recommendedItemIds": [

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -498,14 +498,15 @@
       },
       {
         "description": "Kill K'ril Tsutsaroth. Protect from Melee, eat through Balfrug + Tstanon prayer drain, watch for K'ril's curse special which strips your prayer in one hit.",
-        "worldX": 2914,
-        "worldY": 5350,
+        "worldX": 2925,
+        "worldY": 5322,
         "worldPlane": 2,
         "objectId": 26505,
         "objectInteractAction": "Open",
         "npcId": 3129,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
+        "completionDistance": 15,
         "completionNpcId": 3129,
         "section": "Combat",
         "recommendedItemIds": [

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -1512,6 +1512,7 @@
         "npcId": 965,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
+        "completionDistance": 25,
         "completionNpcId": 965
       },
       {
@@ -1522,6 +1523,7 @@
         "npcId": 965,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",
+        "completionDistance": 25,
         "completionNpcId": 965
       }
     ],

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -668,8 +668,8 @@
       },
       {
         "description": "Kill Kree'arra. Protect from Missiles, use only ranged or magic (melee cannot hit), Armadyl crossbow with ruby/diamond bolts (e) is the standard loadout.",
-        "worldX": 2844,
-        "worldY": 5280,
+        "worldX": 2832,
+        "worldY": 5302,
         "worldPlane": 2,
         "objectId": 26502,
         "objectInteractAction": "Open",
@@ -679,6 +679,7 @@
           9419
         ],
         "completionCondition": "ACTOR_DEATH",
+        "completionDistance": 15,
         "completionNpcId": 3162,
         "section": "Combat",
         "recommendedItemIds": [

--- a/src/test/java/com/collectionloghelper/data/GuidanceConfigInvariantsRegressionTest.java
+++ b/src/test/java/com/collectionloghelper/data/GuidanceConfigInvariantsRegressionTest.java
@@ -74,7 +74,7 @@ public class GuidanceConfigInvariantsRegressionTest
 	 * unknowable are by-design members of this backlog (#775) and will stay
 	 * above zero.
 	 */
-	private static final int AREA_UNCONFIRMABLE_KILL_STEP_CEILING = 347;
+	private static final int AREA_UNCONFIRMABLE_KILL_STEP_CEILING = 338;
 
 	private DropRateDatabase database;
 


### PR DESCRIPTION
First per-boss batch of the #803 area-confirmability burn-down (does NOT close #803 — the class drains in verified batches). One source per commit; spawn/cache receipts in each commit message.

Driven by the new dev-tooling area-confirmability detector (runelite-dev-toolkit#50, PR runelite-dev-toolkit#57), which reads the RAW `completionDistance` field (the engine getter's 5-tile default makes getter-based audits pass vacuously) and whose corpus census matches the `AREA_UNCONFIRMABLE_KILL_STEP_CEILING` ratchet exactly (347 before this PR). Every value below was derived from spawn receipts and gated through an adversarial domain-review pass — no bulk-guessed radii. The review pass corrected three of the proposed values before they landed (K'ril and Kree'arra 30→15 because r=30 would have swallowed each source's own kc anchor and erased the kc/kill phase distinction; Cerberus 130→140 because the east lair's 5x5 boss body extends past the spawn-tile distance).

| Source | Step | Change | Receipt anchor |
|---|---|---|---|
| General Graardor | 3 | `completionDistance: 30` | spawn 2215 at (2872,5358,2), 8 tiles from anchor |
| Commander Zilyana | 3 | anchor (2925,5265,**2**) → (2897,5269,**0**) + `completionDistance: 30` | spawn 2205 at (2897,5269,**0**) — the old anchor failed the engine's plane-equality gate and was permanently unconfirmable |
| K'ril Tsutsaroth | 3 | anchor → (2925,5322,2) + `completionDistance: 15` | spawn 3129; old anchor was the main-dungeon kc spot 28 tiles north |
| Kree'arra | 3 | anchor → (2832,5302,2) + `completionDistance: 15` | spawn 3162; old anchor was the kc/descend spot outside the Eyrie |
| Cerberus | 2 | `completionDistance: 140` | three lairs (5863 spawns at 1238/1366/1302-1314); the band scan found nothing but the lairs + this source's own Key Master |
| Alchemical Hydra | 3 | `completionDistance: 20` | spawn 8615 IDENTICAL to the anchor — static template coords; instanced players resolve via `WorldPoint.fromLocalInstance` |
| Kalphite Queen | 3+4 | `completionDistance: 25` each | crawling form 963 at (3474,9496,0), 10 from anchor; r=25 box scan shows only KQ-chamber content |
| Corporeal Beast | 3 | `completionDistance: 25` | spawn 319 at (2993,4382,2); the (2993,4254) row is the 128-offset instance template, outside the radius |

Ratchet: `AREA_UNCONFIRMABLE_KILL_STEP_CEILING` 347 → **338** (final commit). Completion triggers (npcDeath) unchanged everywhere — `completionDistance` is jump-confirmation only. No loop fields touched.

Local `./gradlew test --rerun-tasks` green (full re-run, not cache); CI remains the authoritative gate for data changes per repo policy.
