### PR TITLE
fix(data): Underwater Crabs - fairy ring AIQ lands at Mudskipper Point

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -30221,7 +30221,7 @@
         "section": "Bank prep"
       },
       {
-        "description": "Travel to Mudskipper Point. Fairy ring AIQ teleports to the Feldip area; run north-west to Mudskipper Point. Alternatively amulet of glory to Draynor Village then run south-west along the coast.",
+        "description": "Travel to Mudskipper Point. Fairy ring AIQ teleports directly to Mudskipper Point. Alternatively amulet of glory to Draynor Village then run south-west along the coast.",
         "worldX": 2987,
         "worldY": 3033,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary
Corrects the fairy ring AIQ destination in the Underwater Crabs guidance (source tail audit).

Fairy ring **AIQ** is located at **Mudskipper Point** — it teleports there directly. The guidance said it lands "in the Feldip area" requiring a north-west run, which is wrong. Corrected.

## Receipt (raw)
- Fairy ring AIQ (wiki): destination is Mudskipper Point. (Code-validity is also detector-checked; AIQ = Mudskipper Point.)
- Wiki: https://oldschool.runescape.wiki/w/Fairy_ring

## Verification
- Single-source, single-line prose edit. Fairy-ring code AIQ unchanged. No IDs/rates/loop markers touched. Privacy clean. Skeptic-confirmed.
