### PR TITLE
fix(data): Wintertodt - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -8733,7 +8733,7 @@
     },
     "guidanceSteps": [
       {
-        "description": "Travel to the Wintertodt Camp with a tinderbox, an axe (rune or better), a knife (optional but speeds up fletching), warm clothing (Pyromancer / Hunter outfit / hooded cloak) to reduce cold damage, and Rejuvenation potions or food",
+        "description": "Travel to the Wintertodt Camp with a tinderbox, an axe (rune or better), a knife (optional but speeds up fletching), warm clothing (Pyromancer outfit / Clue hunter outfit / Wolf cloak) to reduce cold damage, and Rejuvenation potions or food",
         "worldX": 1621,
         "worldY": 3997,
         "worldPlane": 0,
@@ -8784,7 +8784,7 @@
         }
       },
       {
-        "description": "When Wintertodt's health hits zero, claim Supply crates from the box. Aim for 500+ points per game (4 crates) or 850+ (5 crates / Pyromancer outfit fast). Open crates for the Pyromancer outfit, Bruma torch, Warm gloves, Tome of fire pages, and Phoenix pet",
+        "description": "When Wintertodt's health hits zero, claim rewards from the reward cart. Aim for 500+ points per game (2 rolls) or 1000+ (3 rolls) or 1500+ (4 rolls / Pyromancer outfit fast). Open crates for the Pyromancer outfit, Bruma torch, Warm gloves, Tome of fire pages, and Phoenix pet",
         "worldX": 1640,
         "worldY": 3997,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Fixes four confirmed guidance-text errors in the Wintertodt source found during wiki-meta audit tranche 2. All findings have wiki receipts embedded in docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 2 section).

## Applied findings

- [medium] C4: replaced non-qualifying 'hooded cloak' (not listed on Warm_clothing wiki page) with 'Clue hunter outfit / Wolf cloak' which are confirmed qualifying items
- [high] C13: updated stale 'claim Supply crates from the box' to 'claim rewards from the reward cart' -- supply crates were replaced by a reward cart on 9 October 2024 per wiki
- [high] C14: corrected '500+ points per game (4 crates)' to '500+ points per game (2 rolls)' -- wiki reward table: 500 points = 2 rolls, never 4 crates
- [high] C15: removed fabricated '850+ (5 crates)' threshold (does not exist in wiki reward table); replaced with documented 1000+ (3 rolls) and 1500+ (4 rolls) milestones per wiki

## Key wiki receipts

C13/C14/C15 (Supply_crate_(Wintertodt)): "500 points = 2 rolls. 1000 points = 3 rolls. 1500 points = 4 rolls." and "Released 9 October 2024" [reward cart].

C4 (Warm_clothing wiki page): "hooded cloak" does not appear; qualifying cloaks include Wolf cloak, Clue hunter cloak, Rainbow cape, Firemaking cape.

## Skipped findings

None -- all four findings were guidance-text corrections within scope.

## Test plan

- JSON parse: pass
- Non-ASCII check: 0 bytes
- python scripts/audit_drop_rates.py --category MINIGAMES: 0 errors, Wintertodt in verified list