### PR TITLE
fix(data): Skeletal Wyvern - wiki-meta guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -12062,7 +12062,7 @@
         "section": "Travel"
       },
       {
-        "description": "Enter the Asgarnian Ice Dungeon ladder and run east to the Skeletal Wyvern room.",
+        "description": "Enter the Asgarnian Ice Dungeon trapdoor, then run north then east to reach the Skeletal Wyvern chamber.",
         "worldX": 3008,
         "worldY": 3150,
         "worldPlane": 0,
@@ -12073,7 +12073,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Skeletal Wyverns. Equipped Elemental / Mind / Dragonfire shield is mandatory - the icy breath ignores normal antifire and hits for 50+ without one. Use the ranged safespot tile behind the north-west pillar with a Dragon hunter crossbow or blowpipe to take no damage on most kills. Pray ranged for the close-range tail attack if you need to melee.",
+        "description": "Kill Skeletal Wyverns. Equipped Elemental / Mind / Dragonfire shield is mandatory - the icy breath ignores normal antifire and hits for 50+ without one. Use the ranged safespot tile behind the north-west pillar with a Dragon hunter crossbow or blowpipe to take no damage on most kills. Pray Protect from Missiles for their ranged attacks if safespotting is not possible.",
         "worldX": 3008,
         "worldY": 3150,
         "worldPlane": 0,
@@ -12092,7 +12092,7 @@
         ]
       },
       {
-        "description": "Loot the Draconic visage and Granite legs. Long Bones (5 Construction XP each) and the Wyvern visage drop weight makes this a hands-off task.",
+        "description": "Loot the Draconic visage and Granite legs. Skeletal Wyverns drop the Draconic visage, not the Wyvern visage.",
         "worldX": 3008,
         "worldY": 3150,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Fixes five guidance-text errors in the Skeletal Wyvern source, all confirmed against wiki receipts (audit tranche 3).

## Applied findings

- **[medium] C8**: `guidanceSteps[2]` - entrance is a trapdoor, not a ladder. Wiki: "found south of Port Sarim and north of Mudskipper Point, under a trapdoor."
- **[medium] C9**: `guidanceSteps[2]` - directions corrected from "run east" to "run north then east". Wiki (Skeletal Wyvern/Strategies): "first run north and then run east to find an open space."
- **[blocker] C12**: `guidanceSteps[3]` - removed fabricated "close-range tail attack" language. Wiki lists exactly three attack styles: Ranged, Slash, Icy breath - no tail attack. Prayer guidance updated to accurate "Protect from Missiles for their ranged attacks." Wiki: "Protect from Missiles is the suggested Prayer to use against them due to the amount of range damage skeletal wyverns do."
- **[blocker] C13**: `guidanceSteps[4]` - removed Long Bones claim entirely. Wiki confirms Skeletal Wyvern is not listed as a Long Bone source across all 36 drop table entries. XP figure (5 XP) was also wrong (correct is 4,500 via Barlak).
- **[blocker] C14**: `guidanceSteps[4]` - corrected "Wyvern visage" to "Draconic visage." Wiki: "Unlike the wyverns that reside within Fossil Island, skeletal wyverns do not drop the wyvern visage; rather, they drop the draconic visage."

## Skipped findings

None - all five findings were description-text corrections within scope.

## Validation

- JSON parses cleanly
- 0 non-ASCII characters
- `audit_drop_rates.py --category SLAYER`: 0 errors (3 flagged-research on unrelated sources)

Full receipts: docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 3 section)