### PR TITLE
fix(data): The Mimic - correct casket trigger rates by tier

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -29682,7 +29682,7 @@
     "guidanceSteps": [
       {
         "section": "Prerequisites",
-        "description": "Enable Mimic encounters via the Strange casket in Watson's house in Hosidius (no quest required). Watson is located south-east of the Hosidius vinery. Once enabled, elite and master caskets have a 1/35 chance to become a Mimic encounter.",
+        "description": "Enable Mimic encounters via the Strange casket in Watson's house in Hosidius (no quest required). Watson is located south-east of the Hosidius vinery. Once enabled, an elite casket has a 1/35 chance and a master casket a 1/15 chance to become a Mimic encounter.",
         "worldX": 3164,
         "worldY": 3489,
         "worldPlane": 0,
@@ -29691,7 +29691,7 @@
       },
       {
         "section": "Getting the Encounter",
-        "description": "Complete master clue scrolls. Each master casket opened has approx 1/35 chance to trigger The Mimic. Full guidance on obtaining master clues is on the Master Treasure Trails parent activity.",
+        "description": "Complete master clue scrolls. Each master casket opened has approx 1/15 chance to trigger The Mimic. Full guidance on obtaining master clues is on the Master Treasure Trails parent activity.",
         "worldX": 3164,
         "worldY": 3489,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary
Corrects the Mimic-encounter trigger rates in The Mimic guidance (source tail semantic audit).

The guidance stated both elite and master caskets have a 1/35 chance to become a Mimic encounter (and a second step repeated 1/35 for master). The rates differ by tier:
- **Elite casket: 1/35**
- **Master casket: 1/15**

Fixed both occurrences (step 1 enable text and the master-clue step).

## Receipt (raw)
- The Mimic (wiki): the Strange casket grants a 1/35 chance for elite caskets and a 1/15 chance for master caskets to spawn the Mimic encounter.
- Wiki: https://oldschool.runescape.wiki/w/The_Mimic

## Verification
- Single-source edit (two step descriptions). No item IDs / drop rates / loop markers touched (the 1/35 and 1/15 here are prose encounter-trigger odds, not clog drop-rate fields). Privacy clean. Skeptic-confirmed.
