### PR TITLE
fix(data): Crazy archaeologist - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -9160,13 +9160,13 @@
         "section": "Bank"
       },
       {
-        "description": "Travel to the Crazy Archaeologist ruins south of the Lava Maze (Wilderness level 23). Burning amulet -> Bandit Camp then run north-west, or web-walk via the south-of-Lava-Maze ladder. The ruin sits in single-combat so once Crazy is engaged a PKer needs to wait their turn",
+        "description": "Travel to the Crazy Archaeologist ruins south of the Lava Maze (Wilderness level 23). Burning amulet -> Bandit Camp then run west, or web-walk via the south-of-Lava-Maze ladder. The ruin sits in single-combat so once Crazy is engaged a PKer needs to wait their turn",
         "worldX": 2975,
         "worldY": 3696,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
-        "travelTip": "Burning amulet -> Bandit Camp, run north-west to the ruins",
+        "travelTip": "Burning amulet -> Bandit Camp, run west to the ruins",
         "section": "Travel"
       },
       {


### PR DESCRIPTION
## Changes

- [medium] C7: Corrected travel direction from Bandit Camp to ruins. Changed 'run north-west' to 'run west' in both guidanceSteps[1].description and guidanceSteps[1].travelTip.

## Key receipt

Wiki: "a burning amulet can be used to teleport to the Bandit Camp (Wilderness), which is just east of the ruins." Geometry confirms: ruins at (2977, 3702), Bandit Camp landing ~(3038, 3699), dx=-61 (due west), dy=+3 -- bearing is essentially due west, not north-west.

## Full receipts

See docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 2 section) for complete receipts.

## Skipped findings

None -- all confirmed findings for this source have been applied.