### PR TITLE
fix(data): Scorpia - wiki-meta guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -5042,7 +5042,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Bank in Ferox Enclave then travel to the Scorpion Pit in deep Wilderness (level ~53). Bring anti-venom+, a high-tier crush or stab weapon, prayer potions, food, and a Wilderness-cheap kit (Karil's leathertop / Black d'hide) - Scorpia's guardians inflict venom that ticks 6 per hit and burns through brews quickly. Burning amulet -> Lava Maze then run south-west; or web-walk down via the Chaos Elemental ladder. Scorpia is in multi-combat so a PKer team will land specs together - swap to a one-click logout if you spot dots on the minimap",
+        "description": "Bank in Ferox Enclave then travel to the Scorpion Pit in deep Wilderness (level ~53). Bring anti-venom+, a high-tier stab weapon, prayer potions, food, and a Wilderness-cheap kit (Karil's leathertop / Black d'hide) - Scorpia's guardians inflict poison starting at 6 damage and burn through brews quickly. Burning amulet -> Lava Maze then run south-west; or web-walk down via the Chaos Elemental ladder. Scorpia is in multi-combat so a PKer team will land specs together - swap to a one-click logout if you spot dots on the minimap",
         "worldX": 3231,
         "worldY": 3936,
         "worldPlane": 0,
@@ -5075,7 +5075,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Scorpia. Use Protect from Melee, attack with crush (Bandos godsword, Inquisitor's mace) or stab to bypass her defence, and pre-pot anti-venom+. At ~33% HP Scorpia spawns two Scorpia's Guardians that heal her - kill them on sight or DPS Scorpia faster than the heal tick. Sip super combat / overload mid-fight if you brought one",
+        "description": "Kill Scorpia. Use Protect from Missiles to block damage from her guardians, attack with stab (her lowest melee defence), and pre-pot anti-venom+. At ~50% HP Scorpia spawns two Scorpia's Guardians that heal her - kill them on sight or DPS Scorpia faster than the heal tick. Sip super combat / overload mid-fight if you brought one",
         "worldX": 3233,
         "worldY": 10341,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Corrects four guidance-text errors for Scorpia identified in audit tranche 2 (docs/verify/findings-wiki-meta-2026-06.md, PR #829).

## Findings applied

- [medium] C2: guardians inflict **poison** (starting at 6 damage), not venom. Wiki: "Both Scorpia and her offspring are capable of inflicting poison, starting at 20 and 6 damage, respectively."
- [blocker] C7: combat step now recommends **Protect from Missiles** (not Protect from Melee) to block offspring ranged damage. Wiki (Strategies): "praying Protect from Missiles to prevent damage from Scorpia's offspring"
- [high] C8: removed incorrect crush recommendation (crush/slash are tied at +284 defence, highest of all melee styles); now recommends **stab** (her lowest melee defence at +246). Wiki (Strategies): "Stab: +246, Slash: +284, Crush: +284 [melee defence]"
- [high] C9: guardian spawn threshold corrected from ~33% HP to **~50% HP**. Wiki: "Once Scorpia falls below 50% health, the next attack against her ... will cause her to summon two Scorpia's guardians"

## Findings skipped

None. All four confirmed findings were guidance-text corrections within scope.

## Changes

Two description strings modified in the Scorpia source object (step 1 travel, step 3 combat). No drop rates, IDs, coordinates, requirements, or loop markers touched.

## Test plan

- JSON parses cleanly
- No non-ASCII characters introduced
- `python scripts/audit_drop_rates.py --category BOSSES` reports 0 errors

Full receipts: docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 2 section)