### PR TITLE
fix(data): Yama - fix party size, region, and remove wrong travel fallback

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -23433,7 +23433,7 @@
       }
     ],
     "locationDescription": "Yama's Domain, Chasm of Fire beneath Shayzien",
-    "travelTip": "Chasm teleport scroll, or Xeric's talisman -> Heart -> south to chasm",
+    "travelTip": "Chasm teleport scroll -> Chasm of Fire",
     "npcId": 14176,
     "interactAction": "Attack",
     "guidanceSteps": [
@@ -23453,17 +23453,17 @@
         "section": "Bank"
       },
       {
-        "description": "Travel to the Chasm of Fire beneath Shayzien, Varlamore. Use a chasm teleport scroll for the fastest route, or Xeric's talisman to Heart and run south",
+        "description": "Travel to the Chasm of Fire in north-west Shayzien, Great Kourend. Use a chasm teleport scroll for the fastest route",
         "worldX": 1503,
         "worldY": 10091,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 15,
-        "travelTip": "Chasm teleport scroll (one-tick), or Xeric's talisman -> Heart -> run south through chasm",
+        "travelTip": "Chasm teleport scroll (one-tick) -> Chasm of Fire",
         "section": "Travel"
       },
       {
-        "description": "Form a party of 2-4 and enter Yama's instance. Solo is possible at endgame but DPS check is brutal; duo is the standard. Make sure all members have prayer pots and brews.",
+        "description": "Form a party of up to 2 (solo or duo) and enter Yama's instance. Solo is possible at endgame but the DPS check is brutal; duo is the standard. Make sure all members have prayer pots and brews.",
         "worldX": 1503,
         "worldY": 10091,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary
Three corrections to the Yama guidance (source tail audit).

- **Party size:** Yama supports a maximum of **2 players** (solo or duo). The guidance said "party of 2-4".
- **Region:** The Chasm of Fire (Yama's Domain) is in **Shayzien, Great Kourend (Zeah)** — not Varlamore. Corrected to "north-west Shayzien, Great Kourend".
- **Travel:** Removed the "Xeric's talisman -> Heart -> run south" fallback. Xeric's Heart lands in central/eastern Kourend, so "run south" does not reach the NW-Shayzien chasm. The **chasm teleport scroll** (already listed) is the standard, verified access.

## Receipt (raw)
- Yama (wiki): Yama is fought solo or in a duo (maximum 2 players); located in the Chasm of Fire beneath Shayzien, Great Kourend.
- Shayzien is one of the five cities of Great Kourend (Zeah), not Varlamore.
- Wiki: https://oldschool.runescape.wiki/w/Yama

## Verification
- Single-source edit (source travelTip + step travelTip + 2 step descriptions). No IDs/rates/loop markers touched; no fairy-ring code introduced. Privacy clean. Skeptic-confirmed.
