### PR TITLE
fix(data): Vyrewatch Sentinel - remove nonexistent Canifis lodestone route

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -13289,7 +13289,7 @@
         "section": "Bank"
       },
       {
-        "description": "Travel to Darkmeyer. Drakan's medallion to Darkmeyer is the fastest route; Canifis lodestone + walk south is the fallback if the medallion is unequipped.",
+        "description": "Travel to Darkmeyer. Drakan's medallion to Darkmeyer is the fastest route (every player with Darkmeyer access has the medallion from Sins of the Father).",
         "worldX": 3631,
         "worldY": 3325,
         "worldPlane": 0,
@@ -13298,7 +13298,7 @@
         "requiredItemIds": [
           22400
         ],
-        "travelTip": "Drakan's medallion -> Darkmeyer, or Canifis lodestone + walk south",
+        "travelTip": "Drakan's medallion -> Darkmeyer",
         "section": "Travel"
       },
       {


### PR DESCRIPTION
## Summary
Removes a fabricated travel method from the Vyrewatch Sentinel guidance (RS3-only "lodestone" corpus sweep; this source is in the already-audited 1-150 range but the audit missed it).

OSRS has **no lodestone network** (RS3 mechanic). The guidance offered "Canifis lodestone + walk south" as a Darkmeyer fallback, which does not exist. Removed it — **Drakan's medallion** is the canonical Darkmeyer teleport, and every player who can access Darkmeyer obtains the medallion during Sins of the Father, so a non-medallion fallback is not needed.

## Receipt (raw)
- Lodestone (wiki): redirects to Waystone; OSRS has no lodestone network.
- Drakan's medallion (wiki): teleports to Ver Sinhaza / Darkmeyer; obtained in Sins of the Father, the quest that also unlocks Darkmeyer.
- Wiki: https://oldschool.runescape.wiki/w/Drakan%27s_medallion

## Verification
- Single-source edit (description + travelTip, Vyrewatch Sentinel). No fairy-ring code introduced; no IDs/rates/loop markers touched. Privacy clean.
