### PR TITLE
fix(data): Corporeal Beast - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -1365,8 +1365,8 @@
                 "JEWELLERY_BOX_FANCY"
               ]
             },
-            "description": "POH jewellery box -> Games necklace -> Wilderness Volcano, then run south to the lever room and pull the lever to enter the Corporeal Beast cave",
-            "travelTip": "POH Games necklace -> Wilderness Volcano -> south to lever room"
+            "description": "Use the POH jewellery box (Fancy or higher) to access a Games necklace and teleport directly to the Corporeal Beast cave",
+            "travelTip": "POH jewellery box -> Games necklace -> Corporeal Beast"
           }
         ]
       },


### PR DESCRIPTION
## Changes

**[high] C3:** Removed fabricated Wilderness Volcano + lever room route from `conditionalAlternatives` in guidance step 1. Corrected description and travelTip to reflect the actual mechanic: POH jewellery box (Fancy or higher) -> Games necklace -> Corporeal Beast teleport directly.

The previous text routed the player to Wilderness Volcano and described a non-existent lever room, which would send a player into level 50+ Wilderness rather than the cave. The Games necklace teleports directly to the Corporeal Beast cave; no lever or Wilderness traversal is involved.

**Key wiki receipt (Corporeal_Beast/Strategies):**
> "use a games necklace and teleport to the Corporeal Beast. The cave in which the Corporeal Beast resides is not part of the Wilderness."

Full receipts: docs/verify/findings-wiki-meta-2026-06.md (PR #829)

## Skipped findings

None - all confirmed findings for this source were applied.