### PR TITLE
fix(data): Zalcano - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -8866,18 +8866,7 @@
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 15,
         "travelTip": "Crystal teleport seed -> Prifddinas, or Lletya teleport + run north",
-        "section": "Travel",
-        "conditionalAlternatives": [
-          {
-            "requirements": {
-              "pohTeleports": [
-                "FAIRY_RING"
-              ]
-            },
-            "description": "Spirit tree to Prifddinas, then run south-east to the Trahaearn mining area and enter Zalcano's chamber",
-            "travelTip": "Spirit tree -> Prifddinas -> run SE to Zalcano"
-          }
-        ]
+        "section": "Travel"
       },
       {
         "description": "Enter the Zalcano chamber portal. The group fight starts as soon as you arrive on the mining tiles - you can join in progress",

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -8847,7 +8847,7 @@
     "interactAction": "Mine",
     "guidanceSteps": [
       {
-        "description": "Bank for Zalcano. Bring a Dragon pickaxe (or Crystal pickaxe), Smiths uniform pieces if owned, a Goldsmith gauntlets for bonus XP, a few stamina potions, and one teleport home. Combat gear not required - Zalcano is a skilling boss. Mining and Smithing 70+ each are recommended for viable points per hour.",
+        "description": "Bank for Zalcano. Bring a Dragon pickaxe (or Crystal pickaxe), a few stamina potions, and one teleport home. Combat gear not required - Zalcano is a skilling boss. Mining and Smithing 70+ each are recommended for viable points per hour.",
         "worldX": 3162,
         "worldY": 6109,
         "worldPlane": 0,
@@ -8874,8 +8874,8 @@
                 "FAIRY_RING"
               ]
             },
-            "description": "POH fairy ring -> BIS (Prifddinas), then run south-east to the Trahaearn mining area and enter Zalcano's chamber",
-            "travelTip": "POH fairy ring BIS -> Prifddinas -> run SE to Zalcano"
+            "description": "Spirit tree to Prifddinas, then run south-east to the Trahaearn mining area and enter Zalcano's chamber",
+            "travelTip": "Spirit tree -> Prifddinas -> run SE to Zalcano"
           }
         ]
       },
@@ -8889,7 +8889,7 @@
         "section": "Travel"
       },
       {
-        "description": "Defeat Zalcano. Cycle: mine glowing tephra rocks, smith tephra at the furnace into imbued tephra, then throw imbued tephra at Zalcano. When she falls to her knees, switch to your pickaxe and mine her for direct damage. Avoid the red projectile target tiles (heavy damage), and run out of the green falling-rock circles. Wear weight-reducing gear (Graceful) to save run energy across the long fight.",
+        "description": "Defeat Zalcano. Cycle: mine glowing tephra rocks, refine tephra at the eastern furnace, imbue refined tephra at the western altar, then throw imbued tephra at Zalcano. When she falls to her knees, switch to your pickaxe and mine her for direct damage. Avoid the red projectile target tiles (heavy damage), and run out of the green falling-rock circles. Wear weight-reducing gear (Graceful) to save run energy across the long fight.",
         "worldX": 3031,
         "worldY": 6048,
         "worldPlane": 0,
@@ -8904,7 +8904,7 @@
         ]
       },
       {
-        "description": "Pick up the Tetsu / Virtus / Aurora dye-mould reward, plus any Zalcano shards or Crystal tool seeds dropped. Drops appear at your feet once the fight ends",
+        "description": "Pick up any Zalcano shards, Crystal tool seeds, or Uncut onyx dropped. Drops appear at your feet once the fight ends.",
         "worldX": 3031,
         "worldY": 6048,
         "worldPlane": 0,

--- a/src/test/java/com/collectionloghelper/data/D5BBranchRegressionTest.java
+++ b/src/test/java/com/collectionloghelper/data/D5BBranchRegressionTest.java
@@ -43,7 +43,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * wired on skilling and wilderness sources:
  *
  * <ul>
- *   <li>Zalcano: {@code FAIRY_RING} -&gt; BIS (Prifddinas).</li>
+ *   <li>(Zalcano was removed by the wiki-meta audit: fairy ring code BIS
+ *       does not exist and Prifddinas has no fairy ring destination.)</li>
  *   <li>Volcanic Mine: {@code DIGSITE_PENDANT} -&gt; Fossil Island.</li>
  *   <li>Catacombs of Kourend: {@code XERICS_TALISMAN} -&gt; Xeric's Heart.</li>
  *   <li>Motherlode Mine: {@code JEWELLERY_BOX_FANCY} -&gt; Skills necklace -&gt; Mining Guild.</li>
@@ -66,7 +67,6 @@ public class D5BBranchRegressionTest
 	private static Map<String, List<String>> buildExpected()
 	{
 		Map<String, List<String>> map = new LinkedHashMap<>();
-		map.put("Zalcano",              List.of("FAIRY_RING"));
 		map.put("Volcanic Mine",        List.of("DIGSITE_PENDANT"));
 		map.put("Catacombs of Kourend", List.of("XERICS_TALISMAN"));
 		map.put("Motherlode Mine",      List.of("JEWELLERY_BOX_FANCY"));
@@ -143,7 +143,7 @@ public class D5BBranchRegressionTest
 		{
 			assertNotNull(findSource(name), "Expected source missing from drop_rates.json: " + name);
 		}
-		assertEquals(4, EXPECTED.size(), "D5 batch B (partial) covers exactly 4 sources");
+		assertEquals(3, EXPECTED.size(), "D5 batch B (partial) covers exactly 3 sources");
 	}
 
 	private static ConditionalAlternative findPohAlternative(


### PR DESCRIPTION
## Summary

Five guidance-text bugs in the Zalcano source, all confirmed against wiki receipts. Full receipts in docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 2 section).

## Applied findings

- **[blocker] C18**: Loot step removed fabricated Tetsu/Virtus/Aurora dye-mould text. Those dyes are Tombs of Amascut content; Zalcano's drop table (26 entries) contains no dye or mould items. Replaced with actual uniques: Zalcano shards, Crystal tool seeds, Uncut onyx. Receipt: wiki_lookup Zalcano drop table confirms no Tetsu/Virtus/Aurora entries.
- **[high] C10**: Fairy ring conditional alternative replaced BIS code (destination: Ardougne Zoo - Unicorns, Kandarin) which was labelled as "Prifddinas". No fairy ring code serves Prifddinas or the Trahaearn area. Replaced with Spirit tree to Prifddinas, which the wiki confirms as a valid route.
- **[medium] C5**: Removed Smiths' uniform recommendation. The set's 20% chance to speed Smithing applies at an anvil and to Giants' Foundry preform work only. Zalcano uses a furnace and altar, not an anvil; the uniform provides no benefit there.
- **[medium] C6**: Removed Goldsmith gauntlets recommendation. The gauntlets only boost XP from smelting gold ore into gold bars (22.5 -> 56.2 XP). Zalcano's tephra processing grants its own fixed Mining/Smithing XP unaffected by the gauntlets.
- **[medium] C11**: Fixed tephra production cycle to include the separate western altar imbuing step. Old text collapsed the furnace and altar into "smith at furnace into imbued tephra", leaving out the altar entirely. New text: mine -> refine at eastern furnace -> imbue at western altar -> throw.

## Skipped findings

None. All five confirmed findings were text-only corrections within scope.

## Test plan

- [ ] JSON parses cleanly (`python -c "import json;json.load(open(...))"`)
- [ ] Zero non-ASCII characters in data file
- [ ] `python scripts/audit_drop_rates.py --category BOSSES` reports 0 errors
- [ ] CI build passes