### PR TITLE
fix(data): Demonic gorillas - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -5583,7 +5583,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Bank for Demonic gorillas. Bring a ranged setup (Bow of faerdhinen or Toxic blowpipe with rune/amethyst darts) plus a melee swap (Scythe or Ghrazi rapier), Saradomin brews, super restores, prayer potions, and a few sharks. The gorillas hit hard through prayer when you tank a wrong style, so a tank-shield swap or extra brews are worth packing.",
+        "description": "Bank for Demonic gorillas. Bring a ranged setup (Bow of faerdhinen or Toxic blowpipe with rune/amethyst darts) plus a melee swap (Emberlight or Arclight for the demonbane bonus), Saradomin brews, super restores, prayer potions, and a few sharks. Keep protection prayers active and swap styles to match the gorilla's attack - missing prayers will drain supplies fast.",
         "worldX": 2461,
         "worldY": 3444,
         "worldPlane": 0,
@@ -5618,7 +5618,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Demonic gorillas in the Crash Site Cavern. They cycle through Protect from Melee / Magic / Range after every three successful hits of the same style, so swap your style each time the prayer flips. Dodge the falling-boulder special (run one tile when the ground turns red) and the Magic-special purple orb (hits for up to 30 through prayer). Bow of faerdhinen or Toxic blowpipe + Ghrazi rapier on the swap is the modern meta.",
+        "description": "Kill Demonic gorillas in the Crash Site Cavern. They switch attack style after three missed hits in a row (blocked by prayer counts as missed), so watch for the style change and swap your protection prayer accordingly. Dodge the falling-boulder special (run one tile when the ground turns red) and the magic attack (a green orb, up to 30 damage - blocked by Protect from Magic). Use Emberlight or Arclight for the melee swap as demonic gorillas are demons and take bonus damage from demonbane weapons. Toxic blowpipe or Bow of faerdhinen works well for ranged.",
         "worldX": 2405,
         "worldY": 3419,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Corrects three wiki-verified guidance errors in the Demonic gorillas source.

- [blocker] C1: Attack-style switch trigger was inverted. Data said "after three successful hits"; wiki says the gorilla switches after three *missed* hits (prayer-blocked hits count as missed). Players following the old text would mistime their prayer swaps entirely.
- [high] C3: Magic attack described as "purple orb" that "hits through prayer" - wiki confirms it is a green orb and is a normal magic attack blocked by Protect from Magic. Only the boulder special bypasses prayer (and it is dodgeable), not the orb.
- [medium] C7: Ghrazi rapier listed as melee swap meta. Wiki explicitly recommends Emberlight and Arclight because demonic gorillas are demons and demonbane weapons give a significant accuracy and damage bonus. Rapier is absent from the wiki's equipment guidance.

Wiki receipt (C1/C3): "They will switch attack styles after three (3) missed hits against the player (i.e., no damage is taken), regardless if the player's protection prayer blocked them or not. ... The gorilla rears up and dangles its forelegs, then emits a green orb from its mouth ... each one hitting up to 30 damage."

Wiki receipt (C7): "Melee is a preferred style to use at demonics for its cost, ease of use, and early access to Arclight, one of the strongest weapons to fight Demonics with. ... Emberlight for increased damage output against demon-type monsters."

Full receipts: docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 2 section)

## Skipped findings

None - all confirmed findings applied.

## Test plan

- [ ] JSON parses cleanly
- [ ] No non-ASCII characters in file
- [ ] `python scripts/audit_drop_rates.py --category BOSSES` reports 0 errors
- [ ] CI build passes