### PR TITLE
fix(data): Woodcutting (Teak Trees) - correct Isle of Souls fairy ring code BJR to BJP

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -29860,7 +29860,7 @@
       }
     ],
     "locationDescription": "Ape Atoll teak trees",
-    "travelTip": "Fairy ring BJR -> Isle of Souls (no req); or Ape Atoll tele for 2-tick",
+    "travelTip": "Fairy ring BJP -> Isle of Souls (no req); or Ape Atoll tele for 2-tick",
     "guidanceSteps": [
       {
         "description": "Bank for teak chopping. Bring your best axe (dragon or crystal for highest success rate). 35 Woodcutting required. Isle of Souls is best with no extra requirements. Ape Atoll or Prifddinas are optimal for 2-tick manipulation (bring a knife and kebbit claws or karambwanji for the tick cycle).",
@@ -29876,13 +29876,13 @@
         "section": "Bank prep"
       },
       {
-        "description": "Travel to teak trees. Isle of Souls: fairy ring BJR (no requirements). Ape Atoll: Ape Atoll teleport then run to southern grove. Fossil Island: Digsite pendant. Locus Oasis (Varlamore): Quetzal Transport to Outer Fortis, run to grove.",
+        "description": "Travel to teak trees. Isle of Souls: fairy ring BJP (no requirements). Ape Atoll: Ape Atoll teleport then run to southern grove. Fossil Island: Digsite pendant. Locus Oasis (Varlamore): Quetzal Transport to Outer Fortis, run to grove.",
         "worldX": 2770,
         "worldY": 2700,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
-        "travelTip": "Fairy ring BJR -> Isle of Souls; Ape Atoll tele for 2-tick; Digsite pendant -> Fossil Island",
+        "travelTip": "Fairy ring BJP -> Isle of Souls; Ape Atoll tele for 2-tick; Digsite pendant -> Fossil Island",
         "section": "Travel"
       },
       {


### PR DESCRIPTION
## Defect
The **Woodcutting (Teak Trees)** source routes to the Isle of Souls teak grove via **fairy ring BJR**. BJR is the wrong code — it goes to the Realm of the Fisher King (behind Holy Grail). The Isle of Souls fairy ring is **BJP**.

Corrected in all three places: source `travelTip`, step 1 `description`, step 1 `travelTip`.

## Authoritative receipt
[OSRS Wiki fairy-ring transport table](https://oldschool.runescape.wiki/w/Fairy_ring):
- `BJP` = **Isle of Souls** (correct)
- `BJR` = Realm of the Fisher King (wrong)

## How found
Surfaced by the new `run_corpus_detectors` fairy-ring code validity detector (toolkit #80) sweeping all 226 sources — the 1–150 manual wiki-meta audit missed it. Raw detector output:
```json
{ "code": "BJR", "wikiDestination": "Realm of the Fisher King",
  "namedDestination": "isle of souls", "namedDestinationServedBy": ["BJP"] }
```

Single source, text-only change; no rates, ids, coords, or loop/conditional fields touched.
