### PR TITLE
fix(data): Warped Creature - wiki-meta guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -11319,7 +11319,7 @@
       }
     ],
     "locationDescription": "Poison Waste Dungeon, Tirannwn",
-    "travelTip": "Tirannwn quiver -> Poison Waste",
+    "travelTip": "Spirit tree to Poison Waste, then walk west to dungeon entrance.",
     "npcId": 12490,
     "interactAction": "Attack",
     "guidanceSteps": [
@@ -11333,7 +11333,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Warped Creatures in the Warped area beneath Lumbridge Swamp. Requires completion of Song of the Elves",
+        "description": "Kill Warped Creatures in the Poison Waste Dungeon, Tirannwn. Requires completion of The Path of Glouphrie.",
         "worldX": 2032,
         "worldY": 4636,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Three guidance-text errors in the Warped Creature source, all contradicting the OSRS Wiki. All fixes are description/travelTip text only -- no IDs, coordinates, rates, or requirements wiring touched.

## Changes

- **[high] C2**: `travelTip` referenced a non-existent item ("Tirannwn quiver"). No item by that name exists in OSRS; the wiki search page prompts to create it. Replaced with the actual travel method: spirit tree to Poison Waste, then walk west to dungeon entrance. Wiki receipt: *"The dungeon can be accessed by spirit trees (fastest) or by using a crossbow and mithril grapple to cross the river."* (https://oldschool.runescape.wiki/w/Poison_Waste_Dungeon)
- **[blocker] C3**: `guidanceSteps[1].description` stated "Requires completion of Song of the Elves" -- that is the grandmaster elf-city quest that unlocks Prifddinas. Warped Creatures require The Path of Glouphrie. Wiki receipt: *"otherreq = The Path of Glouphrie ... Warped creatures are found exclusively in the Poison Waste Dungeon, requiring completion of The Path of Glouphrie."* (https://oldschool.runescape.wiki/w/Path_of_Glouphrie)  Note: the `requirements.quests` wiring already correctly has `THE_PATH_OF_GLOUPHRIE`; only the description text was wrong.
- **[blocker] C4**: `guidanceSteps[1].description` stated location as "Warped area beneath Lumbridge Swamp" -- no such location exists in OSRS. Wiki receipt: *"Warped Tortoise ... Locations: Poison Waste Dungeon | Warped Terrorbird ... Locations: Poison Waste Dungeon | Mutated Tortoise ... Locations: Poison Waste Dungeon"* (https://oldschool.runescape.wiki/w/Warped_Creature). The top-level `locationDescription` field already correctly reads "Poison Waste Dungeon, Tirannwn"; this was an isolated error in the guidance step text.

## Skipped

None. All three confirmed findings were description/travelTip text corrections within scope.

## Full receipts

See docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 3 section) for full audit receipts.

## Test plan

- [ ] JSON parses cleanly (`python -c "import json;json.load(open(...))"`)
- [ ] No non-ASCII characters
- [ ] `python scripts/audit_drop_rates.py --category SLAYER` reports 0 errors
- [ ] CI build passes