### PR TITLE
fix(data): Zulrah - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -800,8 +800,8 @@
                 "FAIRY_RING"
               ]
             },
-            "description": "Use the POH superior garden fairy ring (dramen/lunar staff equipped) to dial AKQ, then run east to Zul-Andra",
-            "travelTip": "POH superior garden fairy ring -> AKQ -> run east to Zul-Andra"
+            "description": "Use the POH superior garden fairy ring (dramen/lunar staff equipped) to dial BJS, then run east to Zul-Andra",
+            "travelTip": "POH superior garden fairy ring -> BJS -> run east to Zul-Andra"
           },
           {
             "requirements": {
@@ -827,7 +827,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Zulrah. Prayer rotates per form: green (Ranged form) -> Protect from Missiles, blue (Magic form) -> Protect from Magic, red (Melee form) -> Protect from Missiles, jad phase -> swap each attack. Bring a blowpipe + magic setup, swap gear on the rotation, and avoid the toxic clouds the snakelings spit",
+        "description": "Kill Zulrah. Prayer rotates per form: green (Ranged form) -> Protect from Missiles, blue (Magic form) -> Protect from Magic, red (Melee form) -> Protect from Melee, jad phase -> swap each attack. Bring a blowpipe + magic setup, swap gear on the rotation, and avoid the toxic clouds Zulrah summons",
         "worldX": 2268,
         "worldY": 3069,
         "worldPlane": 0,


### PR DESCRIPTION
## Zulrah guidance corrections (audit tranche 1)

Four guidance-text bugs fixed in the Zulrah source. Full receipts in docs/verify/findings-wiki-meta-2026-06.md (PR #829).

### Applied findings

**[blocker] C5:** POH fairy ring `conditionalAlternatives[0]` description -- changed fairy ring code `AKQ` to `BJS`. Wiki confirms AKQ leads to the Piscatoris Hunter area (Kandarin), not Zul-Andra. BJS lands on the island west of Zul-Andra and is already required by Regicide (which this source gates on).

**[blocker] C7:** POH fairy ring `conditionalAlternatives[0]` travelTip -- same AKQ -> BJS fix as C5 for the companion `travelTip` field on the same alternative. C5 and C7 are the two halves of one defect.

> Wiki receipt: "Code: AKQ | Map: Kandarin | Location: Piscatoris Hunter area"

**[blocker] C12:** `guidanceSteps[2].description` -- changed prayer for the red/Melee form from `Protect from Missiles` to `Protect from Melee`. Wiki: "Zulrah's crimson form, in which it will attack with Melee. Players should use Protect from Melee or position themselves at the safespots shown in the images."

**[medium] C16:** `guidanceSteps[2].description` -- changed `toxic clouds the snakelings spit` to `toxic clouds Zulrah summons`. Wiki: "It can also summon snakelings, smaller versions of itself, on the platform to attack the player, along with toxic clouds that deal rapid damage if they stand in one." Snakelings and toxic clouds are separate things Zulrah summons independently; snakelings do not produce the clouds.

### Skipped findings

None -- all four confirmed findings were guidance-text corrections within scope.