### PR TITLE
fix(data): Rooftop Agility - fix Varrock level, marks/hr leader, graceful effect

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -21930,7 +21930,7 @@
     },
     "guidanceSteps": [
       {
-        "description": "Travel to your best rooftop course. Seers' Village (60+ Agility, Camelot teleport) gives the most marks per hour. Use Varrock (10+), Canifis (40+), Falador (50+), or Pollnivneach (70+) depending on your level.",
+        "description": "Travel to your best rooftop course. Canifis (40+ Agility) gives the most marks per hour thanks to its higher spawn rate; Seers' Village (60+, Camelot teleport) is best for Agility XP. Lower-level options: Varrock (30+), Falador (50+), or Pollnivneach (70+).",
         "worldX": 3214,
         "worldY": 3414,
         "worldPlane": 0,
@@ -21940,7 +21940,7 @@
         "section": "Travel"
       },
       {
-        "description": "Complete rooftop agility laps. Collect marks of grace when they appear on the course - they despawn after 10 minutes. Equipping graceful reduces run drain by 30% per piece. Aim for the highest-level course available to maximise marks per hour.",
+        "description": "Complete rooftop agility laps. Collect marks of grace when they appear on the course - they despawn after 10 minutes. The full graceful outfit increases run energy restoration by 30% (about +3-4% per piece plus a 10% full-set bonus). Aim for the highest-level course available to maximise marks per hour.",
         "worldX": 3214,
         "worldY": 3414,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary
Corrects three claims in the Rooftop Agility guidance (source tail semantic audit).

- **Varrock Rooftop Course requires 30 Agility, not 10.** ("Varrock (10+)" -> "Varrock (30+)").
- **Canifis, not Seers' Village, is the marks-per-hour leader** (2/3 spawn rate vs the usual 1/3, no 20-levels-over penalty). Seers' Village is the Agility-XP leader. Reworded accordingly.
- **Graceful does not "reduce run drain by 30% per piece."** It *increases run energy restoration*: ~+3-4% per piece, +10% full-set bonus, for **30% total with the full outfit** (not per piece).

## Receipt (raw)
- Varrock Rooftop Course (wiki): "available to players with an Agility level of 30 or higher."
- Mark of grace (wiki): "Canifis Rooftop Course has the greatest chance at spawning marks for players between level 40 to 89 Agility, due to its higher-than-normal spawn rate of 2/3 instead of 1/3 ... ~12-18 marks per hour."
- Graceful outfit (wiki): "individual pieces ... increase the rate of the player's natural run energy restoration (adding up to 20%), wearing the full graceful outfit gives an additional 10% bonus, giving a total of 30% increased natural run energy restoration."
- Wiki: https://oldschool.runescape.wiki/w/Graceful_outfit , https://oldschool.runescape.wiki/w/Mark_of_grace

## Verification
- Single-source edit (Rooftop Agility, step 1 + step 2 descriptions). No IDs/rates/loop markers/travel keywords touched.
- Privacy grep clean. Skeptic-confirmed against raw wiki quotes.
