### PR TITLE
fix(data): Elite TT Rewards - ranger boots are a medium-clue reward

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -28848,7 +28848,7 @@
     "guidanceSteps": [
       {
         "section": "Overview",
-        "description": "Rare sub-table for elite clue scrolls. Full kill-loop guidance is on the Elite Treasure Trails parent activity. Complete elite clues for a chance at 3rd age items, ranger boots, rangers tunic, and other mega-rare rewards.",
+        "description": "Rare sub-table for elite clue scrolls. Full kill-loop guidance is on the Elite Treasure Trails parent activity. Complete elite clues for a chance at 3rd age items, the rangers' tunic, and other mega-rare rewards.",
         "worldX": 3165,
         "worldY": 3487,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary
Removes a wrong reward from the Elite Treasure Trail Rewards guidance (source tail audit).

The guidance listed **ranger boots** as an elite-clue reward. Ranger boots come from **medium** clue scrolls, not elite. Removed them. (The repo's Medium-casket reward list already correctly includes Ranger boots at 1/1133.)

## Receipt (raw)
- Ranger boots (wiki): obtained from medium clue scroll reward caskets.
- Wiki: https://oldschool.runescape.wiki/w/Ranger_boots

## Verification
- Single-source, single-line prose edit. No IDs/rates/loop markers touched. Privacy clean. Skeptic-confirmed.
