### PR TITLE
fix(data): The Inferno - correct triple-Jad wave and Zuk spawn mechanics

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -24476,7 +24476,7 @@
         ]
       },
       {
-        "description": "Triple-Jad wave 67. Each Jad rotates Magic / Ranged prayers independently - the cue is the rear-back animation. Kill the centre Jad first, then the south, then the north; the order minimises overlap on healer waves. Stand in the south-west corner with line-of-sight blocked on the north Jad until the others die. Do not use Tumeken's shadow on Jads - they have high magic defence; swap to Twisted bow.",
+        "description": "Triple-Jad wave 68. Each Jad rotates Magic / Ranged prayers independently - the cue is the rear-back animation. Kill the centre Jad first, then the south, then the north; the order minimises overlap on healer waves. Stand in the south-west corner with line-of-sight blocked on the north Jad until the others die. Do not use Tumeken's shadow on Jads - they have high magic defence; swap to Twisted bow.",
         "worldX": 2273,
         "worldY": 5341,
         "worldPlane": 0,
@@ -24492,7 +24492,7 @@
         ]
       },
       {
-        "description": "Defeat TzKal-Zuk on wave 69. He hits a fixed-tile attack that follows your previous tile - move 1 tile every 4 ticks (4-tick shuffle). The Igneous shield NPC (Jal-MejJak) spawns once and absorbs one Zuk hit when stood behind - use it at the second healer set spawn. At 480 HP, two healers (Jal-MejJak healers) spawn from the south - 1-tick aggro them off Zuk by attacking each once then leaving range. At 240 HP, the second healer set spawns; same drill. Tumeken's shadow is BIS for Zuk; switch to Twisted bow if low on shadow charges.",
+        "description": "Defeat TzKal-Zuk on wave 69. He hits a fixed-tile attack that follows your previous tile - move 1 tile every 4 ticks (4-tick shuffle). Stay behind the moving shield to block his hits. At 480 HP, a JalTok-Jad spawns and attacks the shield - aggro or kill it so it does not break your cover. At 240 HP, Zuk becomes enraged (attacks ~3 ticks faster) and summons four Jal-MejJak healers - 1-tick aggro them off Zuk by attacking each once then leaving range. Tumeken's shadow is BIS for Zuk; switch to Twisted bow if low on shadow charges.",
         "worldX": 2273,
         "worldY": 5341,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary
Corrects Inferno wave numbering and TzKal-Zuk spawn mechanics (source tail audit).

- **Triple-Jad wave:** is **wave 68**, not 67. (Wave 67 is the single JalTok-Jad; wave 69 is Zuk.)
- **Zuk spawns (step 6):** the guidance said "healers spawn at 480 HP" and described two healer sets. Per the wiki, at **480 HP a JalTok-Jad** spawns and attacks the shield (not healers); the **four Jal-MejJak healers spawn at 240 HP** when Zuk enrages. Rewrote step 6 accordingly and removed the muddled "Igneous shield NPC (Jal-MejJak) ... second healer set" framing.

## Receipt (raw)
- Inferno (wiki): "Wave 67: 1x Jad"; "Wave 68: 3x Jad ... The penultimate wave"; "Wave 69 ... TzKal-Zuk".
- TzKal-Zuk (wiki): "At 480 hitpoints, a JalTok-Jad will appear and attack the shield." / "At 240 hitpoints, Zuk will become enraged ... summoning four Jal-MejJaks on the lava in front of it." JalTok-Jad and Jal-MejJak are distinct NPCs (cache: 7700/7704/10623 vs 7708).
- Wiki: https://oldschool.runescape.wiki/w/Inferno , https://oldschool.runescape.wiki/w/TzKal-Zuk

## Verification
- Single-source edit (two step descriptions). No IDs/rates/loop markers touched. Privacy clean. Skeptic-confirmed (blocker for the 480-HP healer error).
