### PR TITLE
fix(data): Camdozaal - correct Ice Mountain travel directions

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -21676,13 +21676,13 @@
     "travelTip": "Lassar teleport -> Ice Mountain -> Camdozaal",
     "guidanceSteps": [
       {
-        "description": "Travel to the Ruins of Camdozaal beneath Ice Mountain. Cast Lassar Teleport (Ancient Magicks, requires Desert Treasure I), then run south to the Ice Mountain entrance. Alternatively, use amulet of glory to Edgeville and run east to Ice Mountain.",
+        "description": "Travel to the Ruins of Camdozaal beneath Ice Mountain. Cast Lassar Teleport (Ancient Magicks, requires Desert Treasure I) to the top of Ice Mountain, then head down the west side to the Camdozaal entrance (Level 68 Agility shortcut available). Alternatively, use amulet of glory to Edgeville and run west to Ice Mountain.",
         "worldX": 3012,
         "worldY": 3451,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 15,
-        "travelTip": "Lassar teleport -> Ice Mountain; or glory -> Edgeville -> run east",
+        "travelTip": "Lassar teleport -> Ice Mountain; or glory -> Edgeville -> run west",
         "section": "Travel"
       },
       {


### PR DESCRIPTION
## Summary
Corrects two inverted travel directions for the Ruins of Camdozaal (source tail semantic audit).

- **Lassar Teleport** lands on **top of Ice Mountain**, not south of the entrance. From the summit players descend the **west** side to reach the Camdozaal entrance (which sits on the western side of the mountain; a Level 68 Agility shortcut leads directly to it). "run south to the Ice Mountain entrance" was wrong.
- The **amulet of glory -> Edgeville** route runs **west** to Ice Mountain, not east — Ice Mountain is west of Edgeville.

## Receipt (raw)
- Ruins of Camdozaal (wiki): "Casting Lassar Teleport from Ancient Magicks to teleport to the top of Ice Mountain. Level 68 Agility is required to use the shortcut down the mountain which leads directly to the entrance to Camdozaal." / "accessed through the entrance on the western side of the mountain" / access list: "Walking west from Edgeville or Barbarian Village."
- Wiki: https://oldschool.runescape.wiki/w/Ruins_of_Camdozaal

## Verification
- Single-source edit (Camdozaal, step 1 + travelTip); no IDs/rates/loop markers touched. Teleport keywords (`Lassar`, `glory`) unchanged.
- Privacy grep clean. Skeptic-confirmed against raw wiki quotes.
