### PR TITLE
fix(data): Shellbane Gryphon - correct cave location and feather quantity

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -24081,7 +24081,7 @@
         "section": "Bank"
       },
       {
-        "description": "Travel to The Great Conch and locate the Shellbane Gryphon Cave entrance on the eastern beach. Quetzal whistle -> Great Conch then run east to the cliff-side cave mouth",
+        "description": "Travel to The Great Conch and locate the Shellbane Gryphon Cave entrance in the centre of the island, north of fairy ring CJQ. Take fairy ring CJQ or a Quetzal whistle to The Great Conch, then head north to the cave entrance",
         "worldX": 13993,
         "worldY": 9901,
         "worldPlane": 0,
@@ -24119,7 +24119,7 @@
         ]
       },
       {
-        "description": "Pick up the Gryphon feather (1/kill) and any rares, then exit the cave and teleport via Quetzal whistle to restock. Belle's folly (tarnished) is the main unique chase at 1/256",
+        "description": "Pick up the Gryphon feathers (7-10 guaranteed per kill) and any rares, then exit the cave and teleport via Quetzal whistle to restock. Belle's folly (tarnished) is the main unique chase at 1/256",
         "worldX": 1626,
         "worldY": 3093,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary
Two corrections to the Shellbane Gryphon guidance (source tail audit).

- **Cave location:** The cave is in the **centre of The Great Conch, north of fairy ring CJQ** — not "on the eastern beach" reached by running east. Corrected the directions.
- **Feather quantity:** The Gryphon feather is a **guaranteed 7-10 per kill** (100% drop), not "1/kill".

## Receipt (raw)
- Shellbane gryphon (wiki): "The shellbane gryphon is located in a cave in the centre of the Great Conch, north of fairy ring CJQ." / "the cave entrance lies to the north" of CJQ.
- Drop table (wiki_lookup, NPC 14860): "Gryphon feather | qty: 7-10 | rarity: Always" (plus a separate 35-50 at 11/128).
- Wiki: https://oldschool.runescape.wiki/w/Shellbane_gryphon

## Verification
- Single-source edit (two step descriptions). Fairy-ring code CJQ retained as the wiki landmark. No IDs/rates/loop markers touched. Privacy clean. Skeptic-confirmed. (Also resolves the location half of the carry-over Shellbane coordinate question — exact actuation tile can still be refined by an in-game capture.)
