### PR TITLE
fix(data): Callisto - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -5473,7 +5473,7 @@
       }
     ],
     "locationDescription": "Callisto's Den, Wilderness",
-    "travelTip": "Burning amulet -> Chaos Temple, then run south-east into Callisto's Den",
+    "travelTip": "Burning amulet -> Chaos Temple, then run north into Callisto's Den",
     "mutuallyExclusiveSources": [
       "Kalphite Queen",
       "Chaos Elemental",
@@ -5485,7 +5485,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to Callisto's Den in the Wilderness with a melee setup (Bandos / Torva, Voidwaker, Saradomin brews) and prayer potions. Burning amulet to Chaos Temple, then run south-east",
+        "description": "Travel to Callisto's Den in the Wilderness with a ranged setup (Masori or equivalent ranged armour, Webweaver bow or crossbow, Saradomin brews) and prayer potions. Burning amulet to Chaos Temple, then run north",
         "worldX": 3265,
         "worldY": 3832,
         "worldPlane": 0,
@@ -5497,10 +5497,10 @@
           3870,
           0
         ],
-        "travelTip": "Burning amulet -> Chaos Temple + run south-east"
+        "travelTip": "Burning amulet -> Chaos Temple + run north"
       },
       {
-        "description": "Arrive at Callisto's Den and pre-pot Super Combat. Turn on Piety and Protect from Melee before engaging; Callisto deals heavy melee damage even at full health",
+        "description": "Arrive at Callisto's Den and pre-pot Divine ranging potion. Turn on Rigour (or Eagle Eye) and Protect from Magic before engaging; melee combat is not advised as Callisto deals very high melee damage even through Protect from Melee",
         "worldX": 3291,
         "worldY": 3849,
         "worldPlane": 0,
@@ -5508,7 +5508,7 @@
         "completionDistance": 5
       },
       {
-        "description": "Kill Callisto with melee using Protect from Melee - Callisto only attacks with melee. Stand on his tile so the bear-stomp shockwave (knockback that unequips ranged shields and stalls combat) hits at melee range. Kill Callisto cubs immediately on spawn; they heal him if left alive",
+        "description": "Kill Callisto with ranged using Protect from Magic. Callisto uses melee, ranged (if out of reach), and a slow magic attack - Protect from Magic fully negates the magic attack and prevents the knockback/stun. At 66% and 33% HP Callisto deploys bear traps that snare and damage if stepped on. Protect from Melee only reduces his melee damage by ~50% so stay at range",
         "worldX": 3291,
         "worldY": 3849,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

All three guidance steps for Callisto contained factually wrong information, steering players into the discouraged melee combat meta and describing fabricated mechanics. This PR replaces them with accurate wiki-sourced guidance.

## Applied findings

[blocker] C3: Corrected claim that Callisto only attacks with melee - wiki documents three styles: melee, ranged (when out of reach), and a slow magic attack.

[blocker] C2: Corrected framing of Protect from Melee as effective - wiki states it only reduces melee damage by ~50%, whereas Protect from Magic/Ranged fully negate those attack types. Key wiki receipt: "Protection prayers will negate all ranged and magic damage of his attacks, but Protect from Melee will only reduce the damage by ~50%."

[blocker] C13: Replaced Piety (melee prayer) with Rigour/Eagle Eye - wiki states melee combat is not advised and ranged is the ideal method.

[blocker] C9: Replaced melee gear (Bandos/Torva) with ranged gear (Masori, Webweaver bow) - wiki states melee combat is not advised and recommends ranged armour.

[high] C10: Removed Voidwaker (melee weapon) from recommended gear - not mentioned by wiki strategy guide; all recommended weapons are ranged.

[high] C12: Replaced Super Combat potion (melee boost) with Divine ranging potion per wiki inventory recommendations.

[high] C4: Removed fabricated "bear-stomp shockwave" mechanic - wiki attributes knockback/stun to the slow magic attack (negated by Protect from Magic), not a stomp. Bear traps at 66%/33% HP snare and damage but do not knock back.

[high] C5: Removed fabricated shield-unequipping claim - no such mechanic exists anywhere on the Callisto wiki pages.

[high] C6: Removed fabricated combat-stalling claim - no such mechanic documented.

[high] C7: Removed stand-on-tile/shockwave-range instruction - no such mechanic; replaced with accurate bear trap description at 66%/33% HP.

[medium] C8: Removed fabricated Callisto cub healing mechanic - the Callisto cub is a 1/1500 pet drop only; it is not a combat NPC and no healing mechanic is documented.

[blocker] C15: Corrected travel direction from Chaos Temple to Den from "south-east" to "north" - the Den is at Wilderness level 40, north of the Chaos Temple (~level 11-13).

## Skipped findings

None - all confirmed findings were addressed via description-text corrections only.

## References

Full receipts: docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 2 section, Callisto)