### PR TITLE
fix(data): Black Chinchompas - box traps only, not spring traps

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -29790,7 +29790,7 @@
     },
     "guidanceSteps": [
       {
-        "description": "Travel to the black chinchompa hunting area in level 32-36 Wilderness. Bring only what you can afford to lose - PKers actively target this area. Use the Edgeville lever to reach the Wilderness quickly. A spring trap or box trap and emergency teleport are recommended.",
+        "description": "Travel to the black chinchompa hunting area in level 32-36 Wilderness. Bring only what you can afford to lose - PKers actively target this area. Use the Edgeville lever to reach the Wilderness quickly. Box traps (bring spares) and an emergency teleport are recommended.",
         "worldX": 3143,
         "worldY": 3771,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary
Corrects the trap type in the Black Chinchompas guidance (source tail semantic audit).

The guidance offered "a spring trap or box trap". Chinchompas can only be caught with **box traps** — spring traps are for smaller Hunter creatures and cannot catch chinchompas. Removed the spring-trap option.

## Receipt (raw)
- Hunter / Chinchompa (wiki): black chinchompas are caught using box traps (73 Hunter); spring traps are not a valid catching method for chinchompas. The source's own step 2 already correctly says "Set box traps to catch black chinchompas".
- Wiki: https://oldschool.runescape.wiki/w/Black_chinchompa

## Verification
- Single-source, single-line prose edit (step 1). Loop markers NOT touched (confirmed via diff; D4Batch4 loop guard for this source remains satisfied). No IDs/rates touched. Privacy clean. Skeptic-confirmed.
