### PR TITLE
fix(data): Sulphur Nagua - wiki-meta guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -10867,7 +10867,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Bank and prepare for Sulphur Nagua. Bring melee or ranged gear; spectral undead so Salve amulet (ei) outperforms Slayer helmet on task",
+        "description": "Bank and prepare for Sulphur Nagua. Bring melee or ranged gear; spectral but NOT undead so Salve amulet has no effect - use Slayer helmet on task",
         "worldX": 3087,
         "worldY": 3493,
         "worldPlane": 0,
@@ -10895,7 +10895,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Sulphur Nagua. Protect from Melee; melee damage only. Spectral undead - Salve amulet (ei) outperforms Slayer helmet on task. No phase mechanics or special attacks",
+        "description": "Kill Sulphur Nagua. Protect from Melee; melee damage only. Spectral but NOT undead - Salve amulet has no effect; use Slayer helmet on task. No phase mechanics; special attack every 5 hits drains 5 prayer points if in melee range - step away to avoid it",
         "worldX": 1440,
         "worldY": 9602,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Corrects two guidance-text bugs in the Sulphur Nagua source identified in the wiki-meta audit (tranche 3).

## Applied findings

**[blocker] C1: Inverted combat meta - spectral/undead classification and Salve amulet advice**
- Bank-prep step and combat step both claimed Sulphur Nagua are 'spectral undead' and that 'Salve amulet (ei) outperforms Slayer helmet on task'. Both claims are false.
- Wiki receipt: "They are spectral creatures but not undead, meaning the Ectoplasmator will provide prayer experience for defeating them, but the Salve amulet and its variants will not affect them." -- https://oldschool.runescape.wiki/w/Sulphur_Nagua
- Fix: both steps now read 'spectral but NOT undead - Salve amulet has no effect; use Slayer helmet on task'.

**[medium] C4: False claim of no special attacks**
- Combat step stated 'No phase mechanics or special attacks'. Sulphur Nagua have a prayer-draining special attack.
- Wiki receipt: "After five attacks they will use a special attack in which they raise their weapon, and if the player remains within their melee range (including diagonal spaces) after three ticks, they will have 5 prayer points drained." -- https://oldschool.runescape.wiki/w/Sulphur_Nagua
- Fix: combat step now reads 'No phase mechanics; special attack every 5 hits drains 5 prayer points if in melee range - step away to avoid it'.

## Skipped findings

**[high] C8: Missing Perilous Moons partial-quest requirement gate**
- The wiki states partial completion of Perilous Moons is required to access Neypotzli where Sulphur Nagua are found.
- Skipped reason: requirements-wiring follow-up -- adding a partial-quest gate to requirements.quests is a wiring change outside the guidance-text scope of this pass.

## References

Full receipts and audit trail: docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 3 section)