### PR TITLE
fix(data): Deranged Archaeologist - remove incorrect Fedora attribution

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -24583,7 +24583,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill the Deranged Archaeologist. Use Protect from Missiles to negate the basic ranged auto. When the 'Learn to read!' overhead text appears, step 2+ tiles within 2 ticks to dodge the book rain - same mechanic as Crazy archaeologist but the splash zone is slightly smaller. This is a popular early-account boss for the Fedora cosmetic and the Steel ring slayer-task drop",
+        "description": "Kill the Deranged Archaeologist. Use Protect from Missiles to negate the basic ranged auto. When the 'Learn to read!' overhead text appears, step 2+ tiles within 2 ticks to dodge the book rain - same mechanic as Crazy archaeologist but the splash zone is slightly smaller. This is a popular early-account boss for the Steel ring slayer-task drop. (Note: the Fedora is dropped by the Crazy Archaeologist in the Wilderness, not the Deranged Archaeologist.)",
         "worldX": 3683,
         "worldY": 3706,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary
Removes an incorrect Fedora attribution from the Deranged Archaeologist guidance (source tail semantic audit).

The guidance listed the **Fedora** cosmetic as a Deranged Archaeologist drop. The Fedora is dropped only by the **Crazy Archaeologist** in the Wilderness, not the Deranged Archaeologist on Fossil Island. Removed the Fedora reference and added a clarifying note pointing to the correct source.

## Receipt (raw)
- Fedora (wiki): "The fedora is a hat that can be obtained as a drop from the Crazy archaeologist."
- The Crazy Archaeologist (Wilderness) and Deranged Archaeologist (Fossil Island) are distinct NPCs; only the former drops the Fedora.
- Wiki: https://oldschool.runescape.wiki/w/Fedora

## Verification
- Single-source, single-line prose edit; no IDs/rates/loop markers touched. Privacy clean. Skeptic-confirmed against the raw wiki quote.
