### PR TITLE
fix(data): Twisted Banshee - wiki-meta guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -12136,7 +12136,7 @@
       }
     ],
     "locationDescription": "Catacombs of Kourend",
-    "travelTip": "Xeric's talisman -> Xeric's Heart, or fairy ring CIS -> Kourend Castle then descend into the Catacombs",
+    "travelTip": "Xeric's talisman -> Xeric's Heart then enter Catacombs at King Rada I statue; or fairy ring CIS -> Demon's Run northeast entrance directly into the Catacombs",
     "npcId": 7272,
     "interactAction": "Attack",
     "guidanceSteps": [
@@ -12147,11 +12147,11 @@
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
-        "travelTip": "Xeric's talisman -> Xeric's Heart, or fairy ring CIS -> Kourend Castle then descend",
+        "travelTip": "Xeric's talisman -> Xeric's Heart then enter Catacombs at King Rada I statue; or fairy ring CIS -> Demon's Run northeast entrance directly into the Catacombs",
         "section": "Travel"
       },
       {
-        "description": "Find the Twisted Banshees in the Catacombs of Kourend. Earmuffs or a slayer helmet are required or they hit hard.",
+        "description": "Find the Twisted Banshees in the Catacombs of Kourend. Without earmuffs or a slayer helmet, each attack deals 7 damage and heavily drains Attack, Strength, Defence, Ranged, Magic, Prayer, and Agility.",
         "worldX": 1612,
         "worldY": 9994,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Corrects two guidance-text inaccuracies in the Twisted Banshee source, confirmed by wiki receipts (audit tranche 3).

### Applied findings

**[medium] C4:** Step 2 description - corrected banshee no-protection mechanic from vague "hit hard" to the actual effect: each attack deals a fixed 7 damage AND heavily drains Attack, Strength, Defence, Ranged, Magic, Prayer, and Agility. The old text caused players to underestimate the real risk (Prayer drain means losing protection prayers faster; multi-stat drain significantly reduces DPS).
- Wiki receipt: "cause the player to take 7 damage and have their stats greatly reduced in Attack, Strength, Defence, Ranged, Magic, Prayer, and Agility with every attack received" (https://oldschool.runescape.wiki/w/Twisted_Banshee)

**[low] C3:** Travel tip (top-level and step 1) - CIS fairy ring lands at Demon's Run, a northeast entrance directly into the Catacombs, not at Kourend Castle. The old text chained "CIS -> Kourend Castle" as a single route, which is incorrect - these are two distinct access points. Fixed to list each route separately.
- Wiki receipt: "Once the exit has been used it can be quickly accessed via fairy ring CIS and running east." CIS -> Demon's Run northeast entrance (https://oldschool.runescape.wiki/w/Catacombs_of_Kourend)

### Skipped findings

None - all confirmed findings were description-text corrections within scope.

### Full receipts

See docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 3 section) for complete receipts and skeptic reasoning.

## Test plan

- [ ] JSON parses cleanly (`python -c "import json;json.load(open(...))"`)
- [ ] No non-ASCII characters introduced
- [ ] `python scripts/audit_drop_rates.py --category SLAYER` reports 0 errors
- [ ] CI build passes