### PR TITLE
fix(data): Tormented Demons - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -9639,7 +9639,7 @@
         "section": "Bank"
       },
       {
-        "description": "Use a Guthixian temple teleport to drop straight into the Chasm of Tears. The fallback unquested route is attracting a light creature in the chasm with a sapphire lantern - much slower but works without a teleport scroll.",
+        "description": "Use a Guthixian temple teleport to travel directly to the Ancient Guthixian Temple entrance. The fallback unquested route is attracting a light creature in the chasm with a sapphire lantern - much slower but works without a teleport scroll.",
         "worldX": 4100,
         "worldY": 4415,
         "worldPlane": 0,
@@ -9652,7 +9652,7 @@
         "section": "Travel"
       },
       {
-        "description": "Hit the demon with Darklight (or Emberlight) special attack to break its shield. Once the shield is down, it will cycle protection prayers - swap your style between melee / ranged / magic on every two successful hits to keep accuracy up. Use fire spells or Smoke Burst for the magic phase to take advantage of their fire weakness.",
+        "description": "The fire shield drops after your first hit and after each fire bomb attack - demonbane weapons (Darklight, Emberlight) bypass the 20% damage reduction entirely. Switch combat style after dealing roughly 150 damage to trigger the demon's prayer swap, then swap to a different style to keep accuracy up. Use water spells (e.g. Water Surge) for the magic phase to exploit their 30% elemental weakness to water.",
         "worldX": 4100,
         "worldY": 4415,
         "worldPlane": 0,
@@ -9664,7 +9664,7 @@
         "section": "Combat"
       },
       {
-        "description": "Kill the Tormented Demon. Dodge the floor-flame patches by stepping one tile in any direction when they ignite, and step out of the molten spray cone (the demon telegraphs it by raising both arms). Three-style rotation: hit twice with melee, swap to ranged for two hits, then magic for two hits - the demon's protection prayer always lags behind your last successful style by one cycle, so the swap keeps your accuracy high. Burning claw + Tormented synapse are the marquee rare drops.",
+        "description": "Kill the Tormented Demon. Dodge floor-flame patches by stepping one tile when they ignite. When the demon binds you in place, a fire bomb lands on your tile and a second on a random adjacent tile - pre-move before the bind to reduce damage. Switch style after dealing roughly 150 damage (about 25% of the demon's HP) - at that threshold it updates its protection prayer to match your last style, so swap to a different style immediately. Burning claw + Tormented synapse are the marquee rare drops.",
         "worldX": 4100,
         "worldY": 4415,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Corrects seven guidance-text errors in the Tormented Demons source against the current wiki. Full receipts in docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 2 section).

## Applied findings

**[blocker] C10:** Corrected prayer-swap trigger from "every two successful hits" to roughly 150 HP dealt. Wiki: "Every 150 health lost since their last prayer swap (roughly 25% of their max health), they will change their protection prayer to the last combat style they were damaged with."

**[blocker] C11:** Corrected magic weakness from fire/Smoke Burst to water spells (30% elemental weakness). Wiki (June 2025 update): "Tormented demons now have a 30% elemental weakness to water spells."

**[blocker] C14:** Removed rigid "two hits per style" three-style rotation; replaced with HP-threshold guidance consistent with C10 fix.

**[high] C8:** Corrected shield mechanic - the fire shield drops after the player's first attack and after each fire bomb attack; demonbane weapons bypass the 20% damage reduction. Wiki: "They will drop this shield after the player's first attack and after each fire bomb attack."

**[high] C15:** Corrected prayer framing - the demon updates its protection prayer TO the last damaging style at the 150-HP threshold, not a fixed "one cycle lag."

**[medium] C13:** Replaced fabricated "molten spray cone / raises both arms" mechanic with accurate fire bomb description. Wiki: "They will briefly bind the player in place roughly every 60 ticks...then release two fire bombs: one on the player's position as of the start of the attack, and a second on a random one of the 8 adjacent squares."

**[low] C5:** Corrected travel step destination label - Guthixian temple teleport goes to the Ancient Guthixian Temple entrance, not the Chasm of Tears.

## Skipped findings

None - all seven confirmed findings were guidance-text only and within scope.

## Test plan

- [ ] JSON parses cleanly (no syntax errors)
- [ ] No non-ASCII characters introduced
- [ ] `python scripts/audit_drop_rates.py --category BOSSES` reports 0 errors
- [ ] CI build passes