### PR TITLE
fix(data): The Leviathan - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -1893,7 +1893,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to The Scar by taking the rowboat in the Wizards' Tower basement. Bring ranged setup (Bow of faerdhinen or Twisted bow with diamond bolts (e)) or magic with Tumeken's shadow, prayer potions, and Saradomin brews.",
+        "description": "Travel to The Scar. From the Wizards' Tower basement portal, pass through the Temple of the Eye to the Abyssal Rift, then head east to Wizard Persten's camp and take the rowboat to the Leviathan's island. Bring ranged setup (Bow of faerdhinen, Zaryte crossbow, or Twisted bow) or magic with Tumeken's shadow, prayer potions, and Saradomin brews.",
         "worldX": 3104,
         "worldY": 3162,
         "worldPlane": 0,
@@ -1906,7 +1906,7 @@
                 28327
               ]
             },
-            "description": "Use Ring of Shadows -> The Scar to teleport directly. Bring ranged setup (Bow of faerdhinen or Twisted bow with diamond bolts (e)) or magic with Tumeken's shadow, prayer potions, and Saradomin brews.",
+            "description": "Use Ring of Shadows -> The Scar to teleport directly, then take the rowboat at Wizard Persten's camp east of the Abyssal Rift. Bring ranged setup (Bow of faerdhinen, Zaryte crossbow, or Twisted bow) or magic with Tumeken's shadow, prayer potions, and Saradomin brews.",
             "travelTip": "Ring of Shadows -> The Scar"
           }
         ],
@@ -1932,7 +1932,7 @@
         "section": "Combat"
       },
       {
-        "description": "Kill The Leviathan. Switch protection prayers to match the orb colour on its head (blue = Magic, green = Ranged, orange = Melee) and step at least one tile away from the falling-debris warning at the end of each volley to avoid the permanent rock spawns that one-shot lower-defence accounts.",
+        "description": "Kill The Leviathan. Switch protection prayers to match the orb colour on its head (blue = Magic, green = Ranged, orange = Melee) and step at least one tile away from the falling-debris warning at the end of each volley to avoid the permanent rock spawns that restrict movement and can block line of sight for the remainder of the fight.",
         "worldX": 3104,
         "worldY": 3162,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Corrects three guidance-text errors in The Leviathan source, all confirmed against the wiki during audit tranche 1. Full receipts: docs/verify/findings-wiki-meta-2026-06.md (PR #829).

## Findings applied

**[high] C1: rowboat location**
Changed: "Travel to The Scar by taking the rowboat in the Wizards' Tower basement" -> correct route description via Wizard Persten's camp east of the Abyssal Rift.
Wiki receipt: "To reach the Leviathan in the Scar, players must proceed east of the Abyssal Rift towards Wizard Persten's camp. A rowboat there can then be used to reach the island where the Leviathan is located." (oldschool.runescape.wiki/w/The_Leviathan)
Applied to both main travel step and Ring of Shadows conditional alternative.

**[medium] C2: Twisted bow ammunition**
Changed: "Twisted bow with diamond bolts (e)" -> "Zaryte crossbow, or Twisted bow" (Twisted bow fires arrows, not bolts; diamond bolts are crossbow-only ammunition not mentioned on the Strategies page).
Wiki receipt: Zaryte Crossbow uses ruby dragon bolts (e) / ruby bolts (e); no diamond bolts or dragon arrows mentioned; Twisted bow does not require bolts or arrows in this context. (oldschool.runescape.wiki/w/The_Leviathan/Strategies)
Applied to both main travel step and Ring of Shadows conditional alternative.

**[low] C9: debris hazard description**
Changed: "one-shot lower-defence accounts" -> "restrict movement and can block line of sight for the remainder of the fight".
Wiki receipt: "Players will take up to 7 chip damage from the roar but can avoid the debris by moving at least 1 tile away." (oldschool.runescape.wiki/w/The_Leviathan/Strategies) - 7 chip damage cannot one-shot any account; permanent debris is a movement/LoS hazard.

## Findings skipped

None - all three confirmed findings were text-only guidance corrections within scope.

## Test plan

- [x] JSON parses cleanly
- [x] No non-ASCII characters introduced
- [x] `python scripts/audit_drop_rates.py --category BOSSES` reports 0 errors
- [ ] CI build gate