### PR TITLE
fix(data): Wyrm - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -11617,7 +11617,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to Mount Karuulm. Bring boots of stone (mandatory to prevent passive heat damage in the Karuulm dungeon - or use granite or Cerberus boots), Dragon hunter lance, super combat, prayer potions, a few Saradomin brews, super restores, and sharks. Slayer task recommended for the dragon-tier rare drops. Fairy ring CIR drops you right at the dungeon entrance; Rada's blessing teleport to Mount Karuulm is the unquested alternative.",
+        "description": "Travel to Mount Karuulm. Bring boots of stone (mandatory to prevent passive heat damage in the Karuulm dungeon - or use boots of brimstone or granite boots), Dragon hunter lance, super combat, prayer potions, a few Saradomin brews, super restores, and sharks. Slayer task recommended for the dragon-tier rare drops. Fairy ring CIR drops you right at the dungeon entrance; Rada's blessing teleport to Mount Karuulm is the unquested alternative.",
         "worldX": 1311,
         "worldY": 3807,
         "worldPlane": 0,
@@ -11650,7 +11650,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Wyrms on the first level (62 Slayer). Pray Magic for their ranged-magic breath - they hit through prayer for 1s only and you can long-range safespot from outside their attack range with a Dragon hunter lance or Dragon hunter crossbow. Boots of stone keep the heat tick from grinding through your HP. The shortcut safespot tile near the east wall lets you AFK chunks of the task while you stack the rares.",
+        "description": "Kill Wyrms on the first level (62 Slayer). Pray Magic for their magic attacks. You can safespot from outside their 6-square attack range using a Dragon hunter crossbow or other ranged weapon. Boots of stone keep the heat tick from grinding through your HP. The shortcut safespot tile near the east wall lets you AFK chunks of the task while you stack the rares.",
         "worldX": 1311,
         "worldY": 10205,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Three guidance-text bugs in the Wyrm source, all confirmed against the OSRS wiki. Full receipts in docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 3 section).

## Applied findings

**[high] C1:** Travel step - replaced non-existent item 'Cerberus boots' with 'boots of brimstone' in the heat-protection alternatives list. Wiki (Karuulm Slayer Dungeon): *"players who wish to explore further beyond the entrance chamber must wear the boots of stone, boots of brimstone or granite boots to protect themselves from the extreme heat of the dungeon floor."* 'Cerberus boots' does not exist as an in-game item; the wiki page redirects to the Cerberus boss uniques.

**[blocker] C7:** Combat step - removed the fabricated claim "they hit through prayer for 1s only". The Wyrm wiki page describes no prayer-bypass or prayer-penetration mechanic. Protect from Magic is a straightforward defensive option with no caveat. Wiki: *"using a form of magic protection, such as Protect from Magic, or armour with high magic defence bonuses like dragonhide armour, a viable method for killing wyrms."*

**[high] C8:** Combat step - removed Dragon hunter lance from the safespot description. The Wyrm safespot requires staying outside their 6-square magic attack range (a ranged safespot). The Dragon hunter lance is a melee weapon (1-tile range) and mechanically cannot be used at this safespot. Wiki: *"lure them to the corner to trap them, allowing players to range them at a specific spot while staying out of their magic attack range of 6 squares."* Only the Dragon hunter crossbow and other ranged weapons apply.

## Skipped findings

None - all three confirmed findings were guidance-text corrections within scope.

## Test plan

- [ ] JSON syntax valid (`python -c "import json;json.load(...)"`)
- [ ] No non-ASCII characters in file
- [ ] `python scripts/audit_drop_rates.py --category SLAYER` reports 0 errors
- [ ] CI build passes