### PR TITLE
fix(data): Vardorvis (Awakened) - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -2943,7 +2943,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Bank at Ferox Enclave for Vardorvis (Awakened). The Awakened axe pattern is roughly 1 axe denser per phase and adds a heal-spawn enrage at low HP. Bring a full inventory of Saradomin brews and super restores, prayer potions, super combat potion, an Awakener's orb (one per kill), and a Ring of Shadows. Slash mainhand: Scythe of Vitur (BiS) or Soulreaper axe; Blade of Saeldor (c) is the trade-off pick. Voidwaker for spec on the Strangled spawn waves.",
+        "description": "Bank at Ferox Enclave for Vardorvis (Awakened). Awakened mode doubles HP to 1400, grants stat-drain immunity, adds 1 extra axe per phase, and increases axe/bleed/spore damage. Bring a full inventory of Saradomin brews and super restores, prayer potions, super combat potion, an Awakener's orb (one per kill), and a Ring of Shadows. Slash mainhand: Soulreaper axe (BiS; his 2x2 size inhibits Scythe of Vitur) or Blade of Saeldor (c). Voidwaker spec Vardorvis at kill-start when his defence is maximised.",
         "worldX": 3129,
         "worldY": 3636,
         "worldPlane": 0,
@@ -2995,7 +2995,7 @@
         "section": "Combat"
       },
       {
-        "description": "Kill Vardorvis (Awakened). Use Protect from Melee with slash weapons (Scythe of Vitur, Soulreaper axe, or Blade of Saeldor) - he resists stab and crush. Move in a controlled diagonal pattern to dodge the axes spawned from ground cracks; Awakened-mode adds 1 extra axe per phase and tightens the spawn cadence at high HP. Kill the Strangled spawns the moment they appear or they heal him for 15-25 per tick. On the sub-25% enrage, prayer-flick to skip the head-slam and Voidwaker spec the spawn waves to keep pressure.",
+        "description": "Kill Vardorvis (Awakened). Use Protect from Melee with slash weapons (Soulreaper axe or Blade of Saeldor) - he resists stab and crush and his 2x2 size inhibits the Scythe. Move in a controlled diagonal pattern to dodge the axes spawned from ground cracks; Awakened-mode adds 1 extra axe per phase. At sub-33% HP he enters enrage with faster axe cadence; block his Head Gaze projectile with Protect from Missiles to avoid prayer drain. Spec Vardorvis with Voidwaker at kill-start to exploit max defence.",
         "worldX": 1175,
         "worldY": 3424,
         "worldPlane": 0,


### PR DESCRIPTION
Fixes six wiki-meta findings for Vardorvis (Awakened) guidance steps. All receipts from docs/verify/findings-wiki-meta-2026-06.md (PR #829).

## Applied findings

**[blocker] C2:** Removed fabricated heal-spawn-enrage-at-low-HP mechanic. Replaced with accurate awakened-mode summary: doubled HP (700->1400), stat-drain immunity, +1 axe per phase, increased axe/bleed/spore damage.
- Wiki: "In Awakened mode, Vardorvis has the following changes: The boss' health increases from 700 to 1,400. The boss is immune to stat drains. An additional Swinging Axe appears for each set of axe thrown."

**[blocker] C3:** Corrected inverted BiS label. Soulreaper axe is BiS; Scythe of Vitur is inhibited by his 2x2 size.
- Wiki: "The soulreaper axe is the best weapon to use against Vardorvis, as his 2x2 size inhibits the scythe of vitur."

**[blocker] C17:** Removed fabricated Strangled-spawns-during-fight mechanic and the 15-25/tick heal claim. Strangled are travel obstacles in the Stranglewood only, per wiki.
- Wiki: "players will be running past several Strangled and a Strangled Boar while reaching the boss."

**[high] C18:** Corrected enrage threshold from 25% to 33% HP; renamed "head-slam" to "Head Gaze" (the wiki's attack name - a green cone projectile); corrected prayer interaction (block with Protect from Missiles, not prayer-flick to skip); removed spawn-waves reference.
- Wiki: "Upon reaching 33% of his health (~231 health), Vardorvis will enter an enrage phase"
- Wiki: "Head Gaze - Vardorvis' head gazes upon you; fires a green, cone-shaped projectile"

**[medium] C6:** Fixed Voidwaker use-case in bank step: spec Vardorvis at kill-start (max defence), not on fabricated Strangled spawn waves.
- Wiki: "Since Voidwaker ignores defence, it's best used at the start of kills when Vardorvis's defence is maximised."

**[medium] C19:** Same root as C6 (duplicate in combat step). Removed spawn-waves framing; wired into the kill-start fix.

## Skipped findings

None - all confirmed findings were guidance text corrections within scope.

## Validation

- JSON parses cleanly
- Zero non-ASCII characters
- `python scripts/audit_drop_rates.py --category BOSSES` reports 0 errors

Full receipts: docs/verify/findings-wiki-meta-2026-06.md (PR #829)