### PR TITLE
fix(data): Dark Beast - wiki-meta guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -13020,7 +13020,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to the Iorwerth Dungeon in Prifddinas (crystal seed teleport) or Mourner Tunnels",
+        "description": "Travel to the Iorwerth Dungeon in Prifddinas (teleport crystal) or Mourner Tunnels",
         "worldX": 1920,
         "worldY": 4672,
         "worldPlane": 0,
@@ -13033,14 +13033,14 @@
                 "FAIRY_RING"
               ]
             },
-            "description": "POH superior garden fairy ring (dramen/lunar staff equipped) -> dial CIQ to land directly at the Iorwerth Dungeon entrance in Prifddinas",
-            "travelTip": "POH fairy ring -> CIQ -> Iorwerth Dungeon entrance"
+            "description": "No fairy ring leads to Prifddinas. Use a teleport crystal to reach Prifddinas, then enter the Iorwerth Dungeon to the south.",
+            "travelTip": "Teleport crystal -> Prifddinas -> Iorwerth Dungeon"
           }
         ],
         "section": "Travel"
       },
       {
-        "description": "Kill Dark Beasts in the Mourner Tunnels or Catacombs of Kourend. Use Protect from Melee. High Defence - use accurate weapon styles",
+        "description": "Kill Dark Beasts in the Mourner Tunnels or Iorwerth Dungeon. Use Protect from Melee. High Defence - use accurate weapon styles",
         "worldX": 1920,
         "worldY": 4672,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Fixes three wiki-verified guidance errors in the Dark Beast source. Full receipts in docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 3 section).

## Applied findings

**[blocker] C5**: Removed wrong fairy ring code CIQ from conditionalAlternatives. CIQ leads to north-west of Yanille (Kandarin), not Prifddinas. Wiki fairy ring table: "CIQ | North-west of Yanille". No fairy ring code reaches Prifddinas or the Iorwerth Dungeon. Alternative rewritten to direct players to use a teleport crystal instead.

**[high] C3**: Combat step replaced "Catacombs of Kourend" with "Iorwerth Dungeon". Dark Beasts were removed from the Catacombs of Kourend on 25 July 2019 (Song of the Elves update). Wiki update log: "Dark beasts were added to Iorwerth Dungeon and removed from Kourend Catacombs for thematic reasons." Current locations are Mourner Tunnels and Iorwerth Dungeon only.

**[medium] C4**: Travel step replaced "crystal seed teleport" with "teleport crystal". Wiki (Teleport_crystal): "A teleport crystal is a small crystal which can teleport a player to the elven village of Lletya (and Prifddinas upon completion of the Song of the Elves quest)." Wiki (Crystal_teleport_seed): "the crystal teleport seed is a depleted teleport crystal that has run out of charges ... the seed cannot teleport players independently." The travelTip field already correctly read "Teleport crystal -> Prifddinas"; this fixes the inconsistency in the step description.

## Skipped findings

None — all three confirmed findings were description-text corrections within scope.