### PR TITLE
fix(data): Hydra - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -13279,7 +13279,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Hydras on the lower level. Pray against the active style (Magic first, then Ranged after three hits - just like Alchemical Hydra). Move one tile when the fire-puddle telegraph appears under your feet to avoid the 30+ burn tick. Drink antidote++ between kills - their venom attack ticks for 6+ even after they die. Dragon hunter lance + super combat gets sub-15s kill times.",
+        "description": "Kill Hydras on the lower level. Hydra starts on a random style (Magic or Ranged), switching after every three attacks regardless of hit/miss - watch the animation to determine the opening style and switch protection prayer accordingly. Move one tile when a poison splat telegraph (light green orb) appears under your feet to avoid 4 poison damage every two ticks (halved if poison-immune). Drink antidote++ between kills. Dragon hunter lance + super combat gets sub-15s kill times.",
         "worldX": 1310,
         "worldY": 10190,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Four guidance-text errors in the Hydra combat step, all contradicted by the wiki (https://oldschool.runescape.wiki/w/Hydra). Full receipts in docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 3).

## Applied findings

- **[blocker] C5**: Corrected combat-style opening. Old text said "Magic first, then Ranged after three hits - just like Alchemical Hydra." Wiki: "Hydras start off with a random combat style at the start of the battle, switching after three attacks, regardless if they hit or not." New text reflects random opening and attack-count (not hit-count) trigger.
- **[medium] C6**: Corrected special-attack visual. Old text said "fire-puddle telegraph." Wiki describes "poison splats, which are light green orbs." Replaced with "poison splat telegraph (light green orb)."
- **[blocker] C7**: Corrected special-attack damage. Old text said "30+ burn tick." Wiki: "dealing 4 poison damage every two ticks (or 1 to 2 damage if the player has poison immunity)." Replaced with correct figure and damage type.
- **[high] C8**: Corrected damage type for the special attack. Old text said "venom attack ticks for 6+ even after they die." Wiki consistently uses "poison" for this mechanic (not venom, which is a distinct escalating mechanic in OSRS) and gives no support for post-death persistence. Removed the venom/after-death framing; antidote++ advice retained.

## Key wiki receipts

> "Hydras start off with a random combat style at the start of the battle, switching after three attacks, regardless if they hit or not."

> "the middle head of the hydra will spit poison at three random tiles (one at the player's location, two elsewhere), dealing 4 poison damage every two ticks (or 1 to 2 damage if the player has poison immunity)"

## Validation

- JSON parse: clean
- Non-ASCII check: 0 characters
- audit_drop_rates.py --category SLAYER: 0 errors