### PR TITLE
fix(data): Revenants - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -9999,7 +9999,7 @@
     "travelTip": "Burning amulet -> Bandit Camp -> Rev Caves",
     "guidanceSteps": [
       {
-        "description": "Bank in Edgeville or Ferox Enclave. Bring cheap ranged gear, Bracelet of ethereum (prevents revenant passive damage), looting bag, burning amulet, food, and prayer potions. Only risk what you are willing to lose - this is multi-combat Wilderness (level 28-34).",
+        "description": "Bank in Edgeville or Ferox Enclave. Bring cheap ranged gear, Bracelet of ethereum (reduces revenant damage by 75%), looting bag, burning amulet, food, and prayer potions. Only risk what you are willing to lose - this is singles-plus combat Wilderness (level 28-34).",
         "worldX": 3094,
         "worldY": 3492,
         "worldPlane": 0,
@@ -10037,7 +10037,7 @@
         "section": "Bank"
       },
       {
-        "description": "Travel to the Revenant Caves entrance. Rub the burning amulet and teleport to Bandit Camp, then run north-east to the cave entrance at level 28 Wilderness. Watch for PKers along the route.",
+        "description": "Travel to the Revenant Caves entrance. Rub the burning amulet and teleport to Bandit Camp, then run north-east to the cave entrance at level 26 Wilderness. Watch for PKers along the route.",
         "worldX": 3073,
         "worldY": 3654,
         "worldPlane": 0,
@@ -10047,7 +10047,7 @@
         "section": "Travel"
       },
       {
-        "description": "Pay the 100,000-coin entry fee and enter the Revenant Caves. Activate the Bracelet of ethereum to negate revenant passive damage. Warning: the caves are deep Wilderness and multi-combat.",
+        "description": "Pay the 100,000-coin entry fee and enter the Revenant Caves. Activate the Bracelet of ethereum to reduce revenant damage by 75%. Warning: the caves are deep Wilderness and singles-plus combat.",
         "worldX": 3136,
         "worldY": 3672,
         "worldPlane": 0,
@@ -10057,7 +10057,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill revenants in the caves for unique drops. Use Protect from Magic or Protect from Missiles based on the revenant type. The Bracelet of ethereum negates passive damage. Stay alert for PKers - this is one of the most contested multi-combat Wilderness zones. Loot into the looting bag immediately and teleport out if threatened.",
+        "description": "Kill revenants in the caves for unique drops. Revenants use all three combat styles and adapt to your weakness - use Protect from Melee, Magic, or Missiles as appropriate. The Bracelet of ethereum reduces revenant damage by 75%. Stay alert for PKers - this is one of the most contested singles-plus combat Wilderness zones. Loot into the looting bag immediately and teleport out if threatened.",
         "worldX": 3136,
         "worldY": 3672,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Five confirmed wiki-meta inaccuracies in the Revenants guidance steps, sourced from audit tranche 2. Full receipts in docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 2 section).

## Applied findings

- **[blocker] C8**: Replaced "multi-combat" with "singles-plus combat" in guidanceSteps[0], [2], and [3]. The Revenant Caves are exclusively singles-plus combat. Receipt: "it is an extremely dangerous cave that ranges from level 17 to 40 Wilderness and is exclusively a singles-plus combat area." (https://oldschool.runescape.wiki/w/Revenant_Caves)
- **[high] C7**: Updated guidanceSteps[3] prayer instruction from "Use Protect from Magic or Protect from Missiles based on the revenant type" to note revenants use all three combat styles and adapt to the player's weakness. Receipt: "Revenants use all three forms of combat, using a combat style that the player is weak against as their primary attacks, and will adapt to any changes the player does." (https://oldschool.runescape.wiki/w/Revenant_Caves)
- **[medium] C5**: Fixed guidanceSteps[0] bracelet description from "prevents revenant passive damage" to "reduces revenant damage by 75%". The bracelet has not given full immunity since 2020.
- **[medium] C6**: Fixed guidanceSteps[2] bracelet description from "negate revenant passive damage" to "reduce revenant damage by 75%". Same mechanic correction as C5.
- **[medium] C3**: Fixed guidanceSteps[1] entrance level from "level 28 Wilderness" to "level 26 Wilderness". The wiki lists exactly three cave entrances; the one north of Bandit Camp is at level 26, not 28. Receipt: "Level 26 Wilderness - north of the Bandit Camp" (https://oldschool.runescape.wiki/w/Revenant_Caves)

## Skipped findings

None - all five confirmed findings were applied.

## Test plan

- [ ] JSON parses cleanly (python -c "import json;json.load(open(...))")
- [ ] No non-ASCII characters
- [ ] python scripts/audit_drop_rates.py --category OTHER reports 0 errors
- [ ] CI build passes