### PR TITLE
fix(data): Phantom Muspah - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -1602,21 +1602,7 @@
         "worldY": 3940,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
-        "completionDistance": 20,
-        "conditionalAlternatives": [
-          {
-            "requirements": {
-              "inventoryItemIdsAny": [
-                29271,
-                29273,
-                29275,
-                33120
-              ]
-            },
-            "description": "Right-click your Quetzal whistle (basic / enhanced / perfected / perfected-infinite) in the inventory and pick the Phantom Muspah destination to land directly at the Ancient Prison entrance, skipping the Weiss -> Ghorrock overland route",
-            "travelTip": "Inventory Quetzal whistle -> Phantom Muspah"
-          }
-        ]
+        "completionDistance": 20
       },
       {
         "description": "Run south through Ghorrock Dungeon and step onto the Ancient Prison entrance tile",
@@ -1627,7 +1613,7 @@
         "completionDistance": 12
       },
       {
-        "description": "Kill the Phantom Muspah. Ranged form (sitting) -> Protect from Missiles by default and swap to Protect from Magic the instant it stands up and charges the purple prayer-drain orb. Shielded/Melee form -> Protect from Magic. Dodge the cyan teleport heal-orbs (do NOT stand on the spike tile during a transformation), and Bow of faerdhinen / Tbow are the modern meta",
+        "description": "Kill the Phantom Muspah. Ranged form (sitting) -> Protect from Missiles by default and swap to Protect from Magic the instant it stands up and charges the purple prayer-drain orb. Shielded/Melee form -> Protect from Melee. Dodge spikes during form changes (do NOT stand on the spike tile during a transformation, as they heal Muspah on hit), and Bow of faerdhinen / Tbow are the modern meta",
         "worldX": 2846,
         "worldY": 3940,
         "worldPlane": 0,

--- a/src/test/java/com/collectionloghelper/data/CExtensionInventoryTeleportRegressionTest.java
+++ b/src/test/java/com/collectionloghelper/data/CExtensionInventoryTeleportRegressionTest.java
@@ -56,9 +56,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *   <li>Zulrah: existing POH (FAIRY_RING) alternative at [0], new
  *       inventory alternative at [1] listing
  *       {@code TELEPORTSCROLL_ZULANDRA} (12938).</li>
- *   <li>Phantom Muspah: no prior alternatives, new inventory-any
- *       alternative at [0] listing the 4 {@code HG_QUETZALWHISTLE_*}
- *       ItemID variants (29271, 29273, 29275, 33120).</li>
  *   <li>Corrupted Gauntlet / The Gauntlet: existing diary
  *       (WESTERN_ELITE) alternative at [0], new inventory-any
  *       alternative at [1] listing {@code GAUNTLET_TELEPORT_CRYSTAL}
@@ -66,18 +63,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * </ul>
  *
  * <p>Mirrors {@code C6B3OverlapRegressionTest} (stacked-alternative shape)
- * for ToA/Zulrah/Gauntlets, and the unstacked first-alternative shape used
- * by {@code C6B2RegressionTest} for the Muspah insertion.
+ * for ToA/Zulrah/Gauntlets.
+ *
+ * <p>The original wave-8a Phantom Muspah entry (Quetzal-whistle inventory
+ * alternative) was removed from the corpus: the Quetzal Transport System
+ * serves Varlamore landing sites only and has no Muspah destination.
  */
 public class CExtensionInventoryTeleportRegressionTest
 {
 	/** Pharaoh's sceptre variants: uncharged tiers 1-3, charged, charged_initial (jeweled). */
 	private static final List<Integer> PHARAOHS_SCEPTRE_VARIANTS = List.of(
 		26945, 26946, 26947, 26948, 26949, 26950, 26951);
-
-	/** Quetzal whistle variants: basic, enhanced, perfected, perfected-infinite. */
-	private static final List<Integer> QUETZAL_WHISTLE_VARIANTS = List.of(
-		29271, 29273, 29275, 33120);
 
 	/** Teleport crystal variants for Prifddinas: regular + Hard-Mode-charged. */
 	private static final List<Integer> GAUNTLET_TELEPORT_CRYSTAL_VARIANTS = List.of(
@@ -104,8 +100,6 @@ public class CExtensionInventoryTeleportRegressionTest
 			new InventorySpec(1, true, PHARAOHS_SCEPTRE_VARIANTS, 2));
 		map.put("Zulrah",
 			new InventorySpec(1, false, ZULANDRA_SCROLL, 2));
-		map.put("Phantom Muspah",
-			new InventorySpec(0, true, QUETZAL_WHISTLE_VARIANTS, 1));
 		map.put("Corrupted Gauntlet",
 			new InventorySpec(1, true, GAUNTLET_TELEPORT_CRYSTAL_VARIANTS, 2));
 		map.put("The Gauntlet",
@@ -128,7 +122,6 @@ public class CExtensionInventoryTeleportRegressionTest
 		map.put("Tombs of Amascut (300 Invocation)", "Pharaoh's sceptre to teleport to the Necropolis");
 		map.put("Tombs of Amascut (500 Invocation)", "Pharaoh's sceptre to teleport to the Necropolis");
 		map.put("Zulrah", "using a Zul-andra teleport scroll");
-		map.put("Phantom Muspah", "icy basalt to teleport to Weiss");
 		map.put("Corrupted Gauntlet", "Teleport to Prifddinas via teleport crystal");
 		map.put("The Gauntlet", "Teleport to Prifddinas via teleport crystal");
 		return map;
@@ -267,11 +260,14 @@ public class CExtensionInventoryTeleportRegressionTest
 	}
 
 	@Test
-	public void allFiveSourceFamiliesArePresentInDatabase()
+	public void allRemainingSourceFamiliesArePresentInDatabase()
 	{
-		// Cardinality lock: 7 JSON entries across the 5 deferred-source families.
-		assertEquals(7, SPECS.size(),
-			"C-extension wave-8a covers exactly 7 source entries (ToA x 3 + Zulrah + Muspah + Gauntlet x 2)");
+		// Cardinality lock: 6 JSON entries across the 4 remaining source families.
+		// The Phantom Muspah Quetzal-whistle alternative was removed: the Quetzal
+		// Transport System serves Varlamore landing sites only and has no Muspah
+		// destination, so the alternative it asserted was fabricated.
+		assertEquals(6, SPECS.size(),
+			"C-extension wave-8a covers exactly 6 source entries (ToA x 3 + Zulrah + Gauntlet x 2)");
 		for (String name : SPECS.keySet())
 		{
 			assertNotNull(findSource(name),


### PR DESCRIPTION
## Summary

Corrects four confirmed wiki-meta findings for the Phantom Muspah source (audit tranche 1). Full receipts in docs/verify/findings-wiki-meta-2026-06.md (PR #829).

## Applied findings

**[high] C5:** Removed fabricated `conditionalAlternative` claiming a quetzal whistle can reach Phantom Muspah. The Quetzal Transport System is exclusive to the Varlamore region (14 landing sites: Aldarin, Auburnvale, Civitas illa Fortis, Hunter Guild, Quetzacalli Gorge, Sunset Coast, Tal Teklan, The Teomat, Cam Torum entrance, Colossal Wyrm Remains, Fortis Colosseum, Kastori, Outer Fortis, Salvager Overlook). No Ancient Prison or Ghorrock landing site exists.

**[high] C6:** Same fabricated block as C5 - the claim that the whistle "skips the Weiss -> Ghorrock overland route by landing directly at the Ancient Prison entrance" is impossible given the landing site list. Removed together with C5.

**[blocker] C10:** Corrected Shielded/Melee form prayer from `Protect from Magic` to `Protect from Melee`. Wiki receipt: "Muspah will chase and attack player same tick, for 0 damage if protect from melee is active" (https://oldschool.runescape.wiki/w/Phantom_Muspah/Strategies). The prior instruction was gameplay-harmful - players using Protect from Magic during the melee form would take full melee damage.

**[medium] C11:** Replaced fabricated "cyan teleport heal-orbs" label with accurate "spikes". Wiki receipt: "When changing forms it spawns a few spikes around the arena including one under the player, which should be dodged or else it will knock the player aside and heal the Muspah based on damage dealt" (https://oldschool.runescape.wiki/w/Phantom_Muspah). No cyan orb entity exists on the Phantom Muspah page or strategies page.

## Skipped findings

None - all four confirmed findings have been applied.

## Validation

- JSON parses cleanly
- 0 non-ASCII characters
- `python scripts/audit_drop_rates.py --category BOSSES` reports 0 errors