### PR TITLE
fix(data): Brutus - correct hitpoints and special-attack mechanics

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -23955,7 +23955,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Bank in Lumbridge. Required: 'The Ides of Milk' quest complete. Bring melee gear (any tier above mithril works - Brutus has low defence and ~200 HP), prayer potions, food, and a Lumbridge teleport. The Cow slippers / Bottomless milk bucket are joke drops with very low realistic engagement value, so cheap gear is fine",
+        "description": "Bank in Lumbridge. Required: 'The Ides of Milk' quest complete. Bring melee gear (any tier above mithril works - Brutus has low defence and only ~58 HP), prayer potions, food, and a Lumbridge teleport. The Cow slippers / Bottomless milk bucket are joke drops with very low realistic engagement value, so cheap gear is fine",
         "worldX": 3221,
         "worldY": 3219,
         "worldPlane": 0,
@@ -23981,7 +23981,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Brutus. Use Protect from Melee and attack with any decent melee weapon - Brutus is a straightforward fight with only a slam auto-attack and a low-damage stomp. Sip prayer potion every 4-5 kills. The fight is designed as a joke encounter for the Mooleta / Cow slippers cosmetic drops; do not waste BiS supplies",
+        "description": "Kill Brutus. Use Protect from Melee against the basic melee attack and hit with any decent melee weapon. Brutus also has two special attacks that each give you a few ticks to step out of the way - watch for the animation cue and move. Sip prayer potion every 4-5 kills. The fight is a low-stakes encounter for the Mooleta / Cow slippers cosmetic drops; do not waste BiS supplies",
         "worldX": 3263,
         "worldY": 3297,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary
Two corrections to the Brutus guidance (source tail audit).

- **Hitpoints:** Brutus (combat level 30) has **~58 HP**, not "~200 HP".
- **Mechanics:** The guidance described Brutus as having "only a slam auto-attack and a low-damage stomp". Per the wiki, aside from the basic (Protect-from-Melee-able) attack, Brutus has **two special attacks that each give players a few ticks to move out of the way**. Reworded so players know to dodge.

## Receipt (raw)
- Brutus (wiki): "Aside from a basic melee attack that can be negated through the use of the Protect from Melee prayer, Brutus uses two special attacks, both of which give players a few ticks to move out of the way." Infobox: Combat level 30, Hitpoints 58, NPC IDs 15626/15627; drops Mooleta, Bottomless milk bucket, Cow slippers (matches this source).
- Wiki: https://oldschool.runescape.wiki/w/Brutus

## Verification
- Single-source edit (two step descriptions). No IDs/rates/loop markers touched. Privacy clean. Skeptic-confirmed.
