### PR TITLE
fix(data): Terror Dog - correct fairy ring code BIQ -> BIP

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -10572,7 +10572,7 @@
       }
     ],
     "locationDescription": "Tarn's Lair, Abandoned Mine (requires Haunted Mine quest)",
-    "travelTip": "Slayer ring -> Tarn's Lair (fastest), or fairy ring BIQ -> Salve shortcut (50 Agility) -> run south to Abandoned Mine",
+    "travelTip": "Slayer ring -> Tarn's Lair (fastest), or fairy ring BIP -> Salve shortcut (50 Agility) -> run south to Abandoned Mine",
     "npcId": 6474,
     "interactAction": "Attack",
     "guidanceSteps": [
@@ -10586,13 +10586,13 @@
         "section": "Bank"
       },
       {
-        "description": "Teleport to Tarn's Lair using a Slayer ring (fastest direct teleport). Alternatively, use fairy ring BIQ, cross the Salve shortcut (50 Agility), and run south to the Abandoned Mine entrance",
+        "description": "Teleport to Tarn's Lair using a Slayer ring (fastest direct teleport). Alternatively, use fairy ring BIP, cross the Salve shortcut (50 Agility), and run south to the Abandoned Mine entrance",
         "worldX": 3414,
         "worldY": 3232,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
-        "travelTip": "Slayer ring -> Tarn's Lair, or fairy ring BIQ -> Salve shortcut (50 Agility) -> run south to Abandoned Mine entrance",
+        "travelTip": "Slayer ring -> Tarn's Lair, or fairy ring BIP -> Salve shortcut (50 Agility) -> run south to Abandoned Mine entrance",
         "section": "Travel"
       },
       {


### PR DESCRIPTION
## Findings applied

**[high] C3:** corrected fairy ring code from BIQ to BIP in `guidanceSteps[1].description`, `guidanceSteps[1].travelTip`, and the source-level `travelTip` field.

BIQ leads to the Kalphite Hive in the Kharidian Desert - an entirely wrong region. BIP is south-west of Mort Myre Swamp on the river Salve, which is the correct approach for reaching Tarn's Lair.

Wiki receipt (Tarn's Lair): "By fairy ring (50 Agility needed) and then walking south." Fairy rings page confirms BIP = south-west of Mort Myre Swamp; BIQ = Kharidian Desert near Kalphite Hive.

## Skipped findings

None.

## Validation

- JSON parse: pass
- ASCII-only check: pass
- `audit_drop_rates.py --category SLAYER`: 0 errors

## References

Full receipts: docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 3 section)