### PR TITLE
fix(data): Lava Strykewyrm - wiki-meta guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -11731,7 +11731,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Lava Strykewyrms in the Charred Dungeon beneath Charred Island. Standard combat mechanics; no PKer risk",
+        "description": "Kill Lava Strykewyrms in the Charred Dungeon beneath Charred Island. Use Protect from Ranged when attacking at distance; they switch to melee-only within 1 tile. Do not use fire spells - they heal the strykewyrm equal to the damage dealt.",
         "worldX": 2150,
         "worldY": 2968,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Corrects inaccurate guidance text for Lava Strykewyrm that described its combat as \"Standard combat mechanics\" when the wiki documents two material mechanics players need to know.

## Findings applied

- **[blocker] C7**: Replace \"Standard combat mechanics; no PKer risk\" with accurate combat mechanics description.
  - Wiki receipt: \"they use only melee when attacked from within one tile range of them, and only ranged when attacked from a distance. Fire spells will heal them equal to the amount hit. all damage can be avoided with protection prayers.\" -- https://oldschool.runescape.wiki/w/Lava_Strykewyrm
  - The previous text actively suppressed two player-harmful interactions: fire spells restore the creature's HP equal to damage dealt (a trap for mage users), and the creature switches between melee-only (within 1 tile) and ranged-only (at distance), determining the correct protection prayer.

## Skipped findings

None - all confirmed findings applied.

## References

Full receipts: docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 3 section)

## Test plan

- [x] JSON parses cleanly
- [x] Non-ASCII check: 0 non-ASCII characters
- [x] `python scripts/audit_drop_rates.py --category SLAYER` reports 0 errors
- [x] `python scripts/audit_drop_rates.py --category BOSSES` reports 0 errors