### PR TITLE
fix(data): Venenatis - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -5268,7 +5268,7 @@
       }
     ],
     "locationDescription": "Silk Chasm, Wilderness",
-    "travelTip": "Burning amulet -> Bandit Camp, then run east to the Silk Chasm cave",
+    "travelTip": "Wilderness crabs teleport (fastest); or Waka canoe (57 Woodcutting) to reach the Silk Chasm cave",
     "mutuallyExclusiveSources": [
       "Kalphite Queen",
       "Chaos Elemental",
@@ -5280,13 +5280,13 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to the Silk Chasm cave entrance in the Wilderness with anti-pk gear, a Voidwaker / DWH spec weapon if available, and at least one super combat plus restore. Burning amulet to Bandit Camp then run east",
+        "description": "Travel to the Silk Chasm cave entrance in the Wilderness with anti-pk gear, a Voidwaker / DWH spec weapon if available, and at least one super combat plus restore. Use Wilderness crabs teleport (fastest) or Waka canoe (57 Woodcutting)",
         "worldX": 3321,
         "worldY": 3794,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
-        "travelTip": "Burning amulet -> Bandit Camp + run east"
+        "travelTip": "Wilderness crabs teleport (fastest); or Waka canoe with 57 Woodcutting"
       },
       {
         "description": "Enter the Cave Entrance to access the Silk Chasm",
@@ -5299,7 +5299,7 @@
         "completionDistance": 4
       },
       {
-        "description": "Kill Venenatis with melee using Protect from Magic. Venenatis attacks with magic and melee; the web special binds you in place and drains prayer/run energy, so pre-pot prayer and step away when the web lands. Kill the Venenatis spiderlings on sight - they hit hard and heal her if left alive",
+        "description": "Kill Venenatis with melee. She cycles 8 ranged attacks then 8 magic attacks - switch between Protect from Missiles and Protect from Magic each phase. Venenatis attacks with melee, ranged, and magic; the web special binds you in place and drains prayer/run energy, so pre-pot prayer and step away when the web lands. Kill Venenatis spiderlings on sight - they drain your prayer, boost her damage, and allow her to hit through protection prayers if left alive",
         "worldX": 3332,
         "worldY": 3734,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Four guidance-text bugs corrected for Venenatis, all confirmed via wiki receipts (audit tranche 2, docs/verify/findings-wiki-meta-2026-06.md, PR #829).

## Applied findings

**[blocker] C2:** Replaced static `Protect from Magic` prayer advice with prayer-switching guidance. Wiki confirms Venenatis cycles 8 ranged attacks then 8 magic attacks per phase; a single static prayer leaves the entire opening phase unmitigated. Players must alternate Protect from Missiles and Protect from Magic in sync with her cycle.

**[high] C4:** Corrected spiderling mechanic description. Data claimed spiderlings "heal her if left alive" — no such mechanic exists. Wiki receipt: "They will also increase her damage and allow her to hit through prayers if left alive." and "they will drain prayer on every hit." Updated description to reflect the actual danger.

**[high] C8:** Replaced invalid post-2023 travel route. Both `travelTip` and guidance step 1 directed players via "Burning amulet to Bandit Camp then run east" — a route that predates the January 2023 rework and does not reach the current Silk Chasm location. Wiki-confirmed routes used as replacements: Wilderness crabs teleport (listed as fastest option) and Waka canoe (57 Woodcutting).

**[medium] C1:** Added ranged as third attack style. Description said "attacks with magic and melee," omitting ranged entirely. Wiki receipt: "Venenatis attacks with melee towards any player that's adjacent to her, and either magic or ranged for any player out of her melee range." Description now lists all three styles.

## Key wiki receipts

- Attack cycle: "She will begin the fight using 8 range attacks, followed by 8 magic attacks, all while moving position every 4 attacks." (https://oldschool.runescape.wiki/w/Venenatis/Strategies)
- Spiderlings: "they will drain prayer on every hit regardless if prayed against or hits. They will also increase her damage and allow her to hit through prayers if left alive." (https://oldschool.runescape.wiki/w/Venenatis/Strategies)
- Travel: Wiki lists Wilderness crabs teleport, Annakarl Teleport, Waka canoe, Games necklace, Wilderness obelisks, Wilderness Sword 4. Burning amulet/Bandit Camp is absent. (https://oldschool.runescape.wiki/w/Venenatis/Strategies)

## Skipped findings

None — all four confirmed findings were guidance-text corrections within scope.

## References

Full receipts: docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 2 section, source: Venenatis)