### PR TITLE
fix(data): Aquanite - wiki-meta guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -12435,7 +12435,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Sail to Ynysdail island and enter Ynysdail Cavern underground (73 Sailing required, 78 Slayer to kill). Bring a crush weapon (Abyssal bludgeon, Inquisitor's mace) for best accuracy; Aquanite tendon is extremely rare (1/3500)",
+        "description": "Sail to Ynysdail island and enter Ynysdail Cavern underground (73 Sailing required, 78 Slayer to kill). Bring a fast slash weapon (whip, scimitar) and a stab weapon (Ghrazi rapier, Osmumten's fang); Aquanite tendon is extremely rare (1/3500)",
         "worldX": 2218,
         "worldY": 3477,
         "worldPlane": 0,
@@ -12451,7 +12451,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Aquanites in Ynysdail Cavern. Protect from Melee; melee damage only. Use a crush weapon for best accuracy. No special attacks or phase mechanics",
+        "description": "Kill Aquanites in Ynysdail Cavern. Protect from Magic (Magic attacks only, max hit 18). Open with a fast slash weapon (whip or scimitar) to sever the lure (reduces Stab defence from 60 to 10, no damage required), then finish with a stab weapon (Ghrazi rapier, Osmumten's fang) for best accuracy",
         "worldX": 2275,
         "worldY": 9880,
         "worldPlane": 0,
@@ -12461,7 +12461,6 @@
         "completionNpcId": 15497,
         "section": "Combat",
         "recommendedItemIds": [
-          13263,
           4087,
           12695
         ]


### PR DESCRIPTION
## Summary

Corrects four confirmed wiki-meta errors in the Aquanite guidance steps. All findings are from audit tranche 3; full receipts in docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 3 section).

## Applied findings

**[blocker] C3:** Replaced crush weapon recommendation with correct slash-then-stab strategy. Abyssal bludgeon removed from `recommendedItemIds` and step descriptions. Aquanites have +80 Crush defence (worst bracket); correct approach is a fast slash weapon to sever the lure then a stab weapon (Ghrazi rapier / Osmumten's fang) for the kill.
> Wiki receipt: "a fast 4-tick slash weapon such as a Scimitar or Abyssal whip is recommended" [to sever the lure]; primary weapons include Ghrazi rapier and Osmumten's fang. "The wiki does not mention Abyssal bludgeon or Inquisitor's mace in the Aquanite strategies guide."

**[blocker] C4:** Corrected prayer from `Protect from Melee` to `Protect from Magic`.
> Wiki receipt: "Aquanites attack with Magic and have high accuracy, so using Protect from Magic is highly recommended."

**[blocker] C5:** Corrected attack style description from "melee damage only" to "Magic attacks only, max hit 18".
> Wiki receipt: Attack Style: "Magic", Max Hit: 18, Attack Speed: "5 ticks (3.0 seconds)".

**[medium] C6:** Added lure mechanic note: one slash attack severs the lure (no damage required), permanently reducing Stab defence from 60 to 10 for that kill.
> Wiki receipt: "if an Aquanite is hit with a slash attack, its lure will be severed and its stab Defence will be reduced by 50 (from 60 to 10) ... dealing damage is not required to sever the lure"

## Skipped findings

None — all four confirmed findings are description-text corrections within scope.

## Validation

- JSON parses cleanly
- Non-ASCII check: 0 non-ASCII characters
- `python scripts/audit_drop_rates.py --category SLAYER`: Aquanite in verified bucket, 0 errors