### PR TITLE
fix(data): Royal Titans - fix Mudskipper Point run direction

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -23706,7 +23706,7 @@
       }
     ],
     "locationDescription": "Asgarnian Ice Dungeon, south of Port Sarim",
-    "travelTip": "Giantsoul amulet -> direct teleport, or fairy ring AIQ -> run south",
+    "travelTip": "Giantsoul amulet -> direct teleport, or fairy ring AIQ -> Mudskipper Point then run north-east",
     "npcId": 12596,
     "interactAction": "Attack",
     "guidanceSteps": [
@@ -23725,7 +23725,7 @@
         "section": "Bank"
       },
       {
-        "description": "Travel to the Asgarnian Ice Dungeon entrance south of Port Sarim. Giantsoul amulet teleports directly to the boss tunnel; otherwise fairy ring AIQ to Mudskipper Point and run south, then use the level-60 Agility tunnel shortcut west of the dungeon ladder",
+        "description": "Travel to the Asgarnian Ice Dungeon entrance south of Port Sarim. Giantsoul amulet teleports directly to the boss tunnel; otherwise fairy ring AIQ to Mudskipper Point and run north-east, then use the level-60 Agility tunnel shortcut west of the dungeon ladder",
         "worldX": 3008,
         "worldY": 3150,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary
Corrects the Mudskipper Point run direction in the Royal Titans guidance (the bosses are in the Asgarnian Ice Dungeon).

Fairy ring **AIQ** lands at Mudskipper Point (~2989, 3110), which is **south** of the Asgarnian Ice Dungeon entrance (~3007, 3150). The guidance said "run south", which leads away from the dungeon; corrected to **run north-east**.

## Receipt (raw)
- Geometry: Mudskipper Point (AIQ) is at the south-west Asgarnia coast; the Asgarnian Ice Dungeon entrance is north-east of it (south of Port Sarim). Δ ≈ +18 east, +40 north -> north-east.
- Wiki: https://oldschool.runescape.wiki/w/Asgarnian_Ice_Dungeon
- (Sibling: Skeletal Wyverns carries the same "AIQ -> Mudskipper -> run south" error; fixed in a separate PR.)

## Verification
- Single-source edit (Royal Titans source travelTip + step description). Fairy-ring code AIQ unchanged (detector-validated). No IDs/rates/loop markers touched. Privacy clean. Skeptic-confirmed.
