### PR TITLE
fix(data): Cave Horror - wiki-meta guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -11405,7 +11405,7 @@
         ]
       },
       {
-        "description": "Kill Cave Horrors in the Mos Le Harmless cave. Requires witchwood icon necklace equipped to prevent stat drain (58 Slayer)",
+        "description": "Kill Cave Horrors in the Mos Le Harmless cave. Without a witchwood icon equipped, the scream special attack always deals 10% of base HP as damage; wearing the icon converts the scream into a regular attack roll (58 Slayer)",
         "worldX": 3740,
         "worldY": 9373,
         "worldPlane": 0,


### PR DESCRIPTION
## Applied findings

[high] C3: Corrected special attack description from 'stat drain' to '10% of base HP as damage' - wiki confirms the scream always deals HP damage, not a stat drain.
[high] C4: Corrected witchwood icon description from 'prevents stat drain' to accurately state it converts the guaranteed scream into a regular attack roll - wiki: 'Wearing the icon does not negate all damage from the scream, it instead causes the scream attack to roll as a regular attack.'

## Key wiki receipts

Cave Horror wiki: 'The cave horrors have a special attack which always deals damage equal to 10% of the player's base Hitpoints level, rounded down'

Witchwood icon wiki: 'Wearing the icon does not negate all damage from the scream, it instead causes the scream attack to roll as a regular attack.'

Full receipts: docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 3 section)

## Skipped findings

None - both C3 and C4 address the same guidance description and are resolved by the single text correction.