### PR TITLE
fix(data): Skotizo - replace nonexistent Kourend lodestone with real teleport

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -5809,7 +5809,7 @@
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 15,
-        "travelTip": "Xeric's talisman -> Heart, or Kourend lodestone + run south",
+        "travelTip": "Xeric's talisman -> Heart, or Kourend Castle Teleport (lands at the Catacombs entrance)",
         "section": "Travel"
       },
       {


### PR DESCRIPTION
## Summary
Removes a fabricated travel method from the Skotizo guidance (RS3-only "lodestone" corpus sweep; already-audited 1-150 source the audit missed).

OSRS has **no lodestone network** (RS3 mechanic). Replaced "Kourend lodestone + run south" with the real **Kourend Castle Teleport**, which lands at the Statue of King Rada I — the Catacombs of Kourend entrance, where Skotizo is summoned via a dark altar.

## Receipt (raw)
- Lodestone (wiki): redirects to Waystone; OSRS has no lodestone network.
- Kourend Castle Teleport (wiki): "Kourend Castle Teleport teleports the player to the Kourend Castle courtyard, by the statue of King Rada I." Standard spellbook, Magic 48, requires Client of Kourend. (The statue is the Catacombs of Kourend entrance.)
- Wiki: https://oldschool.runescape.wiki/w/Kourend_Castle_Teleport

## Verification
- Single-source, single-line travelTip edit (Skotizo). No IDs/rates/loop markers touched. Privacy clean.
