### PR TITLE
feat(overlay): NPC guidance targets render the collection-log icon only

### DIFF
--- a/src/main/java/com/collectionloghelper/overlay/GuidanceOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/GuidanceOverlay.java
@@ -30,12 +30,8 @@ import com.collectionloghelper.guidance.RequiredItemDisplay;
 import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Dimension;
-import java.awt.Font;
-import java.awt.FontMetrics;
 import java.awt.Graphics2D;
 import java.awt.Polygon;
-import java.awt.Rectangle;
-import java.awt.RenderingHints;
 import java.awt.Shape;
 import java.util.Collections;
 import java.util.List;
@@ -64,11 +60,12 @@ public class GuidanceOverlay extends OverlayPanel
 {
 	private static final int MAX_PANEL_WIDTH = 200;
 	private static final Dimension PANEL_PREFERRED_SIZE = new Dimension(MAX_PANEL_WIDTH, 0);
-	private static final int ARROW_HEIGHT = 14;
-	private static final int ARROW_WIDTH = 12;
-	private static final int ARROW_GAP = 5;
+	/**
+	 * Clearance above an NPC's {@code getLogicalHeight()} for the floating
+	 * collection-log marker, in local height units (#802).
+	 */
+	private static final int MARKER_CLEARANCE = 40;
 	private static final BasicStroke STROKE_2 = new BasicStroke(2.0f);
-	private static final Font BOLD_12 = new Font(Font.DIALOG, Font.BOLD, 12);
 	private static final Color TITLE_COLOR = new Color(255, 200, 0);
 	private static final Color TRAVEL_COLOR = new Color(100, 200, 255);
 	private static final Color ACTION_COLOR = new Color(100, 255, 100);
@@ -100,12 +97,10 @@ public class GuidanceOverlay extends OverlayPanel
 	private volatile boolean suppressTileHighlight;
 	private volatile NPC trackedNpc;
 	private volatile List<RequiredItemDisplay> requiredItems = Collections.emptyList();
-	private final Polygon arrowPolygon = new Polygon();
 	private Color cachedOverlayColor;
 	private Color cachedFillColor50;
 	private Color cachedFillColor30;
 	private volatile String cachedTravelLabel;
-	private volatile String cachedNpcLabel;
 
 	@Inject
 	private GuidanceOverlay(Client client, CollectionLogHelperConfig config, ItemManager itemManager)
@@ -327,39 +322,20 @@ public class GuidanceOverlay extends OverlayPanel
 
 		drawTargetMarker(graphics, npc);
 
-		// Draw downward-pointing arrow above the NPC (reuse hull from HULL case if available)
-		Shape arrowHull = npc.getConvexHull();
-		if (arrowHull != null)
+		// The collection-log marker is the only above-the-model decoration: no
+		// floating arrow or action text. The action/location info stays
+		// discoverable via the hover tooltip on the NPC hull.
+		Shape hoverHull = npc.getConvexHull();
+		if (hoverHull != null)
 		{
-			Rectangle bounds = arrowHull.getBounds();
-			int arrowX = (int) bounds.getCenterX();
-			int arrowTipY = (int) bounds.getMinY() - ARROW_GAP;
-			renderDirectionArrow(graphics, arrowX, arrowTipY, overlayColor);
-
-			// Show tooltip when mouse hovers over the NPC hull
 			String builtTooltip = OverlayTooltipHelper.buildTooltip(locDesc, action);
 			if (builtTooltip != null)
 			{
 				Point mousePos = client.getMouseCanvasPosition();
-				if (mousePos != null && arrowHull.contains(mousePos.getX(), mousePos.getY()))
+				if (mousePos != null && hoverHull.contains(mousePos.getX(), mousePos.getY()))
 				{
 					tooltipManager.add(new Tooltip(builtTooltip));
 				}
-			}
-		}
-
-		// Render action text above the NPC and arrow
-		LocalPoint npcLocal = npc.getLocalLocation();
-		if (npcLocal != null)
-		{
-			String label = cachedNpcLabel != null ? cachedNpcLabel : npc.getName();
-
-			Point textPoint = Perspective.getCanvasTextLocation(
-				client, graphics, npcLocal, label,
-				npc.getLogicalHeight() + ARROW_HEIGHT + ARROW_GAP + 40);
-			if (textPoint != null)
-			{
-				renderOutlinedText(graphics, textPoint, label, overlayColor);
 			}
 		}
 	}
@@ -368,10 +344,10 @@ public class GuidanceOverlay extends OverlayPanel
 	 * Draws the floating collection-log marker above the NPC, same float-above
 	 * pattern as the object and ground-item overlays (#802). The z-offset is
 	 * {@code getLogicalHeight()}-relative (local height units) so the marker
-	 * clears the model and the action label, which renders at
-	 * {@code logicalHeight + ARROW_HEIGHT + ARROW_GAP + 40}. No-op when the
-	 * config toggle is off. The shared marker caches its sprite/glyph, so the
-	 * render path allocates nothing per frame.
+	 * floats just clear of the model — it is the only above-the-model
+	 * decoration (no arrow or action text). No-op when the config toggle is
+	 * off. The shared marker caches its sprite/glyph, so the render path
+	 * allocates nothing per frame.
 	 */
 	private void drawTargetMarker(Graphics2D graphics, NPC npc)
 	{
@@ -380,54 +356,7 @@ public class GuidanceOverlay extends OverlayPanel
 			return;
 		}
 		targetMarker.draw(graphics, client, npc.getLocalLocation(),
-			npc.getLogicalHeight() + ARROW_HEIGHT + ARROW_GAP + 90);
-	}
-
-	/**
-	 * Draws a downward-pointing arrow at the given position, with a black outline
-	 * for visibility. The tip of the arrow is at (x, tipY).
-	 */
-	private void renderDirectionArrow(Graphics2D graphics, int x, int tipY, Color color)
-	{
-		int halfW = ARROW_WIDTH / 2;
-		int topY = tipY - ARROW_HEIGHT;
-
-		arrowPolygon.reset();
-		arrowPolygon.addPoint(x, tipY);
-		arrowPolygon.addPoint(x + halfW, topY);
-		arrowPolygon.addPoint(x - halfW, topY);
-
-		// Colored fill first, then black outline on top
-		graphics.setColor(color);
-		graphics.fillPolygon(arrowPolygon);
-
-		graphics.setColor(Color.BLACK);
-		graphics.setStroke(STROKE_2);
-		graphics.drawPolygon(arrowPolygon);
-	}
-
-	/**
-	 * Renders text with a dark outline for readability against any background.
-	 */
-	private void renderOutlinedText(Graphics2D graphics, Point point, String text, Color color)
-	{
-		graphics.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
-			RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
-		graphics.setFont(BOLD_12);
-		FontMetrics fm = graphics.getFontMetrics();
-		int x = point.getX() - fm.stringWidth(text) / 2;
-		int y = point.getY();
-
-		// Black outline
-		graphics.setColor(Color.BLACK);
-		graphics.drawString(text, x + 1, y + 1);
-		graphics.drawString(text, x - 1, y - 1);
-		graphics.drawString(text, x + 1, y - 1);
-		graphics.drawString(text, x - 1, y + 1);
-
-		// Colored text
-		graphics.setColor(color);
-		graphics.drawString(text, x, y);
+			npc.getLogicalHeight() + MARKER_CLEARANCE);
 	}
 
 	private void updateCachedColors(Color overlayColor)
@@ -477,7 +406,6 @@ public class GuidanceOverlay extends OverlayPanel
 	public void setInteractAction(String action)
 	{
 		this.interactAction = action;
-		rebuildNpcLabel(action, this.trackedNpc);
 	}
 
 	public void setSuppressTileHighlight(boolean suppress)
@@ -498,7 +426,6 @@ public class GuidanceOverlay extends OverlayPanel
 	public void setTrackedNpc(NPC npc)
 	{
 		this.trackedNpc = npc;
-		rebuildNpcLabel(this.interactAction, npc);
 	}
 
 	/**
@@ -525,23 +452,7 @@ public class GuidanceOverlay extends OverlayPanel
 		suppressTileHighlight = false;
 		trackedNpc = null;
 		cachedTravelLabel = null;
-		cachedNpcLabel = null;
 		requiredItems = Collections.emptyList();
-	}
-
-	private void rebuildNpcLabel(String action, NPC npc)
-	{
-		if (npc != null)
-		{
-			String npcName = npc.getName();
-			cachedNpcLabel = (action != null)
-				? action + " " + npcName
-				: npcName;
-		}
-		else
-		{
-			cachedNpcLabel = null;
-		}
 	}
 
 	private void addSyncRemindersIfNeeded(boolean logReminder, boolean bankReminder)

--- a/src/main/java/com/collectionloghelper/overlay/GuidanceOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/GuidanceOverlay.java
@@ -62,9 +62,12 @@ public class GuidanceOverlay extends OverlayPanel
 	private static final Dimension PANEL_PREFERRED_SIZE = new Dimension(MAX_PANEL_WIDTH, 0);
 	/**
 	 * Clearance above an NPC's {@code getLogicalHeight()} for the floating
-	 * collection-log marker, in local height units (#802).
+	 * collection-log marker, in local height units (#802). 40 was not enough —
+	 * the icon overlapped large models (confirmed live on Giant Mole); 90
+	 * matches the headroom the marker effectively had before the arrow/text
+	 * stack was removed.
 	 */
-	private static final int MARKER_CLEARANCE = 40;
+	private static final int MARKER_CLEARANCE = 90;
 	private static final BasicStroke STROKE_2 = new BasicStroke(2.0f);
 	private static final Color TITLE_COLOR = new Color(255, 200, 0);
 	private static final Color TRAVEL_COLOR = new Color(100, 200, 255);

--- a/src/main/java/com/collectionloghelper/overlay/GuidanceTargetMarker.java
+++ b/src/main/java/com/collectionloghelper/overlay/GuidanceTargetMarker.java
@@ -64,7 +64,7 @@ final class GuidanceTargetMarker
 	 * item sprite is ~36x32; 0.6 brings it to a compact ~22x19. Scaled once on
 	 * load and cached, so the render hot path stays allocation-free.
 	 */
-	private static final float MARKER_SCALE = 0.6f;
+	private static final float MARKER_SCALE = 0.75f;
 
 	/**
 	 * Default z-offset lifting the marker above the target, in LOCAL HEIGHT

--- a/src/main/java/com/collectionloghelper/overlay/GuidanceTargetMarker.java
+++ b/src/main/java/com/collectionloghelper/overlay/GuidanceTargetMarker.java
@@ -59,6 +59,14 @@ final class GuidanceTargetMarker
 	private static final int SIZE = 26;
 
 	/**
+	 * Blanket downscale applied to the resolved marker image so it sits above a
+	 * target without dominating small NPCs/objects. The native collection-log
+	 * item sprite is ~36x32; 0.6 brings it to a compact ~22x19. Scaled once on
+	 * load and cached, so the render hot path stays allocation-free.
+	 */
+	private static final float MARKER_SCALE = 0.6f;
+
+	/**
 	 * Default z-offset lifting the marker above the target, in LOCAL HEIGHT
 	 * UNITS (the {@code zOffset} of
 	 * {@link Perspective#getCanvasImageLocation}), not screen pixels. Suits
@@ -80,6 +88,10 @@ final class GuidanceTargetMarker
 	/** Real collection-log book sprite, lazily resolved from {@link ItemManager}. */
 	@Nullable
 	private BufferedImage sprite;
+
+	/** {@link #MARKER_SCALE}-downscaled copy of {@link #sprite}, built once on load. */
+	@Nullable
+	private BufferedImage scaledSprite;
 
 	/** True once {@link #sprite} has finished loading and is safe to blit. */
 	private volatile boolean spriteReady;
@@ -129,9 +141,9 @@ final class GuidanceTargetMarker
 	 */
 	private BufferedImage resolveImage()
 	{
-		if (spriteReady && sprite != null)
+		if (spriteReady && scaledSprite != null)
 		{
-			return sprite;
+			return scaledSprite;
 		}
 		if (sprite == null && itemManager != null)
 		{
@@ -146,7 +158,37 @@ final class GuidanceTargetMarker
 				spriteReady = true;
 			}
 		}
-		return spriteReady && sprite != null ? sprite : glyph;
+		if (spriteReady && sprite != null)
+		{
+			// Build the downscaled copy once, on the client thread (render), after
+			// the async pixels have filled in. Cached so the hot path never scales.
+			if (scaledSprite == null)
+			{
+				scaledSprite = scale(sprite, MARKER_SCALE);
+			}
+			return scaledSprite;
+		}
+		return glyph;
+	}
+
+	/** Smoothly downscale {@code src} by {@code factor} into a fresh ARGB image. */
+	private static BufferedImage scale(BufferedImage src, float factor)
+	{
+		int w = Math.max(1, Math.round(src.getWidth() * factor));
+		int h = Math.max(1, Math.round(src.getHeight() * factor));
+		BufferedImage dst = new BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB);
+		Graphics2D g = dst.createGraphics();
+		try
+		{
+			g.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+				RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+			g.drawImage(src, 0, 0, w, h, null);
+		}
+		finally
+		{
+			g.dispose();
+		}
+		return dst;
 	}
 
 	/**


### PR DESCRIPTION
Requested during the live #802 marker validation: the stack of book marker + arrow + floating action text above an NPC target is visually noisy. NPC targets now render **only the collection-log icon sprite**, floating just clear of the model (logicalHeight + MARKER_CLEARANCE). The action/location info stays discoverable via the unchanged hover tooltip on the NPC hull; the model highlight styles are unchanged. Removes the now-dead label cache, arrow renderer, and outlined-text renderer with their orphaned constants/imports. Full test suite green. Live visual confirm (dev client at Giant Mole) to follow on this branch - this PR doubles as the #730 marker-UX follow-up evidence.