### PR TITLE
fix(data): Lizardman shaman - wiki-meta guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -5679,7 +5679,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Bank for Lizardman shamans. Bring your best crush weapon (Inquisitor's mace, Saradomin sword, or Soulreaper axe), Saradomin brews, super restores, super combat potion, prayer potions, and a few sharks. Slayer task is recommended for the Dragon warhammer rate - confirm one is active before leaving Shayzien.",
+        "description": "Bank for Lizardman shamans. Bring your best stab weapon (Ghrazi rapier or Osmumten's fang), Saradomin brews, super restores, super combat potion, prayer potions, and a few sharks. Slayer task is recommended for the Dragon warhammer rate - confirm one is active before leaving Shayzien.",
         "worldX": 1504,
         "worldY": 3633,
         "worldPlane": 0,
@@ -5705,7 +5705,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Lizardman shamans in the canyon. Stand with your back against a wall to prevent the shamans from leaping on you and resetting your aggro. Step one tile off the green spawn pool as soon as it appears - the spawn explodes for 20+ damage if you stand on it. Use your crush weapon for the Dragon warhammer / Lizardman fang rare drops.",
+        "description": "Kill Lizardman shamans in the canyon. Stand with your back against a wall to prevent the shamans from leaping on you and resetting your aggro. Move at least 3 tiles from the purple spawns as soon as they appear - the spawn explodes for 8-10 damage within 2 tiles. Use your stab weapon for the Dragon warhammer / Lizardman fang rare drops.",
         "worldX": 1472,
         "worldY": 3686,
         "worldPlane": 0,
@@ -5732,7 +5732,7 @@
         "section": "Loot"
       },
       {
-        "description": "Return to bank when supplies run low. Xeric's talisman -> Glade is the fastest cycle back to a Shayzien bank.",
+        "description": "Return to bank when supplies run low. Xeric's talisman -> Lookout is the fastest cycle back to a Shayzien bank.",
         "worldX": 1504,
         "worldY": 3633,
         "worldPlane": 0,


### PR DESCRIPTION
## Findings applied

[blocker] C1: Corrected inverted combat meta in bank step - replaced crush weapon recommendation (Inquisitor's mace, Saradomin sword, Soulreaper axe) with stab weapons (Ghrazi rapier, Osmumten's fang). Wiki Strategies page: "Slash, crush, and magical attacks are not recommended as they have high defensive bonuses against those styles." Defence bonuses: Stab -20, Crush +30.

[high] C2: Saradomin sword is a slash weapon, misclassified as crush in the data. Covered by C1 fix (full weapon list replaced).

[high] C3: Soulreaper axe is a slash weapon, misclassified as crush in the data. Covered by C1 fix (full weapon list replaced).

[blocker] C8: Corrected two factual errors in the combat step spawn mechanic: (1) spawn color changed from "green" to "purple" - wiki main page: "summon 3 small purple spawns that appear next to the player"; (2) explosion damage corrected from "20+ damage" to "8-10 damage within 2 tiles" - wiki Strategies page: "the spawn will explode, dealing 8-10 damage to players that are two spaces or less from it"; (3) avoidance instruction updated to "move at least 3 tiles" (safe distance per wiki is 3+ tiles, not 1 tile).

[blocker] C10: Corrected weapon guidance in combat step for rare drop farming - changed "Use your crush weapon" to "Use your stab weapon". Same inverted-meta error as C1 but in a separate sentence.

[high] C11: Corrected banking teleport from "Xeric's talisman -> Glade" to "Xeric's talisman -> Lookout". Wiki Xeric's talisman page: Glade teleports "by the magic trees north-east of the Hosidius farming patch" (far from Shayzien); Lookout teleports "at its entrance south-east of Shayzien" (the correct destination for a Shayzien bank cycle).

## Skipped findings

None - all confirmed findings in this source were description-text corrections within scope.

## Receipts

Full receipts in docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 2 section).

Key wiki quotes:
- Strategies: "Slash, crush, and magical attacks are not recommended as they have high defensive bonuses against those styles."
- Main page defence: "Stab -20, Slash +40, Crush +30"
- Main page spawns: "summon 3 small purple spawns that appear next to the player"
- Strategies spawns: "the spawn will explode, dealing 8-10 damage to players that are two spaces or less from it"
- Xeric's talisman page: Glade = "north-east of the Hosidius farming patch"; Lookout = "south-east of Shayzien"