### PR TITLE
fix(data): Perilous Moons - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -9484,7 +9484,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to the Perilous Moons dungeon beneath Cam Torum, Varlamore. Before leaving the bank, equip a Dual macuahuitl or Blue moon spear for melee, Bowfa for ranged, Ancient sceptre / Trident for magic - all three styles rotate during the fight. Pack Saradomin brews, super restores, prayer potions, sharks, and your Quetzal whistle for the trip.",
+        "description": "Travel to the Perilous Moons dungeon beneath Cam Torum, Varlamore. Before leaving the bank, equip melee weapons only - each moon is weak to a specific melee style (Eclipse=stab, Blue=crush, Blood=slash) and has +500 ranged and magic defence. Bring a stab weapon, crush weapon, and slash weapon. Pack Saradomin brews, super restores, prayer potions, sharks, and your Quetzal whistle for the trip.",
         "worldX": 1435,
         "worldY": 3131,
         "worldPlane": 0,
@@ -9515,7 +9515,7 @@
         "section": "Travel"
       },
       {
-        "description": "Complete Perilous Moons. Fight Blue Moon (magic, freezes you to ice tiles - step off them), Eclipse Moon (melee, summons mirror clones, kill the real one), and Blood Moon (ranged, teleports around the arena - it auto-targets the same style you used last hit, so rotate styles to control its prayer). Each kill drops a Lunar key; use all three on the Lunar Chest for unique drops.",
+        "description": "Complete Perilous Moons. All three moons are melee-only bosses (ranged and magic are heavily resisted). Blue Moon (typeless melee, weak to crush) - hits freeze your hands causing missed attacks; weapon-freeze special places your weapon in an ice block, punch it to retrieve while dodging icy spikes. Eclipse Moon (melee, weak to stab) - clone special binds you in the centre while clones attack in waves; face your character toward each clone as it spawns to parry and return damage. Blood Moon (typeless melee, weak to slash) - alternates Blood Rain (move off blood pools) and Blood Jaguar (run to glyph and attack the jaguar) specials. After all three are dead, claim the Lunar Chest in the Ancient Shrine (all three moons must be defeated on first visit; 3 moons = 6 loot rolls).",
         "perItemStepDescription": {
           "29019": "Fight the Blue Moon and open the Lunar Chest to receive your Blue Moon armour.",
           "29013": "Fight the Blue Moon and open the Lunar Chest to receive your Blue Moon armour.",
@@ -9562,7 +9562,7 @@
         ]
       },
       {
-        "description": "After all three moons die, open the Lunar Chest in the centre of the arena for armour pieces and unique drops. Empty the chest before resetting the dungeon",
+        "description": "After all three moons die, head south into the Ancient Shrine within Neypotzli and claim the Lunar Chest for armour pieces and unique drops. Empty the chest before resetting the dungeon",
         "worldX": 1435,
         "worldY": 3131,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Corrects 10 confirmed wiki-meta errors in the Perilous Moons guidance steps. The previous guidance described the encounter as a three-style (melee/ranged/magic) fight and included several fabricated mechanics. The wiki confirms all three moons are melee-only bosses with +500 ranged and magic defence.

## Applied findings

- **[blocker] C3**: Removed Bowfa/ranged recommendation from step 0 - moons have +500 ranged defence; ranged is not viable
- **[blocker] C4**: Removed Ancient sceptre/Trident/magic from step 0 - moons have +500 magic defence; magic is not viable
- **[blocker] C5**: Corrected "all three styles rotate during the fight" to melee-only; each moon is weak to a specific melee style (Eclipse=stab, Blue=crush, Blood=slash)
- **[blocker] C9**: Fixed Blue Moon description - typeless melee attacker (not magic); hand-freeze causes missed attacks; weapon-freeze places weapon in ice block to punch (no "ice tiles to step off" mechanic)
- **[high] C10**: Fixed Eclipse Moon clone mechanic - player is bound in the centre, must face character toward each clone to parry (not "kill the real one")
- **[blocker] C11**: Fixed Blood Moon - typeless melee attacker weak to slash (not ranged); no teleport mechanic; specials are Blood Rain and Blood Jaguar
- **[blocker] C12**: Removed fabricated auto-target/style-rotation/prayer-control claim from Blood Moon; no such mechanic exists on the wiki
- **[high] C13**: Removed Lunar key fiction; chest uses a Claim option after defeating bosses, no per-kill key drops
- **[high] C14**: Removed key-insertion mechanic; described loot rolls (3 moons = 6 rolls)
- **[medium] C15**: Fixed Lunar Chest location from "centre of the arena" to Ancient Shrine within Neypotzli

## Key wiki receipts

> "Each boss is weakest to a specific melee style and heavily resistant to magic and ranged attacks. Defensively, they have +100 melee defence to the styles they are not weak to, along with +500 magic and ranged defence."
> -- https://oldschool.runescape.wiki/w/Moons_of_Peril/Strategies

> "Clones - You are shoved to the centre of the room and are bound in place. Clones of the Eclipse Moon will spawn around you, attacking you in five cycles of three, for a total of 15 attacks. You must face your character toward each clone as it spawns to prevent damage."
> -- https://oldschool.runescape.wiki/w/Eclipse_Moon

> "The chest does not require keys to open. Instead, it features a 'Claim' option [...] 1 Moon gives 1 roll, 2 Moons give 3 rolls, 3 Moons give 6 rolls."
> -- https://oldschool.runescape.wiki/w/Lunar_chest

> "The Ancient Shrine within Neypotzli is where this chest is found. Head south to enter the Ancient Shrine to claim your loot."
> -- https://oldschool.runescape.wiki/w/Lunar_chest

Full receipts in docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 2 section).

## Skipped findings

None - all 10 confirmed findings were description-text-only corrections within scope.

## Validation

- JSON parses cleanly
- 0 non-ASCII characters
- `python scripts/audit_drop_rates.py --category BOSSES`: 0 errors