### PR TITLE
feat(dev): guidance step-jump + render-state seam for the dev harness

### DIFF
--- a/src/main/java/com/collectionloghelper/guidance/GuidanceSequencer.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceSequencer.java
@@ -355,6 +355,51 @@ public class GuidanceSequencer
 	}
 
 	/**
+	 * Forces the active sequence directly to {@code index} (0-based), bypassing
+	 * the skip-chain and state-derived start so the step under {@code index} is
+	 * shown regardless of player position. Resets the per-step transient state
+	 * (loop iteration counter, crossed-waypoint progress, restock latch, and the
+	 * step-keyed completion caches) so the target step behaves as a fresh arrival,
+	 * then fires the same step-changed notification the normal advance path fires.
+	 *
+	 * <p>The sequence stays active and all callbacks are preserved. Intended for
+	 * the dev actuation bridge ({@code guidance.gotoStep}) so a validation run can
+	 * jump straight to a specific step.
+	 *
+	 * @throws IllegalStateException     when no sequence is active
+	 * @throws IndexOutOfBoundsException when {@code index} is outside 0..size-1
+	 */
+	public void forceStepIndex(int index)
+	{
+		if (!active || steps == null)
+		{
+			throw new IllegalStateException("no active sequence");
+		}
+		if (index < 0 || index >= steps.size())
+		{
+			throw new IndexOutOfBoundsException(
+				"stepIndex " + index + " out of range 0.." + (steps.size() - 1));
+		}
+
+		currentIndex = index;
+		loopIterationsCompleted = 0;
+		crossedWaypointIndex = 0;
+		awaitingRestock = false;
+		restockStepIndex = 0;
+		resolvedAlternatives.clear();
+		tilePointCache = null;
+		chatPatternCache = null;
+
+		GuidanceStep step = getCurrentStep();
+		if (step != null)
+		{
+			log.info("Guidance forced to step {}/{} for {}",
+				currentIndex + 1, steps.size(), activeSource != null ? activeSource.getName() : "?");
+			notifyStepChanged(step);
+		}
+	}
+
+	/**
 	 * Re-evaluates the activation skip-chain from step 0 against current player
 	 * state and jumps to the first unsatisfied step. Used by the Sync button to
 	 * let the user catch up after picking up items or travelling while guidance

--- a/src/main/java/com/collectionloghelper/overlay/GroundItemHighlightOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/GroundItemHighlightOverlay.java
@@ -67,6 +67,9 @@ public class GroundItemHighlightOverlay extends Overlay
 	private final CollectionLogHelperConfig config;
 	private final Polygon arrowPolygon = new Polygon();
 
+	@Inject
+	private RenderStateRecorder renderRecorder;
+
 	/**
 	 * Floating collection-log marker drawn above each highlighted ground item.
 	 * Assigned in the constructor (not inline) so the injected {@link ItemManager}
@@ -146,6 +149,11 @@ public class GroundItemHighlightOverlay extends Overlay
 
 		if (items.isEmpty() || !config.showOverlays())
 		{
+			// Ground-item highlight renders last in the guidance pass, so it is the
+			// natural frame closer for the dev-bridge render-state recorder. Publish
+			// even with nothing to draw so the snapshot reflects this frame. No-op
+			// (single volatile check) unless the dev harness enabled recording.
+			renderRecorder.publish(client.getTickCount());
 			return null;
 		}
 
@@ -160,8 +168,13 @@ public class GroundItemHighlightOverlay extends Overlay
 		for (TrackedGroundItem tracked : items)
 		{
 			renderGroundItemHighlight(graphics, tracked, overlayColor);
+			// Dev-bridge render-state: this ground item drew this frame.
+			renderRecorder.recordGroundItem(tracked.item.getId());
+			renderRecorder.recordTarget("groundItem", tracked.item.getId(),
+				config.showGuidanceTargetMarker(), 80);
 		}
 
+		renderRecorder.publish(client.getTickCount());
 		return null;
 	}
 

--- a/src/main/java/com/collectionloghelper/overlay/GuidanceOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/GuidanceOverlay.java
@@ -88,6 +88,9 @@ public class GuidanceOverlay extends OverlayPanel
 	@Inject
 	private ModelOutlineRenderer modelOutlineRenderer;
 
+	@Inject
+	private RenderStateRecorder renderRecorder;
+
 	private volatile WorldPoint targetPoint;
 	private volatile String targetName;
 	private volatile String locationDescription;
@@ -134,6 +137,13 @@ public class GuidanceOverlay extends OverlayPanel
 		final boolean logReminder = this.showCollectionLogReminder;
 		final boolean bankReminder = this.showBankReminder;
 		final List<RequiredItemDisplay> items = this.requiredItems;
+
+		// Open the per-frame render-state recording for the dev bridge. No-op
+		// (single volatile check) unless the dev harness enabled the recorder.
+		// GuidanceOverlay is the natural frame opener — it owns the NPC highlight
+		// and the tile. "Active" here means this overlay has a guidance target to
+		// draw this frame.
+		renderRecorder.beginFrame(point != null || npcId > 0 || clueText != null);
 
 		Color overlayColor = config.overlayColor();
 		updateCachedColors(overlayColor);
@@ -236,6 +246,7 @@ public class GuidanceOverlay extends OverlayPanel
 			if (npc != null && npc.getId() == npcId)
 			{
 				renderNpcHighlight(graphics, npc, overlayColor, action, locDesc);
+				renderRecorder.recordNpc(npcId);
 				npcHighlighted = true;
 			}
 		}
@@ -249,6 +260,7 @@ public class GuidanceOverlay extends OverlayPanel
 			{
 				OverlayUtil.renderPolygon(graphics, poly, overlayColor, cachedFillColor50,
 					STROKE_2);
+				renderRecorder.recordTile(point);
 
 				if (name != null)
 				{
@@ -344,6 +356,7 @@ public class GuidanceOverlay extends OverlayPanel
 				if (mousePos != null && arrowHull.contains(mousePos.getX(), mousePos.getY()))
 				{
 					tooltipManager.add(new Tooltip(builtTooltip));
+					renderRecorder.recordTooltip(builtTooltip);
 				}
 			}
 		}
@@ -375,12 +388,16 @@ public class GuidanceOverlay extends OverlayPanel
 	 */
 	private void drawTargetMarker(Graphics2D graphics, NPC npc)
 	{
-		if (!config.showGuidanceTargetMarker())
+		boolean markerOn = config.showGuidanceTargetMarker();
+		int zOffset = npc.getLogicalHeight() + ARROW_HEIGHT + ARROW_GAP + 90;
+		// Record the per-target draw decision for the dev bridge: bookMarker
+		// reflects whether the marker actually drew (the #802/#811 assertion).
+		renderRecorder.recordTarget("npc", npc.getId(), markerOn, zOffset);
+		if (!markerOn)
 		{
 			return;
 		}
-		targetMarker.draw(graphics, client, npc.getLocalLocation(),
-			npc.getLogicalHeight() + ARROW_HEIGHT + ARROW_GAP + 90);
+		targetMarker.draw(graphics, client, npc.getLocalLocation(), zOffset);
 	}
 
 	/**

--- a/src/main/java/com/collectionloghelper/overlay/ObjectHighlightOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/ObjectHighlightOverlay.java
@@ -83,6 +83,9 @@ public class ObjectHighlightOverlay extends Overlay
 	@Inject
 	private ModelOutlineRenderer modelOutlineRenderer;
 
+	@Inject
+	private RenderStateRecorder renderRecorder;
+
 	private volatile Set<Integer> targetObjectIds = Collections.emptySet();
 	private volatile String objectInteractAction;
 	private volatile boolean useItemOnObject;
@@ -329,6 +332,9 @@ public class ObjectHighlightOverlay extends Overlay
 			}
 
 			drawTargetMarker(graphics, localPoint);
+			// Dev-bridge render-state: this object highlight drew this frame.
+			renderRecorder.recordObject(obj.getId());
+			renderRecorder.recordTarget("object", obj.getId(), config.showGuidanceTargetMarker(), 80);
 		}
 
 		return null;
@@ -416,6 +422,7 @@ public class ObjectHighlightOverlay extends Overlay
 				&& mousePos != null && hull.contains(mousePos.getX(), mousePos.getY()))
 			{
 				tooltipManager.add(new Tooltip(builtTooltip));
+				renderRecorder.recordTooltip(builtTooltip);
 				showedTooltip = true;
 			}
 		}

--- a/src/main/java/com/collectionloghelper/overlay/RenderStateRecorder.java
+++ b/src/main/java/com/collectionloghelper/overlay/RenderStateRecorder.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.overlay;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.inject.Singleton;
+import net.runelite.api.coords.WorldPoint;
+
+/**
+ * Records what the guidance overlays actually DREW each rendered frame, so the
+ * dev actuation bridge can read the real on-screen draw-state deterministically
+ * (no OCR). Overlays only know what they draw during their render pass — the
+ * highlighted-id sets, the book-marker decision, the tile poly, and the tooltip
+ * are transient locals of that call — so a read that runs off the render pass
+ * cannot recompute them. This recorder captures them as a side effect of
+ * rendering and publishes an immutable snapshot via a single volatile reference.
+ *
+ * <p><b>Disabled by default — production pays nothing.</b> Recording is gated on
+ * a {@code volatile boolean} that ONLY the dev harness ever flips on. While
+ * disabled, every {@link #beginFrame}, {@code record*}, and {@link #publish}
+ * call is a single boolean check that returns immediately — zero allocation, the
+ * accumulation buffers are never touched, and the published snapshot stays at the
+ * empty sentinel. Behaviour in a shipped build is therefore unchanged in effect.
+ *
+ * <p><b>Concurrency.</b> The accumulation buffers are touched ONLY by the render
+ * thread, ONLY between {@link #beginFrame} and {@link #publish}. {@link #latest}
+ * reads a single volatile reference to an immutable {@link Snapshot}; it takes no
+ * lock and never blocks the render thread. A reader that races a frame in
+ * progress sees the previous complete snapshot, never a half-built one.
+ */
+@Singleton
+public final class RenderStateRecorder
+{
+	/** Immutable per-frame snapshot of what the guidance overlays drew. */
+	public static final class Snapshot
+	{
+		public final int snapshotTick;
+		public final boolean guidanceActive;
+		public final int[] highlightedNpcIds;
+		public final int[] highlightedObjectIds;
+		public final int[] highlightedGroundItemIds;
+		public final List<Target> targets;
+		public final WorldPoint tileTarget;
+		public final String tooltipText;
+
+		Snapshot(int snapshotTick, boolean guidanceActive, int[] highlightedNpcIds,
+			int[] highlightedObjectIds, int[] highlightedGroundItemIds, List<Target> targets,
+			WorldPoint tileTarget, String tooltipText)
+		{
+			this.snapshotTick = snapshotTick;
+			this.guidanceActive = guidanceActive;
+			this.highlightedNpcIds = highlightedNpcIds;
+			this.highlightedObjectIds = highlightedObjectIds;
+			this.highlightedGroundItemIds = highlightedGroundItemIds;
+			this.targets = targets;
+			this.tileTarget = tileTarget;
+			this.tooltipText = tooltipText;
+		}
+	}
+
+	/** A single drawn guidance target: its kind, id, book-marker state, and z-offset. */
+	public static final class Target
+	{
+		public final String type;
+		public final int id;
+		public final boolean bookMarker;
+		public final int zOffset;
+
+		Target(String type, int id, boolean bookMarker, int zOffset)
+		{
+			this.type = type;
+			this.id = id;
+			this.bookMarker = bookMarker;
+			this.zOffset = zOffset;
+		}
+	}
+
+	private static final Snapshot EMPTY = new Snapshot(
+		-1, false, new int[0], new int[0], new int[0],
+		Collections.emptyList(), null, null);
+
+	/**
+	 * Recording master switch. Only the dev harness flips this on. When false,
+	 * every record/begin/publish call is a single volatile read and returns.
+	 */
+	private volatile boolean enabled;
+
+	// Per-frame accumulation buffers — touched only by the render thread between
+	// beginFrame() and publish(). Never read by latest().
+	private final List<Integer> npcIds = new ArrayList<>();
+	private final List<Integer> objectIds = new ArrayList<>();
+	private final List<Integer> groundItemIds = new ArrayList<>();
+	private final List<Target> targets = new ArrayList<>();
+	private WorldPoint tileTarget;
+	private String tooltipText;
+	private boolean active;
+
+	/** Published snapshot — safely published to readers by the volatile write. */
+	private volatile Snapshot latest = EMPTY;
+
+	/** Enables recording. Idempotent. Called only by the dev harness startUp. */
+	public void enable()
+	{
+		this.enabled = true;
+	}
+
+	/**
+	 * Disables recording and resets the published snapshot to the empty sentinel,
+	 * so a later {@link #latest} after the harness shuts down reports no frame.
+	 * Idempotent.
+	 */
+	public void disable()
+	{
+		this.enabled = false;
+		this.latest = EMPTY;
+	}
+
+	public boolean isEnabled()
+	{
+		return enabled;
+	}
+
+	/** Starts a new frame's accumulation. No-op (single boolean check) when disabled. */
+	public void beginFrame(boolean guidanceActive)
+	{
+		if (!enabled)
+		{
+			return;
+		}
+		npcIds.clear();
+		objectIds.clear();
+		groundItemIds.clear();
+		targets.clear();
+		tileTarget = null;
+		tooltipText = null;
+		active = guidanceActive;
+	}
+
+	public void recordNpc(int id)
+	{
+		if (!enabled)
+		{
+			return;
+		}
+		npcIds.add(id);
+	}
+
+	public void recordObject(int id)
+	{
+		if (!enabled)
+		{
+			return;
+		}
+		objectIds.add(id);
+	}
+
+	public void recordGroundItem(int id)
+	{
+		if (!enabled)
+		{
+			return;
+		}
+		groundItemIds.add(id);
+	}
+
+	public void recordTarget(String type, int id, boolean bookMarker, int zOffset)
+	{
+		if (!enabled)
+		{
+			return;
+		}
+		targets.add(new Target(type, id, bookMarker, zOffset));
+	}
+
+	public void recordTile(WorldPoint p)
+	{
+		if (!enabled)
+		{
+			return;
+		}
+		tileTarget = p;
+	}
+
+	public void recordTooltip(String t)
+	{
+		if (!enabled)
+		{
+			return;
+		}
+		tooltipText = t;
+	}
+
+	/**
+	 * Swaps the accumulated frame in as the new published snapshot. No-op (single
+	 * boolean check) when disabled. The new {@link Snapshot} is immutable, so the
+	 * volatile write safely publishes it to {@link #latest} readers.
+	 */
+	public void publish(int clientTick)
+	{
+		if (!enabled)
+		{
+			return;
+		}
+		latest = new Snapshot(clientTick, active,
+			toIntArray(npcIds), toIntArray(objectIds), toIntArray(groundItemIds),
+			List.copyOf(targets), tileTarget, tooltipText);
+	}
+
+	/** Returns the most recently published immutable snapshot (the empty sentinel until the first publish). */
+	public Snapshot latest()
+	{
+		return latest;
+	}
+
+	private static int[] toIntArray(List<Integer> src)
+	{
+		int[] out = new int[src.size()];
+		for (int i = 0; i < out.length; i++)
+		{
+			out[i] = src.get(i);
+		}
+		return out;
+	}
+}

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerForceStepIndexTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerForceStepIndexTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.guidance;
+
+import com.collectionloghelper.data.CollectionLogSource;
+import com.collectionloghelper.data.GuidanceStep;
+import com.collectionloghelper.data.PlayerCollectionState;
+import com.collectionloghelper.data.PlayerInventoryState;
+import com.collectionloghelper.data.RequirementsChecker;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers {@link GuidanceSequencer#forceStepIndex(int)} — the dev-bridge step-jump
+ * seam. Steps are mocked (the real {@code GuidanceStep} constructor has 40+ args
+ * and forceStepIndex only needs {@code steps.size()} and a non-null resolved step
+ * for the notification path).
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class GuidanceSequencerForceStepIndexTest
+{
+	@Mock
+	private PlayerInventoryState inventoryState;
+	@Mock
+	private PlayerCollectionState collectionState;
+	@Mock
+	private RequirementsChecker requirementsChecker;
+
+	private GuidanceSequencer sequencer;
+
+	@BeforeEach
+	public void setUp() throws Exception
+	{
+		Constructor<GuidanceSequencer> ctor = GuidanceSequencer.class.getDeclaredConstructor(
+			PlayerInventoryState.class, PlayerCollectionState.class, RequirementsChecker.class,
+			com.collectionloghelper.guidance.bosses.BossGuidanceRegistry.class);
+		ctor.setAccessible(true);
+		sequencer = ctor.newInstance(inventoryState, collectionState, requirementsChecker, null);
+	}
+
+	private GuidanceStep mockStep(String description)
+	{
+		GuidanceStep step = mock(GuidanceStep.class);
+		// Null conditional-alternatives => resolveStep returns the step as-is.
+		lenient().when(step.getConditionalAlternatives()).thenReturn(null);
+		lenient().when(step.getDescription()).thenReturn(description);
+		return step;
+	}
+
+	/**
+	 * Starts a sequence directly (bypassing skip-chain heuristics) by injecting the
+	 * step list and active flag via reflection, leaving the index at 0.
+	 */
+	private void startWith(List<GuidanceStep> steps, AtomicReference<GuidanceStep> lastNotified) throws Exception
+	{
+		setField("steps", steps);
+		setField("active", true);
+		setField("currentIndex", 0);
+		sequencer.setOnStepChanged(lastNotified::set);
+	}
+
+	private void setField(String name, Object value) throws Exception
+	{
+		Field f = GuidanceSequencer.class.getDeclaredField(name);
+		f.setAccessible(true);
+		f.set(sequencer, value);
+	}
+
+	private Object getField(String name) throws Exception
+	{
+		Field f = GuidanceSequencer.class.getDeclaredField(name);
+		f.setAccessible(true);
+		return f.get(sequencer);
+	}
+
+	@Test
+	public void forceStepIndexJumpsResetsTransientStateAndNotifies() throws Exception
+	{
+		GuidanceStep s0 = mockStep("Step 1");
+		GuidanceStep s1 = mockStep("Step 2");
+		GuidanceStep s2 = mockStep("Step 3");
+		AtomicReference<GuidanceStep> notified = new AtomicReference<>();
+		startWith(Arrays.asList(s0, s1, s2), notified);
+
+		// Dirty the per-step transient state so we can prove it gets reset.
+		setField("loopIterationsCompleted", 3);
+		setField("crossedWaypointIndex", 2);
+		setField("awaitingRestock", true);
+		setField("restockStepIndex", 1);
+
+		sequencer.forceStepIndex(2);
+
+		assertEquals(2, sequencer.getCurrentIndex());
+		assertEquals(0, sequencer.getLoopIterationsCompleted());
+		assertEquals(0, sequencer.getCrossedWaypointIndex());
+		assertEquals(false, getField("awaitingRestock"));
+		assertEquals(0, getField("restockStepIndex"));
+		// Fires the same step-changed notification the normal advance path fires.
+		assertEquals(s2, notified.get());
+	}
+
+	@Test
+	public void forceStepIndexNoActiveSequenceThrowsIllegalState() throws Exception
+	{
+		// Fresh sequencer: never started, no steps, not active.
+		assertFalse(sequencer.isActive());
+		assertThrows(IllegalStateException.class, () -> sequencer.forceStepIndex(0));
+	}
+
+	@Test
+	public void forceStepIndexOutOfRangeThrowsIndexOutOfBounds() throws Exception
+	{
+		startWith(Arrays.asList(mockStep("Step 1"), mockStep("Step 2")), new AtomicReference<>());
+
+		assertThrows(IndexOutOfBoundsException.class, () -> sequencer.forceStepIndex(2));
+		assertThrows(IndexOutOfBoundsException.class, () -> sequencer.forceStepIndex(-1));
+	}
+}

--- a/src/test/java/com/collectionloghelper/overlay/RenderStateRecorderTest.java
+++ b/src/test/java/com/collectionloghelper/overlay/RenderStateRecorderTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.overlay;
+
+import net.runelite.api.coords.WorldPoint;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class RenderStateRecorderTest
+{
+	private RenderStateRecorder recorder;
+
+	@BeforeEach
+	public void setUp()
+	{
+		recorder = new RenderStateRecorder();
+	}
+
+	@Test
+	public void disabledByDefaultLatestStaysEmptySentinel()
+	{
+		assertFalse(recorder.isEnabled());
+
+		RenderStateRecorder.Snapshot before = recorder.latest();
+		assertEquals(-1, before.snapshotTick);
+		assertFalse(before.guidanceActive);
+
+		// Every record/begin/publish is a no-op while disabled.
+		recorder.beginFrame(true);
+		recorder.recordNpc(123);
+		recorder.recordObject(456);
+		recorder.recordGroundItem(789);
+		recorder.recordTarget("npc", 123, true, 90);
+		recorder.recordTile(new WorldPoint(1, 2, 0));
+		recorder.recordTooltip("hello");
+		recorder.publish(42);
+
+		// latest() is unchanged: same sentinel reference, still tick -1, empty arrays.
+		assertSame(before, recorder.latest());
+		assertEquals(-1, recorder.latest().snapshotTick);
+		assertEquals(0, recorder.latest().highlightedNpcIds.length);
+		assertTrue(recorder.latest().targets.isEmpty());
+	}
+
+	@Test
+	public void enabledRoundTripsRecordedFrameIntoLatest()
+	{
+		recorder.enable();
+		assertTrue(recorder.isEnabled());
+
+		recorder.beginFrame(true);
+		recorder.recordNpc(123);
+		recorder.recordObject(456);
+		recorder.recordGroundItem(789);
+		recorder.recordTarget("npc", 123, false, 90);
+		recorder.recordTarget("object", 456, true, 80);
+		recorder.recordTile(new WorldPoint(3200, 3200, 1));
+		recorder.recordTooltip("Open the chest");
+		recorder.publish(99);
+
+		RenderStateRecorder.Snapshot s = recorder.latest();
+		assertEquals(99, s.snapshotTick);
+		assertTrue(s.guidanceActive);
+		assertArrayEquals(new int[]{123}, s.highlightedNpcIds);
+		assertArrayEquals(new int[]{456}, s.highlightedObjectIds);
+		assertArrayEquals(new int[]{789}, s.highlightedGroundItemIds);
+		assertEquals(2, s.targets.size());
+		assertEquals("npc", s.targets.get(0).type);
+		assertFalse(s.targets.get(0).bookMarker);
+		assertEquals(90, s.targets.get(0).zOffset);
+		assertEquals("object", s.targets.get(1).type);
+		assertTrue(s.targets.get(1).bookMarker);
+		assertEquals(80, s.targets.get(1).zOffset);
+		assertEquals(3200, s.tileTarget.getX());
+		assertEquals(1, s.tileTarget.getPlane());
+		assertEquals("Open the chest", s.tooltipText);
+	}
+
+	@Test
+	public void publishedSnapshotIsImmutableAcrossASubsequentFrame()
+	{
+		recorder.enable();
+
+		recorder.beginFrame(true);
+		recorder.recordNpc(111);
+		recorder.recordTarget("npc", 111, true, 90);
+		recorder.recordTile(new WorldPoint(1, 1, 0));
+		recorder.recordTooltip("first");
+		recorder.publish(10);
+		RenderStateRecorder.Snapshot first = recorder.latest();
+
+		// A whole second frame must not mutate the first snapshot.
+		recorder.beginFrame(false);
+		recorder.recordObject(222);
+		recorder.recordTarget("object", 222, true, 80);
+		recorder.publish(20);
+		RenderStateRecorder.Snapshot second = recorder.latest();
+
+		assertNotSame(first, second);
+
+		// First snapshot is frozen at its original values.
+		assertEquals(10, first.snapshotTick);
+		assertTrue(first.guidanceActive);
+		assertArrayEquals(new int[]{111}, first.highlightedNpcIds);
+		assertEquals(1, first.targets.size());
+		assertEquals("npc", first.targets.get(0).type);
+		assertEquals("first", first.tooltipText);
+
+		// Second snapshot reflects only the second frame (tile/tooltip cleared by beginFrame).
+		assertEquals(20, second.snapshotTick);
+		assertFalse(second.guidanceActive);
+		assertEquals(0, second.highlightedNpcIds.length);
+		assertArrayEquals(new int[]{222}, second.highlightedObjectIds);
+		assertNull(second.tileTarget);
+		assertNull(second.tooltipText);
+	}
+
+	@Test
+	public void disableResetsLatestToSentinel()
+	{
+		recorder.enable();
+		recorder.beginFrame(true);
+		recorder.recordNpc(5);
+		recorder.publish(7);
+		assertEquals(7, recorder.latest().snapshotTick);
+
+		recorder.disable();
+		assertFalse(recorder.isEnabled());
+		assertEquals(-1, recorder.latest().snapshotTick);
+	}
+}


### PR DESCRIPTION
## What

Consumer-side wiring for the dev actuation bridge v0.4 — two new capabilities used by the in-game validation loop:

- **`GuidanceSequencer.forceStepIndex(int)`** — jump an active sequence directly to a step index, resetting per-step transient state (loop counters, crossed-waypoint index, awaitingRestock, per-step caches) and firing the normal step-changed notification. Lets validation target the step under test without walking the preceding steps.
- **`RenderStateRecorder`** (new, `overlay/`) — records what the guidance overlays actually drew each frame (highlighted NPC/object/ground-item ids, per-target marker decision + z-offset, tile poly, tooltip) and publishes an immutable snapshot via a single volatile reference, so draw-state can be asserted deterministically instead of via screenshots/OCR.

## Why production is unaffected

The recorder is **disabled by default** and only the local dev harness ever enables it. While disabled, every `beginFrame`/`record*`/`publish` call is a single `volatile boolean` check that returns immediately — zero allocation, buffers untouched. `drawTargetMarker` was refactored to hoist the z-offset into a local; behavior is unchanged.

## Tests

- `GuidanceSequencerForceStepIndexTest` — jump resets transient state + notifies; no active sequence -> `IllegalStateException`; out-of-range -> `IndexOutOfBoundsException`.
- `RenderStateRecorderTest` — disabled-by-default no-op; enabled round-trip; snapshot immutability across frames; disable resets to sentinel.

`./gradlew build test` green.
