### PR TITLE
fix(data): Phosani's Nightmare - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -3524,7 +3524,7 @@
         "completionCondition": "MANUAL"
       },
       {
-        "description": "Fight Phosani's Nightmare solo. Same prayer rotation as The Nightmare but tighter and faster: overhead-staff -> Protect from Magic, claws -> Protect from Melee, crossbow stance -> Protect from Missiles. Sleepwalker minions chase you and must be killed (Sanguinesti heals while burning them down), parasites still drain sanity, and the husk attack will mirror your gear so bring max gear you can lose. Hard to solo without high stats and prayer flicking",
+        "description": "Fight Phosani's Nightmare solo. Same prayer rotation as The Nightmare but tighter and faster: overhead-staff -> Protect from Magic, claws -> Protect from Melee, crossbow stance -> Protect from Missiles. Sleepwalkers spawn at phase end and walk toward Phosani -- kill them before they reach her or each one that does triggers an increasingly lethal blast. Parasites attach to you and burst after ~18 ticks dealing massive damage, then heal Phosani until killed -- drink Sanfew serum or Relicym's balm before the burst to reduce damage. Husks have fixed attack styles: blue (magic) and green (ranged) -- kill the ranged husk first in phases 1-2. Hard to solo without high stats and prayer flicking.",
         "worldX": 3806,
         "worldY": 9757,
         "worldPlane": 1,


### PR DESCRIPTION
## Summary

Three guidance step description errors corrected in the Phosani's Nightmare fight step, all established by wiki receipts from the audit (tranche 1). Full receipts: docs/verify/findings-wiki-meta-2026-06.md (PR #829).

## Applied findings

- [blocker] C8: Sleepwalkers walk toward Phosani's Nightmare (not the player). Kill them before they reach her -- each one that does increases the power blast. Receipt: "sleepwalkers that walk toward her ... The number of sleepwalkers that reach her will determine how strong her power blast will be."
- [blocker] C10: Parasites do not drain sanity (no sanity mechanic in OSRS). They attach to the player, burst after ~18 ticks dealing massive damage, then heal Phosani until killed. Sanfew serum / Relicym's balm taken before the burst reduces damage. Receipt: "it will grow and burst out of the player, dealing massive damage, and will then begin healing Phosani's Nightmare until killed."
- [blocker] C11: Husks do not mirror the player's gear. They have fixed attack styles: blue/skinny husk = magic, green/bulky husk = ranged. Kill the ranged husk first in phases 1-2. Receipt: "The blue, skinny husk uses magic attacks, while the green, bulky husk uses ranged attacks. To fully avoid damage from husks, kill the ranged husk first during phases 1 and 2."

## Skipped findings

- C13 [high]: Waypoint "Drakan's medallion to Slepe" gates on SINS_OF_THE_FATHER quest but the Slepe teleport is unlocked via Slepey tablet (1/25 drop from Phosani's Nightmare), not that quest. Skipped: requirements-wiring follow-up (changes requirements.quests array, out of scope for description-text fixes).

## Validation

- JSON parses cleanly
- No non-ASCII characters
- audit_drop_rates.py --category BOSSES: 0 errors