### PR TITLE
fix(data): Hard TT Rewards - Kalphite Queen drops elite, not hard, clues

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -28533,7 +28533,7 @@
       },
       {
         "section": "Getting Clues",
-        "description": "Obtain hard clue scrolls via PvM (Hellhounds, Kalphite Queen, etc.), skilling, or Ninja impling jars (approx 1/25 per jar) from the Grand Exchange.",
+        "description": "Obtain hard clue scrolls via PvM (Hellhounds, Aberrant spectres, etc.), skilling, or Ninja impling jars (approx 1/25 per jar) from the Grand Exchange.",
         "worldX": 3165,
         "worldY": 3487,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary
Corrects a wrong hard-clue source in the Hard Treasure Trail Rewards guidance (source tail audit).

The guidance listed the **Kalphite Queen** as a hard-clue PvM source. The Kalphite Queen drops **elite** clue scrolls, not hard. Replaced it with **aberrant spectres**, a genuine hard-clue source. (Hellhounds, also listed, are correct.)

## Receipt (raw)
- Kalphite Queen (wiki): drops elite clue scrolls (not hard).
- Aberrant spectre (wiki): drops hard clue scrolls.
- Wiki: https://oldschool.runescape.wiki/w/Clue_scroll_(hard)

## Verification
- Single-source, single-line prose edit. No IDs/rates/loop markers touched. Privacy clean. Skeptic-confirmed.
