### PR TITLE
fix(data): Brine Rat - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -10734,7 +10734,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Brine Rats in the Brine Rat Cavern. Dig with a spade south of the Windswept Tree near Rellekka lighthouse to enter",
+        "description": "Kill Brine Rats in the Brine Rat Cavern. Dig with a spade south of the Windswept Tree (south-east of the Rellekka Hunter area) to enter.",
         "worldX": 2707,
         "worldY": 10132,
         "worldPlane": 0,


### PR DESCRIPTION
## Findings applied

[medium] C3: combat step description contained fabricated landmark 'near Rellekka lighthouse'.
  - Old: 'Dig with a spade south of the Windswept Tree near Rellekka lighthouse to enter'
  - New: 'Dig with a spade south of the Windswept Tree (south-east of the Rellekka Hunter area) to enter.'
  - Wiki receipt: 'Players can enter the dungeon by digging with a spade south of the windswept tree, which is on a plateau east of Olaf Hradson and south-east of the Rellekka Hunter area.' (https://oldschool.runescape.wiki/w/Brine_Rat_Cavern)
  - The Lighthouse is north of the Barbarian Outpost - a separate area on the west side of the Fremennik Province, not near the cavern entrance.

## Skipped findings

None.

## Validation

- JSON parse: ok
- Non-ASCII check: 0 non-ASCII characters
- audit_drop_rates.py --category SLAYER: 0 errors

Full receipts: docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 3 section)