### PR TITLE
fix(data): Tombs of Amascut - wiki-meta guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -7189,8 +7189,8 @@
                 "DESERT_HARD"
               ]
             },
-            "description": "Pharaoh's sceptre to the Necropolis (Desert Hard diary makes the sceptre unlimited-charge, so you can spam-teleport without recharging at the desert lectern). Bring Tbow or Bow of faerdhinen, Osmumten's fang for stab phases, Tumeken's shadow if owned, full brews/restores and prayer potions; set invocations under 150 raid level for entry-mode loot",
-            "travelTip": "Pharaoh's sceptre -> Necropolis (unlimited charges via Desert Hard diary)"
+            "description": "Pharaoh's sceptre to the Necropolis (Desert Hard diary raises the sceptre's max charge capacity to 50; still requires recharging at Jalsavrah when depleted). Bring Tbow or Bow of faerdhinen, Osmumten's fang for stab phases, Tumeken's shadow if owned, full brews/restores and prayer potions; set invocations under 150 raid level for entry-mode loot",
+            "travelTip": "Pharaoh's sceptre -> Necropolis (up to 50 charges via Desert Hard diary)"
           },
           {
             "requirements": {
@@ -7227,7 +7227,7 @@
         "section": "Combat"
       },
       {
-        "description": "Defeat the Wardens. P1/P2: swap prayers to match the active Warden's style and break the obelisk. P3 (Tumeken's Warden): pray Protect from Magic against the energy ball volleys, dodge the obelisk hand-slam, swap prayers when the Warden mimics Akkha/Zebak/Ba-Ba/Kephri attacks",
+        "description": "Defeat the Wardens. P1/P2: swap prayers to match the active Warden's style and break the obelisk. P3 is whichever Warden was not fought in P2. Tumeken's Warden P3 summons Zebak and Ba-Ba phantoms; Elidinis' Warden P3 summons Akkha and Kephri phantoms. Pray Protect from Magic against the energy ball volleys, dodge the obelisk hand-slam, and swap prayers when the Warden mimics its phantom bosses' attacks",
         "worldX": 3234,
         "worldY": 2784,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Fixes three wiki-meta bugs in the Tombs of Amascut guidance steps (base variant). All findings from audit tranche 2; full receipts in docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 2 section).

## Applied findings

**[high] C7:** Desert Hard diary description claimed unlimited charges / no recharging needed. Wiki (Pharaoh's sceptre): 'up to 50 with the hard diary' and recharging always requires the guardian mummy at Jalsavrah (Pyramid Plunder). Corrected description to state the diary raises max capacity to 50 and recharging at Jalsavrah is still needed. travelTip updated from "unlimited charges" to "up to 50 charges".

**[blocker] C16:** P3 guidance hard-coded "P3 (Tumeken's Warden)". Wiki (Tumeken's Warden): 'If Elidinis' Warden was fought in the second phase, players will face against Tumeken's Warden in the third phase. If Tumeken's Warden was fought in the second phase, players will face the final phase against Elidinis' Warden.' Rewritten to state P3 is whichever Warden was not fought in P2.

**[blocker] C19:** P3 description listed all four path-boss phantoms (Akkha/Zebak/Ba-Ba/Kephri) as if a single Warden summons all four. Wiki: Tumeken's Warden P3 summons Zebak's Phantom and Ba-Ba's Phantom; Elidinis' Warden P3 summons Akkha and Kephri phantoms. Description now correctly branches by which P3 Warden the player faces.

## Skipped findings

None — all three confirmed findings were guidance-text corrections within scope.

## Test plan

- [ ] JSON parses cleanly (`python -c "import json;json.load(open('src/main/resources/com/collectionloghelper/drop_rates.json'))"`)
- [ ] No non-ASCII characters in file
- [ ] `python scripts/audit_drop_rates.py --category RAIDS` reports 0 errors (pre-existing low-severity npcId warnings on raid lobbies are unrelated and unchanged)
- [ ] CI build passes