### PR TITLE
fix(data): Skeletal Wyverns - fix Mudskipper Point run direction

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -12002,13 +12002,13 @@
         "section": "Bank"
       },
       {
-        "description": "Travel to the Asgarnian Ice Dungeon. Fairy ring AIQ to Mudskipper Point and run south is the fastest route; Port Sarim charter + run south is the unfairy-ring fallback.",
+        "description": "Travel to the Asgarnian Ice Dungeon. Fairy ring AIQ to Mudskipper Point and run north-east is the fastest route; Port Sarim charter + run south is the unfairy-ring fallback.",
         "worldX": 3008,
         "worldY": 3150,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
-        "travelTip": "Fairy ring AIQ -> Mudskipper Point, then run south to the dungeon entrance",
+        "travelTip": "Fairy ring AIQ -> Mudskipper Point, then run north-east to the dungeon entrance",
         "section": "Travel"
       },
       {


### PR DESCRIPTION
## Summary
Corrects the Mudskipper Point run direction in the Skeletal Wyverns guidance (retroactive corpus sweep of the same class fixed for Royal Titans — this 1-150 source carried the identical error the per-source audit missed).

Fairy ring **AIQ** lands at Mudskipper Point, which is **south** of the Asgarnian Ice Dungeon entrance, so the run is **north-east**, not south. Only the AIQ/Mudskipper leg is changed — the "Port Sarim charter + run south" fallback is correct (Port Sarim is north of the dungeon) and is left unchanged.

## Receipt (raw)
- Geometry: Mudskipper Point (~2989, 3110) is south of the Asgarnian Ice Dungeon entrance (~3007, 3150); the run from Mudskipper is north-east. The same geographic fact was skeptic-confirmed for the Royal Titans fix.
- Wiki: https://oldschool.runescape.wiki/w/Asgarnian_Ice_Dungeon

## Verification
- Single-source edit (Skeletal Wyverns step description + travelTip). Targeted only the AIQ/Mudskipper "run south"; the correct Port Sarim "run south" untouched. Fairy-ring code unchanged. No IDs/rates/loop markers touched. Privacy clean.
