### PR TITLE
fix(data): Shooting Stars - remove fictional Star Sprite, fix spawn timing

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -22771,7 +22771,7 @@
     },
     "guidanceSteps": [
       {
-        "description": "Locate the next crashed star. Use a telescope in your player-owned house Study (mahogany telescope gives a 2-minute window). Alternatively join the Shooting Stars grouping chat or use a community star-tracker site. Stars fall every 85-95 minutes and vary in size (tier 1-9). Teleport to the region the telescope indicates.",
+        "description": "Locate the next crashed star. Use a telescope in your player-owned house Study (mahogany telescope gives a 2-minute window). Alternatively join the Shooting Stars grouping chat or use a community star-tracker site. Stars fall roughly every 90 minutes (a 75-105 minute window) and vary in size (tier 1-9). Teleport to the region the telescope indicates.",
         "worldX": 3214,
         "worldY": 3414,
         "worldPlane": 0,
@@ -22781,7 +22781,7 @@
         "section": "Scout"
       },
       {
-        "description": "Mine the crashed star. Stars degrade through tiers as miners chip away at them - being the first miner awards double stardust for 300 dust mined. Talk to the Star Sprite that emerges from the core (visible when star reaches tier 1) to receive bonus stardust. Collect stardust and exchange at Dusuri's Star Shop (Mining Guild, Falador) for Celestial ring and Star fragments.",
+        "description": "Mine the crashed star. Stars degrade through tiers as miners chip away at them - being the first miner awards double stardust for 300 dust mined. Collect stardust while mining and exchange it at Dusuri's Star Shop (Mining Guild, Falador) for Celestial ring and Star fragments.",
         "worldX": 3214,
         "worldY": 3414,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary
Two corrections to the Shooting Stars guidance (source tail audit).

- **No "Star Sprite".** The guidance claimed a Star Sprite emerges from the core and awards bonus stardust when talked to. OSRS has no such mechanic — stardust is collected by mining the star and exchanged at Dusuri's Star Shop. Removed the sentence.
- **Spawn timing.** "Stars fall every 85-95 minutes" -> "roughly every 90 minutes (a 75-105 minute window)" per the wiki's stated variation.

## Receipt (raw)
- Shooting Stars (wiki): stardust is gained by mining the crashed star and spent at Dusuri's Star Shop; there is no talk-to-sprite bonus. Stars land roughly every 2 hours-ish with the documented variance (~75-105 min window around the ~90 min average).
- Wiki: https://oldschool.runescape.wiki/w/Shooting_Stars

## Verification
- Single-source edit (two step descriptions). No IDs/rates/loop markers touched. Privacy clean. Skeptic-confirmed (blocker for the Star Sprite claim).
