### PR TITLE
fix(data): Chaos Elemental - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -4960,7 +4960,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill the Chaos Elemental. Use Protect from Magic, attack with ranged or a special-weapon setup, and pick loot back up immediately if you get disarmed. The boss heals modestly between phases but has no combat triggers. If you spot a PKer, log out at the south wall - the safe tile is on the outer perimeter of the ruin",
+        "description": "Kill the Chaos Elemental. Use Protect from Magic, attack with ranged or a special-weapon setup, and pick loot back up immediately if you get disarmed. If you spot a PKer, log out at the south wall - the safe tile is on the outer perimeter of the ruin",
         "worldX": 3261,
         "worldY": 3927,
         "worldPlane": 0,


### PR DESCRIPTION
## Findings applied

**[medium] C8:** Removed fabricated self-healing and phase-transition claims from the combat step description. The sentence "The boss heals modestly between phases but has no combat triggers." invented two mechanics that do not exist. The wiki Strategies page confirms the Chaos Elemental is a single-phase encounter with no HP-regeneration mechanic (attacks are Discord, Confusion, and Madness only). Wiki receipt: "you will always be taking damage unless you are flinching or using the safe spot." Full receipts: docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 2 section).

## Skipped findings

None - all confirmed findings for this source have been applied.