### PR TITLE
fix(data): Tempoross - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -8571,7 +8571,7 @@
       }
     ],
     "locationDescription": "Tempoross Cove, south of Al Kharid",
-    "travelTip": "Minigame Grouping teleport -> Tempoross, or sail from the Ruins of Unkah",
+    "travelTip": "Ferryman Sathwood ferry south of Al Kharid bank, or sail from Ruins of Unkah dock",
     "npcId": 10584,
     "interactAction": "Talk-to",
     "requirements": {
@@ -8590,7 +8590,7 @@
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
-        "travelTip": "Minigame Grouping teleport -> Tempoross",
+        "travelTip": "Ferryman Sathwood ferry south of Al Kharid bank",
         "requiredItemIds": [
           311,
           2347
@@ -8613,7 +8613,7 @@
         "section": "Travel"
       },
       {
-        "description": "Fish harpoonfish at the dark cloud spots, then run to a cannon and cook (use Fish on Cannon) and load the harpoonfish into the cannon. Watch for storm clouds (move out before lightning) and fix broken masts / totem poles when prompted",
+        "description": "Fish harpoonfish at the fishing spots (double spots preferred), then cook at the shrine and load cooked harpoonfish into the cannon ammunition crate. Move away from dark clouds before lightning strikes and fix broken masts / totem poles when prompted",
         "worldX": 3027,
         "worldY": 2954,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Corrects four guidance-text bugs in the Tempoross source, all verified against the wiki in audit tranche 2.

## Findings applied

**[high] C7:** step-0 `travelTip` referenced a nonexistent Minigame Group Finder entry for Tempoross. Tempoross does not appear in the Minigame Group Finder activity list. Replaced with Ferryman Sathwood ferry south of Al Kharid bank.

**[high] C8:** top-level `travelTip` contained the same fabricated MGF teleport ("Minigame Grouping teleport -> Tempoross, or sail from the Ruins of Unkah"). MGF receipt: the complete activity list (Barbarian Assault, Blast Furnace, Bounty Hunter, Burthorpe Games Room, Castle Wars, Fishing Trawler, Giants' Foundry, Guardians of the Rift, Last Man Standing, Mage Training Arena, Mastering Mixology, Nightmare Zone, Pest Control, Rat Pits, Sorceress's Garden, Shades of Mort'ton, Soul Wars, Tithe Farm, Trouble Brewing, TzHaar Fight Pit) — no Tempoross. Replaced with ferry + Ruins of Unkah dock.

**[medium] C10:** step-2 description said "Fish harpoonfish at the dark cloud spots". The wiki uses "Fishing spot (Tempoross Cove)" for the fishing locations; dark/grey clouds are the lightning hazard that moves over the island and emits lightning bolts. "Dark cloud spots" conflates the two concepts and could mislead players into standing under incoming lightning. Corrected to "fishing spots (double spots preferred)".

**[blocker] C11:** step-2 description said "cook (use Fish on Cannon)". Cooking is done at the shrine, not the cannon. The cannon's ammunition crate is the loading destination for already-cooked fish. Wiki receipt: cooking location is "the shrine"; then "Load all cooked harpoonfish into the closest harpoonfish cannon ammunition crate." Rewritten to "cook at the shrine and load cooked harpoonfish into the cannon ammunition crate".

## Findings skipped

None — all four findings were guidance-text corrections within scope.

## Full receipts

See docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 2 section) for complete raw wiki receipts and skeptic reasoning for each claimId.

## Test plan

- [x] JSON parses cleanly
- [x] Non-ASCII scan: 0 characters
- [x] `python scripts/audit_drop_rates.py --category MINIGAMES` reports 0 errors, Tempoross verified clean
- [ ] CI build gate