### PR TITLE
fix(data): Gauntlet pair - wiki-meta corrections + drop fabricated Western Elite alternative

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -8078,7 +8078,7 @@
     ],
     "guidanceSteps": [
       {
-        "description": "Teleport to Prifddinas via teleport crystal / house tablet and run north-west to the Gauntlet portal in Lletya district",
+        "description": "Teleport to Prifddinas via teleport crystal / house tablet and run north-west to the Gauntlet portal in Amlodd district",
         "worldX": 3230,
         "worldY": 6073,
         "worldPlane": 0,
@@ -8091,7 +8091,7 @@
                 "WESTERN_ELITE"
               ]
             },
-            "description": "Operate the Crystal teleport seed for the rub-on-cape variant (Western Provinces Elite diary attaches the Prifddinas teleport to your max / quest / achievement cape, so you can teleport from anywhere without dedicating an inventory slot to the seed). Then run north-west to the Gauntlet portal in Lletya district",
+            "description": "Operate the Crystal teleport seed for the rub-on-cape variant (Western Provinces Elite diary attaches the Prifddinas teleport to your max / quest / achievement cape, so you can teleport from anywhere without dedicating an inventory slot to the seed). Then run north-west to the Gauntlet portal in Amlodd district",
             "travelTip": "Cape Crystal teleport -> Prifddinas (Western Provinces Elite diary unlock)"
           },
           {
@@ -8101,7 +8101,7 @@
                 23858
               ]
             },
-            "description": "Right-click your Teleport crystal (regular or HM-charged) in the inventory and pick Prifddinas, then run north-west to the Gauntlet portal in Lletya district",
+            "description": "Right-click your Teleport crystal (regular or HM-charged) in the inventory and pick Prifddinas, then run north-west to the Gauntlet portal in Amlodd district",
             "travelTip": "Inventory Teleport crystal -> Prifddinas"
           }
         ]
@@ -8116,7 +8116,7 @@
         "completionCondition": "MANUAL"
       },
       {
-        "description": "Prep phase (about 7-9 minutes): gather paddlefish + linum tirinum + raw chompy meat + crystal shards, mine ore from crystal deposits, chop bark from phren roots, kill weak/strong monsters for weapon frames, and find a demi-boss for the perfected weapon upgrade. Craft a basic then perfected weapon + tier 3 armour at the singing bowl before the timer expires",
+        "description": "Prep phase (10 minutes): gather paddlefish + linum tirinum + crystal shards, mine ore from crystal deposits, chop bark from phren roots, kill weak/strong monsters for weapon frames, and find a demi-boss for the perfected weapon upgrade. Craft a basic then perfected weapon + tier 3 armour at the singing bowl before the timer expires",
         "worldX": 1920,
         "worldY": 5681,
         "worldPlane": 1,

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -7965,7 +7965,7 @@
     ],
     "guidanceSteps": [
       {
-        "description": "Teleport to Prifddinas via teleport crystal / house tablet and run north-west to the Gauntlet portal in Lletya district",
+        "description": "Teleport to Prifddinas via teleport crystal / house tablet and run north-west to the Gauntlet portal in Amlodd district",
         "worldX": 3230,
         "worldY": 6073,
         "worldPlane": 0,
@@ -7974,21 +7974,12 @@
         "conditionalAlternatives": [
           {
             "requirements": {
-              "diaries": [
-                "WESTERN_ELITE"
-              ]
-            },
-            "description": "Operate the Crystal teleport seed for the rub-on-cape variant (Western Provinces Elite diary attaches the Prifddinas teleport to your max / quest / achievement cape, so you can teleport from anywhere without dedicating an inventory slot to the seed). Then run north-west to the Gauntlet portal in Lletya district",
-            "travelTip": "Cape Crystal teleport -> Prifddinas (Western Provinces Elite diary unlock)"
-          },
-          {
-            "requirements": {
               "inventoryItemIdsAny": [
                 23904,
                 23858
               ]
             },
-            "description": "Right-click your Teleport crystal (regular or HM-charged) in the inventory and pick Prifddinas, then run north-west to the Gauntlet portal in Lletya district",
+            "description": "Right-click your Teleport crystal (regular or HM-charged) in the inventory and pick Prifddinas, then run north-west to the Gauntlet portal in Amlodd district",
             "travelTip": "Inventory Teleport crystal -> Prifddinas"
           }
         ]
@@ -8003,7 +7994,7 @@
         "completionCondition": "MANUAL"
       },
       {
-        "description": "Prep phase (corrupted mobs hit harder and have higher Defence): gather paddlefish + linum tirinum + raw chompy meat + corrupted shards, kill a demi-boss for the perfected weapon upgrade, and craft perfected corrupted tier 3 armour + perfected corrupted staff/halberd/bow at the singing bowl. Corrupted gear is required for full damage on Corrupted Hunllef",
+        "description": "Prep phase (corrupted mobs hit harder and have higher Defence): gather paddlefish + linum tirinum + phren bark + grym leaves + corrupted shards, kill a demi-boss for the perfected weapon upgrade, and craft perfected corrupted tier 3 armour + perfected corrupted staff/halberd/bow at the singing bowl. Corrupted gear is required for full damage on Corrupted Hunllef",
         "worldX": 1920,
         "worldY": 5681,
         "worldPlane": 1,
@@ -8011,7 +8002,7 @@
         "section": "Combat"
       },
       {
-        "description": "Fight the Corrupted Hunllef. Same attack-style rotation as standard (Magic / Ranged swap every 4 attacks per the skull above its head) but it hits noticeably harder and swaps to its own protection prayer faster - flick your protection prayer Magic / Missiles in time with its skull and swap your own attack style every rotation. Run behind a pillar to break line of sight during the tornado enrage and never stand on a tornado tile",
+        "description": "Fight the Corrupted Hunllef. Same attack-style rotation as standard (Magic / Ranged swap every 4 attacks per the skull above its head) but it hits noticeably harder - flick your protection prayer Magic / Missiles in time with its skull and swap your own attack style every rotation. Run behind a pillar to break line of sight during the tornado enrage and never stand on a tornado tile",
         "worldX": 1920,
         "worldY": 5681,
         "worldPlane": 1,

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -8087,15 +8087,6 @@
         "conditionalAlternatives": [
           {
             "requirements": {
-              "diaries": [
-                "WESTERN_ELITE"
-              ]
-            },
-            "description": "Operate the Crystal teleport seed for the rub-on-cape variant (Western Provinces Elite diary attaches the Prifddinas teleport to your max / quest / achievement cape, so you can teleport from anywhere without dedicating an inventory slot to the seed). Then run north-west to the Gauntlet portal in Amlodd district",
-            "travelTip": "Cape Crystal teleport -> Prifddinas (Western Provinces Elite diary unlock)"
-          },
-          {
-            "requirements": {
               "inventoryItemIdsAny": [
                 23904,
                 23858

--- a/src/test/java/com/collectionloghelper/data/C6B3NonOverlapRegressionTest.java
+++ b/src/test/java/com/collectionloghelper/data/C6B3NonOverlapRegressionTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -114,15 +115,31 @@ public class C6B3NonOverlapRegressionTest
 	}
 
 	@Test
-	public void gauntletSourcesCarryWesternEliteDiaryAlternative()
+	public void gauntletSourcesNoLongerCarryWesternEliteDiaryAlternative()
 	{
+		// Wiki-meta audit fix: the WESTERN_ELITE alternative claimed the
+		// Elite Western diary attaches a Prifddinas teleport to capes; no
+		// such reward exists, so the alternative was removed and must not
+		// be reintroduced.
 		for (String name : GAUNTLET_SOURCES)
 		{
-			assertSourceHasDiaryAlternative(
-				name,
-				WESTERN_ELITE,
-				"Crystal teleport",
-				"Western Provinces Elite diary");
+			CollectionLogSource source = findSource(name);
+			assertNotNull(source, "Expected source: " + name);
+			for (GuidanceStep step : source.getGuidanceSteps())
+			{
+				if (step.getConditionalAlternatives() == null)
+				{
+					continue;
+				}
+				for (ConditionalAlternative alt : step.getConditionalAlternatives())
+				{
+					if (alt.getRequirements() != null && alt.getRequirements().getDiaries() != null)
+					{
+						assertFalse(alt.getRequirements().getDiaries().contains(WESTERN_ELITE),
+							name + ": fabricated WESTERN_ELITE alternative must not be reintroduced");
+					}
+				}
+			}
 		}
 	}
 

--- a/src/test/java/com/collectionloghelper/data/CExtensionInventoryTeleportRegressionTest.java
+++ b/src/test/java/com/collectionloghelper/data/CExtensionInventoryTeleportRegressionTest.java
@@ -59,10 +59,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *   <li>Phantom Muspah: no prior alternatives, new inventory-any
  *       alternative at [0] listing the 4 {@code HG_QUETZALWHISTLE_*}
  *       ItemID variants (29271, 29273, 29275, 33120).</li>
- *   <li>Corrupted Gauntlet / The Gauntlet: existing diary
- *       (WESTERN_ELITE) alternative at [0], new inventory-any
- *       alternative at [1] listing {@code GAUNTLET_TELEPORT_CRYSTAL}
- *       (23904) and {@code GAUNTLET_TELEPORT_CRYSTAL_HM} (23858).</li>
+ *   <li>Corrupted Gauntlet / The Gauntlet: inventory-any alternative at
+ *       [0] listing {@code GAUNTLET_TELEPORT_CRYSTAL} (23904) and
+ *       {@code GAUNTLET_TELEPORT_CRYSTAL_HM} (23858). (The WESTERN_ELITE
+ *       diary alternative that used to sit at [0] was removed by the
+ *       wiki-meta audit as fabricated.)</li>
  * </ul>
  *
  * <p>Mirrors {@code C6B3OverlapRegressionTest} (stacked-alternative shape)
@@ -106,10 +107,15 @@ public class CExtensionInventoryTeleportRegressionTest
 			new InventorySpec(1, false, ZULANDRA_SCROLL, 2));
 		map.put("Phantom Muspah",
 			new InventorySpec(0, true, QUETZAL_WHISTLE_VARIANTS, 1));
+		// Wiki-meta audit fix: the WESTERN_ELITE diary alternative both
+		// Gauntlet sources used to stack ahead of the inventory alternative
+		// was fabricated (the Elite Western diary attaches no Prifddinas
+		// teleport to any cape), so the inventory alternative is now the
+		// only conditional alternative, at index 0.
 		map.put("Corrupted Gauntlet",
-			new InventorySpec(1, true, GAUNTLET_TELEPORT_CRYSTAL_VARIANTS, 2));
+			new InventorySpec(0, true, GAUNTLET_TELEPORT_CRYSTAL_VARIANTS, 1));
 		map.put("The Gauntlet",
-			new InventorySpec(1, true, GAUNTLET_TELEPORT_CRYSTAL_VARIANTS, 2));
+			new InventorySpec(0, true, GAUNTLET_TELEPORT_CRYSTAL_VARIANTS, 1));
 		return map;
 	}
 
@@ -233,14 +239,20 @@ public class CExtensionInventoryTeleportRegressionTest
 				name + ": pre-existing DESERT_HARD diary alternative must remain at index 0");
 		}
 
-		// Gauntlets: existing WESTERN_ELITE diary at [0] must survive.
+		// Gauntlets: the fabricated WESTERN_ELITE diary alternative must NOT
+		// return (wiki-meta audit: the Elite Western diary attaches no
+		// Prifddinas teleport to any cape).
 		for (String name : List.of("Corrupted Gauntlet", "The Gauntlet"))
 		{
-			ConditionalAlternative diary =
-				findSource(name).getGuidanceSteps().get(0).getConditionalAlternatives().get(0);
-			assertNotNull(diary.getRequirements());
-			assertEquals(List.of("WESTERN_ELITE"), diary.getRequirements().getDiaries(),
-				name + ": pre-existing WESTERN_ELITE diary alternative must remain at index 0");
+			for (ConditionalAlternative alt
+				: findSource(name).getGuidanceSteps().get(0).getConditionalAlternatives())
+			{
+				if (alt.getRequirements() != null && alt.getRequirements().getDiaries() != null)
+				{
+					assertFalse(alt.getRequirements().getDiaries().contains("WESTERN_ELITE"),
+						name + ": the fabricated WESTERN_ELITE diary alternative must not be reintroduced");
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Consolidated Gauntlet-pair fix from audit tranche 2 (receipts in docs/verify/findings-wiki-meta-2026-06.md, PR #829).

- Corrupted Gauntlet (C1, C4, C7, C16): Lletya -> Amlodd district (x3), removed the fabricated WESTERN_ELITE cape-teleport alternative (the Elite Western diary attaches no Prifddinas teleport to any cape - its rewards are Piscatoris banner teleports, lamp, chompy/slayer/Zulrah perks), chompy meat removed from prep resources (correct list: paddlefish, linum tirinum, phren bark, grym leaves, crystal shards), removed the unsupported 'swaps prayer faster' claim (wiki: same 6-attack cycle as standard).
- The Gauntlet (C1, C6, + C4 cross-applied): same Lletya -> Amlodd and resource fixes, prep timer corrected to 10 minutes, and the same fabricated WESTERN_ELITE alternative removed (identical claim, identical receipt).
- Test guards: CExtensionInventoryTeleportRegressionTest and C6B3NonOverlapRegressionTest updated - the inventory teleport-crystal alternative is now index 0, and both guards assert the fabricated alternative is not reintroduced.

One source per commit. Supersedes #889.