### PR TITLE
fix(data): Dagannoth Rex - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -4231,20 +4231,20 @@
         "conditionalAlternatives": [
           {
             "requirements": { "diaries": ["FREMENNIK_HARD"] },
-            "description": "Rub the enchanted lyre to teleport directly to Rellekka, then take Jarvald's boat to Waterbirth Island for free. Hard Fremennik Diary removes the 1,000 gp boat fee.",
-            "travelTip": "Enchanted lyre -> Rellekka -> free Jarvald boat (Hard Fremennik Diary)"
+            "description": "Rub the enchanted lyre (Hard Fremennik Diary unlocks Waterbirth Island as a direct destination) to teleport straight to Waterbirth Island, skipping the Rellekka boat entirely.",
+            "travelTip": "Enchanted lyre -> Waterbirth Island direct (Hard Fremennik Diary)"
           }
         ]
       },
       {
-        "description": "Climb down the Waterbirth Island Dungeon ladder and navigate to floor 6 - the Kings' lair. Bring a rune thrownaxe (or Mind Altar shortcut at 70 Agility) to pull only Rex",
+        "description": "Climb down the Waterbirth Island Dungeon ladder and navigate to floor 6 - the Kings' lair. Use a rune thrownaxe special attack on the middle (western) door to bounce through and destroy all three locked doors blocking the lair entrance. Alternatively, bypass the doors via the 85 Agility shortcut at the highest point of Waterbirth Island, or use the 81 Agility shortcut to room 14",
         "worldX": 2528,
         "worldY": 3739,
         "worldPlane": 0,
         "completionCondition": "MANUAL"
       },
       {
-        "description": "Kill Dagannoth Rex. Rex attacks only with Melee - keep Protect from Melee on at all times when in melee range. Rex is weak to Magic and crush; fire spells (Fire Surge / Tumeken's Shadow) or a crush weapon work best. Lure him to the edge of the islet so Prime and Supreme cannot reach you - Rex has no ranged attack so safespotting from outside his melee range trivialises the fight. Bring antidote++ for Spinolyps in the moat",
+        "description": "Kill Dagannoth Rex. Rex attacks only with Melee - keep Protect from Melee on at all times when in melee range. Rex is weak to Magic only (+255 defence vs all melee styles); use earth spells (35% elemental weakness) or a powered staff such as Tumeken's Shadow. Slayer Dart and Iban Blast are also effective. Lure him to the edge of the islet so Prime and Supreme cannot reach you - Rex has no ranged attack so safespotting from outside his melee range trivialises the fight. Bring antidote++ for Spinolyps in the moat",
         "worldX": 2521,
         "worldY": 3740,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Fixes six confirmed wiki-meta guidance errors in the Dagannoth Rex source. Full receipts in docs/verify/findings-wiki-meta-2026-06.md (PR #829).

## Applied findings

**[blocker] C14:** Removed false crush weakness. Rex has +255 defence vs stab/slash/crush; crush weapons deal near-zero damage. Wiki: "Melee Defence: +255 against stab, slash, and crush attacks."

**[blocker] C16:** Removed crush weapon recommendation (same root error as C14). Wiki confirms crush is maximally ineffective.

**[high] C15:** Replaced Fire Surge with earth spells. Rex has a 35% elemental weakness to earth spells. Wiki: "Popular choices include Slayer Dart, Iban Blast, powered staves, and Earth spells." Fire Surge (fire school) does not benefit from the earth weakness.

**[high] C9:** Corrected rune thrownaxe step. The thrownaxe special attack on the middle door bounces through and destroys all three locked doors -- it is a one-time entry mechanic, not a Rex-specific pull technique. Wiki: "use a Rune thrownaxe's special attack on the western (middle) door. This will cause the thrownaxe to bounce between and destroy all three doors."

**[high] C10:** Removed fabricated Mind Altar shortcut at 70 Agility. No Mind Altar exists in Waterbirth Island Dungeon. Actual shortcuts: 85 Agility (surface bypass at highest point of island), 81 Agility (Giant Rock Crab room shortcut to room 14). Wiki confirms 70 Agility and Mind Altar do not appear on the dungeon page.

**[medium] C4:** Corrected Hard Fremennik Diary conditionalAlternative. The diary reward is an additional Waterbirth Island destination on the enchanted lyre (direct teleport, bypassing the Rellekka boat entirely). It does not remove the Jarvald boat fee. Wiki: "Enchanted lyre -- With Hard Fremennik Diary Completed: Waterbirth Island (gains this as an additional option)."

## Skipped findings

None -- all six confirmed findings are description-text corrections within scope.

## Test plan

- [x] JSON parses cleanly (`python -c "import json;json.load(open(...))"`)
- [x] No non-ASCII characters
- [x] `python scripts/audit_drop_rates.py --category BOSSES` reports 0 errors
- [ ] CI build gate