### PR TITLE
fix(data): Nex - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -3639,7 +3639,7 @@
     ],
     "guidanceSteps": [
       {
-        "description": "Bank for Nex. Bring Saradomin brews, super restores, prayer potions, sharks, super combat potions, and a Frozen key (or its four pieces). Standard meta is Scythe of Vitur or Soulreaper axe for melee + Twisted bow / Tbow for range; bring a Zaryte crossbow with diamond bolts (e) for solo specs. Salve amulet (ei) is BIS for the helm slot.",
+        "description": "Bank for Nex. Bring Saradomin brews, super restores, prayer potions, sharks, super combat potions, and a Frozen key (or its four pieces). Standard meta is Scythe of Vitur or Soulreaper axe for melee + Twisted bow / Tbow for range; bring a Zaryte crossbow with diamond bolts (e) for solo specs. Recommended amulet slot: Amulet of blood fury or Necklace of anguish (Salve amulet (ei) gives no bonus at Nex as she is not undead).",
         "worldX": 3087,
         "worldY": 3493,
         "worldPlane": 0,
@@ -3688,7 +3688,7 @@
         "section": "Combat"
       },
       {
-        "description": "Kill Nex in the Ancient Prison. Four-phase fight: Smoke (Protect from Magic, dodge smoke clouds), Shadow (Protect from Magic, run from the shadow target marker), Blood (Protect from Melee, stop attacking during the siphon or she heals), Ice (Protect from Magic, free frozen teammates with melee). Pop the icicle wall on Ice phase fast; she enrages below 25%. Team-scale recommended (4-7 players); solo is possible but slow with Tumeken's shadow.",
+        "description": "Kill Nex in the Ancient Prison. Five-phase fight: Smoke (Protect from Melee, stand in melee distance, dodge smoke clouds), Shadow (Protect from Missiles, stand far away to reduce shadow shot damage), Blood (Protect from Magic, stop attacking during the siphon or she heals), Ice (Protect from Magic, free frozen teammates with melee), Zaros (Protect from Melee, she heals 500 HP and gains Soul Split). Pop the icicle wall on Ice phase fast; Zaros phase begins at 20% HP. Team-scale recommended (4-7 players); solo is possible but slow with Tumeken's shadow.",
         "worldX": 2905,
         "worldY": 5190,
         "worldPlane": 0,
@@ -3707,7 +3707,7 @@
         ]
       },
       {
-        "description": "Loot the drop pile under Nex; uniques split based on damage contribution. Pick up Nihil shards for extending Ancient ceremonial robes too",
+        "description": "Loot the drop pile under Nex; uniques split based on damage contribution. Pick up Nihil shards (used to brew ancient brews via herblore, and to craft a Zaryte crossbow with a Nihil horn and Armadyl crossbow).",
         "worldX": 2905,
         "worldY": 5190,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Corrects seven guidance-text errors in the Nex source, all confirmed against the OSRS wiki Strategies and item pages. Full receipts in docs/verify/findings-wiki-meta-2026-06.md (PR #829).

## Applied findings

**[blocker] C13:** Smoke phase prayer changed from `Protect from Magic` to `Protect from Melee`. Wiki: players stand in melee distance so Nex uses her single-target melee attack rather than multi-target magic; Protect from Melee is the baseline prayer for this phase.

**[blocker] C15:** Shadow phase prayer changed from `Protect from Magic` to `Protect from Missiles`. Wiki: "Having Protect from Missiles active will cut the damage taken in half." Nex's shadow attacks are ranged, not magic.

**[blocker] C17:** Blood phase prayer changed from `Protect from Melee` to `Protect from Magic`. Wiki: "Protect from Magic is recommended since Nex uses Blood Barrage, a magic-based attack that heals her based on damage dealt."

**[high] C23:** Fight description updated from "Four-phase" to "Five-phase" with the Zaros phase added. Wiki: "The fight contains five total phases" - four elemental phases plus the Zaros/empowered phase at 20% HP.

**[medium] C22:** Zaros phase threshold corrected from 25% to 20% HP. Wiki: "Nex enters the Zaros phase when her health reaches 20% (680 hitpoints)."

**[high] C27:** Nihil shard description corrected. "extending Ancient ceremonial robes" is fabricated - the wiki lists only two uses: grinding into nihil dust for ancient brews (85 Herblore), and 250 shards to craft a Zaryte crossbow. Description updated accordingly.

**[high] C6:** Bank step corrected Salve amulet (ei) from "BIS for the helm slot" to noting it occupies the amulet slot and gives no bonus at Nex (she is not undead). Recommended amulet slot items from the wiki Strategies page (Amulet of blood fury, Necklace of anguish) are called out instead.

## Skipped findings

None - all confirmed findings were guidance text corrections within scope.

## Test plan

- [x] JSON parses cleanly
- [x] No non-ASCII characters
- [x] `python scripts/audit_drop_rates.py --category BOSSES` reports 0 errors
- [ ] CI build gate