### PR TITLE
fix(data): Cyclopes - correct warrior guild token cost

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -22196,7 +22196,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Cyclopes for defender drops. Each kill costs 10 warrior guild tokens. Hold the current tier defender in inventory to unlock the next tier. Protect from Melee recommended.",
+        "description": "Kill Cyclopes for defender drops. Warrior guild tokens are spent on entry (10) and another 10 each minute inside the room - bring a large supply. Hold the current tier defender in inventory to unlock the next tier. Protect from Melee recommended.",
         "perItemStepDescription": {
           "8844": "Kill Cyclopes (no prerequisite) to receive a Bronze defender and start the chain.",
           "8845": "Kill Cyclopes while holding a Bronze defender in inventory to receive an Iron defender.",

--- a/src/test/java/com/collectionloghelper/data/GuidanceStepTest.java
+++ b/src/test/java/com/collectionloghelper/data/GuidanceStepTest.java
@@ -175,7 +175,7 @@ public class GuidanceStepTest
 	private static final int DRAGON_DEFENDER = 12954;
 
 	private static final String CYCLOPES_STATIC_DESC =
-		"Kill Cyclopes for defender drops. Each kill costs 10 warrior guild tokens";
+		"Kill Cyclopes for defender drops. Warrior guild tokens are spent on entry (10) and another 10 each minute inside the room";
 
 	/**
 	 * Verifies that resolveDescription returns the Iron defender override text


### PR DESCRIPTION
## Summary
Corrects the Warrior guild token cost in the Cyclopes guidance (source tail semantic audit).

The guidance said "Each kill costs 10 warrior guild tokens." Tokens are not consumed per kill — **ten are spent on entering the room, and another ten every minute inside it**. Reworded to "spent on entry (10) and another 10 each minute inside the room - bring a large supply."

## Receipt (raw)
- Warriors' Guild (wiki), Top floor section: "Ten tokens are spent upon entering the room, and another ten every minute inside." / "If the player runs out of tokens, they have a minute left before being teleported outside of the room."
- Wiki: https://oldschool.runescape.wiki/w/Warriors%27_Guild

## Verification
- Touches two files at the **same layer**: the data prose (`drop_rates.json`, Cyclopes step) and the `GuidanceStepTest.CYCLOPES_STATIC_DESC` fixture that mirrors it (the test asserts `resolveDescription(null)` returns the constant; both sides use it).
- `./gradlew test --tests GuidanceStepTest` passes locally.
- No item IDs / rates / loop markers / travel keywords touched. Privacy + ASCII clean. Skeptic-confirmed against the raw wiki quote.
