### PR TITLE
fix(data): Fossil Island Wyvern - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -11863,7 +11863,7 @@
         "section": "Travel"
       },
       {
-        "description": "Enter the Wyvern Cave. Elemental/mind/dragonfire shield required",
+        "description": "Enter the Wyvern Cave",
         "worldX": 3745,
         "worldY": 3777,
         "worldPlane": 0,


### PR DESCRIPTION
## Fossil Island Wyvern - wiki-meta guidance corrections (audit tranche 1)

### Applied findings

- [medium] C2: entry step description removed false shield-as-entry-gate claim. 'Enter the Wyvern Cave. Elemental/mind/dragonfire shield required' incorrectly framed the shield as a cave-entry prerequisite. Wiki receipt: 'the northern cavern is monitored by Weve (Steve's son) who only allows players on a Slayer task to kill the wyverns inside; the wyverns in the southern cavern can be killed at any time.' -- no shield is checked at the door. The kill step already correctly states the shield requirement for ice breath protection. Entry step simplified to 'Enter the Wyvern Cave'.

### Skipped findings

None.

### Full receipts

See docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 3 section) for complete wiki receipts and skeptic reasoning.