### PR TITLE
fix(data): Aberrant Spectre - remove incorrect Ranging Guild -> Slayer Tower travel alternative

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -11459,17 +11459,6 @@
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
-        "conditionalAlternatives": [
-          {
-            "requirements": {
-              "pohTeleports": [
-                "JEWELLERY_BOX_FANCY"
-              ]
-            },
-            "description": "POH jewellery box -> Combat bracelet -> Ranging Guild, then run south-east along the road to the Slayer Tower entrance",
-            "travelTip": "POH Combat bracelet -> Ranging Guild -> run south-east to Slayer Tower"
-          }
-        ],
         "section": "Travel"
       },
       {


### PR DESCRIPTION
## Summary

Fixes one confirmed blocker finding from audit tranche 3 (wiki-meta pass) for Aberrant Spectre.

## Changes

- **[blocker] C5**: Removed incorrect `conditionalAlternative` routing via POH Combat bracelet -> Ranging Guild -> run south-east to reach the Slayer Tower. The Ranging Guild is in Kandarin (between Ardougne and Seers' Village); the Slayer Tower is in Morytania north-west of Canifis. These are different regions with no road connecting them. Running south-east from the Ranging Guild leads toward East Ardougne, not toward the Slayer Tower. The main travel step already lists the correct options (slayer ring, fairy ring CKS), so the faulty alternative was removed.

  Wiki receipt: "The Ranging Guild is East of Hemenster, between Ardougne and Seers' Village ... leagueRegion = Kandarin" (https://oldschool.runescape.wiki/w/Ranging_Guild); "The tower is located north-west of Canifis ... Location: Morytania" (https://oldschool.runescape.wiki/w/Slayer_Tower).

## Skipped

None -- C5 was the only confirmed finding for this source.

## Full receipts

See docs/verify/findings-wiki-meta-2026-06.md (PR #829, tranche 3 section) for the complete verification record.