### PR TITLE
fix(data): Bryophyta - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -3985,7 +3985,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Bank in Varrock west bank. Required: Mossy key (farmed from Moss giants in Varrock Sewers / Brimhaven dungeon / Ardougne). Bring melee gear (Salve amulet (ei) is BiS - Bryophyta is undead), super combat, food, prayer potions, and an Amulet of glory for the return teleport",
+        "description": "Bank in Varrock west bank. Required: Mossy key (farmed from Moss giants in Varrock Sewers or Brimhaven Dungeon at 1/150, or 1/75 on a moss giant Slayer task). Bring melee gear, super combat, food, prayer potions, and an Amulet of glory for the return teleport",
         "worldX": 3185,
         "worldY": 3439,
         "worldPlane": 0,
@@ -4001,7 +4001,7 @@
         "section": "Bank"
       },
       {
-        "description": "Travel to the Varrock Sewers via the manhole behind Varrock Palace (preferred) or via the Edgeville Dungeon ladder. The manhole route lands you 10 tiles north of Bryophyta's gate",
+        "description": "Travel to the Varrock Sewers via the manhole just east of Varrock Palace (preferred) or via the Edgeville Dungeon pipe shortcut near Vannaka (requires 51 Agility). The manhole route lands you 10 tiles north of Bryophyta's gate",
         "worldX": 3174,
         "worldY": 3435,
         "worldPlane": 0,
@@ -4011,7 +4011,7 @@
         "section": "Travel"
       },
       {
-        "description": "Use the Mossy key on the gate to enter Bryophyta's lair. The key is consumed on use - each kill needs a fresh key, so the farm rate is gated by moss giant key drops (~1/16)",
+        "description": "Use the Mossy key on the gate to unlock Bryophyta's lair for the first time. The key is NOT consumed when opening the gate, and subsequent visits do not require a key - the lair stays open after the first unlock",
         "worldX": 3174,
         "worldY": 3435,
         "worldPlane": 0,
@@ -4024,7 +4024,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Bryophyta. Use Protect from Melee and attack with a strong crush or slash weapon (Bryophyta has high stab defence). Kill the Growthlings the moment they spawn - each living Growthling heals Bryophyta for 3 HP per tick, so leaving one alive negates your DPS. Salve amulet (ei) is mandatory for the +20% melee bonus against this undead boss",
+        "description": "Kill Bryophyta. Activate Protect from Magic before entering or immediately on entry. All melee styles are equally effective (no elevated stab defence; 50% fire magic weakness). Kill Growthlings the moment they spawn - Bryophyta is immune to all damage (except poison and venom) while any Growthling is alive",
         "worldX": 3174,
         "worldY": 3435,
         "worldPlane": 0,
@@ -4035,14 +4035,13 @@
         "section": "Combat",
         "recommendedItemIds": [
           4151,
-          12018,
           6685,
           2434,
           385
         ]
       },
       {
-        "description": "Teleport out via Amulet of glory or a Varrock teleport tab. Restock a fresh Mossy key + supplies before the next kill - the fight is gated by key drops, not supplies",
+        "description": "Teleport out via Amulet of glory or a Varrock teleport tab. Restock supplies before the next kill",
         "worldX": 3185,
         "worldY": 3439,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Corrects multiple guidance-text errors in the Bryophyta source, all established by wiki receipts from the audit tranche 1 review (see docs/verify/findings-wiki-meta-2026-06.md, PR #829 for full receipts).

## Applied findings

- **[blocker] C3/C4**: Removed false undead classification and Salve amulet (ei) BiS claim. Wiki: Bryophyta examine text is "This is what organic growth looks like!" - no undead attribute; salve amulet not mentioned anywhere in strategy or equipment recommendations.
- **[blocker] C7**: Corrected key mechanic. Wiki: "A mossy key is needed to unlock the gate leading to Bryophyta's lair for the first time, but subsequent access to the lair does not require a key. The key will not be consumed when unlocking Bryophyta's lair." Previous text claimed key was consumed on use and a fresh key was needed per kill.
- **[blocker] C9**: Changed Protect from Melee to Protect from Magic. Wiki: "It is recommended to activate Protect from Magic before entering, or immediately upon entry, before opening the gate."
- **[blocker] C13**: Removed mandatory salve amulet (ei) claim from combat step; removed item 12018 (NZONE_SALVE_AMULET_E) from recommendedItemIds. Bryophyta is not undead; salve gives no bonus.
- **[high] C8**: Corrected moss giant key drop rate from wrong 1/16 (was the boss drop rate, misattributed to moss giants) to 1/150 standard / 1/75 on Slayer task. Wiki Mossy key: "The drop rate of mossy keys is 1/150 from moss giants... while on a moss giant Slayer task, the drop rate is increased to 1/75."
- **[high] C10**: Removed fabricated high stab defence claim. Wiki infobox: stab/slash/crush defence all +0; actual exploitable weakness is 50% fire magic.
- **[high] C12**: Replaced false 3 HP/tick Growthling heal claim with correct immunity mechanic. Wiki: "Bryophyta is immune to all damage (except poison and venom) while they are alive."
- **[medium] C2**: Removed Ardougne as a mossy key farming location (not a moss giant spawn per wiki); corrected drop rate in description text.
- **[low] C5**: Fixed Varrock Sewers access description - manhole is "just east of" (not "behind") Varrock Palace; Edgeville Dungeon access is a pipe shortcut requiring 51 Agility, not a ladder.

## Skipped findings

None - all confirmed findings in scope were applied.

## Test plan

- [x] JSON parses clean (`python -c "import json;json.load(open(...))"`)
- [x] No non-ASCII characters
- [x] `python scripts/audit_drop_rates.py --category BOSSES` reports 0 errors
- [ ] CI build gate (authoritative for data changes)