### PR TITLE
fix(data): Alchemical Hydra - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -1264,7 +1264,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill the Alchemical Hydra. Hydra rotates phases at 75%, 50%, 25% HP - Green/poison (lure to red south-east vent), Blue/electric (lure to green north-east vent), Red/flame (lure to blue north-west vent), then Enrage. The Hydra alternates Magic and Ranged auto-attacks; watch the head sway between basic attacks - Magic head sways one way, Ranged the other - flick Protect from Magic vs Magic and Protect from Missiles vs Ranged. Bring Toxic blowpipe and ranged tank gear; on the Flame phase dodge the fire walls and the lightning chase. 95 Slayer required; Hydra task only",
+        "description": "Kill the Alchemical Hydra. Hydra rotates phases at 75%, 50%, 25% HP - Green/poison (lure to red south-east vent), Blue/electric (lure to green north-east vent), Red/flame (lure to blue north-west vent), then Enrage. The Hydra alternates Magic and Ranged auto-attacks; watch for the head sway after every three attacks as a signal that the style is changing - flick Protect from Magic vs Magic and Protect from Missiles vs Ranged. Bring Toxic blowpipe and ranged tank gear; on the Blue/electric phase dodge the lightning; on the Flame/red phase dodge the fire walls. 95 Slayer required; Hydra task only",
         "worldX": 1364,
         "worldY": 10265,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Corrects two guidance-text errors in the Alchemical Hydra combat step, identified by wiki-meta audit tranche 1.

## Applied findings

**[medium] C13/C14: Head sway directional tell removed**
- Old: `watch the head sway between basic attacks - Magic head sways one way, Ranged the other`
- New: `watch for the head sway after every three attacks as a signal that the style is changing`
- Wiki receipt: "after every three basic attacks, the Hydra will sway its heads backwards as an indicator that it is changing combat styles." The direction of the sway does not predict whether Magic or Ranged will follow. The directional claim was fabricated and would teach players to react to a non-existent signal.

**[high] C20: Lightning phase attribution corrected**
- Old: `on the Flame phase dodge the fire walls and the lightning chase`
- New: `on the Blue/electric phase dodge the lightning; on the Flame/red phase dodge the fire walls`
- Wiki receipt: "It also has special attacks for each phase: poison pools when green and black, electricity when blue and fire when red." Lightning currents converge on the player during the blue (electric) phase, not the red (flame) phase. The previous text would mislead players into expecting lightning during the red phase.

Full receipts: docs/verify/findings-wiki-meta-2026-06.md (PR #829)

## Skipped findings

- **C21** (low): Fairy ring CIR waypoint gates on `FAIRYTALE_II__CURE_A_QUEEN` but only Fairytale I is required for fairy ring access. Skipped - requirements-wiring follow-up (changing `requirements.quests` is out of scope for this description-text pass; needs its own targeted PR).

## Test plan

- [x] JSON parses cleanly (`python -c "import json;json.load(open(...))"`)
- [x] Zero non-ASCII characters
- [x] `python scripts/audit_drop_rates.py --category BOSSES` - Alchemical Hydra in verified list; 0 errors in scope
- [ ] CI build gate