### PR TITLE
fix(data): Easy Treasure Trails - correct easy clue types

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -25573,7 +25573,7 @@
         ]
       },
       {
-        "description": "Complete all clue steps with the RuneLite Clue Scroll plugin. Easy clues add cryptic clues, emote clues, and 6 anagram clues. Always wear the exact emote-clue costume the clue requests - missing one piece resets the puzzle.",
+        "description": "Complete all clue steps with the RuneLite Clue Scroll plugin. Easy clues add cryptic clues, emote clues, map clues, and music clues (no anagram or coordinate clues at this tier). Always wear the exact emote-clue costume the clue requests - missing one piece resets the puzzle.",
         "worldX": 3165,
         "worldY": 3487,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary
Corrects the listed easy-clue types in the Easy Treasure Trails guidance (source tail semantic audit).

The guidance said easy clues contain "cryptic clues, emote clues, and 6 anagram clues." Easy clue scrolls do **not** include anagram clues at all. The correct easy-tier clue types are **cryptic, emote, map, and music** clues (and no coordinate clues).

## Receipt (raw)
- Clue scroll (easy) (wiki): clue-type list is "Cryptic clues / Emote clues / Maps / Music"; "Easy clue scrolls do not feature any coordinate clues". Anagrams are not part of the easy tier.
- Wiki: https://oldschool.runescape.wiki/w/Clue_scroll_(easy)

## Verification
- Single-source, single-line prose edit (step 3). No IDs/rates/loop markers touched (efficiency/estimator tests assert clue math, unaffected). Privacy clean. Skeptic-confirmed.
