### PR TITLE
fix(data): Dagannoth Prime - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -4317,13 +4317,13 @@
         "conditionalAlternatives": [
           {
             "requirements": { "diaries": ["FREMENNIK_HARD"] },
-            "description": "Rub the enchanted lyre to teleport directly to Rellekka, then take Jarvald's boat to Waterbirth Island for free. Hard Fremennik Diary removes the 1,000 gp boat fee.",
-            "travelTip": "Enchanted lyre -> Rellekka -> free Jarvald boat (Hard Fremennik Diary)"
+            "description": "Rub the enchanted lyre to teleport directly to Rellekka, then take Jarvald's boat to Waterbirth Island. The Hard Fremennik Diary adds Waterbirth Island as an enchanted lyre destination. Free boat passage requires completing The Fremennik Trials quest.",
+            "travelTip": "Enchanted lyre -> Rellekka -> Jarvald boat (Hard Fremennik Diary)"
           }
         ]
       },
       {
-        "description": "Descend the Waterbirth Island Dungeon to floor 6 and reach the Kings' lair. Bring a rune thrownaxe (or pet rock + 70 Agility shortcut) to lure Prime away from Supreme and Rex",
+        "description": "Descend the Waterbirth Island Dungeon to floor 6 and reach the Kings' lair. Bring a rune thrownaxe to lure Prime away from Supreme and Rex. Alternatively, bring a pet rock to substitute as a second player to open the multi-player doors. 85 Agility bypasses door mechanics entirely.",
         "worldX": 2528,
         "worldY": 3739,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Fixes three confirmed guidance-text errors in the Dagannoth Prime source. All findings from audit tranche 1; full receipts in docs/verify/findings-wiki-meta-2026-06.md (PR #829).

## Applied findings

**[high] C3:** Removed false claim that the Hard Fremennik Diary waives Jarvald's 1,000 gp boat fee. Wiki receipt: "If the player has not completed The Fremennik Trials quest, they must pay 1,000 coins per trip; after the quest, Jarvald will transport players for free." (https://oldschool.runescape.wiki/w/Jarvald). The diary's actual benefit (enchanted lyre -> Waterbirth Island destination) is now stated instead.

**[high] C4:** Same underlying error as C3 - the conditionalAlternatives description for FREMENNIK_HARD incorrectly attributed free boat passage to the diary. Description now correctly states the Hard Diary adds Waterbirth Island as an enchanted lyre destination, and notes free passage requires The Fremennik Trials quest.

**[high] C7:** Removed nonexistent "70 Agility shortcut" combined with pet rock. Wiki receipt: Waterbirth Island Dungeon shortcuts are at 85 (bypasses doors entirely) and 81 (Giant Rock Crab room). Pet rock substitutes as a second player to open multi-player doors - not combined with any agility shortcut. Description now correctly distinguishes: rune thrownaxe to lure, OR pet rock for door mechanics, OR 85 Agility to bypass doors entirely.

## Skipped findings

None - all three confirmed findings were description-text corrections within scope.

## Test plan

- [ ] JSON parses cleanly (`python -c "import json;json.load(open('src/main/resources/com/collectionloghelper/drop_rates.json'))"`)
- [ ] No non-ASCII characters
- [ ] `python scripts/audit_drop_rates.py --category BOSSES` reports 0 errors
- [ ] CI build passes