### PR TITLE
fix(data): Thermonuclear smoke devil - wiki-meta guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -4617,7 +4617,7 @@
         "section": "Travel"
       },
       {
-        "description": "Enter the smoky cave. A facemask, Slayer helmet, or Masked earmuffs is required to survive the dungeon's smoke without constant damage. Active Smoke devil Slayer task is required to attack the Thermonuclear smoke devil",
+        "description": "Enter the smoky cave. A facemask, gas mask, or Slayer helmet is required to survive the dungeon's smoke without constant damage. Active Smoke devil Slayer task is required to attack the Thermonuclear smoke devil",
         "worldX": 2412,
         "worldY": 3061,
         "worldPlane": 0,
@@ -4637,7 +4637,7 @@
         "section": "Travel"
       },
       {
-        "description": "Navigate north-west through the smoke devil cave to the Thermonuclear boss room. Take care of the regular smoke devils on the way if Protect from Magic is not flicked",
+        "description": "Navigate north-west through the smoke devil cave to the Thermonuclear boss room. Take care of the regular smoke devils on the way if Protect from Missiles is not flicked",
         "worldX": 2379,
         "worldY": 9452,
         "worldPlane": 0,
@@ -4646,7 +4646,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill the Thermonuclear smoke devil. Use Protect from Magic - it hits 30s+ through no prayer. Stay back at max distance with Trident of the Swamp/Seas or Tumeken's shadow; safe-spot the boss behind a rock so you can flick the prayer easily. Bring an Occult necklace yourself once it drops - the boss is the source of it.",
+        "description": "Kill the Thermonuclear smoke devil. Its attack is typeless (max hit 8); no protection prayer reduces it. Use Piety for melee or Redemption for magic. Stay at max distance with Trident of the Swamp/Seas or Tumeken's shadow - magic has 9-tile range vs the boss's 8-tile attack range, so freeze it and step back to exploit this gap. No static rock safe-spot exists; the boss walks through obstacles to prevent it. Bring an Occult necklace yourself once it drops - the boss is the source of it.",
         "worldX": 2379,
         "worldY": 9452,
         "worldPlane": 0,


### PR DESCRIPTION
## Applied findings

- [medium] C6: replace invalid 'Masked earmuffs' with 'gas mask' in enter-cave step. Wiki receipt: "players must equip either a gas mask, facemask, or slayer helmet." Masked earmuffs is not a real smoke-protection item.
- [blocker] C9: replace 'Protect from Magic' with 'Protect from Missiles' for the traversal step past regular smoke devils. Wiki receipt: "When fighting them, using Protect from Missiles will negate their attacks." Smoke devils use a magical ranged attack (Ranged-type), negated by Missiles, not Magic.
- [blocker] C10: remove Protect from Magic recommendation for the boss kill step. Wiki receipt: "The thermonuclear smoke devil only attacks with a typeless magical ranged attack" and "Typeless means that protection prayers will not have any effect." Replaced with Piety (melee) / Redemption (magic) advice.
- [blocker] C11: correct claimed max hit from '30s+' to '8'. Wiki receipt (Strategies page): "The max hit of this attack is 8."
- [high] C12: remove false rock safe-spot claim. Wiki receipt: "Unlike most NPCs, the Thermonuclear smoke devil is always able to walk through other monsters/players. This is to prevent players from safespotting the boss using the smoke devils found in its lair." Replaced with the freeze-kite technique (magic 9-tile range vs boss 8-tile range).

## Skipped

None - all findings were description-text corrections only; no requirements wiring or ID changes required.

## Full receipts

See docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 2 section) for complete wiki quotes and skeptic receipts.