### PR TITLE
fix(data): Theatre of Blood (Hard Mode) - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -6870,7 +6870,7 @@
     ],
     "guidanceSteps": [
       {
-        "description": "Travel to Ver Sinhaza - Kharyrll teleport to Canifis then run south through Mort'ton. Hard Mode hits noticeably harder - bring Scythe of vitur, Tbow + diamond bolts (e), Sanguinesti staff, Soulreaper axe for spec, full brews/restores and extra prayer potions; expect tighter Nylo waves and a longer Verzik fight",
+        "description": "Travel to Ver Sinhaza - Kharyrll teleport to Canifis then run south through Mort'ton. Hard Mode hits noticeably harder - bring Scythe of vitur, Tbow + dragon arrows, Sanguinesti staff, Soulreaper axe for spec, full brews/restores and extra prayer potions; expect tighter Nylo waves and a longer Verzik fight",
         "worldX": 3650,
         "worldY": 3218,
         "worldPlane": 0,
@@ -6885,7 +6885,7 @@
                 22400
               ]
             },
-            "description": "Use Drakan's medallion to teleport directly to Ver Sinhaza. Hard Mode hits noticeably harder - bring Scythe of vitur, Tbow + diamond bolts (e), Sanguinesti staff, Soulreaper axe for spec, full brews/restores and extra prayer potions; expect tighter Nylo waves and a longer Verzik fight",
+            "description": "Use Drakan's medallion to teleport directly to Ver Sinhaza. Hard Mode hits noticeably harder - bring Scythe of vitur, Tbow + dragon arrows, Sanguinesti staff, Soulreaper axe for spec, full brews/restores and extra prayer potions; expect tighter Nylo waves and a longer Verzik fight",
             "travelTip": "Drakan's medallion -> Ver Sinhaza"
           }
         ],
@@ -6908,7 +6908,7 @@
         "section": "Combat"
       },
       {
-        "description": "Defeat Verzik Vitur in Hard Mode. P1: pray Protect from Magic and dagger the Athanatos. P2: dodge red ball, match prayer to Nylocas colour - HM spawns are denser. P3: Tbow with diamond bolts (e), pray Protect from Magic, dance the lightning zaps and never stand on a tornado",
+        "description": "Defeat Verzik Vitur in Hard Mode. P1: take turns using the Dawnbringer special attack to damage Verzik, hide behind a pillar between turns. P2: dodge urnbombs, poison or venom the Nylocas Athanatos to burst them into Verzik, match prayer to Nylocas colour - HM spawns are denser. P3: Tbow with dragon arrows, pray Protect from Magic, never stand on a tornado",
         "worldX": 3650,
         "worldY": 3218,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Corrects five guidance-text bugs in the Theatre of Blood (Hard Mode) source, all confirmed in audit tranche 2. Full receipts: docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 2 section).

## Applied findings

- [blocker] C6: travel step gear list - corrected 'Tbow + diamond bolts (e)' to 'Tbow + dragon arrows'. The Twisted bow uses arrows only; diamond bolts (e) are crossbow ammunition and are physically incompatible (wiki: 'It can fire any type of arrow, including dragon arrows').
- [blocker] C19: Verzik P1 step - replaced 'dagger the Athanatos' with the actual P1 mechanic (take turns using the Dawnbringer special attack, hide behind pillar). The Nylocas Athanatos spawns in Phase 2, not Phase 1 (wiki: 'the Nylocas Athanatos appears during the second phase of the Verzik Vitur encounter'). Athanatos mechanic moved into the P2 description.
- [blocker] C23: Verzik P3 step - corrected 'Tbow with diamond bolts (e)' to 'Tbow with dragon arrows' (same incompatibility as C6).
- [medium] C20: Verzik P2 step - replaced 'dodge red ball' with 'dodge urnbombs'. The P2 projectile is the urnbomb (wiki: 'She tosses out urnbombs at the players positions which deals up to 44 damage'). No red projectile exists in any documented Verzik phase.
- [medium] C25: Verzik P3 step - removed 'dance the lightning zaps'. The lightning chain attack is a Phase 2 mechanic (wiki: 'She will send a lightning ball that will chain between players'); it does not appear in Phase 3.

## Skipped findings

None - all confirmed findings are description-text corrections within scope.

## Test plan

- [ ] JSON parses cleanly
- [ ] Zero non-ASCII characters in the data file
- [ ] python scripts/audit_drop_rates.py --category RAIDS reports 0 errors (pre-existing low-severity flagged-research warnings on all raid lobby sources are unaffected)
- [ ] CI build passes