### PR TITLE
fix(data): Superior Slayer Monster - wiki-meta guidance corrections (audit tranche 1)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -13597,7 +13597,7 @@
     "travelTip": "",
     "guidanceSteps": [
       {
-        "description": "This rare table applies on any slayer task above the superior-unlock level. Superior monsters have a 1/200 spawn chance in place of a standard monster while on the matching task. Unlock the Bigger and Badder reward (50 Slayer points) in the Slayer reward shop to enable superior spawns. Slayer level 5 is the minimum to receive any task",
+        "description": "This rare table applies on any slayer task above the superior-unlock level. Superior monsters have a 1/200 spawn chance in place of a standard monster while on the matching task. Unlock the Bigger and Badder reward (50 Slayer points) in the Slayer reward shop to enable superior spawns. Slayer level 5 is the minimum required to kill a Crawling Hand, the lowest monster with a superior variant",
         "worldX": 3429,
         "worldY": 3534,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Corrects one factually wrong guidance step for the Superior Slayer Monster source, identified in the wiki-meta audit (tranche 3).

## Changes

**[medium] C3:** Guidance step 1 description incorrectly stated "Slayer level 5 is the minimum to receive any task." Corrected to: "Slayer level 5 is the minimum required to kill a Crawling Hand, the lowest monster with a superior variant."

Key wiki receipt (https://oldschool.runescape.wiki/w/Slayer_Masters): Turael and Spria have no Slayer level requirement - "They have no minimum combat or Slayer level requirements before players may receive assignments." Tasks are available at Slayer level 1. The level 5 floor applies to killing a Crawling Hand (its superior is Crushing Hand), not to receiving any task.

## Skipped

None - all confirmed findings for this source applied.

## References

Full receipts: docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 3 section)