### PR TITLE
fix(data): Araxxor - wiki-meta guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -9294,7 +9294,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Bank for Araxxor. Bring Saradomin brews, super restores, and combat potions; mage gear for path 1 (Aviansie/Spitting), melee tank for path 2 (Mirror), ranged for path 3 (Minions). A salve amulet (ei) and crush weapon (Inquisitor's mace, Soulreaper axe, or Scythe) are the standard meta picks.",
+        "description": "Bank for Araxxor. Bring Saradomin brews, super restores, and combat potions. Use melee (scythe, Inquisitor's mace, or Soulreaper axe) or ranged; bring a halberd for mirrorback araxytes. Saradomin brews and super restores for sustain.",
         "worldX": 3087,
         "worldY": 3493,
         "worldPlane": 0,
@@ -9318,7 +9318,7 @@
         "section": "Travel"
       },
       {
-        "description": "Enter the Araxyte hive and descend to the Araxxor arena. The first encounter is randomly assigned one of three paths; subsequent kills cycle through the remaining two",
+        "description": "Enter the Araxyte hive and descend to the Araxxor arena. Each fight, eggs hatch in one of three fixed patterns (Green>White>Red, White>Red>Green, or Red>Green>White) determining which araxyte type spawns first.",
         "worldX": 3686,
         "worldY": 3426,
         "worldPlane": 0,
@@ -9329,7 +9329,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Araxxor. Three rotating paths: Path 1 (Aviansie) - use magic to break acid spitting; Path 2 (Mirror) - tank with Protect from Melee and high def, ignore the reflection; Path 3 (Minions) - kill spiderlings before they reach you. Phase 4 (final) requires Protect from Magic, dodge the web cocoon special, and pop minions with chinchompas if you brought them. Sip super combat / overload between phases.",
+        "description": "Kill Araxxor. Acidic araxytes (green eggs) explode into acid pools on death - kill them quickly and avoid the pools. Mirrorback araxytes (white eggs) recoil 50% of melee damage - attack with ranged, magic, or a halberd from one tile away to ignore the deflection. Ruptura araxytes (red eggs) spawn spiderlings - kill them before they reach you. Phase 4 enrage: Araxxor replaces melee with a 1x3 cleave attack; use Protect from Melee to reduce damage and stand under Araxxor to shrink the cleave to 1x1. Sip super combat between phases.",
         "worldX": 3686,
         "worldY": 3426,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Corrects eight guidance-text errors in the Araxxor source, all of which appear to be RS3 mechanics incorrectly applied to the OSRS version of the boss.

## Applied findings

**[blocker] C1:** Removed fabricated "use magic to break acid spitting" mechanic. OSRS acidic araxytes are ranged attackers that explode into acid pools on death; there is no magic-breaks-acid mechanic. Receipt: "If killed, it will explode, splattering acid on random squares within a 7x7 AoE surrounding it." (https://oldschool.runescape.wiki/w/Araxxor/Strategies)

**[blocker] C2:** Fixed inverted mirrorback strategy. Old text told players to tank with Protect from Melee and ignore the reflection. The wiki says mirrorbacks recoil 50% of melee damage back and players should attack with ranged, magic, or a halberd from one tile away. Receipt: "Attacking it with ranged, magic, or with a halberd (while one tile away) will ignore their deflection." (https://oldschool.runescape.wiki/w/Araxxor/Strategies)

**[blocker] C4:** Fixed enrage-phase prayer from Protect from Magic to Protect from Melee. The Phase 4 enrage converts Araxxor's melee into a cleave attack; the wiki recommends Protect from Melee (reduces it ~50%). Receipt: "If the player fails to dodge the cleave attack, Protect from Melee will still reduce its damage by ~50%." (https://oldschool.runescape.wiki/w/Araxxor/Strategies)

**[blocker] C5:** Removed nonexistent "web cocoon special attack". No such mechanic exists on any Araxxor wiki page. Replaced with accurate enrage cleave description (1x3 cleave, stand under Araxxor to reduce to 1x1). Receipt: Special attacks listed are Acid Ball, Acid Splatter, and Acid Drip; no web cocoon exists. (https://oldschool.runescape.wiki/w/Araxxor/Strategies)

**[blocker] C8:** Removed melee tank gear recommendation for the mirrorback encounter. Meleeing a mirrorback in melee range incurs the 50% recoil; wiki directs ranged/magic/halberd-from-range instead. Same receipt as C2.

**[high] C9:** Removed mage gear recommendation. The wiki discourages magic against Araxxor (+237 Magic Defence); the Strategies page lists only melee and ranged setups. Receipt: "his high magical defences makes this trait mostly thematic, and the generally lower defences of magic robes will have the player take more damage overall."

**[high] C12:** Replaced "randomly assigned one of three paths" with accurate egg-pattern mechanics. OSRS Araxxor has no numbered per-kill paths; the fight uses egg-hatching patterns within each kill. Receipt: "The eggs will always follow one of three potential patterns, with the last two sets copying that of the first: Green > White > Red / White > Red > Green / Red > Green > White." (https://oldschool.runescape.wiki/w/Araxxor/Strategies)

**[high] C13:** Removed cross-kill cycling claim ("subsequent kills cycle through the remaining two"). No such cross-kill rotation exists in OSRS Araxxor; the egg pattern system operates within individual fights. Same receipt as C12.

## Skipped findings

None - all confirmed findings were pure description text corrections within scope.

## References

Full receipts in docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 2 section), Araxxor entries.