### PR TITLE
fix(data): Drake - wiki-meta guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -12750,7 +12750,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to Mount Karuulm. Bring boots of stone (mandatory - the Karuulm heat tick will eat through your HP without them), Dragon hunter lance, super combat, prayer potions, Saradomin brews, super restores, and a few sharks. Karuulm-friendly footwear (boots of stone / granite / Cerberus boots) is non-negotiable. Fairy ring CIR drops you right at the dungeon entrance; Rada's blessing 3/4 teleport is the unquested alternative.",
+        "description": "Travel to Mount Karuulm. Bring boots of stone (mandatory - the Karuulm heat tick will eat through your HP without them), Dragon hunter lance, super combat, prayer potions, Saradomin brews, super restores, and a few sharks. Karuulm-friendly footwear (boots of stone / granite / Cerberus boots) is non-negotiable. Fairy ring CIR - short walk north up the volcano to the dungeon entrance; Rada's blessing 3/4 (requires Kourend & Kebos Hard Diary) teleports straight to the dungeon.",
         "worldX": 1311,
         "worldY": 3807,
         "worldPlane": 0,
@@ -12783,7 +12783,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Drakes on the mid level (84 Slayer). Move one tile when you see the dragonfire breath telegraph (orange beam under your feet) - it hits up to 40 if you stand still. Pray Magic for the standard ranged-magic style; Dragon hunter lance + super combat gets sub-12s kill times. The room safespot tile at the south-east edge lets you AFK most of the task with prayer potions.",
+        "description": "Kill Drakes on the mid level (84 Slayer). Move one tile when you see the dragonfire breath telegraph (orange beam under your feet) - it deals up to 32 damage (four hits of up to 8 each) if you stand still. Pray Missiles (Protect from Missiles) for the standard ranged attack style; Dragon hunter lance + super combat gets sub-12s kill times. The room safespot tile at the south-east edge lets you AFK most of the task with prayer potions.",
         "worldX": 1310,
         "worldY": 10057,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Corrects four guidance-text errors in the Drake source identified during wiki-meta audit tranche 3.

## Applied findings

- **[blocker] C6**: dragonfire breath max hit corrected from 40 to 32. Wiki: "deals 6-8 damage for four hits" (max 4x8=32); Drake infobox lists 32 (Dragonfire). The previous value overstated the ceiling by 8.
- **[blocker] C7**: prayer corrected from "Pray Magic" to "Pray Missiles (Protect from Missiles)". Wiki: "Drakes normal ranged attacks can be fully blocked by Protect from Missiles." Drake has no Magic-based standard attack; the old text left players fully exposed.
- **[medium] C3**: Rada's blessing 3/4 qualifier corrected from "unquested" to "requires Kourend & Kebos Hard Diary". Wiki: "unlocked after completing the Kourend & Kebos Hard Diary" (which itself requires six quests).
- **[low] C2**: Fairy ring CIR proximity corrected from "drops you right at the dungeon entrance" to "short walk north up the volcano to the dungeon entrance". Wiki: "The mountain is a short walk north of this fairy ring."

## Skipped findings

None — all four confirmed findings were description-text corrections within scope.

## Full receipts

See docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 3 section) for raw wiki quotes and skeptic receipts.