### PR TITLE
fix(data): Scurrius - correct manhole location and healing mechanic

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -24175,7 +24175,7 @@
         "section": "Bank"
       },
       {
-        "description": "Travel to Varrock Sewers via the manhole behind Varrock Palace or south of Edgeville bank. Use the Varrock teleport for the fastest route",
+        "description": "Travel to Varrock Sewers via the manhole just east of Varrock Palace or south of Edgeville bank. Use the Varrock teleport for the fastest route",
         "worldX": 3237,
         "worldY": 3458,
         "worldPlane": 0,
@@ -24215,7 +24215,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Scurrius. Stand under the boss for melee, dodge the falling rocks (red tiles), and kill the Giant rat spawns immediately - they heal Scurrius if left alive. Use Protect from Missiles to negate his ranged-style auto. Easy first-boss fight that often drops the Scurrius' spine (rune pouch upgrade).",
+        "description": "Kill Scurrius. Stand under the boss for melee, dodge the falling rocks (red tiles), and kill the Giant rat spawns immediately to disrupt the fight. Scurrius heals from the Food Piles between phases (not from the rats), so push damage through the phase transitions. Use Protect from Missiles to negate his ranged-style auto. Easy first-boss fight that often drops the Scurrius' spine (rune pouch upgrade).",
         "worldX": 3299,
         "worldY": 9867,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary
Two corrections to the Scurrius guidance (source tail audit).

- **Manhole location:** The Varrock Sewers manhole is **just east of Varrock Palace**, not "behind" it. (The repo's Bryophyta source already uses the correct "just east" phrasing.)
- **Healing mechanic:** Scurrius heals from the **Food Piles between phases**, *not* from the giant rats. The rats are a disruption to clear; the heal happens at the food piles during phase transitions. Reworded.

## Receipt (raw)
- Scurrius (wiki): "Scurrius' lair is located within the Varrock Sewers, with the sewers being accessible via a manhole just east of Varrock Palace." / "Scurrius may heal from the Food Piles between each phase. While he is eating, he has a slight damage reduction applied to him." (Giant rats are summoned to aid him; no healing is attributed to them.)
- Scurrius/Strategies (wiki): "At the food piles, Scurrius will eat every few seconds, healing 5 or 10 hitpoints per player in the arena."
- Wiki: https://oldschool.runescape.wiki/w/Scurrius

## Verification
- Single-source edit (two step descriptions). No IDs/rates/loop markers touched. Privacy clean. Skeptic-confirmed.
