### PR TITLE
fix(data): Master TT Rewards - master clues are not a PvM drop

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -29238,7 +29238,7 @@
       },
       {
         "section": "Getting Clues",
-        "description": "Obtain master clues by trading one clue of each tier (easy, medium, hard, elite) to Watson in Hosidius, or as a rare drop from high-level PvM.",
+        "description": "Obtain master clues by trading one clue of each tier (easy, medium, hard, elite) to Watson in Hosidius, or as a chance reward for completing any easy, medium, hard, or elite clue scroll.",
         "worldX": 3165,
         "worldY": 3487,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary
Corrects how master clues are obtained in the Master Treasure Trail Rewards guidance (source tail audit).

The guidance said master clues drop "as a rare drop from high-level PvM". Master clues are **not** a monster drop. They are obtained by handing one clue of each tier (easy/medium/hard/elite) to Watson, **or** as a chance reward upon completing any easy, medium, hard, or elite clue scroll. Corrected the second clause.

## Receipt (raw)
- Clue scroll (master) (wiki): obtained from Watson (one of each lower tier) or as a chance at the end of completing any easy/medium/hard/elite clue. Not a PvM/monster drop.
- Wiki: https://oldschool.runescape.wiki/w/Clue_scroll_(master)

## Verification
- Single-source, single-line prose edit. No IDs/rates/loop markers touched. Privacy clean. Skeptic-confirmed.
