### PR TITLE
fix(data): The Whisperer - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -2045,7 +2045,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to Lassar Undercity by entering the sinkhole north-west of Camdozaal. Bring the blackstone fragment (required to start the fight), ranged setup (Bow of faerdhinen or Twisted bow with diamond bolts (e)), prayer potions, and Saradomin brews.",
+        "description": "Travel to Lassar Undercity by entering the sinkhole north-west of Camdozaal. Bring the blackstone fragment (required to start the fight), ranged setup (Bow of faerdhinen or Venator bow for the souls phase), prayer potions, and Saradomin brews.",
         "worldX": 3007,
         "worldY": 3477,
         "worldPlane": 0,
@@ -2061,7 +2061,7 @@
                 28327
               ]
             },
-            "description": "Use Ring of Shadows -> Lassar Undercity to teleport directly. Bring the blackstone fragment (required to start the fight), ranged setup (Bow of faerdhinen or Twisted bow with diamond bolts (e)), prayer potions, and Saradomin brews.",
+            "description": "Use Ring of Shadows -> Lassar Undercity to teleport directly. Bring the blackstone fragment (required to start the fight), ranged setup (Bow of faerdhinen or Venator bow for the souls phase), prayer potions, and Saradomin brews.",
             "travelTip": "Ring of Shadows -> Lassar Undercity"
           }
         ],
@@ -2093,7 +2093,7 @@
         "section": "Combat"
       },
       {
-        "description": "Kill The Whisperer. Switch Protect from Missiles for grey-barb ranged volleys and Protect from Magic for blue-orb magic volleys, use the blackstone fragment to enter the Shadow Realm and step on the four correct tiles to bank her shield, and keep your sanity bar above zero or you will die in 10 ticks.",
+        "description": "Kill The Whisperer. Switch Protect from Missiles for purple-barb ranged volleys and Protect from Magic for blue-orb magic volleys. During the Soul Siphon special attack, activate the blackstone fragment to enter the Shadow Realm and kill at least one full set of lost souls (grouped by chant phrase) before the 20-tick timer expires; failure deals 50 damage and heals her 100 HP. Keep your sanity bar above zero or you will die in 10 ticks.",
         "worldX": 3007,
         "worldY": 3477,
         "worldPlane": 0,


### PR DESCRIPTION
## Findings fixed

**[blocker] C4:** Removed mechanically impossible Twisted bow + diamond bolts (e) equipment combination. A Twisted bow is a bow and fires arrows; diamond bolts (e) are crossbow ammunition. Replaced with Bow of faerdhinen or Venator bow (BiS for souls phase per wiki). Affects travel step description (main path + Ring of Shadows alternative).

**[high] C9:** Replaced fabricated tile-stepping/shield-banking mechanic with the correct Soul Siphon description. The guidance said "step on the four correct tiles to bank her shield" -- no such mechanic exists. Wiki receipt: "Players must activate their blackstone fragment to enter the Shadow Realm and kill at least one set of souls chanting the same phrase. If the player fails to kill a full set of souls within the time limit, the chant will complete, dealing 50 damage to the player and heals her for 100 health." Combat step description rewritten accordingly.

**[low] C6:** Corrected ranged projectile colour from "grey-barb" to "purple-barb" per wiki ("The ranged shots are purple barbs, while the magic shots are blue orbs."). Prayer recommendation (Protect from Missiles) was already correct.

## Skipped findings

None -- all three confirmed findings were description-text corrections within scope.

## References

Full receipts and skeptic reasoning: docs/verify/findings-wiki-meta-2026-06.md (PR #829)