### PR TITLE
fix(data): Vet'ion - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -5384,7 +5384,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to Vet'ion's Rest in the Wilderness with a crush weapon (Inquisitor's mace, Soulreaper axe, or Saradomin sword), prayer potions, Saradomin brews, and a Voidwaker / DWH spec. Burning amulet to Chaos Temple, then run east",
+        "description": "Travel to Vet'ion's Rest in the Wilderness with a crush weapon (Inquisitor's mace or Soulreaper axe), prayer potions, Saradomin brews, and a Voidwaker / DWH spec. Burning amulet to Chaos Temple, then run east",
         "worldX": 3196,
         "worldY": 3776,
         "worldPlane": 0,
@@ -5407,7 +5407,7 @@
         "completionDistance": 5
       },
       {
-        "description": "Kill Vet'ion. Use Protect from Magic for his magic attack and swap to Protect from Missiles when he switches to a ranged attack. He spawns Skeletal Hellhounds at 75%, 50%, and 25% HP - kill them immediately or they will overwhelm you. Use a crush weapon since his stab and slash defence are higher",
+        "description": "Kill Vet'ion. Use Protect from Magic throughout - he attacks with magic only. Skeletal Hellhounds spawn at 50% HP in his first form; Greater Skeletal Hellhounds spawn at 50% HP in his enraged second form - kill them immediately as they grant him full damage immunity while alive. Use crush attacks since his stab and slash defence are very high",
         "worldX": 3220,
         "worldY": 3783,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Three factual errors in guidance text corrected against wiki receipts (audit tranche 2, PR #829).

## Applied findings

- [blocker] C2: Removed Saradomin sword from the crush weapon list in the travel step. The Saradomin sword has only Stab/Slash/Lunge attack styles; it cannot benefit from Vet'ion's -10 crush defence and instead hits against his +200 slash defence. Wiki receipt: "Vet'ion is highly resistant to any combat style other than crush. [Defensive stats: Stab +201, Slash +200, Crush -10]"
- [blocker] C8: Removed the instruction to swap to Protect from Missiles for a ranged attack. Wiki confirms Vet'ion's attack styles are Magic and Melee only - he has no ranged attack at any point. The instruction caused players to drop their correct Protect from Magic for a mechanic that does not exist.
- [high] C9: Corrected hellhound spawn thresholds. The data said "75%, 50%, and 25% HP" (three thresholds). Wiki receipt: "When he reaches half health in his first form for the first time, he summons two level 194 skeleton hellhounds... [Greater Skeletal Hellhounds spawn at 50% HP in his second/enraged form]." Fixed to: Skeletal Hellhounds at 50% HP in first form; Greater Skeletal Hellhounds at 50% HP in enraged second form.

## Skipped findings

None - all three confirmed findings were guidance text corrections within scope.

## Validation

- JSON parse: pass
- Non-ASCII check: 0 characters
- `python scripts/audit_drop_rates.py --category BOSSES`: 0 errors

Full receipts: docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 2 section)