### PR TITLE
fix(data): Runecrafting (Fire Runes) - Duel Arena renamed to Emir's Arena

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -30079,7 +30079,7 @@
       }
     ],
     "locationDescription": "Fire Altar, north-east of Al Kharid",
-    "travelTip": "Ring of dueling -> Duel Arena (Al Kharid) -> run north-east to fire altar ruins; or Abyss (requires Enter the Abyss miniquest, omit glory/prayer for PvP danger)",
+    "travelTip": "Ring of dueling -> Emir's Arena (Al Kharid) -> run north-east to fire altar ruins; or Abyss (requires Enter the Abyss miniquest, omit glory/prayer for PvP danger)",
     "requirements": {
       "skills": [
         {
@@ -30090,13 +30090,13 @@
     },
     "guidanceSteps": [
       {
-        "description": "Travel to the Fire Altar north-east of Al Kharid. Bring a fire tiara (wear it to enter freely) or a fire talisman. Equip a large pouch and medium pouch to carry more essence per trip. Ring of dueling to Duel Arena is the standard banking method - use it to teleport to Castle Wars bank between trips.",
+        "description": "Travel to the Fire Altar north-east of Al Kharid. Bring a fire tiara (wear it to enter freely) or a fire talisman. Equip a large pouch and medium pouch to carry more essence per trip. Ring of dueling to Emir's Arena is the standard banking method - use it to teleport to the Castle Wars or Ferox Enclave bank between trips.",
         "worldX": 2583,
         "worldY": 4838,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 15,
-        "travelTip": "Ring of dueling -> Duel Arena -> run north-east to fire altar ruins",
+        "travelTip": "Ring of dueling -> Emir's Arena -> run north-east to fire altar ruins",
         "requiredItemIds": [
           6527
         ],


### PR DESCRIPTION
## Summary
Updates the stale "Duel Arena" name in the Runecrafting (Fire Runes) guidance (source tail audit).

The Ring of dueling teleport destination near Al Kharid is **Emir's Arena** — the Duel Arena was renamed with the PvP Arena update. Updated all three references in this source. (The repo's Mage Training Arena source already uses "Emir's Arena", confirming the current name.)

## Receipt (raw)
- Ring of dueling (wiki): teleports to Emir's Arena (formerly the Duel Arena), Castle Wars, and Ferox Enclave.
- Wiki: https://oldschool.runescape.wiki/w/Emir%27s_Arena

## Verification
- Single-source edit (source travelTip + step description + step travelTip). No IDs/rates/loop markers touched. Privacy clean. Skeptic-confirmed.
