### PR TITLE
fix(data): Duke Sucellus (Awakened) - wiki-meta guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -2361,7 +2361,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Bank at Ferox Enclave for Duke Sucellus (Awakened). Awakened hits roughly 2x harder than the base fight; bring a full inventory of Saradomin brews and super restores, prayer potions, super combat potion, a pickaxe for the salt vents, an Awakener's orb (one per kill), and a Ring of Shadows for fast re-entry. Crush is mandatory - Bandos godsword for spec, Inquisitor's mace or Saradomin sword as main weapon.",
+        "description": "Bank at Ferox Enclave for Duke Sucellus (Awakened). Awakened hits roughly 2x harder than the base fight; bring a full inventory of Saradomin brews and super restores, prayer potions, super combat potion, a pickaxe for the salt vents, an Awakener's orb (one per kill), and a Ring of Shadows for fast re-entry. Slash is preferred - Bandos godsword for spec, use a slash weapon (Scythe of vitur, Emberlight, or Soulreaper axe) as main weapon.",
         "worldX": 3129,
         "worldY": 3636,
         "worldPlane": 0,
@@ -2416,7 +2416,7 @@
         "section": "Combat"
       },
       {
-        "description": "Kill Duke Sucellus (Awakened). Mine arder powder + musca powder + salax salt from the asylum vents and craft arder-musca poison to weaken Duke before each phase. Use Protect from Melee with crush weapons (Bandos godsword or Inquisitor's mace) - Duke resists slash and stab. Awakened-mode mechanics: ice patches fall in a tighter pattern, gas vents activate one tick earlier, and Duke gains a second extremity orientation halfway through the fight. Step diagonally off ice patches the moment they spawn or you will tick-die through brews.",
+        "description": "Kill Duke Sucellus (Awakened). Mine arder powder + musca powder + salax salt from the asylum vents and craft arder-musca poison to weaken Duke before each phase. Use Protect from Melee with slash weapons (Bandos godsword for spec, slash main weapon) - Duke resists stab and crush. Awakened-mode mechanics: ice patches fall in a tighter pattern, gas vents activate one tick earlier, and Duke gains a second extremity orientation halfway through the fight. Step diagonally off ice patches the moment they spawn or you will tick-die through brews.",
         "worldX": 2846,
         "worldY": 3938,
         "worldPlane": 0,


### PR DESCRIPTION
## Changes

Corrects two blocker-severity guidance-text errors for Duke Sucellus (Awakened) where the recommended combat style and stated resistances were inverted relative to the wiki.

**[blocker] C1: Bank step - crush framing replaced with slash**

Old: "Crush is mandatory - Bandos godsword for spec, Inquisitor's mace or Saradomin sword as main weapon."
New: "Slash is preferred - Bandos godsword for spec, use a slash weapon (Scythe of vitur, Emberlight, or Soulreaper axe) as main weapon."

Wiki receipt: "Duke Sucellus is weak to slash, so slashing weapons are preferred for the fight. It is not recommended to use an elder maul or dragon warhammer because it is much more likely to miss due to Duke Sucellus' high crush Defence." (https://oldschool.runescape.wiki/w/Duke_Sucellus/Strategies) Defence bonuses: Stab +255, Slash +65, Crush +190.

**[blocker] C2: Combat step - inverted resistance claim corrected**

Old: "Use Protect from Melee with crush weapons (Bandos godsword or Inquisitor's mace) - Duke resists slash and stab."
New: "Use Protect from Melee with slash weapons (Bandos godsword for spec, slash main weapon) - Duke resists stab and crush."

Wiki receipt: Slash defence +65 (lowest / weakness); Stab +255 (highest); Crush +190. Claiming Duke resists slash is directly inverted.

## Skipped findings

None - all confirmed findings applied.

## Validation

- JSON parses cleanly
- 0 non-ASCII characters
- audit_drop_rates.py --category BOSSES: 0 errors

Full receipts: docs/verify/findings-wiki-meta-2026-06.md (PR #829)