### PR TITLE
fix(data): King Black Dragon - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -4878,7 +4878,7 @@
         "completionCondition": "MANUAL"
       },
       {
-        "description": "Kill the King Black Dragon. Use Protect from Magic, keep an antifire potion active (the dragon also has a venom-laced melee attack), and fight with ranged or melee stab. The KBD uses dragonfire, magic, melee, ranged and a poison breath, so anti-dragon shield plus antifire is non-negotiable",
+        "description": "Kill the King Black Dragon. Use Protect from Melee when fighting at melee distance (use Protect from Magic only if using a two-handed ranged or magic setup such as twisted bow). Keep an antifire potion active and equip an anti-dragon shield. KBD uses melee (stab) and four dragonfire variants (normal, shock, ice, poison); its toxic breath inflicts poison starting at 8 damage, so bring antipoison or antidote++.",
         "worldX": 2269,
         "worldY": 4705,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Corrects three guidance-text errors in the King Black Dragon combat step. All findings confirmed from wiki receipts (audit tranche 2, full receipts in docs/verify/findings-wiki-meta-2026-06.md, PR #829).

## Applied findings

**[blocker] C9:** Corrected inverted prayer meta. Old text recommended Protect from Magic unconditionally. Wiki primary recommendation is Protect from Melee at melee distance; Protect from Magic is the exception for two-handed weapon setups (e.g. twisted bow) that cannot also equip a shield.
> Wiki receipt: "It is recommended to fight the King Black Dragon in Melee distance with the Protect from Melee prayer activated." / "when a player is using a two-handed weapon, such as the twisted bow, the Protect from Magic prayer is necessary to partly negate the damage of the dragonfire attacks."

**[high] C10:** Removed fabricated venom-laced melee attack claim. KBD melee is a plain stab attack (wiki infobox: Attack style "Stab, Dragonfire"). Poison comes from the toxic breath (dragonfire variant), not melee.
> Wiki receipt: "Toxic breath inflicts poison to the player, starting at 8 damage" / infobox Attack style: "Stab, Dragonfire"

**[high] C11:** Removed fabricated ranged attack claim. KBD has no ranged attack style. Wiki infobox lists only "Stab, Dragonfire"; the page states "The King Black Dragon uses melee and dragonfire".
> Wiki receipt: infobox Attack style: "Stab, Dragonfire" / "The King Black Dragon uses melee and dragonfire"

## Skipped findings

None - all three findings were guidance-text corrections within scope.

## Test plan

- [ ] JSON parses cleanly (python json.load)
- [ ] No non-ASCII characters in file
- [ ] python scripts/audit_drop_rates.py --category BOSSES reports 0 errors
- [ ] CI build passes

Full receipts: docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 2 section)