### PR TITLE
fix(data): General Graardor - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -123,8 +123,8 @@
                 "FREMENNIK_HARD"
               ]
             },
-            "description": "Trollheim teleport not required: use the Fremennik Hard diary unlocks (e.g. Lighthouse-area transport) plus the Goblin Village agility shortcut to reach the God Wars Dungeon entrance overland",
-            "travelTip": "Fremennik Hard diary route -> Goblin Village shortcut -> GWD"
+            "description": "Fremennik Hard diary: stony basalt teleports to top of Troll Stronghold (requires Making Friends with My Arm). Run south-east down to the God Wars Dungeon entrance from there.",
+            "travelTip": "Stony basalt -> Troll Stronghold top -> run south-east to GWD"
           },
           {
             "requirements": {

--- a/src/test/java/com/collectionloghelper/data/C6B3OverlapRegressionTest.java
+++ b/src/test/java/com/collectionloghelper/data/C6B3OverlapRegressionTest.java
@@ -105,11 +105,15 @@ public class C6B3OverlapRegressionTest
 	@Test
 	public void generalGraardorStacksFremennikHardAheadOfJewelleryBox()
 	{
+		// Diary-alternative keyword updated with the wiki-meta audit fix: the
+		// Hard Fremennik reward is the stony basalt teleport to the top of
+		// Troll Stronghold (the previously described Lighthouse transport and
+		// Goblin Village shortcut do not exist).
 		assertStackedDiaryAndPoh(
 			"General Graardor",
 			FREMENNIK_HARD,
 			"JEWELLERY_BOX_FANCY",
-			"Goblin Village",
+			"Troll Stronghold",
 			"Teleport to Trollheim and run north to the God Wars Dungeon entrance");
 	}
 


### PR DESCRIPTION
## Summary

Fixes one confirmed high-severity guidance text bug for General Graardor, identified in the wiki-meta audit (tranche 1). Full receipts: docs/verify/findings-wiki-meta-2026-06.md (PR #829).

## Applied findings

- **[high] C2:** Replaced fabricated Fremennik Hard diary route description. The old text referenced a "Lighthouse-area transport" and a "Goblin Village agility shortcut to GWD" — neither reward exists in the Hard tier of the Fremennik Province Diary. Replaced with the actual Hard-tier unlock: stony basalt teleports to top of Troll Stronghold (requires Making Friends with My Arm), then run south-east to the GWD entrance. Wiki receipt: "Stony basalt now teleports you on top of the Troll Stronghold, past the rocky shortcut" (Fremennik Province Diary, Hard tier rewards).

## Skipped findings

- **[medium] C10:** `TROLL_STRONGHOLD` listed as a full-completion quest requirement; wiki confirms only partial completion (defeating Dad) is needed, or Easy Combat Achievements bypass via Ghommal's Hilt 1. Skipped — this is a requirements-wiring change (`requirements.quests[]`) which is out of scope for this guidance-text pass. Requires a dedicated requirements-model follow-up.

## Test plan

- [ ] JSON parses cleanly (`python -c "import json;json.load(open('src/main/resources/com/collectionloghelper/drop_rates.json'))"`)
- [ ] No non-ASCII characters introduced
- [ ] `python scripts/audit_drop_rates.py --category BOSSES` reports 0 errors
- [ ] CI build passes