### PR TITLE
fix(data): Miscellaneous - correct Merfolk trident and Dragon metal sources

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -21341,7 +21341,7 @@
     "travelTip": "Varies by item - see step description",
     "guidanceSteps": [
       {
-        "description": "The Miscellaneous tab collects items with no dedicated source. Key items and primary sources: Big bass/swordfish/shark (big-net fishing or Fishing Trawler), Long/curved bone (giant/big bones drops), Giant key (Hill Giants), Mossy key (Moss Giants), Xeric's talisman (Lizardmen Brutes/Shamans), Mining gloves set (Mining Guild shop), Herbi (Herbiboar), Merfolk trident (Tempoross), Dragon metal pieces (Vorkath). Check each item's Wiki page for its specific drop source.",
+        "description": "The Miscellaneous tab collects items with no dedicated source. Key items and primary sources: Big bass/swordfish/shark (big-net fishing or Fishing Trawler), Long/curved bone (giant/big bones drops), Giant key (Hill Giants), Mossy key (Moss Giants), Xeric's talisman (Lizardmen Brutes/Shamans), Mining gloves set (Mining Guild shop), Herbi (Herbiboar), Merfolk trident (Mairin's Market, Fossil Island - 400 mermaid's tears), Dragon metal slice/lump (Adamant/Rune Dragons). Check each item's Wiki page for its specific drop source.",
         "worldX": 0,
         "worldY": 0,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary
Corrects two wrong item-source attributions in the Miscellaneous tab guidance (source tail semantic audit).

- **Merfolk trident** was listed as a Tempoross reward. It is actually bought from **Mairin's Market** in the Fossil Island underwater area for **400 mermaid's tears** (earned via Underwater Agility & Thieving) — it is not on the Tempoross drop/reward table.
- **Dragon metal pieces (Vorkath)** is wrong on both counts. Vorkath's drop table has no dragon metal item. The **dragon metal slice** drops from **adamant dragons** and the **dragon metal lump** from **rune dragons** (the shard is bought from the Myths' Guild Armoury).

## Receipt (raw)
- Merfolk trident (wiki): "A merfolk trident can be bought from Mairin's Market in the underwater area of Fossil Island for 400 mermaid's tears obtained from Underwater Agility and Thieving."
- Dragon metal slice (wiki): "The dragon metal slice is an item dropped exclusively by adamant dragons."
- Dragon metal lump (wiki): "Dragon metal lumps are dropped by rune dragons."
- Vorkath (wiki): 47-entry drop table contains no dragon metal item of any kind.
- Wiki: https://oldschool.runescape.wiki/w/Merfolk_trident , https://oldschool.runescape.wiki/w/Dragon_metal_slice

## Verification
- Single-source, single-line prose edit; no IDs/rates/loop markers/travel keywords touched (this is the catch-all "Miscellaneous" descriptive list, not item data).
- Privacy grep clean. Skeptic-confirmed against raw wiki quotes (cite-or-discard).
