### PR TITLE
fix(data): Dagannoth Supreme - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -4385,7 +4385,7 @@
       }
     ],
     "locationDescription": "Waterbirth Island, Rellekka",
-    "travelTip": "Lunar Isle tele -> Rellekka",
+    "travelTip": "Waterbirth Teleport (Lunar spellbook) -> Waterbirth Island",
     "mutuallyExclusiveSources": [
       "Dagannoth Rex",
       "Dagannoth Prime"
@@ -4394,7 +4394,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to Waterbirth Island via Rellekka docks (1,000 gp without The Fremennik Trials) or Lunar Isle teleport",
+        "description": "Travel to Waterbirth Island via Rellekka docks (1,000 gp without The Fremennik Trials) or Waterbirth Teleport (Lunar spellbook)",
         "worldX": 2521,
         "worldY": 3740,
         "worldPlane": 0,
@@ -4403,8 +4403,8 @@
         "conditionalAlternatives": [
           {
             "requirements": { "diaries": ["FREMENNIK_HARD"] },
-            "description": "Rub the enchanted lyre to teleport directly to Rellekka, then take Jarvald's boat to Waterbirth Island for free. Hard Fremennik Diary removes the 1,000 gp boat fee.",
-            "travelTip": "Enchanted lyre -> Rellekka -> free Jarvald boat (Hard Fremennik Diary)"
+            "description": "Rub the enchanted lyre to teleport directly to Waterbirth Island. Hard Fremennik Diary adds Waterbirth Island as a lyre teleport destination, skipping the boat entirely.",
+            "travelTip": "Enchanted lyre -> Waterbirth Island (Hard Fremennik Diary)"
           }
         ]
       },
@@ -4416,7 +4416,7 @@
         "completionCondition": "MANUAL"
       },
       {
-        "description": "Kill Dagannoth Supreme. Supreme attacks ONLY with Ranged - keep Protect from Missiles on at all times. Supreme is weak to stab/slash and Melee is the strongest style here; Dragon scimitar, abyssal whip, or osmumten's fang with Bandos armour clears him fastest. His ranged attack hits everyone facing him, so position yourself so other players don't catch the splash. Spinolyps in the moat poison; bring antidote++",
+        "description": "Kill Dagannoth Supreme. Supreme attacks ONLY with Ranged - keep Protect from Missiles on at all times. Supreme is weak to Melee (stab, slash, and crush equally); Dragon scimitar, abyssal whip, or osmumten's fang with Bandos armour clears him fastest. His ranged attack hits everyone facing him, so position yourself so other players don't catch the splash. Spinolyps in the moat poison; bring antidote++",
         "worldX": 2521,
         "worldY": 3740,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Corrects four guidance-text errors in the Dagannoth Supreme source. All findings confirmed against wiki receipts. Full receipts in docs/verify/findings-wiki-meta-2026-06.md (PR #829).

## Applied findings

**[medium] C2** - step[0] desc + travelTip: replaced 'Lunar Isle teleport' with 'Waterbirth Teleport (Lunar spellbook)'. The Lunar spellbook spell is Waterbirth Teleport, which teleports to Waterbirth Island directly; Lunar Isle Teleport (Moonclan Teleport) is a different spell with a different destination. Wiki receipt: "There are several methods to quickly getting to Waterbirth Island, with the Waterbirth Teleport from the Lunar spellbook ... being the fastest ways." (oldschool.runescape.wiki/w/Dagannoth_Kings)

**[high] C3** - conditionalAlternative (Hard Fremennik Diary) desc + travelTip: rewritten from 'teleport to Rellekka, then take Jarvald's boat ... for free' to 'teleport directly to Waterbirth Island'. The old text described the pre-diary route and assigned it to the diary path. Wiki receipt: "When the hard Fremennik Diary is completed, the enchanted lyre can also teleport to Waterbirth Island." (oldschool.runescape.wiki/w/Enchanted_lyre)

**[high] C5** - conditionalAlternative desc: removed false claim 'Hard Fremennik Diary removes the 1,000 gp boat fee'. The 1,000 gp fee is removed by completing The Fremennik Trials quest (already correctly noted in the base step text). The diary reward is a new lyre teleport destination, not a fee waiver. Same wiki receipt as C3 above.

**[low] C10** - step[2] desc: replaced 'weak to stab/slash' with 'weak to Melee (stab, slash, and crush equally)'. Wiki confirms Supreme's melee defence is +10 for all three styles with no differential; the general weakness is melee, not a specific style. Wiki receipt: "Dagannoth Supreme is most weak to melee attacks" with equal +10 defence for stab, slash, and crush. (oldschool.runescape.wiki/w/Dagannoth_Supreme)

## Skipped findings

None - all four confirmed findings were guidance-text corrections within scope.

## Test plan

- [ ] JSON parses cleanly (python json.load)
- [ ] No non-ASCII characters introduced
- [ ] python scripts/audit_drop_rates.py --category BOSSES reports 0 errors
- [ ] CI build passes