### PR TITLE
fix(data): Obor - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -4076,7 +4076,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Bank in Edgeville. Required: Giant key (farmed from hill giants in Edgeville Dungeon or Varrock Sewers - ~1/64 drop rate). Bring melee gear, super combat, food, prayer potions, and an Amulet of glory for the return teleport. The fight is short but Obor hits ~25 with melee, so brews are wasteful here - sharks are sufficient",
+        "description": "Bank in Edgeville. Required: Giant key (farmed from hill giants in Edgeville Dungeon at ~1/128; rate is 1/64 only inside Wilderness). Bring melee gear, super combat, food, prayer potions, and an Amulet of glory for the return teleport. The fight is short but Obor hits up to 22 with melee, so brews are wasteful here - sharks are sufficient",
         "worldX": 3093,
         "worldY": 3493,
         "worldPlane": 0,
@@ -4111,14 +4111,14 @@
                 19707
               ]
             },
-            "description": "Rub an Amulet of glory from your inventory and select Edgeville to land at the Edgeville bank, then run east to the dungeon trapdoor north of the bank.",
+            "description": "Rub an Amulet of glory from your inventory and select Edgeville to land at the Edgeville bank, then run east to the dungeon trapdoor south of the bank.",
             "travelTip": "Amulet of glory (inventory) -> Edgeville bank"
           }
         ],
         "section": "Bank"
       },
       {
-        "description": "Travel to the Edgeville Dungeon and descend to the hill giant area. Amulet of glory -> Edgeville then run east into the trapdoor north of the bank. The dungeon entrance puts you 8 tiles from Obor's gate",
+        "description": "Travel to the Edgeville Dungeon and descend to the hill giant area. Amulet of glory -> Edgeville then run east into the trapdoor south of the bank (ruined house). The dungeon entrance puts you 8 tiles from Obor's gate",
         "worldX": 3097,
         "worldY": 3468,
         "worldPlane": 0,
@@ -4128,7 +4128,7 @@
         "section": "Travel"
       },
       {
-        "description": "Use the Giant key on the gate to enter Obor's lair. The key is consumed - each kill needs a fresh key, so per-trip farm rate is gated by hill giant key drops",
+        "description": "Use the Giant key on the gate to enter Obor's lair. The key is NOT consumed to open the gate. A key is consumed when you open the loot chest inside - one key per chest open, so per-trip farm rate is gated by hill giant key drops",
         "worldX": 3097,
         "worldY": 3468,
         "worldPlane": 0,
@@ -4141,7 +4141,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Obor. Use Protect from Melee and attack with the strongest melee weapon available - Obor has weak defence but a 25-damage smash auto. Stand under him to bait the melee animation; he occasionally throws a small boulder for ~8 ranged damage that ignores Protect from Melee. Sip prayer potion every ~3 kills to keep Protect from Melee active",
+        "description": "Kill Obor. Use Protect from Missiles and attack with the strongest melee weapon available - Obor has weak defence. His melee max hit is 22; his ranged slam (boulder) max hit is 26 (13 with Protect from Missiles active). Stand with your back against a wall to limit knockback displacement from his slam attack. Sip prayer potion as needed to keep Protect from Missiles active",
         "worldX": 3097,
         "worldY": 3468,
         "worldPlane": 0,
@@ -4159,7 +4159,7 @@
         ]
       },
       {
-        "description": "Teleport out via Amulet of glory after Obor dies. Restock a fresh Giant key + supplies before the next kill - the farm is bottlenecked by key drops, not by trip duration",
+        "description": "Teleport out via Amulet of glory after Obor dies. Restock a Giant key + supplies before the next kill - one key is consumed when opening the loot chest, so the farm is bottlenecked by key drops, not by trip duration",
         "worldX": 3093,
         "worldY": 3493,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Corrects eight guidance-text errors in the Obor source identified in the wiki-meta audit (tranche 1). Full receipts are in docs/verify/findings-wiki-meta-2026-06.md (PR #829).

## Applied findings

**[blocker] C7:** Combat prayer corrected from Protect from Melee to Protect from Missiles. Wiki: "always turn on Protect from Missiles before climbing down and starting the fight" / "Obor's ranged attack deals 50% less damage when Protect from Missiles is used."

**[blocker] C10:** Ranged slam max hit corrected from ~8 to 26 (13 with Protect from Missiles). "ignores Protect from Melee" framing removed; correct prayer (Missiles) and actual mitigation noted.

**[high] C1:** Gate key consumption inverted. The Giant key is NOT consumed to open the gate; it is consumed when opening the loot chest inside. Wiki: "The key will not be consumed when unlocking Obor's lair. ... the chest present in his lair can be opened for loot by consuming the giant key."

**[high] C3:** Varrock Sewers removed as a hill giant key farming location. Hill giants do not spawn in the Varrock Sewers (those are Moss Giants / Mossy key). Edgeville Dungeon retained as the correct F2P location.

**[medium] C2:** Giant key drop rate corrected from ~1/64 to ~1/128 for Edgeville Dungeon (outside Wilderness). Wiki: rate is doubled to 1/64 only inside the Wilderness.

**[medium] C5:** Edgeville Dungeon trapdoor direction corrected from north of bank to south of bank in two steps plus one conditional alternative. Wiki: "One is found in Edgeville, in the ruined house south of the bank."

**[medium] C8:** Obor melee max hit corrected from ~25 to 22. Wiki: "Max hit: 22 (Melee) 26 (Ranged)".

**[medium] C11:** "Stand under him to bait the melee animation" replaced with accurate knockback mechanic: stand with back against wall to limit knockback displacement. Wiki: "Obor's slam attack can knock you back ... Stand with your back against a wall to avoid knock-backs."

## Skipped findings

None - all confirmed findings were description-text corrections within scope.

## Test plan

- [ ] JSON parses cleanly (python json.load)
- [ ] Zero non-ASCII characters in file
- [ ] python scripts/audit_drop_rates.py --category BOSSES reports 0 errors
- [ ] CI build passes