### PR TITLE
fix(data): Custodian Stalker - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -12357,7 +12357,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to the Stalker Den entrance south of Custodia Pass, Varlamore (fairy ring AIS to Auburnvale, run south). Requires Shadows of Custodia quest. Bring melee gear and food; Elder Custodian Stalkers apply a Bleed effect from infected spore patches - no key required to enter",
+        "description": "Travel to the Stalker Den entrance south of Custodia Pass, Varlamore (fairy ring AIS to Auburnvale, run south). Requires Shadows of Custodia quest. Bring melee gear and food; Elder Custodian Stalkers apply a Bleed via a targeted spore attack - no key required to enter",
         "worldX": 1324,
         "worldY": 3364,
         "worldPlane": 0,
@@ -12383,7 +12383,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Custodian Stalkers. Protect from Melee; Elder variants apply a Bleed - move off infected spore patches when they appear. Cannon works in the multi-combat south-western area. Higher-tier variants (mature, elder) have better rates on Antler guard and Alchemist's signet",
+        "description": "Kill Custodian Stalkers. Protect from Melee; at 20% HP Elder variants douse the player in spores (targeted Bleed attack) - use Protect from Magic to block it or heal through the 9 damage. Cannon works in the multi-combat south-western area. Elder/Ancient variants have better rates on Antler guard and are the only sources of Alchemist's signet; mature drops Antler guard at a lower rate and does not drop Alchemist's signet",
         "worldX": 1301,
         "worldY": 9820,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Two guidance-text corrections for the Custodian Stalker source, based on wiki verification (tranche 3 audit).

## Applied findings

**[medium] C4:** Replaced positional ground-patch dodge mechanic with correct targeted attack mechanic.
- Old: `move off infected spore patches when they appear`
- New: `use Protect from Magic to block it or heal through the 9 damage`
- Wiki receipt: "they can perform a special attack where they stomp the ground and douse the player in spores. The attack can miss or be blocked by Protect from Magic, but if it hits, it will cause the player to bleed for 9 total damage over 15 ticks" (Elder custodian stalker wiki). No ground patches or positional mechanic exists; attack targets the player directly.
- Also updated the travel step which had the same "infected spore patches" wording for consistency.

**[medium] C6:** Corrected Alchemist's signet tier claim - mature does not drop it.
- Old: `Higher-tier variants (mature, elder) have better rates on Antler guard and Alchemist's signet`
- New: `Elder/Ancient variants have better rates on Antler guard and are the only sources of Alchemist's signet; mature drops Antler guard at a lower rate and does not drop Alchemist's signet`
- Wiki receipt: Mature custodian stalker drop table (16 entries) contains no Alchemist's signet; Elder custodian stalker drops Alchemist's signet at 2/124.

## Skipped findings

None - all confirmed findings were description-text corrections within scope.

## References

Full receipts: docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 3 section)