### PR TITLE
fix(data): Duke Sucellus - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -1739,7 +1739,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to Ghorrock Prison via the Weiss Salt Mine. Bring crush weapon (Bandos godsword or Inquisitor's mace), Saradomin brews, super restores, and a pickaxe for the salt vents.",
+        "description": "Travel to Ghorrock Prison via the Weiss Salt Mine. Bring a slash weapon (scythe of vitur, emberlight, or soulreaper axe), Saradomin brews, super restores, and a pickaxe for the salt vents.",
         "worldX": 2846,
         "worldY": 3938,
         "worldPlane": 0,
@@ -1752,14 +1752,14 @@
                 28327
               ]
             },
-            "description": "Use Ring of Shadows -> Ghorrock Dungeon to teleport directly. Bring crush weapon (Bandos godsword or Inquisitor's mace), Saradomin brews, super restores, and a pickaxe for the salt vents.",
+            "description": "Use Ring of Shadows -> Ghorrock Dungeon to teleport directly. Bring a slash weapon (scythe of vitur, emberlight, or soulreaper axe), Saradomin brews, super restores, and a pickaxe for the salt vents.",
             "travelTip": "Ring of Shadows -> Ghorrock Dungeon"
           }
         ],
         "section": "Travel"
       },
       {
-        "description": "Navigate through Ghorrock Prison to the Asylum stairs",
+        "description": "Navigate through Ghorrock Prison to the Asylum stairs. Watch for falling ice in the corridors near the second staircase - step off the shadow before it strikes.",
         "worldX": 2973,
         "worldY": 6440,
         "worldPlane": 2,
@@ -1778,7 +1778,7 @@
         "section": "Combat"
       },
       {
-        "description": "Kill Duke Sucellus. Mine arder powder, musca powder and salax salt from the asylum vents, craft arder-musca poisons, then use Protect from Melee with crush weapons (Bandos godsword or Inquisitor's mace) since Duke resists slash and stab. Dodge the falling ice patches and stay clear of the gas vents.",
+        "description": "Kill Duke Sucellus. While Duke is asleep, mine arder powder, musca powder and salax salt from the asylum vents and craft arder-musca poisons to wake him. Use Protect from Melee with a slash weapon (Duke is weak to slash; crush weapons will frequently miss due to his high crush Defence). Stay clear of the gas vents.",
         "worldX": 2846,
         "worldY": 3938,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Corrects five guidance-text errors in the Duke Sucellus source, all confirmed against the wiki Strategies page (https://oldschool.runescape.wiki/w/Duke_Sucellus/Strategies). Full receipts in docs/verify/findings-wiki-meta-2026-06.md (PR #829).

## Applied findings

- **[blocker] C2**: Travel step descriptions recommended "crush weapon (Bandos godsword or Inquisitor's mace)". Duke is weak to slash; replaced with slash weapon examples (scythe of vitur, emberlight, soulreaper axe). Wiki: "Duke Sucellus is weak to slash attacks."
- **[blocker] C6**: Kill step stated "Duke resists slash and stab" - the exact inverse of reality. Replaced with "Duke is weak to slash; crush weapons will frequently miss due to his high crush Defence." Wiki: "It is not recommended to use an elder maul or dragon warhammer because it is much more likely to miss due to Duke Sucellus' high crush Defence."
- **[high] C8**: Kill step placed mine/craft arder-musca poisons instruction inside the ACTOR_DEATH combat step. The wiki is explicit this happens while Duke is asleep before combat. Clarified in description: "While Duke is asleep, mine ... and craft arder-musca poisons to wake him."
- **[medium] C9**: Same root cause as C8 (crafting verb placement). Addressed together with C8 in the single kill step description rewrite.
- **[medium] C10**: Kill step instructed "Dodge the falling ice patches" as a fight mechanic. Wiki localises ice falls to the corridors near the second staircase during navigation, not the boss arena. Moved the ice hazard note to the navigation step description; removed from kill step.

## Skipped findings

None. All five confirmed findings were addressable as description text edits within scope.

## Files changed

- `src/main/resources/com/collectionloghelper/drop_rates.json` - Duke Sucellus guidanceSteps descriptions only (4 lines changed)