### PR TITLE
fix(data): Vorkath - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -964,7 +964,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Vorkath. Pray Protect from Magic during standard phases (the standard meta for melee, blowpipe, and bow setups), keep a super antifire active, sidestep the red acid puddles, walk diagonally to dodge the slow purple ice projectile, and click the Zombified Spawn the instant it appears (it deals ramping damage if ignored). Zombie axe and Bow of faerdhinen are the modern meta",
+        "description": "Kill Vorkath. Pray Protect from Magic during standard phases, keep a super antifire active, sidestep the acid puddles during the Rapid Fire phase. When frozen by the ice attack, cast Crumble Undead on the Zombified Spawn before it reaches you (explodes on contact for up to 60 damage based on remaining HP). Dragon Hunter Lance and Bow of faerdhinen are the primary meta weapons",
         "worldX": 2273,
         "worldY": 4049,
         "worldPlane": 0,


### PR DESCRIPTION
## Changes

Three guidance-text errors in the Vorkath combat step, all verified against the Strategies wiki page:

- [blocker] C11: Removed impossible diagonal-walking instruction for the freeze phase. The ice attack freezes the player in place (deals no damage); diagonal movement is not possible when immobilised. The Woox Walk technique applies to the Rapid Fire/acid phase, not the freeze. Receipt: "While this deals no damage, it will freeze the player in place, and Vorkath will spit out a Zombified Spawn."
- [high] C12: Replaced "click the Zombified Spawn immediately (ramping damage)" with "cast Crumble Undead before it reaches you (explodes on contact for up to 60 damage based on remaining HP)". Two corrections: the wiki's recommended method is Crumble Undead (instant kill, always hits at Magic bonus > -64), not a click; and damage is HP-based on explosion contact, not a ramping-over-time mechanic. Receipt: "Casting Crumble Undead will instantly kill the spawn... If it reaches the player, it will explode, dealing damage based on its current Hitpoints prior to explosion; this can deal up to 60 damage."
- [high] C13: Replaced unsupported "Zombie axe" meta claim with "Dragon Hunter Lance". The wiki names the Dragon Hunter Lance as the most effective melee weapon against Vorkath; the zombie axe does not appear on the Strategies page. Bow of faerdhinen retained as valid ranged option.

Full receipts: docs/verify/findings-wiki-meta-2026-06.md (PR #829)

## Skipped

None - all three findings were description-text corrections within scope.