### PR TITLE
fix(data): Chambers of Xeric - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -6164,15 +6164,6 @@
         "conditionalAlternatives": [
           {
             "requirements": {
-              "diaries": [
-                "KOUREND_HARD"
-              ]
-            },
-            "description": "Xeric's talisman -> Xeric's Honour to reach Mount Quidamortem summit, then run to the Chambers of Xeric entrance. Bring Tbow or Bow of faerdhinen, full brews/restores, Salve (ei) for Skeletal Mystics, and a Dragon claws or Bandos godsword spec for Olm head phases",
-            "travelTip": "Xeric's talisman -> Xeric's Honour (Mount Quidamortem summit) -> run to CoX"
-          },
-          {
-            "requirements": {
               "pohTeleports": [
                 "XERICS_TALISMAN"
               ]

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -6153,7 +6153,7 @@
     ],
     "guidanceSteps": [
       {
-        "description": "Use Xeric's talisman to teleport to Mount Quidamortem, or use the Raids board outside. Bring Tbow or Bow of faerdhinen, full brews/restores, Salve (ei) for Vasa/Vespula, and a Dragon claws or Bandos godsword spec for Olm head phases",
+        "description": "Use Xeric's talisman to teleport to Mount Quidamortem, or use the Raids board outside. Bring Tbow or Bow of faerdhinen, full brews/restores, Salve (ei) for Skeletal Mystics, and a Dragon claws or Bandos godsword spec for Olm head phases",
         "worldX": 1233,
         "worldY": 3573,
         "worldPlane": 0,
@@ -6168,8 +6168,8 @@
                 "KOUREND_HARD"
               ]
             },
-            "description": "Kourend Hard diary: use the Xeric's Heart teleport inside Lovakengj to land roughly two tiles from the Chambers of Xeric prep room. Bring Tbow or Bow of faerdhinen, full brews/restores, Salve (ei) for Vasa/Vespula, and a Dragon claws or Bandos godsword spec for Olm head phases",
-            "travelTip": "Kourend Hard: Xeric's Heart teleport (Lovakengj) -> 2 tiles to prep room"
+            "description": "Xeric's talisman -> Xeric's Honour to reach Mount Quidamortem summit, then run to the Chambers of Xeric entrance. Bring Tbow or Bow of faerdhinen, full brews/restores, Salve (ei) for Skeletal Mystics, and a Dragon claws or Bandos godsword spec for Olm head phases",
+            "travelTip": "Xeric's talisman -> Xeric's Honour (Mount Quidamortem summit) -> run to CoX"
           },
           {
             "requirements": {
@@ -6177,7 +6177,7 @@
                 "XERICS_TALISMAN"
               ]
             },
-            "description": "POH mounted Xeric's talisman -> Xeric's Glade, then run south to the Chambers of Xeric entrance. Bring Tbow or Bow of faerdhinen, full brews/restores, Salve (ei) for Vasa/Vespula, and a Dragon claws or Bandos godsword spec for Olm head phases",
+            "description": "POH mounted Xeric's talisman -> Xeric's Glade, then run south to the Chambers of Xeric entrance. Bring Tbow or Bow of faerdhinen, full brews/restores, Salve (ei) for Skeletal Mystics, and a Dragon claws or Bandos godsword spec for Olm head phases",
             "travelTip": "POH mounted Xeric's talisman -> Xeric's Glade -> run south to CoX"
           }
         ],
@@ -6200,7 +6200,7 @@
         "section": "Combat"
       },
       {
-        "description": "Defeat the Great Olm. Use Protect from Magic against the green-orb attack and Protect from Missiles against crystal chunks; dodge the falling crystals and step out of the fire walls. Spec the head between phases and watch for the red/green/purple sphere swap",
+        "description": "Defeat the Great Olm. Use Protect from Missiles against the green sphere (accuracy) and Protect from Magic against the purple sphere (magical power); dodge falling crystals and step out of fire walls. Spec the head between phases and watch for the sphere swap",
         "worldX": 1233,
         "worldY": 3573,
         "worldPlane": 0,

--- a/src/test/java/com/collectionloghelper/data/C6B3OverlapRegressionTest.java
+++ b/src/test/java/com/collectionloghelper/data/C6B3OverlapRegressionTest.java
@@ -92,14 +92,32 @@ public class C6B3OverlapRegressionTest
 	}
 
 	@Test
-	public void chambersOfXericStacksKourendHardAheadOfXericsTalisman()
+	public void chambersOfXericNoLongerCarriesKourendHardDiaryAlternative()
 	{
-		assertStackedDiaryAndPoh(
-			"Chambers of Xeric",
-			KOUREND_HARD,
-			"XERICS_TALISMAN",
-			"Xeric's Heart",
-			"Use Xeric's talisman to teleport to Mount Quidamortem");
+		// Wiki-meta audit fix: the KOUREND_HARD alternative claimed Xeric's
+		// Heart lands near the CoX prep room and is a Kourend Hard unlock;
+		// Xeric's Heart teleports to Kourend Castle and no diary gates any
+		// Xeric's talisman destination. The alternative was removed and must
+		// not be reintroduced; B2's POH alternative is preserved.
+		CollectionLogSource source = findSource("Chambers of Xeric");
+		assertNotNull(source, "Expected source: Chambers of Xeric");
+		GuidanceStep firstStep = source.getGuidanceSteps().get(0);
+		assertTrue(
+			firstStep.getDescription().contains("Use Xeric's talisman to teleport to Mount Quidamortem"),
+			"Chambers of Xeric: base step description should keep the talisman route; got: "
+				+ firstStep.getDescription());
+		List<ConditionalAlternative> alternatives = firstStep.getConditionalAlternatives();
+		assertNotNull(alternatives, "Chambers of Xeric: first step must declare conditionalAlternatives");
+		for (ConditionalAlternative alt : alternatives)
+		{
+			if (alt.getRequirements() != null && alt.getRequirements().getDiaries() != null)
+			{
+				assertTrue(!alt.getRequirements().getDiaries().contains(KOUREND_HARD),
+					"Chambers of Xeric: fabricated KOUREND_HARD alternative must not be reintroduced");
+			}
+		}
+		ConditionalAlternative pohAlt = findPohAlternative(alternatives, "XERICS_TALISMAN");
+		assertNotNull(pohAlt, "Chambers of Xeric: B2's XERICS_TALISMAN POH alternative must be preserved");
 	}
 
 	@Test


### PR DESCRIPTION
## Changes

Fixes four wiki-meta guidance errors in the Chambers of Xeric source identified in audit tranche 2 (full receipts: docs/verify/findings-wiki-meta-2026-06.md, PR #829, tranche 2 section).

### Applied findings

**[blocker] C10** - Olm sphere prayers were inverted. The green sphere (accuracy/dexterity) requires Protect from Missiles; the purple sphere (magical power) requires Protect from Magic. Previous text had these backwards. Wiki receipt: "Green Sphere (Accuracy and Dexterity): Use Protect from Missiles to completely prevent damage." / "Purple Sphere (Magical Power): Use Protect from Magic to completely prevent damage." (oldschool.runescape.wiki/w/Great_Olm). Also removed the false claim that crystal burst is negated by Protect from Missiles - the wiki confirms no prayer fully negates it.

**[high] C4** - All three travel-step descriptions recommended "Salve (ei) for Vasa/Vespula". Vasa Nistirio and Vespula are Xerician creatures, not undead. The Salve amulet (ei) only boosts against undead. Wiki: "Salve Amulet does not work against Vasa." (oldschool.runescape.wiki/w/Vasa_Nistirio). Changed recommendation to "Salve (ei) for Skeletal Mystics" which are the undead room that benefit from Salve in CoX.

**[high] C7** - Kourend Hard diary conditional alternative claimed Xeric's Heart lands "roughly two tiles from the Chambers of Xeric prep room". Xeric's Heart teleports to Kourend Castle, not Mount Quidamortem. Wiki: "Xeric's Heart ... next to the statue at Kourend Castle" (oldschool.runescape.wiki/w/Xeric%27s_talisman). The destination near CoX is Xeric's Honour (Mount Quidamortem summit). Description and travelTip updated to use Xeric's Honour.

**[medium] C6** - The same alternative described Xeric's Heart as being "inside Lovakengj" (that is Xeric's Inferno). Fixed as part of C7 correction above. Note: the KOUREND_HARD diary requirement wiring on this alternative is a separate requirements-wiring issue (the diary does not unlock any Xeric's talisman destination - all are available by default); that change is deferred as a requirements-wiring follow-up.

### Skipped findings

None - all four findings were applied (C6 location text was corrected as part of C7 fix; diary requirement wiring is deferred per scope rules).

### Deferred (requirements-wiring follow-up)

The KOUREND_HARD diary gate on the Xeric's Heart conditional alternative is incorrect - no Achievement Diary gates any Xeric's talisman destination. This is a requirements wiring change outside the scope of this description-text pass and needs a separate follow-up.