### PR TITLE
fix(data): Nechryael - correct travel direction to Slayer Tower

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -12512,8 +12512,8 @@
                 "JEWELLERY_BOX_FANCY"
               ]
             },
-            "description": "POH jewellery box -> Combat bracelet -> Ranging Guild, then run south-east along the road to the Slayer Tower entrance",
-            "travelTip": "POH Combat bracelet -> Ranging Guild -> run south-east to Slayer Tower"
+            "description": "POH jewellery box -> Combat bracelet -> Ranging Guild, then run north-east along the road to the Slayer Tower entrance",
+            "travelTip": "POH Combat bracelet -> Ranging Guild -> run north-east to Slayer Tower"
           },
           {
             "requirements": {


### PR DESCRIPTION
## Changes

- [medium] C3: Corrected travel direction in Nechryael guidance step `conditionalAlternatives` — changed `south-east` to `north-east` in both the description and travelTip for the Combat bracelet / Ranging Guild route to Slayer Tower.

## Key receipt (C3)

Wiki confirms Slayer Tower is north-west of Canifis. Coordinate delta from Ranging Guild teleport (~2655,3445) to Slayer Tower entrance (3429,3535): delta-X = +774 (east), delta-Y = +90 (north) — the tower is east-northeast of the Ranging Guild. "South-east" actively misguides players in the wrong direction.

## Full receipts

See docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 3 section) for complete audit receipts.

## Skipped

None — all confirmed findings for this source were applied.