### PR TITLE
fix(data): The Gauntlet - wiki-meta guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -8087,7 +8087,7 @@
     ],
     "guidanceSteps": [
       {
-        "description": "Teleport to Prifddinas via teleport crystal / house tablet and run north-west to the Gauntlet portal in Lletya district",
+        "description": "Teleport to Prifddinas via teleport crystal / house tablet and run north-west to the Gauntlet portal in Amlodd district",
         "worldX": 3230,
         "worldY": 6073,
         "worldPlane": 0,
@@ -8100,7 +8100,7 @@
                 "WESTERN_ELITE"
               ]
             },
-            "description": "Operate the Crystal teleport seed for the rub-on-cape variant (Western Provinces Elite diary attaches the Prifddinas teleport to your max / quest / achievement cape, so you can teleport from anywhere without dedicating an inventory slot to the seed). Then run north-west to the Gauntlet portal in Lletya district",
+            "description": "Operate the Crystal teleport seed for the rub-on-cape variant (Western Provinces Elite diary attaches the Prifddinas teleport to your max / quest / achievement cape, so you can teleport from anywhere without dedicating an inventory slot to the seed). Then run north-west to the Gauntlet portal in Amlodd district",
             "travelTip": "Cape Crystal teleport -> Prifddinas (Western Provinces Elite diary unlock)"
           },
           {
@@ -8110,7 +8110,7 @@
                 23858
               ]
             },
-            "description": "Right-click your Teleport crystal (regular or HM-charged) in the inventory and pick Prifddinas, then run north-west to the Gauntlet portal in Lletya district",
+            "description": "Right-click your Teleport crystal (regular or HM-charged) in the inventory and pick Prifddinas, then run north-west to the Gauntlet portal in Amlodd district",
             "travelTip": "Inventory Teleport crystal -> Prifddinas"
           }
         ]
@@ -8125,7 +8125,7 @@
         "completionCondition": "MANUAL"
       },
       {
-        "description": "Prep phase (about 7-9 minutes): gather paddlefish + linum tirinum + raw chompy meat + crystal shards, mine ore from crystal deposits, chop bark from phren roots, kill weak/strong monsters for weapon frames, and find a demi-boss for the perfected weapon upgrade. Craft a basic then perfected weapon + tier 3 armour at the singing bowl before the timer expires",
+        "description": "Prep phase (10 minutes): gather paddlefish + linum tirinum + crystal shards, mine ore from crystal deposits, chop bark from phren roots, kill weak/strong monsters for weapon frames, and find a demi-boss for the perfected weapon upgrade. Craft a basic then perfected weapon + tier 3 armour at the singing bowl before the timer expires",
         "worldX": 1920,
         "worldY": 5681,
         "worldPlane": 1,


### PR DESCRIPTION
## Summary

Two guidance-text corrections for The Gauntlet source, confirmed against wiki receipts (audit tranche 2, PR #829).

## Changes

**[medium] C1: Wrong navigation district in guidance steps**

All three travel descriptions named "Lletya district" as the location of the Gauntlet portal. Lletya is a separate hidden village outside Prifddinas in Isafdar - it is not a district within the city. The Gauntlet is in the Amlodd district (north-western part of Prifddinas).

Wiki receipt: "The Amlodd district is located in the north-western part of the city and features the following: The Gauntlet, a training ground created by the elves"

Fixed in: step 0 description + both conditionalAlternatives descriptions.

**[medium] C6: Non-existent prep resource + wrong prep timer**

The prep step listed "raw chompy meat" as a resource gathered during the Gauntlet prep phase. Raw chompy meat is a Western Provinces hunting item and plays no role in the Gauntlet. The correct prep resources are paddlefish, linum tirinum, phren bark, grym leaf, crystal ore, and crystal shards.

Additionally, the prep timer was stated as "about 7-9 minutes" but the regular Gauntlet gives 10 minutes to prepare (7:30 is the Corrupted Gauntlet variant timer).

Wiki receipt: prep resources are "Raw paddlefish ... Crystal ore ... Phren bark ... Grym leaf ... Linum tirinum"; timer: "Regular Gauntlet: 10 minutes to prepare to fight this boss"

Fixed in: step 2 (prep phase description) - removed "raw chompy meat", changed timer to "10 minutes".

## Skipped

None - both findings are description-text only and required no wiring changes.

## Full receipts

See docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 2 section) for complete audit receipts.