### PR TITLE
fix(data): Nechryael - remove fabricated Ranging Guild -> Slayer Tower POH route

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -12457,15 +12457,6 @@
         "conditionalAlternatives": [
           {
             "requirements": {
-              "pohTeleports": [
-                "JEWELLERY_BOX_FANCY"
-              ]
-            },
-            "description": "POH jewellery box -> Combat bracelet -> Ranging Guild, then run south-east along the road to the Slayer Tower entrance",
-            "travelTip": "POH Combat bracelet -> Ranging Guild -> run south-east to Slayer Tower"
-          },
-          {
-            "requirements": {
               "inventoryItemIdsAny": [
                 11866,
                 11867,


### PR DESCRIPTION
## Summary

Removes the fabricated `JEWELLERY_BOX_FANCY` `conditionalAlternative` that routed "POH Combat bracelet -> Ranging Guild -> run to the Slayer Tower". Part of #916.

## Receipt

The Ranging Guild is in **Kandarin** (between Ardougne and Seers' Village — https://oldschool.runescape.wiki/w/Ranging_Guild); the Slayer Tower is in **Morytania**, NW of Canifis (https://oldschool.runescape.wiki/w/Slayer_Tower). `coordinate_helper` gives ~770 tiles east across regions with no connecting road — no compass direction reaches the tower, and no jewellery-box teleport lands near it. The slayer-ring and base-step routes already cover travel.

This applies the same resolution the **Aberrant Spectre C5 [blocker]** finding prescribed ("remove this alternative entirely") to the identical route on Nechryael, and supersedes the incorrect direction-flip in the closed #914. The D5A regression guard that previously pinned these routes was corrected in #917.

Fixes the Nechryael portion of #916.