### PR TITLE
fix(data): Earthen Nagua - wiki-meta guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -10937,13 +10937,13 @@
         "wikiPage": "Earthbound_tecpatl"
       }
     ],
-    "locationDescription": "Tonali Cavern, beneath Cam Torum, Varlamore",
-    "travelTip": "Quetzal whistle -> Cam Torum -> Tonali Cavern entrance",
+    "locationDescription": "Tonali Cavern, beneath the Crypt of Tonali, Tlati Rainforest, Varlamore",
+    "travelTip": "Quetzal whistle -> Kastori -> run west to Tonali Cavern entrance",
     "npcId": 14420,
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Bank and prepare for Earthen Nagua. Bring melee or ranged gear; they are spectral undead so Salve amulet (ei) outperforms Slayer helmet on task. No consumable key required",
+        "description": "Bank and prepare for Earthen Nagua. Bring melee or ranged gear; use Slayer helmet on task. No consumable key required",
         "worldX": 3087,
         "worldY": 3493,
         "worldPlane": 0,
@@ -10952,13 +10952,13 @@
         "section": "Bank"
       },
       {
-        "description": "Use the quetzal whistle to travel to Cam Torum in Varlamore, then enter the Tonali Cavern beneath the city",
+        "description": "Use the quetzal whistle to travel to Kastori in Varlamore, then run west to the Tonali Cavern entrance beneath the Crypt of Tonali",
         "worldX": 1309,
         "worldY": 3104,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
-        "travelTip": "Quetzal whistle -> Cam Torum -> Tonali Cavern entrance",
+        "travelTip": "Quetzal whistle -> Kastori -> run west to Tonali Cavern entrance",
         "section": "Travel"
       },
       {
@@ -10971,7 +10971,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Earthen Nagua. Protect from Melee; spectral undead weak to slash. Salve amulet (ei) gives a stronger damage bonus than Slayer helmet on task. No phase mechanics or special attacks",
+        "description": "Kill Earthen Nagua. Protect from Melee; weak to Air (15%). Use slash above 60% HP; below 60% HP nagua reinforces and shifts weaker to crush, more resistant to slash. Use Slayer helmet on task",
         "worldX": 1309,
         "worldY": 9450,
         "worldPlane": 0,


### PR DESCRIPTION
## Changes

Fixes confirmed wiki-meta findings for Earthen Nagua from the tranche 3 audit. Full receipts in docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 3 section).

### Applied findings

**[blocker] C1/C2**: Removed false 'spectral undead' label and Salve amulet (ei) on-task recommendation. Wiki: Earthen Nagua type is 'Spectral creature' — the Undead attribute is absent from the infobox. Spectral creature wiki: 'this does not apply to all spectral creatures' re salve. Salve amulet (ei) wiki: bonus applies to undead only. Replaced with Slayer helmet on task.

**[high] C4**: Updated travel step from Cam Torum quetzal stop to Kastori. Tonali Cavern wiki: 'The Quetzal Transport System can be used to land at Tal Teklan or Kastori, both near the cavern's entrances.' Cam Torum is not listed as a routing option.

**[high] C5**: Updated locationDescription from 'beneath Cam Torum' to 'beneath the Crypt of Tonali, Tlati Rainforest'. Tonali Cavern wiki: 'The Tonali Cavern is a dungeon located beneath the Crypt of Tonali in the Tlati Rainforest region of Varlamore.'

**[blocker] C7**: Corrected weakness from slash to Air (15%). Wiki: Air elemental weakness 15%; in reinforced phase (below 60% HP) nagua 'shifting their defences to be more resistant to slash while being weaker to crush weapons.'

**[blocker] C8**: Removed 'No phase mechanics' claim; added phase description. Wiki: 'When an earthen nagua is damaged after falling below 60% health, they enter a reinforced form, shifting their defences to be more resistant to slash while being weaker to crush weapons.'

### Skipped findings

None — all confirmed findings were guidance text corrections within scope.

### Validation

- JSON parses clean
- No non-ASCII characters
- `audit_drop_rates.py --category BOSSES` reports 0 errors