### PR TITLE
fix(data): Frost Nagua - wiki-meta guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -10786,12 +10786,12 @@
       }
     ],
     "locationDescription": "Ruins of Tapoyauik, beneath Twilight Temple, Varlamore",
-    "travelTip": "Pendant of ates -> Ruins of Tapoyauik (requires The Heart of Darkness), or quetzal whistle -> Civitas illa Fortis -> walk south",
+    "travelTip": "Pendant of ates -> Twilight Temple (requires The Heart of Darkness), or quetzal whistle -> Civitas illa Fortis -> walk south",
     "npcId": 13788,
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Bank and prepare for Frost Nagua. Fire-spell magic or melee crush gear works best; spectral undead so Salve amulet (ei) outperforms Slayer helmet on task",
+        "description": "Bank and prepare for Frost Nagua. Fire-spell magic or melee stab gear works best; spectral (not undead) so Slayer helmet applies on task",
         "worldX": 3087,
         "worldY": 3493,
         "worldPlane": 0,
@@ -10800,13 +10800,13 @@
         "section": "Bank"
       },
       {
-        "description": "Use the Pendant of ates to teleport directly to the Ruins of Tapoyauik (requires The Heart of Darkness). Without the pendant, use quetzal whistle to Civitas illa Fortis then walk south to the Twilight Temple entrance",
+        "description": "Use the Pendant of ates to teleport to the Twilight Temple (requires The Heart of Darkness). Without the pendant, use quetzal whistle to Civitas illa Fortis then walk south to the Twilight Temple entrance",
         "worldX": 1350,
         "worldY": 3050,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 25,
-        "travelTip": "Pendant of ates -> Ruins of Tapoyauik, or quetzal whistle -> Civitas illa Fortis -> walk south",
+        "travelTip": "Pendant of ates -> Twilight Temple, or quetzal whistle -> Civitas illa Fortis -> walk south",
         "section": "Travel"
       },
       {
@@ -10819,7 +10819,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Frost Nagua. Protect from Melee; fire spells deal bonus damage. Spectral undead - Salve amulet (ei) gives a stronger bonus than Slayer helmet on task. No phase mechanics",
+        "description": "Kill Frost Nagua. Protect from Magic; fire spells deal bonus damage. Spectral (not undead) - Slayer helmet applies on task. No phase mechanics",
         "worldX": 1362,
         "worldY": 4511,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Five guidance-text bugs corrected for Frost Nagua, all confirmed against the wiki. Full receipts in docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 3 section).

## Applied findings

**[blocker] C4:** Protect from Melee -> Protect from Magic in combat step description. Wiki: \"Protect from Magic will negate all damage from their basic attacks.\" (attack style is Magic, not Melee)

**[blocker] C3:** Removed Salve amulet (ei) recommendation from bank prep and combat steps. Wiki confirms Frost Nagua has only the Spectral attribute, not undead. Salve amulet (ei) works exclusively on undead monsters and provides no bonus here.

**[high] C2:** Removed \"undead\" from classification in both description fields. Wiki lists attribute as Spectral only; there is no undead attribute on this monster.

**[medium] C1:** melee crush -> melee stab in bank prep description. Wiki defensive stats: Stab +0, Slash +50, Crush +10. Stab is strictly the lowest-resistance melee style.

**[medium] C9:** Pendant of ates teleport destination corrected from \"Ruins of Tapoyauik\" to \"Twilight Temple\" in top-level travelTip, guidanceSteps[1] description, and guidanceSteps[1] travelTip. Wiki (Ruins of Tapoyauik page): \"The pendant of ates can teleport directly to the Twilight Temple, near the lift.\" The Ruins are accessed via the lift after arriving at the Temple.

## Skipped findings

None - all five confirmed findings were description-text fixes within scope.

## Test plan

- [ ] JSON parses cleanly (python -c "import json;json.load(open(...))")
- [ ] Zero non-ASCII characters
- [ ] python scripts/audit_drop_rates.py --category SLAYER reports 0 errors
- [ ] CI build passes