### PR TITLE
fix(data): Colossal Wyrm Agility - correct currency and vendor

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -21802,7 +21802,7 @@
       }
     ],
     "locationDescription": "Colossal Wyrm Agility Course in Avium Savannah, Varlamore",
-    "travelTip": "Quetzal transport whistle -> Civitas illa Fortis, run south-west to Avium Savannah; or Colossal wyrm teleport scroll (purchased from Telia)",
+    "travelTip": "Quetzal transport whistle -> Civitas illa Fortis, run south-west to Avium Savannah; or Colossal wyrm teleport scroll (bought from Worm Tongue for 40 termites, or the Grand Exchange)",
     "guidanceSteps": [
       {
         "description": "Travel to the Colossal Wyrm Agility Course in Avium Savannah, Varlamore. Requires Children of the Sun and 50 Agility. Use the quetzal transport whistle to Civitas illa Fortis then run south-west, or use a Colossal wyrm teleport scroll.",
@@ -21826,7 +21826,7 @@
         ]
       },
       {
-        "description": "Complete laps of the Colossal Wyrm Agility Course for Varlamore marks of grace and termite currency. Collect marks when they appear on obstacles - they despawn after 10 minutes. Spend marks at Telia for Varlamore graceful pieces and Calcified acorns. Higher Agility level increases lap speed and mark rate.",
+        "description": "Complete laps of the Colossal Wyrm Agility Course to earn termites (the course's currency). Spend termites at Worm Tongue's Wares for the Graceful crafting kit (re-skins graceful to the Varlamore theme) and Calcified acorns. Higher Agility level increases lap speed and termite rate.",
         "worldX": 1652,
         "worldY": 2931,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary
Corrects the currency, vendor, and reward description for the Colossal Wyrm Agility Course (source tail semantic audit).

The guidance claimed laps reward "Varlamore marks of grace" spent at an NPC named **"Telia"**. Both are wrong:
- The course's currency is **termites**, not marks of grace. Marks of grace are a Rooftop-Agility reward; the Colossal Wyrm course does not award them.
- There is no vendor named "Telia". Termites are spent at **Worm Tongue's Wares**. Varlamore graceful is obtained via the **Graceful crafting kit** (a re-skin of existing graceful), and Calcified acorns are also bought there.
- The teleport scroll is bought from **Worm Tongue** (40 termites) or the Grand Exchange, not "Telia".

## Receipt (raw)
- Colossal Wyrm Agility Course (wiki): "Termites collected from running the Colossal Wyrm Agility Course can be exchanged at Worm Tongue's Wares." / Worm Tongue's Wares sells "Graceful crafting kit" (650 termites) and "Calcified acorns" (900 termites).
- Colossal wyrm teleport scroll (wiki): "purchased from Worm Tongue's Wares for 40 termites obtained from the Colossal Wyrm Agility Course."
- Worm Tongue (wiki): "an anteater in charge of the Colossal Wyrm Agility Course."
- Wiki: https://oldschool.runescape.wiki/w/Colossal_Wyrm_Agility_Course

## Verification
- Single-source edit (travelTip + step 2 description). Loop markers (`loopCount`/`loopBackToStep`) NOT touched — confirmed via diff; D4Batch4 loop guard for "Colossal Wyrm Agility" remains satisfied. No IDs/rates touched.
- Privacy grep clean. Skeptic-confirmed (blocker-grade) against raw wiki quotes.
