### PR TITLE
fix(data): Pyrefiend - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -10397,7 +10397,7 @@
         "section": "Travel"
       },
       {
-        "description": "Enter the Fremennik Slayer Dungeon (fairy ring AJR) or use Catacombs of Kourend",
+        "description": "Enter the Fremennik Slayer Dungeon (fairy ring AJR).",
         "worldX": 2797,
         "worldY": 3614,
         "worldPlane": 0,
@@ -10407,7 +10407,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Pyrefiends in the Fremennik Slayer Dungeon or Catacombs of Kourend (30 Slayer). Use Protect from Magic",
+        "description": "Kill Pyrefiends in the Fremennik Slayer Dungeon (30 Slayer). Wear dragonhide for magic defence; use Protect from Melee (43 Prayer) to avoid damage.",
         "worldX": 2761,
         "worldY": 10008,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Fixes three confirmed audit findings for the Pyrefiend slayer source in `drop_rates.json`. All findings come from the wiki-meta audit tranche 2; full receipts are in docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 2 section).

## Applied findings

- **[blocker] C5**: Corrected prayer recommendation from Protect from Magic to Protect from Melee. Pyrefiends use magical melee - an attack style blocked by Protect from Melee (not Protect from Magic). Wiki receipt: "Players who intend to use melee and have 43 Prayer can flick the Protect from Melee prayer to avoid being damaged." Also added dragonhide wear note per wiki strategy ("wear armour with a high magic defence bonus, such as dragonhide"). Old text: "Use Protect from Magic". New text: "Wear dragonhide for magic defence; use Protect from Melee (43 Prayer) to avoid damage."

- **[high] C3**: Removed fabricated Catacombs of Kourend reference from the travel guidance step. Wiki lists six Pyrefiend locations (Fremennik Slayer Cave, God Wars Dungeon, Isle of Souls, Sisterhood Sanctuary, Smoke Dungeon, Wilderness God Wars Dungeon) - Catacombs of Kourend is not among them.

- **[high] C6**: Removed Catacombs of Kourend from the combat guidance step description. Duplicate defect of C3 (same wrong-location reference); resolved by the same edit.

## Skipped findings

None - all three confirmed findings were addressed by these two description-text edits.

## Validation

- JSON parses cleanly
- No non-ASCII characters
- `python scripts/audit_drop_rates.py --category SLAYER` reports 0 errors (3 flagged-research items are pre-existing on unrelated sources)