### PR TITLE
fix(data): Zombie Pirate Locker - wiki-meta guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -13639,7 +13639,7 @@
     "travelTip": "Burning amulet -> Bandit Camp",
     "guidanceSteps": [
       {
-        "description": "Travel to the zombie pirate ship east of the Chaos Temple (level 14 Wilderness). Bring zombie pirate keys dropped by zombie pirates on the ship.",
+        "description": "Travel to the zombie pirate ship east of the Chaos Temple (level 14 Wilderness). Bring zombie pirate keys dropped by zombie pirates at the Chaos Temple.",
         "worldX": 3373,
         "worldY": 3625,
         "worldPlane": 0,


### PR DESCRIPTION
## Findings applied

- [medium] C3: corrected key-farming location in guidance step 1 from 'on the ship' to 'at the Chaos Temple'
  - Old text: "Bring zombie pirate keys dropped by zombie pirates on the ship."
  - New text: "Bring zombie pirate keys dropped by zombie pirates at the Chaos Temple."
  - Wiki receipt: "Zombie pirate keys are dropped by zombie pirates found at the Wilderness Chaos Temple. They are used to open the pirates' lockers on the shipwreck located on the coast east of the Chaos Temple." (https://oldschool.runescape.wiki/w/Zombie_pirate_key)

## Skipped findings

None.

## Full receipts

See docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 3 section) for full audit receipts.