### PR TITLE
fix(data): Bloodveld - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -11057,7 +11057,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Bloodvelds in the Slayer Tower or Catacombs of Kourend. Use Protect from Melee, weak to ranged (50 Slayer)",
+        "description": "Kill Bloodvelds in the Slayer Tower or Catacombs of Kourend. Use Protect from Melee; wear dragonhide for magic defence as their attack is checked against magic defence (50 Slayer)",
         "worldX": 3442,
         "worldY": 3543,
         "worldPlane": 1,


### PR DESCRIPTION
## Summary

Corrects factually wrong guidance text in the Bloodveld source identified in the tranche 3 wiki-meta audit.

## Applied findings

- **[high] C6:** Removed false 'weak to ranged' claim from the kill step description. The wiki states all Bloodveld defensive bonuses are +0 across all attack styles (stab, slash, crush, magic, ranged) and lists 'No elemental weakness'. Replaced with correct guidance: wear dragonhide for magic defence, as Bloodveld attacks are accuracy-checked against the player's magic defence stat, not melee defence.
  - Wiki receipt: "All defensive bonuses are +0 across stab, slash, crush, magic, and ranged categories. The creature has No elemental weakness." and "it is the player's magic defence (rather than their melee defence) that is used to determine the accuracy of the bloodveld's attack." (https://oldschool.runescape.wiki/w/Bloodveld)

## Skipped findings

None.

## References

Full receipts and tranche context: docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 3 section).