### PR TITLE
fix(data): Shellbane Gryphon - correct inverted combat meta + missing on-task gate

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -24151,18 +24151,17 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Bank in Civitas illa Fortis (Varlamore). Required: 51 Slayer and 'Troubled Tortugans' quest complete. Bring ranged or magic gear (Shellbane Gryphon resists melee), prayer potions, food, Slayer helmet (i) on-task for the bonus, and a Quetzal whistle for the return teleport",
+        "description": "Bank in Civitas illa Fortis (Varlamore). Requires an active gryphon Slayer task - the boss cannot be attacked off-task. Required: 51 Slayer and 'Troubled Tortugans' quest complete. Bring strong melee gear, a Tortugan shield (REQUIRED - heavy damage without it), equipped weight >= 40kg to counter the knockback special, prayer potions, food, Slayer helmet (i) on-task, and a Quetzal whistle for the return teleport",
         "worldX": 1626,
         "worldY": 3093,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 8,
         "requiredItemIds": [
-          24417,
+          31398,
           11865,
           6685,
-          2434,
-          12924
+          2434
         ],
         "section": "Bank"
       },
@@ -24187,7 +24186,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill the Shellbane Gryphon. Use Protect from Melee for the slam auto, then swap to Protect from Missiles when the gryphon takes flight for the wing-gust special. Attack with ranged (blowpipe / crossbow) or magic - melee is heavily resisted. Sip ranging / magic potion mid-fight to keep DPS high. On-task with Slayer helmet (i) for the +16.67% damage bonus is the standard farm setup",
+        "description": "Kill the Shellbane Gryphon. Active gryphon Slayer task required. Use Protect from Melee; the gryphon is primarily weak to melee - attack with your best melee setup. Keep the Tortugan shield equipped at all times (heavy damage without it). Maintain >= 40kg equipped weight to counter the knockback special attack. Respond to the corrosive spit (move) and whirlwind (move) specials as they occur. Slayer helmet (i) on-task for the damage bonus",
         "worldX": 13993,
         "worldY": 9901,
         "worldPlane": 0,
@@ -24197,7 +24196,7 @@
         "completionNpcId": 14860,
         "section": "Combat",
         "recommendedItemIds": [
-          12924,
+          31398,
           11865,
           6685,
           2434,


### PR DESCRIPTION
One-source data fix for Shellbane Gryphon, covering the two coordinate-independent findings from the 2026-06-12 adversarial review (live wiki receipts). The bogus coordinates (steps 1-3 share an out-of-bounds tile) and the bank re-anchor are a SEPARATE follow-up blocked on in-game tile capture.

## F2 — inverted/fabricated combat meta (blocker)

Wiki (Shellbane gryphon): "Like normal gryphons, the shellbane gryphon is primarily weak to melee." There is no flight phase (specials are knockback / corrosive spit / whirlwind; knockback is "countered by having the player's equipped weight be >=40kg"), and "A tortugan shield is required for the fight, otherwise the player will take heavy damage." The data said the opposite: "resists melee", a fabricated Protect-from-Missiles flight phase, and required a blowpipe while also requiring a melee mace.

- Step 0 + kill-step texts rewritten to the melee strategy (Protect from Melee, Tortugan shield always equipped, >=40kg weight, spit/whirlwind responses).
- requiredItemIds: removed Inquisitor's mace 24417 + Toxic blowpipe (empty) 12924; added Tortugan shield 31398 (cache: `cross_check_ids` 31398 -> "Tortugan shield" match; sibling id 31399 is unnamed in cache, not wired). Kill-step recommendedItemIds: 12924 -> 31398.

## F4 — missing on-task gate (high)

Wiki: the boss "may only be killed while on a gryphons Slayer task". Encoded text-first per the existing convention (same pattern as Thermonuclear smoke devil / Kraken sources): step 0 opens with the task requirement; kill step restates it. No new schema field.

## Validation

`data_ascii_lint` 0 violations; `validate_drop_rates` + `guidance_lint` show only pre-existing warnings on the untouched coordinate fields (pending the follow-up); `./gradlew build test` green incl. `D4Batch1RegressionTest` (this source is in its list; no loop fields touched); `python scripts/audit_drop_rates.py --category BOSSES` 0 errors. Drop rates/ids untouched (verified clean against the wiki: folly 1/256, jar 1/2000, pet 1/3000, feather always).
