### PR TITLE
fix(data): Vardorvis - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -2247,7 +2247,7 @@
         "section": "Combat"
       },
       {
-        "description": "Kill Vardorvis. Use Protect from Melee with slash weapons (Soulreaper axe or Blade of Saeldor) since he resists stab and crush, keep moving to dodge the spinning axes spawned from ground cracks (they one-shot if you stand still late-fight), and kill the Strangled spawns immediately or they will heal him.",
+        "description": "Kill Vardorvis. Use Protect from Melee with slash weapons (Soulreaper axe or Blade of Saeldor) since he resists stab and crush. Dodge the swinging axes released across the arena by the Strangler's tendrils (more axes spawn as HP drops). Step away from ground cracks caused by the Darting Spikes attack before they erupt into tendrils.",
         "worldX": 1175,
         "worldY": 3424,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Fixes three confirmed findings from the wiki-meta guidance audit (tranche 1) for the Vardorvis source. All three findings target the same defective clause in guidanceSteps[3] (the combat fight step).

## Findings applied

**[blocker] C11:** Removed false Strangled-spawn arena mechanic. The wiki confirms Strangled creatures are path hazards encountered while traversing the Stranglewood to reach the boss, not spawns inside the fight arena.
- Wiki receipt: "All routes will require player to traverse the Stranglewood, and players will be running past several Strangled and a Strangled Boar while reaching the boss."

**[blocker] C12:** Removed fabricated Strangled-heals-boss claim. The wiki has no mechanic where killing spawns prevents Vardorvis from healing. His healing is self-generated via his own attacks.
- Wiki receipt: "Both his normal and special attacks will also heal him for 50% of the damage inflicted, rounded down."

**[medium] C9:** Corrected the swinging axes description. Axes are brought up by the Strangler's tendrils and released across the arena (Swinging Axes attack). Ground cracks are from the separate Darting Spikes attack, which releases tendrils (not axes).
- Wiki receipt: Swinging Axes: "The Strangler's tendrils will bring up Vardorvis' axes into the arena before releasing them across the arena." Darting Spikes: "Vardorvis will dart around the player, causing cracks in the ground which will release tendrils after a few seconds, dealing up to 25 damage and healing him for half the damage dealt."

## Change

Single clause in guidanceSteps[3] description:

Before: "...keep moving to dodge the spinning axes spawned from ground cracks (they one-shot if you stand still late-fight), and kill the Strangled spawns immediately or they will heal him."

After: "Dodge the swinging axes released across the arena by the Strangler's tendrils (more axes spawn as HP drops). Step away from ground cracks caused by the Darting Spikes attack before they erupt into tendrils."

## Validation

- JSON parse: pass
- ASCII-only check: pass
- audit_drop_rates.py --category BOSSES: 0 errors

Full receipts: docs/verify/findings-wiki-meta-2026-06.md (PR #829)

## Skipped findings

None - all three confirmed findings for Vardorvis were applied in this PR (C11 and C12 are two facets of the same clause; fixed together).