### PR TITLE
fix(data): Theatre of Blood - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -6642,7 +6642,7 @@
     ],
     "guidanceSteps": [
       {
-        "description": "Travel to Ver Sinhaza - Kharyrll teleport to Canifis then run south through Mort'ton. Bring Scythe of vitur (or Soulreaper axe), Tbow + diamond bolts (e) for Verzik P3, full brews/restores, Sanguinesti staff or Trident, and a Dragon dagger(p++) for the Nylocas Athanatos on Verzik P1",
+        "description": "Travel to Ver Sinhaza - Kharyrll teleport to Canifis then run south through Mort'ton. Bring Scythe of vitur (or Soulreaper axe), Tbow + dragon arrows for Verzik P3, full brews/restores, Sanguinesti staff or Trident, and a Dragon dagger(p++) for the Nylocas Athanatos on Verzik P1",
         "worldX": 3650,
         "worldY": 3218,
         "worldPlane": 0,
@@ -6657,7 +6657,7 @@
                 22400
               ]
             },
-            "description": "Use Drakan's medallion to teleport directly to Ver Sinhaza. Bring Scythe of vitur (or Soulreaper axe), Tbow + diamond bolts (e) for Verzik P3, full brews/restores, Sanguinesti staff or Trident, and a Dragon dagger(p++) for the Nylocas Athanatos on Verzik P1",
+            "description": "Use Drakan's medallion to teleport directly to Ver Sinhaza. Bring Scythe of vitur (or Soulreaper axe), Tbow + dragon arrows for Verzik P3, full brews/restores, Sanguinesti staff or Trident, and a Dragon dagger(p++) for the Nylocas Athanatos on Verzik P1",
             "travelTip": "Drakan's medallion -> Ver Sinhaza"
           }
         ],
@@ -6672,7 +6672,7 @@
         "section": "Combat"
       },
       {
-        "description": "Clear The Maiden, Pestilent Bloat, Nylocas, Sotetseg, and Xarpus. Refresh supplies at each chest and prep gear for the Verzik fight",
+        "description": "Clear The Maiden, Pestilent Bloat, Nylocas, Sotetseg, and Xarpus. Refresh supplies at the chests after Bloat and Sotetseg and prep gear for the Verzik fight",
         "worldX": 3650,
         "worldY": 3218,
         "worldPlane": 0,
@@ -6680,7 +6680,7 @@
         "section": "Combat"
       },
       {
-        "description": "Defeat Verzik Vitur. P1: pray Protect from Magic and dagger the Athanatos. P2: dodge red ball, switch prayers to match the Nylocas colour. P3: Tbow with diamond bolts (e), pray Protect from Magic, dance the lightning zaps and never stand on a tornado",
+        "description": "Defeat Verzik Vitur. P1: pray Protect from Magic and dagger the Athanatos. P2: dodge the purple projectile, switch prayers to match the Nylocas colour. P3: Tbow with dragon arrows, pray Protect from Magic, dance the lightning zaps and never stand on a tornado",
         "worldX": 3650,
         "worldY": 3218,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Corrects four guidance-text bugs in the Theatre of Blood source identified in audit tranche 2 (docs/verify/findings-wiki-meta-2026-06.md, PR #829).

- [blocker] C4: Travel steps (main + Drakan's medallion alt) listed "Tbow + diamond bolts (e)" -- Twisted bow fires arrows, not bolts; diamond bolts (e) are crossbow-only ammunition. Changed to "Tbow + dragon arrows". Wiki: "It can fire any type of arrow, including dragon arrows."
- [blocker] C14: Verzik Vitur fight step repeated the same incompatible pairing "Tbow with diamond bolts (e)". Changed to "Tbow with dragon arrows".
- [medium] C10: "Refresh supplies at each chest" implies a chest after every boss. The Theatre of Blood wiki confirms supply chests exist only after Bloat (boss 2) and Sotetseg (boss 4). Changed to "at the chests after Bloat and Sotetseg".
- [low] C13: "dodge red ball" in P2 Verzik description. The Verzik Vitur wiki names the chaining projectile a "lightning ball" and the avoidable dodge-able projectile a "slow purple projectile". No "red ball" is named anywhere. Changed to "dodge the purple projectile".

Full receipts: docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 2 section).

## Test plan

- [x] JSON parses cleanly
- [x] Zero non-ASCII characters in file
- [x] `python scripts/audit_drop_rates.py --category RAIDS` -- 0 errors (pre-existing flagged-research warnings on raid-lobby npcId omission across all RAIDS sources, unrelated to this change)
- [ ] CI build passes