### PR TITLE
fix(data): Drake - drop Cerberus boots from Karuulm heat-protection list

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -12699,7 +12699,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to Mount Karuulm. Bring boots of stone (mandatory - the Karuulm heat tick will eat through your HP without them), Dragon hunter lance, super combat, prayer potions, Saradomin brews, super restores, and a few sharks. Karuulm-friendly footwear (boots of stone / granite / Cerberus boots) is non-negotiable. Fairy ring CIR - short walk north up the volcano to the dungeon entrance; Rada's blessing 3/4 (requires Kourend & Kebos Hard Diary) teleports straight to the dungeon.",
+        "description": "Travel to Mount Karuulm. Bring boots of stone (mandatory - the Karuulm heat tick will eat through your HP without them), Dragon hunter lance, super combat, prayer potions, Saradomin brews, super restores, and a few sharks. Karuulm-friendly footwear (boots of stone / boots of brimstone / granite boots) is non-negotiable. Fairy ring CIR - short walk north up the volcano to the dungeon entrance; Rada's blessing 3/4 (requires Kourend & Kebos Hard Diary) teleports straight to the dungeon.",
         "worldX": 1311,
         "worldY": 3807,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Removes "Cerberus boots" from Drake's Karuulm-dungeon footwear recommendation. Cerberus boots provide **no** heat protection in the Karuulm Slayer Dungeon — a player equipping them takes continuous heat damage.

## Receipt

The wiki lists exactly three valid heat-protection boots: **boots of stone, boots of brimstone, granite boots** (https://oldschool.runescape.wiki/w/Karuulm_Slayer_Dungeon). Corrected `boots of stone / granite / Cerberus boots` → `boots of stone / boots of brimstone / granite boots`.

## Retroactive sweep

This completes the corpus sweep for the class: the identical error was fixed on **Wyrm in #894**; a `grep "Cerberus boots"` over `drop_rates.json` found **Drake as the only remaining source** (the Drake findings batch didn't include this correction, so #897 merged with it intact).