### PR TITLE
fix(data): Skotizo - wiki-meta guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -5803,7 +5803,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Bank for Skotizo. Bring Arclight (or Emberlight) for the demonbane bonus, Saradomin brews, super restores, Protect from Magic prayer potions, and 3 Dark totem pieces. Tank gear and Protect from Magic recommended - Skotizo hits through the protection on every attack.",
+        "description": "Bank for Skotizo. Bring Arclight (or Emberlight) for the demonbane bonus, Saradomin brews, super restores, prayer potions, and 3 Dark totem pieces. Use Protect from Melee as your primary prayer; wear high Magic Defence gear (e.g. black dragonhide) to absorb his magic attacks.",
         "worldX": 1638,
         "worldY": 3673,
         "worldPlane": 0,
@@ -5828,7 +5828,7 @@
         "section": "Travel"
       },
       {
-        "description": "Use the Dark totem on the Dark Altar in the Catacombs to spawn Skotizo. The totem is assembled from three pieces (Dark totem top / middle / base) dropped by Catacomb monsters and combined at the altar",
+        "description": "Use the Dark totem on the Dark Altar in the Catacombs to spawn Skotizo. Combine the three pieces (Dark totem base / middle / top) in your inventory first - they are dropped by Catacomb monsters.",
         "worldX": 1636,
         "worldY": 3673,
         "worldPlane": 0,
@@ -5840,7 +5840,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Skotizo. Use Protect from Magic and attack the four Awakened Altars around the arena as soon as they spawn - leaving them alive amplifies Skotizo's damage dramatically. Arclight (or upgraded Emberlight) gives huge accuracy and damage against demons. Drink prayer potions on cooldown; Skotizo's magic still hits through the protection.",
+        "description": "Kill Skotizo. Use Protect from Melee in melee range; switch to Protect from Magic when running to disable the four Awakened Altars. Disable altars quickly - each active altar reduces your damage dealt to Skotizo by 25% (up to 100% with non-demonbane weapons, 15% each up to 60% with Arclight/Emberlight). Arclight (or Emberlight) gives huge accuracy and damage against demons.",
         "worldX": 1636,
         "worldY": 3673,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Corrects five guidance-text bugs in the Skotizo source, all verified against the wiki receipts in docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 2 section).

## Applied findings

**[blocker] C2:** Correct primary prayer from Protect from Magic to Protect from Melee. Wiki receipt: "Wearing armour with high Magic Defence (e.g. black dragonhide armour) while using Protect from Melee so the only source of damage is from his Magic attacks is helpful" (https://oldschool.runescape.wiki/w/Skotizo/Strategies)

**[blocker] C4:** Bank step claimed "Skotizo hits through Protect from Magic on every attack." Removed. Wiki explicitly recommends switching to Protect from Magic during altar runs, confirming PfM does protect.

**[medium] C8:** "combined at the altar" was wrong. The three pieces combine in the player's inventory; only the assembled totem is used on the altar. Corrected piece order to base/middle/top per wiki. Wiki receipt: "You bring the totem pieces together with a click" then the assembled totem is used on "the altar in the centre of the Catacombs of Kourend" (https://oldschool.runescape.wiki/w/Dark_totem)

**[blocker] C10:** Combat step said "leaving them alive amplifies Skotizo's damage dramatically." Inverted. Active altars reduce the player's damage dealt to Skotizo, not amplify his damage. Wiki receipt: "These altars reduce all damage inflicted on Skotizo while they are active. [...] 15% less with Arclight/Emberlight and 25% less with other weapons (up to a maximum of 60% and 100% damage reduction, respectively)" (https://oldschool.runescape.wiki/w/Awakened_Altar)

**[blocker] C12:** Combat step repeated "Skotizo's magic still hits through the protection." Removed. Replaced with correct prayer-switch guidance: Protect from Melee in melee range, switch to Protect from Magic when running to disable altars.

## Skipped findings

None - all five confirmed findings were guidance-text corrections within scope.

## Test plan

- [ ] JSON parses cleanly (`python -c "import json;json.load(open(...))"`)
- [ ] Zero non-ASCII characters
- [ ] `python scripts/audit_drop_rates.py --category BOSSES` reports 0 errors
- [ ] CI build passes