### PR TITLE
fix(data): Doom of Mokhaiotl - correct travel (quetzal dest, remove lodestone)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -23568,7 +23568,7 @@
       }
     ],
     "locationDescription": "Ruins of Mokhaiotl, beneath Tlati Rainforest in Varlamore",
-    "travelTip": "Quetzal whistle -> Mokhaiotl waystone, or Civitas illa Fortis lodestone",
+    "travelTip": "Mokhaiotl waystone -> direct teleport, or Quetzal whistle -> Tal Teklan then run east to the Tonali Cavern",
     "npcId": 14707,
     "interactAction": "Attack",
     "guidanceSteps": [
@@ -23589,13 +23589,13 @@
         "section": "Bank"
       },
       {
-        "description": "Travel to the Ruins of Mokhaiotl beneath the Tlati Rainforest, Varlamore. Use a Mokhaiotl waystone for direct teleport, or Civitas illa Fortis lodestone and run west to the rainforest entrance",
+        "description": "Travel to the Ruins of Mokhaiotl, Varlamore. Use a Mokhaiotl waystone for a direct teleport, or take a Quetzal whistle to Tal Teklan and run east to the Tonali Cavern entrance",
         "worldX": 1311,
         "worldY": 9520,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 15,
-        "travelTip": "Mokhaiotl waystone -> direct teleport, or Civitas illa Fortis -> run west",
+        "travelTip": "Mokhaiotl waystone -> direct teleport, or Quetzal whistle -> Tal Teklan, run east to the Tonali Cavern",
         "section": "Travel"
       },
       {


### PR DESCRIPTION
## Summary
Corrects the travel guidance for Doom of Mokhaiotl (source tail audit + RS3-only lodestone sweep).

Three problems, all travel-related:
- The Quetzal whistle was listed as flying to a "Mokhaiotl waystone". It actually flies to **Tal Teklan**, from where you run **east** to the **Tonali Cavern**. The Mokhaiotl waystone is a separate direct-teleport item.
- "Civitas illa Fortis lodestone" — OSRS has **no lodestone network** (RS3 mechanic). Removed.
- The lodestone clause also said "run west to the rainforest entrance", contradicting the wiki's "run east to the Tonali Cavern". Removed.

## Receipt (raw)
- Doom of Mokhaiotl (wiki, action=raw): "Players can use a Mokhaiotl waystone to teleport to the Ruins of Mokhaiotl." / "Use a Quetzal whistle to fly to Tal Teklan, and then run east to the Tonali Cavern."
- Lodestone (wiki): redirects to Waystone; OSRS has no lodestone network.
- Wiki: https://oldschool.runescape.wiki/w/Doom_of_Mokhaiotl

## Verification
- Single-source edit (Doom of Mokhaiotl: source travelTip + step description + step travelTip). No IDs/rates/loop markers touched. Privacy clean. Skeptic-confirmed.
