### PR TITLE
fix(data): Larran's Big Chest - correct Wilderness level in travel guidance

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -13525,7 +13525,7 @@
     "travelTip": "Obelisk -> lvl 35 Wildy",
     "guidanceSteps": [
       {
-        "description": "Travel to the ship west of Pirates' Hideout (level 39 Wilderness). Use Larran's keys from Wilderness Slayer creatures assigned by Krystilia.",
+        "description": "Travel to the ship west of Pirates' Hideout (level 55 Wilderness). Use Larran's keys from Wilderness Slayer creatures assigned by Krystilia.",
         "worldX": 3018,
         "worldY": 3955,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Corrects a wrong Wilderness level in the travel guidance step for Larran's Big Chest.

## Findings applied

- **[high] C2**: Changed "level 39 Wilderness" to "level 55 Wilderness" in guidanceSteps[0].description. The chest coordinates (worldX=3018, worldY=3955) resolve to Wilderness level 55 via the standard formula floor((3955-3520)/8)+1=55. The Pirates' Hideout wiki page also lists the area at Wilderness level 54 (the building; the ship is one tile deeper). The previous value of 39 was mid-Wilderness and would have severely underprepared players for the actual deep-Wilderness risk.

Key wiki receipt: "Wilderness level: 54" (Pirates' Hideout infobox, https://oldschool.runescape.wiki/w/Pirates%27_Hideout). Chest coordinates from data entry confirm level 55.

## Skipped findings

None.

## Full receipts

See docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 3 section) for complete audit receipts.