### PR TITLE
fix(data): highlight the Scurrius manhole while closed too (objectIds 881 + 882)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -24276,6 +24276,10 @@
         "worldY": 3458,
         "worldPlane": 0,
         "objectId": 882,
+        "objectIds": [
+          881,
+          882
+        ],
         "objectInteractAction": "Climb-down",
         "completionCondition": "ARRIVE_AT_ZONE",
         "completionZone": [


### PR DESCRIPTION
Closes #819 for the Scurrius case. The `Climb down the manhole` step targeted only object **882** (the *open* manhole). While closed, the tile object is **881**, so `ObjectHighlightOverlay` matched nothing and the player saw only the directional arrow — no object glow, no collection-log book marker — until they manually opened the cover. Confirmed live this session: closed = arrow only, opened = highlighted.

Adds `objectIds: [881, 882]` (keeps `objectId: 882` so the `regression_806` `getObjectId() > 0` assertion holds; `getAllObjectIds()` unions them, so the overlay highlights whichever manhole object is loaded). Cache receipts: 881 Manhole closed, mejrs spawn (3237,3458,0); 882 Manhole open. `lintDropRates` + full `test --rerun-tasks` green; cache-ids clean for both.

The broader closed/open-cover entrance **class** (other manholes/trapdoors/hatches whose step lists only the open-state ID) stays open under #819 for a corpus pass. CI is the authoritative gate for this data change.