### PR TITLE
fix(data): Grotesque Guardians - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -3141,7 +3141,7 @@
         "completionCondition": "MANUAL"
       },
       {
-        "description": "Kill the Grotesque Guardians on the Slayer Tower roof. Requires gargoyle Slayer task + brittle key + a rock hammer or thrownhammer to finish them off. Dusk (melee) and Dawn (ranged) fight together until one dies, then the survivor enrages - pray Melee against Dusk and Missiles against Dawn, swapping prayers when they switch attack styles. Dodge Dawn's lightning AoE (move 2 tiles when she raises her arms) and step out of Dusk's prison rocks. After the first Guardian dies, the survivor heals to full and gains a stomp special - move off the marked tile",
+        "description": "Kill the Grotesque Guardians on the Slayer Tower roof. Requires gargoyle Slayer task + brittle key + a rock hammer or thrownhammer to finish them off. Phase 1: fight Dawn solo (Dusk is fully immune); use ranged, magic, or a halberd as she is airborne. Phase 2: fight Dusk solo. Phase 3 (lightning charge): both are temporarily invulnerable; move off any vortex that spawns on your tile (one-second colour warning). Pray Melee against Dusk and Missiles against Dawn, swapping when they switch styles. Do not stand under Dusk; doing so triggers a trample dealing up to 40 damage. After Dawn dies, Dusk absorbs her essence and his stats are significantly boosted (Attack 300, Strength/Magic/Ranged 250, Defence 150) for the final phase.",
         "worldX": 3427,
         "worldY": 3543,
         "worldPlane": 2,


### PR DESCRIPTION
## Summary

Four guidance-text errors in the Grotesque Guardians combat description, confirmed against the wiki strategies page (https://oldschool.runescape.wiki/w/Grotesque_Guardians/Strategies). Full receipts in docs/verify/findings-wiki-meta-2026-06.md (PR #829).

## Changes applied

**[blocker] C6: Phase structure inverted**
Old text modelled Dusk and Dawn as simultaneously attackable from the start. Wiki: "Dusk is immune to all damage during this phase, so the player must fight Dawn first." Corrected to describe the correct phase sequence (P1 Dawn solo, P2 Dusk solo, P3 lightning charge, P4 Dusk final).

**[medium] C9: Fabricated full-HP heal on phase transition**
Old text said "the survivor heals to full". Wiki describes Dusk absorbing Dawn's essence and gaining a stat boost (Attack to 300, Strength/Magic/Ranged to 250, Defence to 150, +1 flat armour) with no HP reset. Replaced accordingly.

**[low] C14: Fabricated '2 tile' dodge distance and 'raises her arms' telegraph**
Wiki describes a one-second colour vortex warning with the mechanic being to move off any vortex that spawns on the player's tile. No '2 tile' figure or animation-based trigger exists on the wiki. Replaced with the accurate vortex mechanic.

**[medium] C16: Fabricated 'marked tile' indicator for trample**
Wiki describes a pure positional mechanic: "standing under Dusk during this phase can result in him trampling the player for up to 40 damage and should be avoided at all costs." No pre-marked tile indicator exists. Replaced with the accurate trample description.

## Test plan

- [ ] JSON parses cleanly (python -c "import json;json.load(...)")
- [ ] Zero non-ASCII characters confirmed
- [ ] audit_drop_rates.py --category BOSSES: 0 errors
- [ ] CI build passes