### PR TITLE
fix(data): Barrows - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -8390,7 +8390,7 @@
         "section": "Combat"
       },
       {
-        "description": "Dig on Verac's mound (north-west) and kill Verac the Defiled. Verac's flail ignores Protect from Melee and armour - use Protect from Melee anyway to halve the chance, wear high-prayer gear, and attack with Melee (he is weak to Crush)",
+        "description": "Dig on Verac's mound (north-west) and kill Verac the Defiled. Verac's flail ignores Protect from Melee and armour - use Protect from Melee anyway (it fully negates 75% of his attacks; only 25% bypass prayer), wear high-prayer gear, and attack with Magic (his weakness)",
         "worldX": 3557,
         "worldY": 3298,
         "worldPlane": 0,
@@ -8420,7 +8420,7 @@
         "section": "Combat"
       },
       {
-        "description": "Dig on Karil's mound (south) and kill Karil the Tainted. Karil uses Ranged and can halve your Agility - use Protect from Missiles and attack with Magic (his weakness)",
+        "description": "Dig on Karil's mound (south) and kill Karil the Tainted. Karil uses Ranged and can reduce your Agility by 20% on a 25% chance per hit - use Protect from Missiles and attack with Magic (his weakness)",
         "worldX": 3566,
         "worldY": 3275,
         "worldPlane": 0,
@@ -8435,7 +8435,7 @@
         "section": "Combat"
       },
       {
-        "description": "Dig on Guthan's mound (south-east) and kill Guthan the Infested. Guthan uses Melee and his warspear heals him on hit - use Protect from Melee and attack with Ranged (his weakness)",
+        "description": "Dig on Guthan's mound (south-east) and kill Guthan the Infested. Guthan uses Melee and his warspear heals him on hit - use Protect from Melee and attack with Magic (his weakness)",
         "worldX": 3577,
         "worldY": 3283,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Fixes four guidance-text errors in the Barrows source, all verified against OSRS Wiki receipts.

## Findings applied

- [blocker] C17: Verac step - corrected prayer mechanic wording from "use Protect from Melee anyway to halve the chance" to accurately reflect the 75%/25% split (wiki: "it negates on average 75% of his attacks"; "penetrates through protection prayers with a 25% chance per attack")
- [high] C18: Verac step - corrected stated weakness from Crush to Magic (wiki: "He uses melee equipment, which make him vulnerable to Magic attacks"; Crush defence is +221)
- [medium] C24: Karil step - corrected Agility drain from "can halve your Agility" to "can reduce your Agility by 20% on a 25% chance per hit" (wiki: "Tainted Shot, which gives him a 25% chance per successful hit to lower the player's Agility by 20%")
- [high] C29: Guthan step - corrected stated weakness from Ranged to Magic (wiki: "Guthan is vulnerable to Magic attacks"; Ranged defence is +250; recommended methods: trident, Iban Blast, Wind spells, Magic Dart)

## Key wiki receipts

C17/C18 - Verac the Defiled (https://oldschool.runescape.wiki/w/Verac_the_Defiled): "Despite being able to hit through Protect from Melee, it is still recommended as it negates on average 75% of his attacks and when the set effect does activate, lowers his max hit from 23 to 15. His special penetrates through protection prayers with a 25% chance per attack. He uses melee equipment, which make him vulnerable to Magic attacks."

C24 - Karil the Tainted (https://oldschool.runescape.wiki/w/Karil_the_Tainted): "Karil's set effect is Tainted Shot, which gives him a 25% chance per successful hit to lower the player's Agility by 20%."

C29 - Guthan the Infested (https://oldschool.runescape.wiki/w/Guthan_the_Infested): "Guthan uses melee equipment, making him vulnerable to Magic attacks. Recommended defeat methods include: trident of the swamp/seas, Iban Blast, Wind spells, or Magic Dart. Ranged defence: +250."

Full receipts and audit context: docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 2 section)

## Skipped findings

None - all four confirmed findings were guidance-text changes within scope.

## Test plan

- [x] JSON parses cleanly (`python -c "import json;json.load(...)"`)
- [x] Zero non-ASCII characters
- [x] `python scripts/audit_drop_rates.py --category BOSSES` reports 0 errors
- [ ] CI build gate