### PR TITLE
fix(data): The Whisperer (Awakened) - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -2745,7 +2745,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Bank at Ferox Enclave for The Whisperer (Awakened). Awakened Whisperer is widely considered the hardest of the four; tentacle patterns chain into the screech attack twice as fast, and a single missed prayer flick can chain-hit through brews. Bring a full inventory of Saradomin brews and super restores, prayer potions, ranged potion, diamond bolts (e), an Awakener's orb (one per kill), the blackstone fragment (required to enter the Shadow Realm), and a Ring of Shadows. Bow of faerdhinen (c) plus Masori is the standard meta.",
+        "description": "Bank at Ferox Enclave for The Whisperer (Awakened). Awakened Whisperer is widely considered the hardest of the four; more tentacles (7 in X formation, 6 in + formation vs 4), and a single missed prayer flick can cause rapid damage. Magic is the combat meta: use Tumeken's Shadow or Harmonised Nightmare Staff with Ancestral robes. Bring 12-13 prayer potions (4-dose), 3-4 anglerfish or manta rays, a rune pouch (ice spells and thralls), a Venator bow with arrows for the Soul Siphon phase, a special attack weapon (Eldritch Nightmare Staff recommended), an Awakener's orb (one per kill), and the blackstone fragment (required to enter the Shadow Realm).",
         "worldX": 3129,
         "worldY": 3636,
         "worldPlane": 0,
@@ -2803,7 +2803,7 @@
         "section": "Combat"
       },
       {
-        "description": "Kill The Whisperer (Awakened). Switch Protect from Missiles for grey-barb ranged volleys and Protect from Magic for blue-orb magic volleys. Use the blackstone fragment to hop into the Shadow Realm and break the four shadow tiles before her shield resets - missing one resets her shield to full and extends the kill 30 seconds. Never let your sanity bar fully deplete or you take a 10-tick degen that hits for 10 per tick. Awakened-mode: tentacle patterns chain into the screech attack roughly twice as fast, and the Shadow Realm has 3 extra shadow puddles to dodge. Switch prayers a tick early on every volley.",
+        "description": "Kill The Whisperer (Awakened). Switch Protect from Missiles for grey-barb ranged volleys and Protect from Magic for blue-orb magic volleys. Use the blackstone fragment to hop into the Shadow Realm and break the four shadow tiles before her shield resets - missing one resets her shield to full and extends the kill 30 seconds. Never let your sanity bar fully deplete; full depletion causes near-instant death within 10 ticks - teleport immediately if this occurs. Awakened-mode: more tentacles (7 in X formation, 6 in + formation vs 4 in base); Soul Siphon has 16 souls (up from 12) with a 21-second timer. Switch prayers a tick early on every volley.",
         "worldX": 3007,
         "worldY": 3477,
         "worldPlane": 0,
@@ -2830,7 +2830,7 @@
         "section": "Loot"
       },
       {
-        "description": "Return to Ferox Enclave bank to restock brews, super restores, prayer potions, ranged potions, and another Awakener's orb before the next kill",
+        "description": "Return to Ferox Enclave bank to restock prayer potions, food (anglerfish or manta rays), rune pouch supplies, and another Awakener's orb before the next kill",
         "worldX": 3129,
         "worldY": 3636,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Corrects five guidance-text errors in The Whisperer (Awakened) source, all verified against the wiki strategy page (https://oldschool.runescape.wiki/w/The_Whisperer/Strategies). Full receipts in docs/verify/findings-wiki-meta-2026-06.md (PR #829).

## Applied findings

**[blocker] C13:** Replaced incorrect ranged meta (Bow of faerdhinen (c) + Masori) with correct magic meta (Tumeken's Shadow or Harmonised Nightmare Staff + Ancestral robes). Wiki: "best weapons: Tumeken's shadow / Venator bow (for souls); best armor: Ancestral hat / Ancestral robe top / Ancestral robe bottom."

**[high] C11:** Replaced ranged-centric inventory (Saradomin brews, super restores, ranged potion, diamond bolts (e)) with magic-meta inventory (prayer potions, anglerfish/manta rays, rune pouch for ice spells/thralls, Venator bow for Soul Siphon phase, Eldritch Nightmare Staff for spec). Wiki verbatim inventory contains no brews, no ranged potion, no diamond bolts.

**[high] C7:** Replaced "10-tick degen that hits for 10 per tick" with accurate description: full sanity depletion causes near-instant death within 10 ticks, mandatory teleport. Wiki: "the player will go insane and will quickly die within 10 ticks; therefore, if this occurs, teleportation is mandatory."

**[low] C2:** Replaced fabricated "tentacle patterns chain into screech attack twice as fast" with accurate awakened-mode tentacle counts (7 in X formation, 6 in + formation vs 4 in base). The Screech is a HP-threshold-triggered special in rotation, not chained from tentacles.

**[low] C8:** Replaced fabricated "3 extra shadow puddles to dodge" with accurate awakened Soul Siphon description (16 souls vs 12, 21-second timer). Three separate wiki fetches confirm no "shadow puddles" mechanic exists.

## Skipped findings

None - all five confirmed findings are description-text corrections within scope.

## Test plan

- [ ] JSON parses: `python -c "import json;json.load(open('src/main/resources/com/collectionloghelper/drop_rates.json'))"`
- [ ] No non-ASCII characters
- [ ] `python scripts/audit_drop_rates.py --category BOSSES` reports 0 errors
- [ ] CI build passes