### PR TITLE
fix(data): Beginner Treasure Trails - wiki-meta guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -9842,7 +9842,7 @@
         "section": "Travel"
       },
       {
-        "description": "Obtain a beginner clue scroll. Lowest-tier monsters (chickens, cows, men, goblins) drop them at ~1/50; Hans in Lumbridge gives a free one per day on the H.A.M. encampment task; Young impling jars open to a beginner clue at 1/25.",
+        "description": "Obtain a beginner clue scroll. Lowest-tier monsters (chickens, cows, men, goblins) drop them at ~1/50. Young impling jars also open to a beginner clue at 1/25.",
         "worldX": 3165,
         "worldY": 3487,
         "worldPlane": 0,
@@ -9857,7 +9857,7 @@
         ]
       },
       {
-        "description": "Complete all clue steps with the RuneLite Clue Scroll plugin. Beginner clues are short (1-5 steps) and cover Lumbridge / Varrock / Falador / Draynor only. No combat encounters - skip the world-3 sandwich lady wave by accepting whichever sandwich she offers first.",
+        "description": "Complete all clue steps with the RuneLite Clue Scroll plugin. Beginner clues are short (1-3 steps) and cover starter areas including Lumbridge, Varrock, Falador, Draynor, and Al Kharid. No combat encounters required.",
         "worldX": 3165,
         "worldY": 3487,
         "worldPlane": 0,
@@ -9883,7 +9883,7 @@
       }
     ],
     "afkLevel": 1,
-    "travelTip": "Obtain from low-level monsters, Young impling jars, or Hans in Lumbridge"
+    "travelTip": "Obtain from low-level monsters or Young impling jars"
   },
   {
     "name": "Revenants",


### PR DESCRIPTION
## Summary

Three guidance-text corrections for Beginner Treasure Trails based on wiki verification (audit tranche 2, full receipts in docs/verify/findings-wiki-meta-2026-06.md, PR #829, tranche 2 section).

## Applied findings

- **[high] C4**: Removed fabricated Hans/H.A.M. daily clue mechanic. Hans is a cryptic-clue answer NPC (players visit him to complete a step); he does not distribute clue scrolls. The H.A.M. encampment task reference is also invented. Removed from both the obtain-step description and the source-level travelTip. Wiki: https://oldschool.runescape.wiki/w/Hans
- **[high] C8**: Removed non-existent "world-3 sandwich lady wave" instruction. The Sandwich Lady is a game-wide random event, not a step or encounter within a beginner clue scroll. Her outfit is a reward from beginner caskets (correctly listed in the reward step). Wiki: https://oldschool.runescape.wiki/w/Sandwich_lady
- **[medium] C6**: Corrected step count from "1-5 steps" to "1-3 steps" per wiki. Broadened location coverage to include Al Kharid (a documented beginner emote-clue location outside the previously listed four towns). Wiki: https://oldschool.runescape.wiki/w/Clue_scroll_(beginner)

## Skipped findings

None - all three confirmed findings were description-text fixes within scope.

## Test plan

- [ ] JSON parses (python -c "import json;json.load(open(...))")
- [ ] No non-ASCII characters
- [ ] python scripts/audit_drop_rates.py --category CLUES reports 0 errors
- [ ] CI build passes