### PR TITLE
docs(code): purge the last collectionlog.net mentions from Javadoc (#728)

### DIFF
--- a/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
+++ b/src/main/java/com/collectionloghelper/CollectionLogHelperPlugin.java
@@ -195,8 +195,8 @@ public class CollectionLogHelperPlugin extends Plugin
 	private BufferedImage collectionLogIcon;
 
 	/**
-	 * Daemon executor used to wait on async sync futures (collectionlog.net import,
-	 * TempleOSRS KC sync) off the EDT/client thread. Lazily created in startUp and
+	 * Daemon executor used to wait on async sync futures (TempleOSRS KC sync)
+	 * off the EDT/client thread. Lazily created in startUp and
 	 * shut down in shutDown; one shared instance prevents the per-click executor
 	 * leak that the ad-hoc {@code Executors.newSingleThreadExecutor()} pattern caused.
 	 */

--- a/src/main/java/com/collectionloghelper/lifecycle/PluginShutdownRoutine.java
+++ b/src/main/java/com/collectionloghelper/lifecycle/PluginShutdownRoutine.java
@@ -63,10 +63,9 @@ import net.runelite.client.ui.NavigationButton;
  *       state, inventory state, slayer state, travel caps, collection state,
  *       plugin data manager).</li>
  *   <li>Shut down the shared HTTP result executor (if present).  The
- *       collectionlog.net importer and TempleOSRS syncer no longer manage
- *       their own executors (#478, #479) -- the runtime-provided
- *       {@code ScheduledExecutorService} they use is shut down by the
- *       RuneLite runtime, not by this routine.</li>
+ *       TempleOSRS syncer no longer manages its own executor (#478, #479)
+ *       -- the runtime-provided {@code ScheduledExecutorService} it uses is
+ *       shut down by the RuneLite runtime, not by this routine.</li>
  *   <li>Clear plugin-private state via the {@code clearPluginState}
  *       callback -- the plugin owns {@code sourcesWithMissingItems},
  *       {@code pendingPanelRebuild}, {@code rankedSourcesDirty}, and


### PR DESCRIPTION
PR #798 removed the dead importer code path entirely (classes, tests, config, Guice, wiring, lifecycle, panel). Two stale Javadoc comments still named the defunct service; this removes them, completing #728's acceptance item 'No remaining reference to collectionlog.net / api.collectionlog.net in src/'. Comment-only change - compiles clean. Closes #728.