### PR TITLE
fix(data): Sarachnis - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -3835,7 +3835,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Sarachnis. Use a crush weapon - her stab and slash defence is huge. Flick prayers: Protect from Magic when her body glows red, Protect from Ranged when she glows yellow. Kill the spawned Sarachnis spiderlings the instant they appear or they will out-damage you. Stay at least one tile off the wall so spawns have a path to you and do not stack damage.",
+        "description": "Kill Sarachnis. Use a crush weapon - her stab and slash defence is huge. Flick prayers: Protect from Magic when her body glows red, Protect from Ranged when she glows yellow. Prioritise killing the magic-using spawn; the melee spawn can be tanked if your defensive bonuses are sufficient. All remaining spawns die automatically when Sarachnis is killed. Standing on tiles directly adjacent to walls puts you out of her melee range; pray Protect from Missiles there to nullify all her damage, though spawn damage is unaffected by wall positioning.",
         "worldX": 1847,
         "worldY": 9910,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Corrects two mechanically wrong guidance-text claims in the Sarachnis combat step, both verified against the Sarachnis/Strategies wiki page.

## Applied findings

- [medium] C8: removed false mandatory-kill framing for spiderlings. The melee spawn (level 107) may be tanked with sufficient defensive bonuses and is not required to kill. All remaining spawns die automatically when Sarachnis is killed. Key receipt: *"the melee spawns may be tanked with sufficiently high defensive bonuses, but are not necessary to kill ... When Sarachnis is killed, any remaining spawns will automatically die off with her."* (https://oldschool.runescape.wiki/w/Sarachnis/Strategies)

- [medium] C9: corrected inverted wall-tile mechanic. The old text said "stay at least one tile off the wall ... spawns do not stack damage" -- both axes were wrong. Adjacent-to-wall tiles put you OUT of Sarachnis's melee range (not spawn range); praying Protect from Missiles there nullifies all her damage but does not prevent spawn damage. Key receipt: *"All tiles directly adjacent to walls are out of Sarachnis's melee range. Standing on one of these tiles and praying Protect from Missiles will nullify all of her damage, but not the damage of her spawn."* (https://oldschool.runescape.wiki/w/Sarachnis/Strategies)

Full receipts: docs/verify/findings-wiki-meta-2026-06.md (PR #829)

## Skipped findings

None -- all confirmed findings for this source were text-only guidance corrections within scope.

## Test plan

- [ ] JSON parses cleanly (python -c "import json;json.load(open(...))" -- passed locally)
- [ ] No non-ASCII characters (passed locally)
- [ ] audit_drop_rates.py --category BOSSES reports 0 errors (passed locally)
- [ ] CI build passes