### PR TITLE
fix(data): The Leviathan (Awakened) - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -2571,13 +2571,13 @@
         "section": "Bank"
       },
       {
-        "description": "Travel to The Scar entrance beneath the Wizards' Tower. Ring of Shadows -> The Scar is the fastest route; otherwise take the rowboat in the Wizards' Tower basement. Keep the Awakener's orb in your inventory before climbing in.",
+        "description": "Travel to The Scar entrance beneath the Wizards' Tower. Ring of Shadows -> The Scar is the fastest route. Keep the Awakener's orb in your inventory before climbing in.",
         "worldX": 3104,
         "worldY": 3162,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
-        "travelTip": "Ring of Shadows -> The Scar, or Wizards' Tower basement rowboat",
+        "travelTip": "Ring of Shadows -> The Scar",
         "requiredItemIds": [
           28327,
           28334
@@ -2607,7 +2607,7 @@
         "section": "Combat"
       },
       {
-        "description": "Kill The Leviathan (Awakened). Switch protection prayers to match the orb colour on its head (blue = Magic, green = Ranged, orange = Melee) - getting flicks wrong in Awakened mode is a near-instant death. Awakened-mode volley speed is roughly 2 ticks faster, the Rocks phase adds 6-8 thrown rocks you must run between, and the end-of-volley debris warning leaves permanent spike spawns - step at least 2 tiles off the warning tile or take a 60+ unprotectable hit. Spec with Voidwaker on the Rocks phase to skip it.",
+        "description": "Kill The Leviathan (Awakened). Switch protection prayers to match the orb colour on its head (blue = Magic, green = Ranged, orange = Melee) - getting flicks wrong in Awakened mode is a near-instant death. Awakened-mode volley speed is roughly 2 ticks faster, and end-of-volley roar drops 5 permanent debris pieces in a '+' formation - step at least 1 tile off the warning tile to avoid the debris (the roar itself deals up to 7 chip damage regardless). Spec with Voidwaker on the Rocks phase to skip it.",
         "worldX": 3104,
         "worldY": 3162,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Corrects three guidance-text inaccuracies for The Leviathan (Awakened) identified in the wiki-meta audit (tranche 1). Full receipts in docs/verify/findings-wiki-meta-2026-06.md (PR #829).

## Applied findings

**[high] C7: Rowboat location misdirection**
The travel step previously instructed players to "take the rowboat in the Wizards' Tower basement." The rowboat used to reach the Leviathan's island is located inside The Scar at Wizard Persten's camp (east of the Abyssal Rift) -- not in the Wizards' Tower basement, which holds the Temple of the Eye portal (a separate, earlier step in the chain). Removed the false rowboat alternative from the travel step description and travelTip.

Key wiki receipt: "To reach the Leviathan in the Scar, players must proceed east of the Abyssal Rift towards Wizard Persten's camp. A rowboat there can then be used to reach the island where the Leviathan is located." (https://oldschool.runescape.wiki/w/The_Leviathan)

**[medium] C11: Rocks-phase debris count and framing**
The combat step described "6-8 thrown rocks you must run between." The wiki describes end-of-volley roar debris as permanent blocker spawns: 1 in normal mode, increased to 5 in a '+' formation in Awakened mode. No '6-8 thrown rocks' figure is supported. Updated to reflect the '+' formation count.

Key wiki receipt: "The permanent blocker debris is increased, from one to five dropped in a '+' style formation on the player." (https://oldschool.runescape.wiki/w/The_Leviathan/Strategies)

**[medium] C13: Debris-avoidance tile threshold and damage figure**
The combat step required stepping "at least 2 tiles off the warning tile" and warned of a "60+ unprotectable hit." The wiki states moving at least 1 tile away avoids the debris, and the roar deals "up to 7 chip damage" regardless. Corrected both the tile count (2 -> 1) and the damage characterisation.

Key wiki receipt: "Players will take up to 7 chip damage from the roar but can avoid the debris by moving at least 1 tile away." (https://oldschool.runescape.wiki/w/The_Leviathan/Strategies)

## Skipped findings

None -- all three confirmed findings were guidance-text corrections within scope.

## Test plan

- [x] JSON parses without error
- [x] No non-ASCII characters introduced
- [x] `python scripts/audit_drop_rates.py --category BOSSES` reports 0 errors
- [ ] CI build gate