### PR TITLE
fix(data): Araxyte - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -13106,7 +13106,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Araxytes in the Araxyte Cave (north-east of Darkmeyer). Dodge the web and venom attacks. Use melee with crush (92 Slayer)",
+        "description": "Kill Araxytes in the Araxyte Cave (north-east of Darkmeyer). Bring antivenoms or a serpentine helm - Araxytes inflict venom. Use melee with crush (92 Slayer)",
         "worldX": 3657,
         "worldY": 3407,
         "worldPlane": 0,


### PR DESCRIPTION
## Araxyte guidance corrections

Fixes two guidance-text errors in the Araxyte combat step identified in the tranche 3 wiki-meta audit (see docs/verify/findings-wiki-meta-2026-06.md, PR #829).

### Applied findings

**[blocker] C3**: removed fabricated web attack dodge mechanic. The Araxyte wiki page documents a single Crush attack (4-tick, max hit 13/17) with no special attacks section. No web attack or dodgeable projectile appears on the Araxyte or Morytania Spider Cave wiki pages. The guidance "Dodge the web and venom attacks" described a mechanic that does not exist.

**[medium] C4**: replaced "dodge venom attacks" framing with antivenom item guidance. Wiki receipt: "it is dangerous to fight them without prayer and a method to stave off venom." Venom from Araxytes is a passive on-hit affliction, not a dodgeable projectile. Correct counter is bringing antivenoms or a serpentine helm.

### Change

- Before: `Kill Araxytes in the Araxyte Cave (north-east of Darkmeyer). Dodge the web and venom attacks. Use melee with crush (92 Slayer)`
- After: `Kill Araxytes in the Araxyte Cave (north-east of Darkmeyer). Bring antivenoms or a serpentine helm - Araxytes inflict venom. Use melee with crush (92 Slayer)`

### Skipped findings

None - both confirmed findings addressed in the combat description text.

### Validation

- JSON parse: pass
- Non-ASCII check: 0 non-ASCII characters
- `audit_drop_rates.py --category SLAYER`: 0 errors