### PR TITLE
fix(data): Cerberus - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -1082,7 +1082,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Cerberus. She rotates Melee, Ranged, and Magic attacks - flick Protect from Magic when she rears back and fires a smooth black ball, Protect from Missiles when she kicks a translucent spiky ball, otherwise Protect from Melee. Every 10 attacks she summons three souls (Magic ghost, Ranged ghost, Melee ghost) - run to the matching tile under each soul before they reach her, or pray the soul's attack style. Bring Salve amulet (ei) and use Bandos godsword spec to drop her Defence",
+        "description": "Kill Cerberus. She rotates Melee, Ranged, and Magic attacks - flick Protect from Magic when she lowers her head and fires a smooth black ball, Protect from Missiles when she kicks a translucent spiky ball, otherwise Protect from Melee. Every 7 attacks once below 400 HP she summons three souls (Magic ghost, Ranged ghost, Melee ghost) - run to the matching tile under each soul before they reach her, or pray the soul's attack style. Use Bandos godsword spec to drop her Defence",
         "worldX": 1240,
         "worldY": 1251,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Three guidance-text corrections for Cerberus, all confirmed against the wiki Strategies page.

- [medium] C3: Magic attack animation cue was inverted. Changed "rears back and fires" to "lowers her head and fires" to match wiki: "Cerberus lowers her head and fires a smooth black ball."
- [blocker] C6: Souls mechanic trigger was wrong on both the interval and the gate condition. Changed "Every 10 attacks she summons three souls" to "Every 7 attacks once below 400 HP she summons three souls". Wiki: "This attack is performed every seventh attack, but only after Cerberus has under 400 hitpoints." The "10 attacks" figure belongs to the unrelated triple-attack sequence, which has no souls.
- [blocker] C8: Removed "Bring Salve amulet (ei)" from the combat description. Cerberus is classified as demon (not undead); Salve amulet (ei) grants no bonus against demons. Cache npc_lookup confirms Attributes: demon. The wiki Strategies gear table never lists Salve for Cerberus.

No loopBackToStep/loopCount, drop rates, npcId/objectId, coordinates, or requirements wiring was changed.

## Skipped

None - all three confirmed findings were applicable as description-text edits.

## References

Full receipts: docs/verify/findings-wiki-meta-2026-06.md (PR #829)

## Test plan

- [ ] JSON parses cleanly
- [ ] Zero non-ASCII characters
- [ ] `python scripts/audit_drop_rates.py --category BOSSES` reports 0 errors (Cerberus in verified)
- [ ] CI build passes