### PR TITLE
fix(data): Sol Heredit - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -9016,7 +9016,7 @@
     ],
     "guidanceSteps": [
       {
-        "description": "Bank at Civitas illa Fortis for the Colosseum. Bring Saradomin brews, super restores, ranging potions, sharks, a Quetzal whistle (or fast teleport), and a Sunfire fanatic / Crystal armour ranged setup. Meta loadout is Bow of faerdhinen (c) with Crystal helm/body/legs + Pegasian boots + Necklace of anguish; bring a Voidwaker or Volatile nature staff spec for damage windows. Take 4-6 brews, 6-8 restores, 6 ranging potions, sharks to fill the rest, and at least 5 Sunfire splinters in case you reset on early waves.",
+        "description": "Bank at Civitas illa Fortis for the Colosseum. Bring Saradomin brews, super restores, ranging potions, sharks, a Quetzal whistle (or fast teleport), and a Sunfire fanatic / Crystal armour ranged setup. Meta loadout is Bow of faerdhinen (c) with Crystal helm/body/legs + Pegasian boots + Necklace of anguish; bring a Voidwaker or Volatile nature staff spec for damage windows. Take 4-6 brews, 6-8 restores, 6 ranging potions, and sharks to fill the rest.",
         "worldX": 1593,
         "worldY": 3091,
         "worldPlane": 0,
@@ -9053,7 +9053,7 @@
         "section": "Travel"
       },
       {
-        "description": "Clear waves 1-11. Use Protect from Missiles vs Fremennik Archers, Protect from Melee vs Manticores, and step under Serpent Shamans to break their long-range chain. Drink Sunfire splinters when low; do not over-stack modifiers if you are still learning the wave",
+        "description": "Clear waves 1-11. Use Protect from Missiles vs Fremennik Archers. Against Manticores, prayer-flick through their triple-hit sequence: the first two hits are ranged then magic (or magic then ranged), and the final hit is always melee - flick Protect from Missiles, Protect from Magic, then Protect from Melee in order. Step under Serpent Shamans to break their long-range chain. Do not over-stack modifiers if you are still learning the waves.",
         "worldX": 1794,
         "worldY": 3107,
         "worldPlane": 0,
@@ -9068,7 +9068,7 @@
         ]
       },
       {
-        "description": "Defeat Sol Heredit on wave 12. He cycles three melee specials: Triple Spear (move 2 tiles perpendicular), Triple Shield (run 4 tiles away then back), and Spear Wall (run to the wall opposite his facing). His shockwave attack is unavoidable - take it with full HP and Protect from Melee on. Use the white pillar to stall his shield slam and keep up Crystal armour set effect.",
+        "description": "Defeat Sol Heredit on wave 12. His AoE attacks are unaffected by prayer and must be dodged by movement. Spear 1 (always opens the fight): move back from his centre or edge tiles. Spear 2: move to any off-centre tile. Shield 1: move 1 tile back. Shield 2: move 2 tiles back. Below 90% HP he uses Triple Parry - activate Protect from Melee on the tick before each of his three spear hits. Below 75% HP he uses Grapple - he calls a body part and you must click the item in that equipment slot within 4 ticks. Keep up Crystal armour set effect.",
         "worldX": 1794,
         "worldY": 3107,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Corrects five guidance-text errors in the Sol Heredit (Fortis Colosseum) entry, all identified in audit tranche 2 (docs/verify/findings-wiki-meta-2026-06.md, PR #829).

## Applied findings

**[blocker] C11:** Waves 1-11 step now correctly describes the Manticore triple-hit prayer-flick sequence (ranged/magic first two hits in either order, melee always last), replacing the static "Protect from Melee" instruction that left the player exposed to the ranged (max 36) and magic (max 31) hits.
- Wiki receipt: "the Manticore will proceed to charge up a triple attack with all three combat styles. It will either use a range-magic or magic-range as the first two hits; the last hit is always melee. [...] Tier 1 causes each orb to hit twice rather than once, intended to punish players who do not flick the attacks correctly"

**[blocker] C13:** Removed the nonexistent "Drink Sunfire splinters when low" instruction from the waves step. Sunfire splinters are a crafting/charging material with no eat/drink action; wiki documents uses as quiver charging, sunfire rune creation, and sunfire wine brewing only.

**[high] C15:** Rewrote the Sol Heredit step with the wiki's actual attack names (Spear 1, Spear 2, Shield 1, Shield 2) and correct dodge directions. Fabricated names (Triple Spear, Triple Shield, Spear Wall) and wrong dodge descriptions (perpendicular, 4-tiles-away, wall-opposite) removed. Added the Grapple mechanic (below 75% HP, click called body-part slot within 4 ticks) and Triple Parry mechanic (below 90% HP, activate Protect from Melee on the tick before each of three hits).
- Wiki receipt: "Spear 1: Sol will always begin the fight with this attack. Dodged by moving back from his centre or edge tiles. Spear 2: Dodged by moving to any of his off-centre tiles. Shield 1: dodged by moving 1 tile back. Shield 2: dodged by moving 2 tiles back. Grapple (below 75% HP): [...] 4 ticks to click on the item in the respective slot to parry. Triple Parry (under 90% HP): requires the player to precisely activate Protect from Melee on the tick before he lands his spear."

**[high] C16:** Removed the nonexistent "shockwave attack is unavoidable" claim. Sol Heredit has no documented shockwave attack; his six attacks are Spear 1/2, Shield 1/2, Grapple, and Triple Parry. His AoE attacks are unaffected by prayer (must be dodged by movement), which is now stated correctly.
- Wiki receipt: "Sol primarily uses AoE attacks that are unaffected by prayer, forcing the player to dodge his attacks to avoid taking up to 44 typeless melee damage."

**[medium] C6:** Bank step - removed false recommendation to bring "at least 5 Sunfire splinters in case you reset on early waves". Splinters are a Colosseum drop (not a pre-run consumable) and serve no in-run function.

## Skipped findings

None - all five confirmed findings were guidance-text corrections within scope.

## Test plan

- [x] JSON syntax valid (python -c "import json;json.load(...)")
- [x] Zero non-ASCII characters
- [x] audit_drop_rates.py --category BOSSES reports 0 errors
- [ ] CI build gate

Full receipts: docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 2 section)