### PR TITLE
fix(data): Wilderness God Wars Dungeon - fix Dareeyak run direction

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -20897,7 +20897,7 @@
       }
     ],
     "locationDescription": "God Wars Dungeon entrance in the Wilderness (level 28 Wilderness)",
-    "travelTip": "Cemetery teleport (Arceuus) -> run east; or Dareeyak teleport (Desert Treasure I) -> run south",
+    "travelTip": "Cemetery teleport (Arceuus) -> run east; or Dareeyak teleport (Desert Treasure I) -> run north-east",
     "waypoints": [
       {
         "description": "Arceuus spellbook required: cast Cemetery Teleport and run east to the cave entrance.",


### PR DESCRIPTION
## Summary
Corrects the Dareeyak travel direction for the Wilderness God Wars Dungeon (source tail semantic audit).

The travelTip told players to "run south" from the Dareeyak Teleport landing spot. The Dareeyak ruins are *south* of The Forgotten Cemetery (~2977, 3702, level 23 Wilderness); the Wilderness GWD entrance is *north-east* of there (~3017, 3740, level 28). Running south leads away from the dungeon. Corrected to "run north-east".

## Receipt (raw)
- Dareeyak Teleport (wiki): lands at the ruins "south of The Forgotten Cemetery in level 23 Wilderness" (~x:2977, y:3702).
- Wilderness God Wars Dungeon (wiki, action=raw): dungeon entrance map frame "x=3016.5, y=3739.5".
- Geometry: from (2977,3702) to (3017,3740) is +40 east, +38 north -> north-east.
- Wiki: https://oldschool.runescape.wiki/w/Wilderness_God_Wars_Dungeon

## Verification
- Single-source, single-line travelTip edit; teleport keywords (`Cemetery teleport`, `Dareeyak teleport`) unchanged, so travel-branch parsing (D4Batch12c full-bar guard) is unaffected. No IDs/rates/loop markers touched.
- Privacy grep clean. Skeptic-confirmed against raw wiki coordinates.
