### PR TITLE
fix(data): Gargoyle - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -12272,7 +12272,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Gargoyles on the top floor. Once a Gargoyle drops below 9 HP, smash it with a Rock hammer (or the Gargoyle smasher perk auto-smashes for you above 75 Slayer). Granite maul spec is the fastest finisher for 2-tick tasks. Watch for the boost-the-HP trick on early Slayer accounts - if you over-damage them they reset to full HP.",
+        "description": "Kill Gargoyles on the top floor. Once a Gargoyle drops to 8 HP or lower, smash it with a Rock hammer (or the Gargoyle Smasher perk, costing 120 Slayer points, auto-smashes provided a rock hammer is in your inventory). Granite maul Quick Smash (instant special, 60% spec energy) is the fastest finisher.",
         "worldX": 3429,
         "worldY": 3534,
         "worldPlane": 2,
@@ -12291,7 +12291,7 @@
         ]
       },
       {
-        "description": "Loot the Granite maul (3-tick spec weapon), Mystic robe top (dark), and Adamant boots. Granite mauls stack high - high alch them for GP between tasks.",
+        "description": "Loot the Granite maul (instant Quick Smash special attack), Mystic robe top (dark), and Adamant boots. Granite mauls stack high - high alch them for GP between tasks.",
         "worldX": 3429,
         "worldY": 3534,
         "worldPlane": 2,


### PR DESCRIPTION
## Findings applied

[blocker] C12: removed fabricated boost-the-HP mechanic from combat step. The wiki states only that a rock hammer must be used at 8 HP or lower to kill a gargoyle; no HP-reset or over-damage penalty mechanic exists. Receipt: "In order to kill a gargoyle, a rock hammer, a rock thrownhammer, or a granite hammer must be used when they reach 8 or lower Hitpoints." (https://oldschool.runescape.wiki/w/Gargoyle)

[medium] C13: corrected granite maul from "3-tick spec weapon" to "instant Quick Smash special attack". The wiki describes the special as "an instant attack" that fires outside the normal attack cycle. Receipt: "The granite maul's special attack, Quick Smash, consumes 60% of the player's special attack energy and deals an instant attack." (https://oldschool.runescape.wiki/w/Granite_maul)

[low] C10: removed false 75+ Slayer gate on the Gargoyle Smasher perk from combat step description. The perk costs 120 Slayer points from any Slayer Master; it carries no separate Slayer level requirement. The 75 Slayer level is a task-assignment requirement, not a perk-purchase requirement. Receipt: "players can buy the Gargoyle Smasher perk from Slayer Masters for 120 Slayer points, which will automatically smash the gargoyle when it falls to 9 or lower Hitpoints, provided that the player has a rock hammer (or equivalent) in their inventory." (https://oldschool.runescape.wiki/w/Gargoyle)

Full receipts: docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 3 section)

## Skipped findings

None - all three confirmed findings were description-text corrections within scope.

## Validation

- JSON parses cleanly
- Zero non-ASCII characters
- audit_drop_rates.py --category SLAYER: 0 errors, Gargoyle listed as verified