### PR TITLE
fix(data): Tombs of Amascut (300 Invocation) - wiki-meta guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -7509,8 +7509,8 @@
                 "DESERT_HARD"
               ]
             },
-            "description": "Pharaoh's sceptre to the Necropolis (Desert Hard diary makes the sceptre unlimited-charge, so you can spam-teleport without recharging at the desert lectern). Bring Tbow or Bow of faerdhinen, Osmumten's fang, Tumeken's shadow if owned, full brews/restores; aim for invocations totalling raid level 300-450 for solid loot efficiency before entering",
-            "travelTip": "Pharaoh's sceptre -> Necropolis (unlimited charges via Desert Hard diary)"
+            "description": "Pharaoh's sceptre to the Necropolis (Desert Hard diary increases the sceptre to 50 charges per recharge, 100 with Elite diary, reducing recharge trips to the desert lectern). Bring Tbow or Bow of faerdhinen, Osmumten's fang, Tumeken's shadow if owned, full brews/restores; aim for invocations totalling raid level 300-450 for solid loot efficiency before entering",
+            "travelTip": "Pharaoh's sceptre -> Necropolis (50 charges via Desert Hard diary, 100 with Elite)"
           },
           {
             "requirements": {
@@ -7554,7 +7554,7 @@
         "section": "Combat"
       },
       {
-        "description": "Defeat the Wardens at raid level 300. P1/P2: rotate prayers to match the active style and break the obelisk. P3 (Tumeken's Warden): pray Protect from Magic against the energy balls, dodge the obelisk hand-slam, swap prayers when the Warden mimics Akkha/Zebak/Ba-Ba/Kephri attacks",
+        "description": "Defeat the Wardens at raid level 300. P1/P2: rotate prayers to match the active style and break the obelisk. P3 (Tumeken's Warden): pray Protect from Magic against the energy balls, dodge the obelisk hand-slam, swap prayers when the Warden mimics Zebak/Ba-Ba attacks (Elidinis' Warden mimics Akkha/Kephri instead)",
         "worldX": 3234,
         "worldY": 2784,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Fixes two factually wrong guidance step descriptions for Tombs of Amascut (300 Invocation).

- [high] C7: Desert Hard diary sceptre charge cap corrected. The description claimed "unlimited-charge" for the Desert Hard diary. The wiki (oldschool.runescape.wiki/w/Pharaoh%27s_sceptre#Recharging) is unambiguous: Hard diary = 50 charges, Elite diary = 100 charges. No tier grants unlimited charges. Updated both the description and travelTip to state the correct charge caps.
- [medium] C13: Tumeken's Warden phantom roster corrected. The description listed Akkha/Zebak/Ba-Ba/Kephri as phantoms for Tumeken's Warden in Phase 3. The wiki (oldschool.runescape.wiki/w/Tumeken%27s_Warden) documents that Tumeken's Warden summons only Zebak's Phantom and Ba-Ba's Phantom; Akkha and Kephri belong to Elidinis' Warden. Updated the step to name Zebak/Ba-Ba for Tumeken's Warden and note that Elidinis' Warden handles Akkha/Kephri.

Key wiki receipt for C7: "up to 50 with the hard diary, and 100 with the elite diary" (Pharaoh's_sceptre#Recharging). Skeptic verdict: "No tier grants infinite charges. The Elite Diary provides the maximum at 100 charges."

Key wiki receipt for C13: "summon phantoms of the bosses the player fought in the upper levels of the tomb (Zebak's Phantom and Ba-Ba's Phantom)" (Tumeken's_Warden). Elidinis' Warden page confirms Akkha and Kephri belong to the other warden.

Full receipts: docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 2 section).

## Skipped findings

None - all confirmed findings for this source were text-only guidance corrections within scope.

## Test plan

- [ ] JSON parses cleanly
- [ ] No non-ASCII characters in file
- [ ] `python scripts/audit_drop_rates.py --category RAIDS` reports 0 errors (pre-existing low-severity npcId warnings on all raid sources are unaffected)
- [ ] CI build passes