### PR TITLE
fix(data): The Nightmare - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -3306,7 +3306,7 @@
         ]
       },
       {
-        "description": "Climb down the stairs in Slepe church to enter the Sisterhood Sanctuary",
+        "description": "Climb down the stairs in the small building south of the graveyard in Slepe to enter the Sisterhood Sanctuary",
         "worldX": 3728,
         "worldY": 3302,
         "worldPlane": 0,
@@ -3315,7 +3315,7 @@
         "completionCondition": "PLAYER_ON_PLANE"
       },
       {
-        "description": "Run south to The Nightmare's arena in the Sisterhood Sanctuary",
+        "description": "Run north to The Nightmare's arena in the Sisterhood Sanctuary",
         "worldX": 3806,
         "worldY": 9757,
         "worldPlane": 1,
@@ -3323,7 +3323,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Disturb The Nightmare to start the fight. Prayer rotates per attack animation: overhead-staff wind-up -> Protect from Magic, claws sweep -> Protect from Melee, crossbow-style stance -> Protect from Missiles. Bring a Sanguinesti staff plus a crush weapon (Inquisitor's mace / Soulreaper axe), kill the parasites quickly to avoid sanity drops and Hitpoints damage, and break the healing totems each phase. One unprotected mistake in a group will wipe the team",
+        "description": "Disturb The Nightmare to start the fight. Prayer rotates per attack animation: overhead-staff wind-up -> Protect from Magic, claws sweep -> Protect from Melee, crossbow-style stance -> Protect from Missiles. Bring a Sanguinesti staff plus a crush weapon (Inquisitor's mace / Soulreaper axe), kill parasites before they burst out (uncontrolled parasites deal massive HP damage then heal the Nightmare), and charge the four corner totems each phase (fully charged totems deal 800 damage to the Nightmare). One unprotected mistake in a group will wipe the team",
         "worldX": 3806,
         "worldY": 9757,
         "worldPlane": 1,


### PR DESCRIPTION
## Changes

Corrects four guidance-text errors in The Nightmare source identified by the wiki-meta audit (tranche 1). Full receipts in docs/verify/findings-wiki-meta-2026-06.md (PR #829).

### Applied findings

- **[medium] C5**: entrance building corrected from "Slepe church" to "the small building south of the graveyard in Slepe". Wiki: *"the player can go down the stairs in the small building directly south of the graveyard"* (https://oldschool.runescape.wiki/w/The_Nightmare)
- **[blocker] C6**: direction corrected from "south" to "north" within the Sisterhood Sanctuary. Wiki: *"Farther north, players will find Shura and The Nightmare, where players can fight her."* (https://oldschool.runescape.wiki/w/Sisterhood_Sanctuary)
- **[blocker] C12**: removed fabricated "sanity drops" consequence; corrected to HP damage + Nightmare healing. Wiki: *"it will grow and burst out of the player, dealing massive damage, and will then begin healing the Nightmare until killed"* (https://oldschool.runescape.wiki/w/The_Nightmare/Strategies)
- **[blocker] C14**: corrected player action from "break the healing totems" to "charge the four corner totems each phase (fully charged totems deal 800 damage to the Nightmare)". Wiki: *"charge the four totems in the corners of the arena, unleashing a magical blast that deals massive damage to her"* (https://oldschool.runescape.wiki/w/The_Nightmare)

### Skipped findings

- **[high] C4**: Drakan's medallion Slepe teleport gated by wrong quest (SINS_OF_THE_FATHER vs Slepey tablet 1/25 drop from Phosani's Nightmare). Skipped: requirements-wiring follow-up -- the `waypoints[].requirements.quests` field is wiring, not description text, and is out of scope for this text-only pass.

## Validation

- JSON parse: pass
- Non-ASCII check: 0 characters
- `python scripts/audit_drop_rates.py --category BOSSES`: 0 errors