### PR TITLE
fix(sync): fetch boss KCs from the TempleOSRS stats endpoint, not player_info

### DIFF
--- a/src/main/java/com/collectionloghelper/sync/TempleOsrsKcSyncer.java
+++ b/src/main/java/com/collectionloghelper/sync/TempleOsrsKcSyncer.java
@@ -30,9 +30,12 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonSyntaxException;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.inject.Inject;
@@ -46,18 +49,35 @@ import okhttp3.Response;
  * Fetches boss/activity kill counts from the TempleOSRS API and maps them to
  * CLH source names.
  *
- * <p>API endpoint: {@code GET https://templeosrs.com/api/player_info.php?player={username}}
+ * <p>API endpoint:
+ * {@code GET https://templeosrs.com/api/player_stats.php?player={username}&bosses=1}
+ *
+ * <p>The {@code player_info.php} endpoint was previously used by mistake: it returns
+ * only account metadata (username, country, game-mode flags, last-checked timestamps)
+ * and contains no kill-count data, so every entry was rejected as non-numeric and the
+ * sync mapped zero sources. {@code player_stats.php} is the endpoint that actually
+ * carries per-boss KCs.
  *
  * <p>Response shape (simplified):
  * <pre>
  * {
  *   "data": {
- *     "Abyssal Sire": 0,
- *     "K'ril Tsutsaroth": 100,
+ *     "info":  { "Username": "...", ... },   // account metadata, skipped
+ *     "date":  "2026-06-11 19:26:28",          // skipped
+ *     "Overall": 2277, "Overall_rank": 1, ...  // skill stats, skipped
+ *     "Abyssal Sire": 0,                        // boss KC (flat key)
+ *     "K'ril Tsutsaroth": 100,                  // boss KC (flat key)
+ *     "Zulrah_ehb": 7.3,                        // derived metadata, skipped
  *     ...
  *   }
  * }
  * </pre>
+ *
+ * <p>Boss/activity KCs sit alongside skill stats and several families of derived
+ * metadata in the same flat {@code data} object. Metadata is distinguished by key
+ * shape — derived-stat suffixes ({@code _rank}, {@code _level}, {@code _ehp},
+ * {@code _ehb}, {@code _xp}), the fixed skill names, and the {@code info}/{@code date}
+ * fields — and is skipped quietly rather than counted as a rejected anomaly.
  *
  * <p>Fail-soft: any HTTP error, parse failure, or timeout yields
  * {@link SyncResult#failure(String)}; no exception propagates to the caller.
@@ -68,10 +88,36 @@ import okhttp3.Response;
 @Singleton
 public class TempleOsrsKcSyncer
 {
-	static final String BASE_URL = "https://templeosrs.com/api/player_info.php";
+	static final String BASE_URL = "https://templeosrs.com/api/player_stats.php";
 
 	/** Hard cap on response body size to prevent OOM from a misbehaving/malicious server. */
 	private static final long MAX_RESPONSE_BYTES = 1L * 1024L * 1024L;
+
+	/**
+	 * Key-name suffixes used by TempleOSRS for derived per-skill/per-boss metadata
+	 * (e.g. {@code Zulrah_ehb}, {@code Overall_rank}). Any {@code data} key ending in
+	 * one of these is metadata, not a KC, and is skipped quietly.
+	 */
+	private static final String[] METADATA_SUFFIXES = {"_rank", "_level", "_ehp", "_ehb", "_xp"};
+
+	/**
+	 * Fixed account-metadata keys in the {@code data} object that are neither skill
+	 * stats nor boss KCs. {@code info} is an object and {@code date} is a string, so
+	 * both are already non-primitive/non-numeric, but listing them keeps the skip
+	 * explicit and self-documenting.
+	 */
+	private static final Set<String> METADATA_KEYS = new HashSet<>(Arrays.asList("info", "date"));
+
+	/**
+	 * Base skill names TempleOSRS reports as bare integer keys (alongside their
+	 * {@code _rank}/{@code _level}/{@code _ehp} siblings). These collide in shape with
+	 * boss KCs (bare integer values) so they must be filtered by name.
+	 */
+	private static final Set<String> SKILL_NAMES = new HashSet<>(Arrays.asList(
+		"Overall", "Attack", "Defence", "Strength", "Hitpoints", "Ranged", "Prayer",
+		"Magic", "Cooking", "Woodcutting", "Fletching", "Fishing", "Firemaking",
+		"Crafting", "Smithing", "Mining", "Herblore", "Agility", "Thieving", "Slayer",
+		"Farming", "Runecraft", "Hunter", "Construction", "Sailing", "Ehp", "Ehb"));
 
 	/**
 	 * Static name mapping from TempleOSRS display name to CLH source name.
@@ -166,7 +212,8 @@ public class TempleOsrsKcSyncer
 		}
 
 		// The URL embeds the RSN — never log the name or the full URL (T0.7)
-		String url = BASE_URL + "?player=" + encodeUsername(username.trim());
+		// bosses=1 asks player_stats.php to include per-boss KCs in the data object.
+		String url = BASE_URL + "?player=" + encodeUsername(username.trim()) + "&bosses=1";
 		log.debug("Fetching TempleOSRS KC for the current player");
 
 		Request request = new Request.Builder()
@@ -224,7 +271,9 @@ public class TempleOsrsKcSyncer
 	/**
 	 * Parses the TempleOSRS JSON response into a {@link SyncResult}.
 	 *
-	 * <p>Expected shape: {@code {"data": {"Boss Name": 100, ...}}}
+	 * <p>Expected shape: {@code {"data": {"info": {...}, "Overall": 2277, "Boss Name": 100, ...}}}
+	 * — boss KCs are flat integer keys mixed in with skill stats and account metadata
+	 * (see {@link #mapActivitiesToSources}).
 	 */
 	SyncResult parseResponse(String json)
 	{
@@ -256,10 +305,16 @@ public class TempleOsrsKcSyncer
 	 *
 	 * <p>Mapping strategy:
 	 * <ol>
+	 *   <li>Account metadata and skill-stat keys are skipped quietly by key shape
+	 *       (see {@link #isMetadataKey}) and never counted as anomalies</li>
 	 *   <li>Explicit override in {@link #TEMPLE_TO_CLH}</li>
 	 *   <li>Identity — return the name as-is (caller validates against the DB)</li>
 	 *   <li>Zero-KC entries are skipped (player has not done that activity)</li>
 	 * </ol>
+	 *
+	 * <p>The {@code skipped} count reported on the result reflects only genuine KC
+	 * entries that failed to parse as a positive integer — not the metadata keys,
+	 * which are an expected part of the {@code player_stats.php} payload.
 	 */
 	SyncResult mapActivitiesToSources(JsonObject data)
 	{
@@ -270,6 +325,13 @@ public class TempleOsrsKcSyncer
 		{
 			String templeName = entry.getKey();
 			JsonElement kcEl = entry.getValue();
+
+			// Account metadata and skill stats share the data object with boss KCs;
+			// skip them by key shape so they never inflate the skipped/anomaly count.
+			if (isMetadataKey(templeName))
+			{
+				continue;
+			}
 
 			if (!kcEl.isJsonPrimitive())
 			{
@@ -302,6 +364,31 @@ public class TempleOsrsKcSyncer
 		log.debug("TempleOSRS KC mapped {} sources, skipped {} non-numeric entries",
 			result.size(), skipped);
 		return SyncResult.success(result, skipped);
+	}
+
+	/**
+	 * Returns {@code true} if a {@code data} key is account metadata or a skill stat
+	 * rather than a boss/activity kill count.
+	 *
+	 * <p>Metadata is identified by shape: the fixed {@code info}/{@code date} keys, any
+	 * key ending in a derived-stat suffix ({@code _rank}, {@code _level}, {@code _ehp},
+	 * {@code _ehb}, {@code _xp}), or a bare skill name ({@code Overall}, {@code Attack},
+	 * &hellip;). Everything else is treated as a candidate KC entry.
+	 */
+	boolean isMetadataKey(String key)
+	{
+		if (METADATA_KEYS.contains(key) || SKILL_NAMES.contains(key))
+		{
+			return true;
+		}
+		for (String suffix : METADATA_SUFFIXES)
+		{
+			if (key.endsWith(suffix))
+			{
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**

--- a/src/test/java/com/collectionloghelper/sync/TempleOsrsKcSyncerTest.java
+++ b/src/test/java/com/collectionloghelper/sync/TempleOsrsKcSyncerTest.java
@@ -308,6 +308,103 @@ public class TempleOsrsKcSyncerTest
 	}
 
 	// ========================================================================
+	// player_stats.php payload shape — the real endpoint (regression for the
+	// player_info.php endpoint bug, where the syncer mapped zero sources)
+	// ========================================================================
+
+	/**
+	 * Trimmed fixture of the real {@code player_stats.php?...&bosses=1} response: boss
+	 * KCs are flat integer keys mixed in with the {@code info} object, the {@code date}
+	 * string, skill stats, and derived {@code _rank}/{@code _level}/{@code _ehp}/
+	 * {@code _ehb} metadata. Built from a verified live response; the player name is
+	 * a placeholder and never a real RSN.
+	 */
+	private static final String PLAYER_STATS_FIXTURE = "{\"data\": {"
+		+ "\"info\": {\"Username\": \"ExamplePlayer\", \"Country\": \"-\", \"Game mode\": 0,"
+		+ " \"Clan preference\": null, \"Last checked\": \"2026-06-11 19:26:28\"},"
+		+ "\"date\": \"2026-06-11 19:26:28\","
+		+ "\"Overall\": 2277, \"Overall_rank\": 1, \"Overall_level\": 2277, \"Overall_ehp\": 1234.5,"
+		+ "\"Attack\": 200000000, \"Attack_rank\": 5, \"Attack_level\": 99, \"Attack_ehp\": 0,"
+		+ "\"Zulrah\": 341, \"Zulrah_ehb\": 7.3,"
+		+ "\"Vorkath\": 2781, \"Vorkath_ehb\": 55.6,"
+		+ "\"Cerberus\": 2657, \"Cerberus_ehb\": 44.4,"
+		+ "\"Barrows Chests\": 1833,"
+		+ "\"The Whisperer\": 2450, \"The Whisperer_ehb\": 12.0,"
+		+ "\"Abyssal Sire\": 0, \"Abyssal Sire_ehb\": 0"
+		+ "}}";
+
+	@Test
+	public void parseResponse_playerStatsShape_mapsBossKcAndSkipsMetadataQuietly()
+	{
+		SyncResult result = syncer.parseResponse(PLAYER_STATS_FIXTURE);
+
+		assertTrue(result.isSuccess());
+
+		// Boss KCs are mapped from their flat keys.
+		assertEquals(341, (int) result.getKcBySource().get("Zulrah"));
+		assertEquals(2781, (int) result.getKcBySource().get("Vorkath"));
+		assertEquals(2657, (int) result.getKcBySource().get("Cerberus"));
+		assertEquals(1833, (int) result.getKcBySource().get("Barrows"));
+		assertEquals(2450, (int) result.getKcBySource().get("The Whisperer"));
+
+		// Only the five positive-KC bosses are present (Abyssal Sire is 0 -> skipped).
+		assertEquals(5, result.getKcBySource().size());
+
+		// Account metadata and skill stats must NOT be mapped as sources...
+		assertNull(result.getKcBySource().get("Overall"));
+		assertNull(result.getKcBySource().get("Attack"));
+		assertNull(result.getKcBySource().get("info"));
+		assertNull(result.getKcBySource().get("date"));
+		assertNull(result.getKcBySource().get("Zulrah_ehb"));
+		assertNull(result.getKcBySource().get("Overall_rank"));
+
+		// ...and they must NOT be counted as skipped/anomalous entries either.
+		assertEquals(0, result.getSkippedCount(),
+			"Metadata keys are expected payload, not non-numeric anomalies");
+	}
+
+	@Test
+	public void parseResponse_playerInfoMetadataOnlyShape_mapsZeroSources()
+	{
+		// The OLD player_info.php payload: account metadata only, no KC data. The
+		// previous syncer fetched this and mapped zero sources. With player_stats.php
+		// this shape can still appear nested as the "info" object; if it ever arrives
+		// at the top level it must yield zero mapped sources and no false anomalies.
+		String metadataOnly = "{\"data\": {"
+			+ "\"Username\": \"ExamplePlayer\", \"Country\": \"-\", \"Game mode\": 0,"
+			+ " \"GIM\": 0, \"F2p\": 0, \"Banned\": 0, \"Disqualified\": 0,"
+			+ " \"Clan preference\": null, \"Last checked\": \"2026-06-11 19:26:28\","
+			+ " \"Last changed\": \"2026-06-11 19:26:28\""
+			+ "}}";
+
+		SyncResult result = syncer.parseResponse(metadataOnly);
+
+		assertTrue(result.isSuccess());
+		assertTrue(result.getKcBySource().isEmpty(),
+			"Metadata-only payload must map zero KC sources");
+	}
+
+	@Test
+	public void isMetadataKey_classifiesMetadataAndBossKeys()
+	{
+		// Metadata: fixed keys, skill names, and derived-stat suffixes.
+		assertTrue(syncer.isMetadataKey("info"));
+		assertTrue(syncer.isMetadataKey("date"));
+		assertTrue(syncer.isMetadataKey("Overall"));
+		assertTrue(syncer.isMetadataKey("Attack"));
+		assertTrue(syncer.isMetadataKey("Attack_rank"));
+		assertTrue(syncer.isMetadataKey("Attack_level"));
+		assertTrue(syncer.isMetadataKey("Attack_ehp"));
+		assertTrue(syncer.isMetadataKey("Zulrah_ehb"));
+
+		// Boss/activity keys are NOT metadata.
+		assertFalse(syncer.isMetadataKey("Zulrah"));
+		assertFalse(syncer.isMetadataKey("Barrows Chests"));
+		assertFalse(syncer.isMetadataKey("The Whisperer"));
+		assertFalse(syncer.isMetadataKey("K'ril Tsutsaroth"));
+	}
+
+	// ========================================================================
 	// resolveClhName
 	// ========================================================================
 


### PR DESCRIPTION
## Bug

T1.4 #2: with a TempleOSRS-tracked account, login sync always logged `TempleOSRS KC mapped 0 sources, skipped 7 non-numeric entries` and no KC ever synced.

## Root cause (live-API receipt, username redacted)

The syncer fetched `player_info.php`, which returns **only account metadata** — no KC data exists in that payload:

```
data: { Username: "<redacted>" (string), Country: "-" (string), Game mode: 0, GIM: 0,
        fresh_start_account: 0, Cb-3: 0, F2p: 0, Banned: 0, Disqualified: 0,
        Clan preference: null, Last checked: "2026-06-11 ..." (string), ... }
```

The 7 string/null metadata fields are exactly the "7 non-numeric" rejects. The parse/mapping code worked as coded — the endpoint was wrong.

## Fix

- `BASE_URL` -> `player_stats.php`, request appends `&bosses=1`. Verified live: boss KCs are flat integer keys in `data` (`"Zulrah": 341, "Barrows Chests": 1833, "The Whisperer": 2450, ...`).
- That payload mixes in skill stats and derived metadata, so a new `isMetadataKey` filter quietly skips `info`/`date`, bare skill names, and `_rank`/`_level`/`_ehp`/`_ehb`/`_xp` suffixed keys — the `skipped` count now reflects only genuine KC anomalies.
- `TEMPLE_TO_CLH` rename table and accept/reject semantics unchanged; identity fallback covers the API's newer `"The Whisperer"`-style keys.

## Tests

`TempleOsrsKcSyncerTest` (fixtures use a fake player name): real `player_stats` shape maps 5 bosses incl. `Barrows Chests` -> `Barrows` with zero skipped; the old metadata-only shape maps zero sources; `isMetadataKey` classifier unit test.

`./gradlew build test` green.
