### PR TITLE
fix(data): The Fight Caves - correct TzTok-Jad prayer-switch cues

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -24342,7 +24342,7 @@
         ]
       },
       {
-        "description": "Defeat TzTok-Jad on wave 63. Pray Protect from Missiles when he rears back (ranged attack) and Protect from Magic when he stomps (magic attack); the cue is roughly 3 ticks before the projectile lands. When he hits half HP, 4 Yt-HurKot healers spawn - kill them or aggro them off Jad to stop the heal cycle. Stand on the Italy Rock (the rock that looks like a boot) to deny line-of-sight from a healer wave if you get overwhelmed.",
+        "description": "Defeat TzTok-Jad on wave 63. Pray Protect from Missiles when he slams/stomps his front legs (ranged attack) and Protect from Magic when he rears up and dangles his front legs (magic attack); the cue is roughly 3 ticks before the projectile lands. When he hits half HP, 4 Yt-HurKot healers spawn - kill them or aggro them off Jad to stop the heal cycle. Stand on the Italy Rock (the rock that looks like a boot) to deny line-of-sight from a healer wave if you get overwhelmed.",
         "worldX": 2401,
         "worldY": 5093,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary
Corrects the inverted TzTok-Jad prayer-switch cues in The Fight Caves guidance (source tail semantic audit).

The guidance paired the cues backwards: it told players to pray Protect from Missiles when Jad *rears back* and Protect from Magic when he *stomps*. The actual cues are reversed:
- **Ranged attack** = Jad slams/stomps his front legs -> Protect from **Missiles**.
- **Magic attack** = Jad rears up and dangles his front legs -> Protect from **Magic**.

## Receipt (raw)
- TzTok-Jad (wiki): the magic attack is signalled by Jad rearing up on its hind legs; the ranged attack is the front-leg slam. The prayers stay matched to attack type, but the data had the visual cue for each attack swapped.
- Wiki: https://oldschool.runescape.wiki/w/TzTok-Jad

## Verification
- Single-source, single-line prose edit. No IDs/rates/kill-time/loop markers touched (efficiency tests assert kill time/rates, unaffected). Privacy clean. Skeptic-confirmed (blocker-grade).
