### PR TITLE
fix(overlay): render NPC kill-step highlight independent of step-tile resolution (instanced arenas)

### DIFF
--- a/src/main/java/com/collectionloghelper/overlay/GuidanceOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/GuidanceOverlay.java
@@ -179,18 +179,56 @@ public class GuidanceOverlay extends OverlayPanel
 			return null;
 		}
 
-		// Skip world rendering if player is on a different plane than the target
 		Player localPlayer = client.getLocalPlayer();
+
+		// NPC highlighting — use event-driven tracked NPC (set via onNpcSpawned/onNpcDespawned).
+		// This is INDEPENDENT of the step-tile resolution below: inside instanced arenas the
+		// step's overworld tile can never resolve to the local scene, but the tracked NPC lives
+		// in the real scene and must still be highlighted (#807). Plane-gate against the NPC's
+		// OWN world location, not the step tile's plane.
+		boolean npcHighlighted = false;
+		NPC npc = this.trackedNpc;
+		if (localPlayer != null
+			&& shouldDrawNpcHighlight(npcId, npc, localPlayer.getWorldLocation().getPlane()))
+		{
+			renderNpcHighlight(graphics, npc, overlayColor, action, locDesc);
+			npcHighlighted = true;
+		}
+
+		// Skip world tile rendering if player is on a different plane than the target tile.
 		boolean samePlane = localPlayer != null
 			&& localPlayer.getWorldLocation().getPlane() == point.getPlane();
 
-		// Tile highlight rendering
+		// Tile highlight rendering — resolve the step tile to the local scene.
 		net.runelite.api.WorldView wv = client.getTopLevelWorldView();
 		LocalPoint localPoint = samePlane && wv != null
 			? LocalPoint.fromWorld(wv, point) : null;
-		if (localPoint == null)
+
+		// Tile highlight rendering (skip if NPC is already highlighted nearby,
+		// or if an object highlight is handling the visual for this step)
+		if (localPoint != null && !npcHighlighted && !suppressTileHighlight)
 		{
-			// Target tile is not on screen — show compact direction panel
+			Polygon poly = Perspective.getCanvasTilePoly(client, localPoint);
+			if (poly != null)
+			{
+				OverlayUtil.renderPolygon(graphics, poly, overlayColor, cachedFillColor50,
+					STROKE_2);
+
+				if (name != null)
+				{
+					Point tileTextPoint = Perspective.getCanvasTextLocation(client, graphics, localPoint, name, 150);
+					if (tileTextPoint != null)
+					{
+						OverlayUtil.renderTextLocation(graphics, tileTextPoint, name, overlayColor);
+					}
+				}
+			}
+		}
+
+		// Compact direction panel fallback: render only when NOTHING world-anchored was drawn —
+		// no NPC highlighted AND the step tile could not be resolved to the local scene.
+		if (!npcHighlighted && localPoint == null)
+		{
 			if (name != null)
 			{
 				panelComponent.getChildren().clear();
@@ -228,39 +266,6 @@ public class GuidanceOverlay extends OverlayPanel
 			return null;
 		}
 
-		// NPC highlighting — use event-driven tracked NPC (set via onNpcSpawned/onNpcDespawned)
-		boolean npcHighlighted = false;
-		if (npcId > 0)
-		{
-			NPC npc = this.trackedNpc;
-			if (npc != null && npc.getId() == npcId)
-			{
-				renderNpcHighlight(graphics, npc, overlayColor, action, locDesc);
-				npcHighlighted = true;
-			}
-		}
-
-		// Tile highlight rendering (skip if NPC is already highlighted nearby,
-		// or if an object highlight is handling the visual for this step)
-		if (!npcHighlighted && !suppressTileHighlight)
-		{
-			Polygon poly = Perspective.getCanvasTilePoly(client, localPoint);
-			if (poly != null)
-			{
-				OverlayUtil.renderPolygon(graphics, poly, overlayColor, cachedFillColor50,
-					STROKE_2);
-
-				if (name != null)
-				{
-					Point tileTextPoint = Perspective.getCanvasTextLocation(client, graphics, localPoint, name, 150);
-					if (tileTextPoint != null)
-					{
-						OverlayUtil.renderTextLocation(graphics, tileTextPoint, name, overlayColor);
-					}
-				}
-			}
-		}
-
 		// When the target is on-screen we normally skip the side panel, but a
 		// required-items list still needs to be visible so the player can
 		// confirm they have what the step needs (or notice what's missing).
@@ -274,6 +279,23 @@ public class GuidanceOverlay extends OverlayPanel
 		}
 
 		return null;
+	}
+
+	/**
+	 * Pure decision for whether the tracked NPC highlight should be drawn this
+	 * frame. Extracted so the instanced-arena reachability (highlight is
+	 * independent of step-tile resolution) can be unit-tested without the
+	 * RuneLite render scaffolding. The NPC is plane-gated against its OWN plane,
+	 * never the step tile's.
+	 */
+	static boolean shouldDrawNpcHighlight(int stepNpcId, NPC trackedNpc, int localPlayerPlane)
+	{
+		if (stepNpcId <= 0 || trackedNpc == null || trackedNpc.getId() != stepNpcId)
+		{
+			return false;
+		}
+		WorldPoint npcLoc = trackedNpc.getWorldLocation();
+		return npcLoc != null && npcLoc.getPlane() == localPlayerPlane;
 	}
 
 	/**

--- a/src/main/java/com/collectionloghelper/overlay/GuidanceOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/GuidanceOverlay.java
@@ -184,7 +184,7 @@ public class GuidanceOverlay extends OverlayPanel
 		// NPC highlighting — use event-driven tracked NPC (set via onNpcSpawned/onNpcDespawned).
 		// This is INDEPENDENT of the step-tile resolution below: inside instanced arenas the
 		// step's overworld tile can never resolve to the local scene, but the tracked NPC lives
-		// in the real scene and must still be highlighted (#807). Plane-gate against the NPC's
+		// in the real scene and must still be highlighted. Plane-gate against the NPC's
 		// OWN world location, not the step tile's plane.
 		boolean npcHighlighted = false;
 		NPC npc = this.trackedNpc;

--- a/src/test/java/com/collectionloghelper/overlay/GuidanceOverlayNpcHighlightTest.java
+++ b/src/test/java/com/collectionloghelper/overlay/GuidanceOverlayNpcHighlightTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.overlay;
+
+import net.runelite.api.NPC;
+import net.runelite.api.coords.WorldPoint;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the tracked-NPC highlight decision in {@link GuidanceOverlay}.
+ *
+ * <p>The render path returns early when the step's overworld tile cannot be
+ * resolved to the local scene (which is ALWAYS the case inside instanced arenas,
+ * where the scene is instance template space). Before the #807 fix that early
+ * return ran <em>before</em> the NPC-highlight block, so NPC kill-step highlights
+ * never drew for any instanced boss. The fix hoists the highlight decision so it
+ * is independent of step-tile resolution; that decision is extracted into
+ * {@link GuidanceOverlay#shouldDrawNpcHighlight(int, NPC, int)} so it can be
+ * verified without the RuneLite render scaffolding (static
+ * {@code LocalPoint.fromWorld} / {@code Perspective} calls).
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class GuidanceOverlayNpcHighlightTest
+{
+	private static final int BOSS_NPC_ID = 12345;
+
+	@Mock
+	private NPC npc;
+
+	@Test
+	public void drawsHighlight_whenTrackedNpcMatchesAndSamePlane()
+	{
+		// The NPC is plane-gated against its OWN location, not the step tile's.
+		// Inside an instanced arena the step tile is unresolvable, but the NPC
+		// lives in the real scene and must still be highlighted.
+		when(npc.getId()).thenReturn(BOSS_NPC_ID);
+		when(npc.getWorldLocation()).thenReturn(new WorldPoint(3000, 3000, 0));
+
+		assertTrue(GuidanceOverlay.shouldDrawNpcHighlight(BOSS_NPC_ID, npc, 0),
+			"Tracked NPC matching the step id on the player's plane must be highlighted");
+	}
+
+	@Test
+	public void noHighlight_whenNoNpcId()
+	{
+		assertFalse(GuidanceOverlay.shouldDrawNpcHighlight(0, npc, 0),
+			"A step with no NPC id must not highlight anything");
+	}
+
+	@Test
+	public void noHighlight_whenTrackedNpcNull()
+	{
+		assertFalse(GuidanceOverlay.shouldDrawNpcHighlight(BOSS_NPC_ID, null, 0),
+			"No tracked NPC means no highlight");
+	}
+
+	@Test
+	public void noHighlight_whenTrackedNpcIdMismatch()
+	{
+		when(npc.getId()).thenReturn(BOSS_NPC_ID + 1);
+
+		assertFalse(GuidanceOverlay.shouldDrawNpcHighlight(BOSS_NPC_ID, npc, 0),
+			"A tracked NPC whose id differs from the step's must not be highlighted");
+	}
+
+	@Test
+	public void noHighlight_whenNpcOnDifferentPlane()
+	{
+		when(npc.getId()).thenReturn(BOSS_NPC_ID);
+		when(npc.getWorldLocation()).thenReturn(new WorldPoint(3000, 3000, 2));
+
+		assertFalse(GuidanceOverlay.shouldDrawNpcHighlight(BOSS_NPC_ID, npc, 0),
+			"An NPC on a different plane than the player must not be highlighted");
+	}
+
+	@Test
+	public void noHighlight_whenNpcWorldLocationNull()
+	{
+		when(npc.getId()).thenReturn(BOSS_NPC_ID);
+		when(npc.getWorldLocation()).thenReturn(null);
+
+		assertFalse(GuidanceOverlay.shouldDrawNpcHighlight(BOSS_NPC_ID, npc, 0),
+			"An NPC with no resolvable world location must not be highlighted");
+	}
+}


### PR DESCRIPTION
Fixes #826.

## What

`GuidanceOverlay.render` previously resolved the step tile first and early-returned into the compact direction panel whenever `LocalPoint.fromWorld` failed — which is always the case inside instanced arenas (template-space scene). The NPC-highlight block sat below that return and was unreachable, so kill-step highlights + the collection-log marker never rendered for any instanced boss (live-confirmed at the Shellbane Gryphon via the dev seam: empty draw-state mid-fight with the boss tracked).

## Change

- The tracked-NPC highlight now runs first, independent of step-tile resolution, plane-gated against the NPC's OWN world location (previously the block had no plane check at all).
- Tile rendering keeps identical semantics (`suppressTileHighlight`, skip-if-NPC-highlighted), guarded by `localPoint != null` instead of an early return.
- The compact direction panel is now a true fallback: it renders only when nothing world-anchored was drawn (no NPC highlighted AND tile unresolvable); content unchanged.
- The required-items side panel is now reachable after an instanced-NPC highlight, matching non-instanced behavior.
- The draw decision is extracted into a pure package-private helper, `shouldDrawNpcHighlight`, for testability. No new per-frame allocations.

## Tests

`GuidanceOverlayNpcHighlightTest` — 6 cases: match+same-plane draws; no npcId / null tracked NPC / id mismatch / different plane / null world location all skip. `./gradlew build test` green.

## Conflicts note

Touches the same `render` flow as #816 and #824; whichever merges last needs a small manual resolution (the recorder calls from #824 slot into the new structure; #816's `MARKER_CLEARANCE` applies in `drawTargetMarker`).
