### PR TITLE
fix(data): Abyssal Sire - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -4792,7 +4792,7 @@
         "completionCondition": "MANUAL"
       },
       {
-        "description": "Kill the Abyssal Sire. Phase 1: stun the Sire with Shadow Barrage (100% stun chance) or deal 75 ranged/magic damage, then kill all 4 respiratory systems while the Sire is stunned - tentacles guarding them deactivate during stun. Phase 2 (50% HP): Sire walks to the centre; tentacles become inactive - melee him with Protect from Melee, watch for the teleport grab that drags you toward him. Phase 3 (25% HP): tentacles re-activate and Sire releases poison miasma pools - stay mobile, do NOT stand in green pools, keep Protect from Melee. Bandos chestplate/tassets + Abyssal bludgeon or scythe with Soulreaper axe clears phase 2-3 fastest. 85 Slayer + Abyssal demon task required",
+        "description": "Kill the Abyssal Sire. Phase 1: stun the Sire with Shadow Barrage (100% stun chance) or deal 75 ranged/magic damage, then kill all 4 respiratory systems while the Sire is stunned - tentacles guarding them deactivate during stun. Phase 2 (50% HP): Sire walks to the centre; tentacles become inactive - melee him with Protect from Melee, watch for the teleport grab that drags you toward him. Phase 3 (~50% HP, <210 health): tentacles re-activate and Sire releases miasma pools - switch to Protect from Missiles (spawns deal ranged damage; Sire no longer melees), stay mobile, do NOT stand in green pools. Bandos chestplate/tassets + Abyssal bludgeon or scythe with Soulreaper axe clears phase 2-3 fastest. 85 Slayer + Abyssal demon task required",
         "worldX": 3039,
         "worldY": 4763,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Corrects two inaccurate guidance-text fields in the Abyssal Sire kill step, identified in audit tranche 2 (docs/verify/findings-wiki-meta-2026-06.md, PR #829).

## Findings applied

- **[medium] C12**: Phase 3 HP threshold corrected from "25% HP" to "~50% HP (<210 health)". The 25% figure matches no documented wiki trigger; the Sire walks to centre and releases miasma pools at <210 health (~50% of 424 HP).
  - Wiki receipt: "Once the Sire is damaged below 50% of its health (212 health or less) it will start walking south."
- **[blocker] C17**: Phase 3 prayer corrected from "keep Protect from Melee" to "switch to Protect from Missiles". In Phase 3 the Sire stops all melee attacks; spawns/scions deal ranged damage and are the primary lethal threat.
  - Wiki receipt: "It no longer attacks with melee, instead creating many spawns and summoning a miasma pool under the player every few seconds." / "Run to Row 2 and activate Protect from Missiles."

## Findings skipped

None.

## Test plan

- [x] JSON parse: valid
- [x] ASCII-only check: 0 non-ASCII characters
- [x] `python scripts/audit_drop_rates.py --category BOSSES`: 0 errors
- [ ] CI build gate (authoritative for data changes)

Full receipts: docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 2 section, Abyssal Sire)