### PR TITLE
fix(data): Abyssal Demon - remove fabricated Ranging Guild -> Slayer Tower POH route

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -12820,17 +12820,6 @@
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
-        "conditionalAlternatives": [
-          {
-            "requirements": {
-              "pohTeleports": [
-                "JEWELLERY_BOX_FANCY"
-              ]
-            },
-            "description": "POH jewellery box -> Combat bracelet -> Ranging Guild, then run south-east along the road to the Slayer Tower entrance",
-            "travelTip": "POH Combat bracelet -> Ranging Guild -> run south-east to Slayer Tower"
-          }
-        ],
         "section": "Travel"
       },
       {


### PR DESCRIPTION
## Summary

Removes the fabricated `JEWELLERY_BOX_FANCY` `conditionalAlternative` ("POH Combat bracelet -> Ranging Guild -> run to the Slayer Tower"). It was the sole alternative on the step, so the array is removed entirely. Part of #916.

## Receipt

Ranging Guild = **Kandarin**; Slayer Tower = **Morytania** (NW of Canifis); ~770 tiles apart with no connecting road, and no jewellery-box teleport lands near the tower. Same geography as Aberrant Spectre (C5 [blocker], already removed in #915) and Nechryael (#918).

**This source was not flagged by the audit** — the retroactive corpus grep for the identical route surfaced it (the audit covered Aberrant Spectre/Nechryael but missed Abyssal Demon). The D5A regression guard was corrected in #917.

Fixes the Abyssal Demon portion of #916.