### PR TITLE
fix(data): Kalphite Queen - correct desert amulet 4 diary tier to Elite

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -1478,12 +1478,12 @@
           9520,
           0
         ],
-        "travelTip": "Fairy ring BIQ, or desert amulet to Kalphite Cave (with Hard Desert Diary)",
+        "travelTip": "Fairy ring BIQ, or desert amulet to Kalphite Cave (with Elite Desert Diary)",
         "conditionalAlternatives": [
           {
-            "requirements": { "diaries": ["DESERT_HARD"] },
+            "requirements": { "diaries": ["DESERT_ELITE"] },
             "description": "Use the desert amulet 4 to teleport directly to the Kalphite Cave entrance, eliminating the fairy ring detour.",
-            "travelTip": "Desert amulet 4 -> Kalphite Cave (Hard Desert Diary reward)"
+            "travelTip": "Desert amulet 4 -> Kalphite Cave (Elite Desert Diary reward)"
           }
         ]
       },

--- a/src/test/java/com/collectionloghelper/data/D5CBranchRegressionTest.java
+++ b/src/test/java/com/collectionloghelper/data/D5CBranchRegressionTest.java
@@ -53,7 +53,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * <p>Wired sources and diary constants:
  * <ul>
- *   <li>Kalphite Queen      — {@code DESERT_HARD}</li>
+ *   <li>Kalphite Queen      — {@code DESERT_ELITE}</li>
  *   <li>Dagannoth Rex       — {@code FREMENNIK_HARD}</li>
  *   <li>Dagannoth Prime     — {@code FREMENNIK_HARD}</li>
  *   <li>Dagannoth Supreme   — {@code FREMENNIK_HARD}</li>
@@ -69,7 +69,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class D5CBranchRegressionTest
 {
-	private static final String DESERT_HARD = "DESERT_HARD";
+	// Wiki-meta audit fix: the desert amulet 4 teleport described by the KQ
+	// alternative is an Elite Desert Diary reward, not Hard.
+	private static final String DESERT_ELITE = "DESERT_ELITE";
 	private static final String FREMENNIK_HARD = "FREMENNIK_HARD";
 	private static final String KOUREND_ELITE = "KOUREND_ELITE";
 
@@ -82,7 +84,7 @@ public class D5CBranchRegressionTest
 	private static Map<String, String> buildExpected()
 	{
 		Map<String, String> map = new LinkedHashMap<>();
-		map.put("Kalphite Queen", DESERT_HARD);
+		map.put("Kalphite Queen", DESERT_ELITE);
 		map.put("Dagannoth Rex", FREMENNIK_HARD);
 		map.put("Dagannoth Prime", FREMENNIK_HARD);
 		map.put("Dagannoth Supreme", FREMENNIK_HARD);


### PR DESCRIPTION
## Changes

**[high] C2:** Corrected desert amulet 4 diary tier from Hard to Elite in guidance step 1.

- `travelTip` on step 1 updated: "with Hard Desert Diary" -> "with Elite Desert Diary"
- `conditionalAlternatives[0].travelTip` updated: "Hard Desert Diary reward" -> "Elite Desert Diary reward"
- `conditionalAlternatives[0].requirements.diaries` updated: `["DESERT_HARD"]` -> `["DESERT_ELITE"]`

Key wiki receipt: "The desert amulet 4 is a reward from completing the Elite Desert Diary. ... Unlimited teleports to Nardah and the Kalphite Cave" (https://oldschool.runescape.wiki/w/Desert_amulet_4). The Hard Desert Diary only provides permanently secured ropes at the Kalphite Lair entrance, not the amulet.

Full receipts: docs/verify/findings-wiki-meta-2026-06.md (PR #829)

## Skipped findings

None - C2 is the only confirmed finding for Kalphite Queen.