### PR TITLE
fix(data): K'ril Tsutsaroth - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -497,7 +497,7 @@
         "section": "Combat"
       },
       {
-        "description": "Kill K'ril Tsutsaroth. Protect from Melee, eat through Balfrug + Tstanon prayer drain, watch for K'ril's curse special which strips your prayer in one hit.",
+        "description": "Kill K'ril Tsutsaroth. Protect from Melee; Balfrug deals magic damage (up to 16) and Tstanon deals melee damage (up to 15). Watch for K'ril's Prayer Smash special which deals 35-49 damage and drains half your current prayer points.",
         "worldX": 2925,
         "worldY": 5322,
         "worldPlane": 2,


### PR DESCRIPTION
## Summary

Corrects two wiki-meta accuracy bugs in the K'ril Tsutsaroth guidance step description.

## Changes

**[high] C9:** Removed false prayer-drain attribution from Balfrug Kreeyath and Tstanon Karlak. The wiki (oldschool.runescape.wiki/w/K%27ril_Tsutsaroth/Strategies) is explicit that Balfrug is a magic attacker dealing up to 16 damage and Tstanon is a melee attacker dealing up to 15 damage; neither minion drains prayer. Only K'ril's Prayer Smash has that mechanic. The fabricated "eat through Balfrug + Tstanon prayer drain" instruction could cause players to misidentify the source of prayer loss and mismanage prayer restores.

**[medium] C10:** Corrected K'ril's special attack name from "curse" to "Prayer Smash" and corrected the drain from "strips your prayer in one hit" (implies full drain) to "drains half your current prayer points". Wiki receipt: "He will yell YARRRRRRR! when using his prayer smash, always dealing 35-49 damage and draining his target's current prayer points by half, rounded down." (oldschool.runescape.wiki/w/K%27ril_Tsutsaroth/Strategies). The strategic difference is material: the player retains ~half their prayer after the special and does not need to immediately pot.

Full receipts: docs/verify/findings-wiki-meta-2026-06.md (PR #829)

## Validation

- JSON parse: pass
- Non-ASCII check: 0 non-ASCII characters
- `python scripts/audit_drop_rates.py --category BOSSES`: 0 errors

## Skipped findings

None - both findings were guidance text corrections within scope.