### PR TITLE
fix(data): Vyrewatch Sentinel - wiki-meta guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -13344,7 +13344,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Bank for Vyrewatch Sentinels. Bring a Blisterwood flail (mandatory - Sentinels are immune to all non-blisterwood weapons) or an Ivandis flail as a fallback, your best magic gear (an Amulet of blood fury is BIS for the lifesteal), prayer potions, super restores, and Saradomin brews. Vyre noble outfit can speed up the disguise step but is not required for combat.",
+        "description": "Bank for Vyrewatch Sentinels. Bring a Blisterwood flail (mandatory - Sentinels are immune to all non-blisterwood weapons) or an Ivandis flail as a fallback, your best melee gear (Amulet of rancour is BIS neck; Amulet of blood fury is a budget option), prayer potions, super restores, and Saradomin brews. Vyre noble outfit can speed up the disguise step but is not required for combat.",
         "worldX": 3631,
         "worldY": 3303,
         "worldPlane": 0,
@@ -13373,7 +13373,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Vyrewatch Sentinels in the central Darkmeyer square. Blisterwood flail (or Ivandis flail) is mandatory - any non-blisterwood weapon does zero damage. Use Protect from Melee for the standard attack; the Sentinels do not phase or have special mechanics, so the fight is essentially a Slayer-XP loop tuned for the Blood shard drop. Amulet of blood fury speccing keeps your HP topped without brews.",
+        "description": "Kill Vyrewatch Sentinels in the upper and middle tiers of Darkmeyer. Blisterwood flail (or Ivandis flail) is mandatory - any non-blisterwood weapon does zero damage. Use Protect from Melee for the standard attack; the Sentinels do not phase or have special mechanics, so the fight is essentially a Slayer-XP loop tuned for the Blood shard drop.",
         "worldX": 3631,
         "worldY": 3325,
         "worldPlane": 0,
@@ -13400,7 +13400,7 @@
         "section": "Loot"
       },
       {
-        "description": "Return to bank when supplies run low. Drakan's medallion to Ver Sinhaza or Canifis lodestone for the fastest bank cycle.",
+        "description": "Return to bank when supplies run low. Walk north to the Darkmeyer bank (on-site, upper tier, next to an altar). No teleport needed.",
         "worldX": 3631,
         "worldY": 3303,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Corrects four wiki-meta inaccuracies in the Vyrewatch Sentinel guidance steps. Full receipts in docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 3 section).

## Applied findings

- **[medium] C3**: Bank step - replaced blood fury BIS neck claim with Amulet of rancour as BIS; blood fury demoted to budget option. Receipt: strategies page neck slot lists "Amulet of rancour" first in both DPS and AFK/prayer tables; blood fury not mentioned.
- **[medium] C7**: Combat step - replaced "central Darkmeyer square" (nonexistent location) with "upper and middle tiers of Darkmeyer". Receipt: Darkmeyer wiki confirms Sentinels patrol both tiers with 19 spawn locations; no "central square" exists.
- **[medium] C11**: Combat step - removed "Amulet of blood fury speccing keeps your HP topped without brews". Receipt: blood fury has no special attack (passive 20% heal only); not mentioned anywhere on the strategies page.
- **[high] C12**: Bank-return step - replaced medallion/Canifis teleport banking with on-site Darkmeyer bank. Receipt: strategies page explicitly says "run north to the Bank area. There is a Bank and an Altar." Main wiki: "they can be killed next to an altar and bank."

## Skipped findings

None - all four findings were text-only description corrections within scope.

## Test plan

- [x] JSON parses clean (`python -c "import json;json.load(open(...))"`)
- [x] No non-ASCII characters
- [x] `python scripts/audit_drop_rates.py --category SLAYER` reports 0 errors
- [ ] CI build gate