### PR TITLE
fix(data): Chaos Fanatic - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -5169,14 +5169,14 @@
                 2566
               ]
             },
-            "description": "Rub a Ring of dueling from your inventory and select Ferox Enclave to bank instantly, restock the cheap kit, and recharge amulets at the fountain before entering the Wilderness.",
+            "description": "Rub a Ring of dueling from your inventory and select Ferox Enclave to bank instantly and restock the cheap kit before entering the Wilderness.",
             "travelTip": "Ring of dueling (inventory) -> Ferox Enclave bank"
           }
         ],
         "section": "Bank"
       },
       {
-        "description": "Travel to the Chaos Fanatic camp in the Wilderness (level 42). Burning amulet -> Lava Maze then run south-west past the lava pits, or web-walk via the Mage of Zamorak teleport (Lvl-60 Magic). Watch for PKers along the canyon corridor",
+        "description": "Travel to the Chaos Fanatic camp in the Wilderness (level 42). Burning amulet -> Lava Maze, run south-west past the lava pits. Alternatively, cast Ghorrock Teleport or use a POH obelisk (hard Wilderness Diary) to select level 44 Wilderness. Watch for PKers along the canyon corridor",
         "worldX": 2979,
         "worldY": 3846,
         "worldPlane": 0,
@@ -5186,7 +5186,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill the Chaos Fanatic. Use Protect from Magic and stand 1-2 tiles away (range is fine) - the multi-hit projectile splash deals 4-12 if you cluster with the spawn point. The boss has a self-damage tantrum animation that briefly stuns it; capitalise with a special attack. Logout on the south rocks if a PKer triggers",
+        "description": "Kill the Chaos Fanatic. Use Protect from Magic. Move away from the green AoE projectile landing spot to avoid the explosion. The boss can disarm your weapon or shield (like Chaos Elemental); keep a spare equipped or in inventory. Logout on the south rocks if a PKer triggers",
         "worldX": 2979,
         "worldY": 3846,
         "worldPlane": 0,
@@ -5204,7 +5204,7 @@
         ]
       },
       {
-        "description": "Stash drops in the looting bag and teleport via burning amulet or glory. Recharge amulets at Ferox Enclave fountain and bank loot from the looting bag before the next trip",
+        "description": "Stash drops in the looting bag and teleport via burning amulet or glory. Bank loot from the looting bag at Ferox Enclave before the next trip",
         "worldX": 3151,
         "worldY": 3635,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Corrects five wiki-meta guidance errors in the Chaos Fanatic source, confirmed in docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 2 section).

## Applied findings

- **[high] C3**: Travel step replaced Mage of Zamorak teleport (which goes to the Abyss, not the Lava Maze/level 42 Wilderness) with the wiki-documented alternatives: Ghorrock Teleport and POH obelisk (hard Wilderness Diary). Receipt: wiki travel section - "The fastest way to get there is by casting Ghorrock Teleport or using its magic tablet equivalent. Alternatively, a burning amulet can teleport players to the entrance of the Lava Maze; run west from there. Alternatively, players with the hard Wilderness Diary completed and a POH obelisk can select the level 44 Wilderness teleport."
- **[blocker] C7**: Removed fabricated self-damage tantrum/stun animation mechanic from combat step. Neither the main page nor Strategies page documents this mechanic. Added the documented item-disarming mechanic instead.
- **[blocker] C8**: Removed clustering/multi-hit splash damage claim. April 2, 2025 patch changed the AoE to only affect the last player who engaged in combat, making the clustering premise invalid. Receipt: wiki patch note - "The Chaos Fanatic's area-of-effect attack will now only affect the last player who engaged in combat."
- **[medium] C6**: Removed unsupported 1-2 tile mitigation distance and 4-12 damage range (addressed by same combat step rewrite as C7/C8). Wiki only advises moving away from the explosion.
- **[medium] C11**: Removed amulet recharge claims from the Ring of Dueling conditional alternative and the post-kill bank step. The Ferox Enclave Pool of Refreshment restores HP/stats/prayer/run energy only; it does not recharge charged jewelry.

## Skipped findings

None - all five confirmed findings were text-only guidance corrections within scope.

## Test plan

- [ ] JSON parses without errors
- [ ] No non-ASCII characters in file
- [ ] `python scripts/audit_drop_rates.py --category BOSSES` reports 0 errors
- [ ] CI build passes

Full receipts: docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 2 section)