### PR TITLE
fix(data): Amoxliatl - replace nonexistent lodestone with real teleport

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -23840,7 +23840,7 @@
       }
     ],
     "locationDescription": "Ruins of Tapoyauik, Varlamore",
-    "travelTip": "Quetzal whistle -> Tapoyauik, or Civitas illa Fortis lodestone",
+    "travelTip": "Quetzal whistle -> Tapoyauik, or Civitas illa Fortis Teleport (standard spell)",
     "npcId": 13685,
     "interactAction": "Attack",
     "guidanceSteps": [
@@ -23859,7 +23859,7 @@
         "section": "Bank"
       },
       {
-        "description": "Travel to the Ruins of Tapoyauik, Varlamore. Use a quetzal whistle to fly directly to the ruins, or Civitas illa Fortis lodestone and run south. Pendant of ates teleport (uncharged drops from Amoxliatl) skips the run entirely once charged",
+        "description": "Travel to the Ruins of Tapoyauik, Varlamore. Use a quetzal whistle to fly directly to the ruins, or Civitas illa Fortis Teleport (standard spell) and run south. Pendant of ates teleport (uncharged drops from Amoxliatl) skips the run entirely once charged",
         "worldX": 1362,
         "worldY": 4511,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary
Removes a fabricated travel method from the Amoxliatl guidance (RS3-only "lodestone" corpus sweep).

OSRS has **no lodestone network** (RS3 mechanic). Replaced "Civitas illa Fortis lodestone" (travelTip and step) with the real **Civitas illa Fortis Teleport** (standard spellbook).

Note: the semantic audit's per-source pass returned *zero* findings for Amoxliatl — the cross-game knowledge that lodestones are RS3-only was caught by a corpus-wide grep, not the per-source review.

## Receipt (raw)
- Lodestone (wiki): redirects to Waystone; OSRS has no lodestone network.
- Civitas illa Fortis Teleport (wiki): "Civitas illa Fortis Teleport teleports the caster to Civitas illa Fortis." Standard spellbook, Magic 54.
- Wiki: https://oldschool.runescape.wiki/w/Civitas_illa_Fortis_Teleport

## Verification
- Single-source edit (travelTip + step description, Amoxliatl). No IDs/rates/loop markers touched. Privacy clean.
