### PR TITLE
fix(data): Catacombs of Kourend - correct stale Slayer monster list

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -20861,7 +20861,7 @@
         "section": "Bank"
       },
       {
-        "description": "Kill monsters in the Catacombs for dark totem pieces (base, middle, top - each 1/500 from any monster). Burying bones restores Prayer. Popular Slayer tasks here include abyssal demons, nechryaels, dark beasts, and skeletal wyverns. Combine Slayer trips with totem piece hunting for efficient farming.",
+        "description": "Kill monsters in the Catacombs for dark totem pieces (base, middle, top - each 1/500 from any monster). Burying bones restores Prayer. Popular Slayer tasks here include abyssal demons, nechryaels, hellhounds, and brutal black dragons. Combine Slayer trips with totem piece hunting for efficient farming.",
         "worldX": 1664,
         "worldY": 10050,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary
Corrects the stale Slayer-monster list in the Catacombs of Kourend guidance (source tail semantic audit, sources 151-226).

The step 4 guidance listed **skeletal wyverns** and **dark beasts** as popular Catacombs Slayer tasks. Neither spawns in the Catacombs:
- **Skeletal wyverns** are found at the end of the Asgarnian Ice Dungeon (Slayer 72, category "Skeletal Wyverns").
- **Dark beasts** were removed from the Catacombs of Kourend in 2019 (Song of the Elves) and now spawn only in the Iorwerth Dungeon and Mourner Tunnels.

Replaced with **hellhounds** and **brutal black dragons**, both confirmed present by the wiki's Catacombs monster list. Totem-piece rates/IDs untouched.

## Receipt (raw)
- Skeletal Wyvern (wiki): "found at the end of the Asgarnian Ice Dungeon ... Slayer level 72 ... Slayer category: Skeletal Wyverns" — no Catacombs spawn.
- Dark beast (wiki, action=raw): "Dark beasts were added to [[Iorwerth Dungeon]] and removed from [[Catacombs of Kourend|Kourend Catacombs]] for thematic reasons." / "found in the [[Mourner Tunnels]] as well as in [[Iorwerth Dungeon]]".
- Catacombs of Kourend monster list (wiki): Demon's Run includes Abyssal demon, Greater nechryael, Hellhound; Dragon's Den includes Brutal black dragon. No skeletal wyvern or dark beast in any section.
- Wiki: https://oldschool.runescape.wiki/w/Catacombs_of_Kourend

## Verification
- Single-source, single-line prose edit; no item IDs, rates, loop markers, travel keywords, or `conditionalAlternatives` touched.
- Checked `src/test/java/` for assertions on this prose: structural guards (D4Batch10b, D5BBranch, DropRateDatabaseTest) assert travel/coords/step-structure, not the monster list — unaffected.
- Skeptic-confirmed against raw wiki quotes (cite-or-discard).
