### PR TITLE
fix(data): Tombs of Amascut (500 Invocation) - wiki-meta guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -7836,8 +7836,8 @@
                 "DESERT_HARD"
               ]
             },
-            "description": "Pharaoh's sceptre to the Necropolis (Desert Hard diary makes the sceptre unlimited-charge, so you can spam-teleport without recharging at the desert lectern). At raid level 500 bring Tumeken's shadow or Tbow, Osmumten's fang, full brews/restores, extra prayer potions and a Soulreaper axe spec; gear must be top-tier or kill times balloon",
-            "travelTip": "Pharaoh's sceptre -> Necropolis (unlimited charges via Desert Hard diary)"
+            "description": "Pharaoh's sceptre to the Necropolis (Desert Hard diary raises the sceptre charge cap to 50, up from 25, reducing how often it needs recharging at the desert lectern). At raid level 500 bring Tumeken's shadow or Tbow, Osmumten's fang, full brews/restores, extra prayer potions and a Soulreaper axe spec; gear must be top-tier or kill times balloon",
+            "travelTip": "Pharaoh's sceptre -> Necropolis (50 charges with Desert Hard diary)"
           },
           {
             "requirements": {
@@ -7881,7 +7881,7 @@
         "section": "Combat"
       },
       {
-        "description": "Defeat the Wardens at raid level 500. P1/P2: rotate prayers to match the active style; obelisk health-bar is much longer. P3 (Tumeken's Warden): pray Protect from Magic against the energy balls, dodge the obelisk hand-slam, swap prayers exactly when the Warden mimics Akkha/Zebak/Ba-Ba/Kephri attacks - mistakes cost 30+ hp at this scale",
+        "description": "Defeat the Wardens at raid level 500. P1/P2: rotate prayers to match the active style; obelisk health-bar is much longer. P3 phantoms depend on which Warden enraged: Tumeken's Warden summons Zebak and Ba-Ba phantoms; Elidinis' Warden summons Akkha and Kephri phantoms. Pray to each phantom's attack style and dodge the obelisk hand-slam - mistakes cost 30+ hp at this scale",
         "worldX": 3234,
         "worldY": 2784,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Corrects two guidance-text inaccuracies in the Tombs of Amascut (500 Invocation) source, identified during wiki-meta audit tranche 2.

## Applied findings

**[high] C9: Desert Hard diary sceptre charge cap**
- Was: "Desert Hard diary makes the sceptre unlimited-charge, so you can spam-teleport without recharging"
- Now: "Desert Hard diary raises the sceptre charge cap to 50, up from 25, reducing how often it needs recharging"
- Key receipt: "By default, the sceptre holds three charges. Players who have progressed in the Desert Diary have their sceptre hold more charges; up to 10 with the easy diary, 25 with the medium diary, 50 with the hard diary, and 100 with the elite diary." (OSRS Wiki, Pharaoh's sceptre). No unlimited-charge tier exists at any diary level.

**[medium] C19: P3 Warden phantom set**
- Was: "swap prayers exactly when the Warden mimics Akkha/Zebak/Ba-Ba/Kephri attacks" (listed all four)
- Now: explicitly names which two phantoms each Warden summons (Tumeken's -> Zebak + Ba-Ba; Elidinis' -> Akkha + Kephri)
- Key receipt: Tumeken's Warden: "summon phantoms of the bosses the player fought in the upper levels of the tomb (Zebak's Phantom and Ba-Ba's Phantom)". Elidinis' Warden: "summon phantoms of the bosses the player fought in the upper levels (Akkha's Phantom and Kephri's Phantom)." (OSRS Wiki, Tumeken's Warden / Elidinis' Warden)

Full receipts: docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 2 section).

## Skipped findings

None - all confirmed findings for this source were description-text fixes within scope.

## Test plan

- [x] JSON parses cleanly (python -c "import json;json.load(...)")
- [x] Zero non-ASCII characters
- [x] python scripts/audit_drop_rates.py --category RAIDS reports 0 errors (7 pre-existing low flagged-research warnings for raid lobby npcId, unchanged)
- [ ] CI build gate