### PR TITLE
fix(data): Mithril Dragon - Ancient Cavern access and chewed bones

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -31620,7 +31620,7 @@
     "travelTip": "Barbarian Outpost -> dive into whirlpool",
     "guidanceSteps": [
       {
-        "description": "Travel to Otto's Grotto, south of the Barbarian Outpost (games necklace). Barbarian Fishing training is required to dive into the whirlpool.",
+        "description": "Travel to Otto's Grotto, south of the Barbarian Outpost (games necklace). Barbarian Firemaking training (the pyre-ship part of the Barbarian Training miniquest) is required to dive into the whirlpool.",
         "worldX": 2512,
         "worldY": 3509,
         "worldPlane": 0,
@@ -31642,7 +31642,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill mithril dragons in the Ancient Cavern. Use extended antifire and Protect from Magic. Chewed bones unlock the Ourg bones prayer XP method. Ancient pages and Dragon full helm are the rarest drops.",
+        "description": "Kill mithril dragons in the Ancient Cavern. Use extended antifire and Protect from Magic. Chewed bones can be offered on a pyre ship for a chance at the Dragon full helm. Ancient pages and Dragon full helm are the rarest drops.",
         "worldX": 1745,
         "worldY": 5323,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary
Two corrections to the Mithril Dragon guidance (source tail audit).

- **Ancient Cavern access:** diving the whirlpool requires **Barbarian Firemaking** training (the pyre-ship part of the Barbarian Training miniquest), not "Barbarian Fishing training".
- **Chewed bones:** are offered on a **pyre ship for a chance at the Dragon full helm** — they are not "ourg bones" and do not "unlock the Ourg bones prayer XP method".

## Receipt (raw)
- Ancient Cavern (wiki): access via diving the whirlpool requires the Firemaking part of Barbarian Training (building a pyre ship).
- Chewed bones / Dragon full helm (wiki): chewed bones (from mithril dragons) are placed on a pyre ship for a chance at the Dragon full helm.
- Wiki: https://oldschool.runescape.wiki/w/Ancient_Cavern , https://oldschool.runescape.wiki/w/Chewed_bones

## Verification
- Single-source edit (two step descriptions; the identical whirlpool block also exists in the Waterfiend source — anchored to Mithril Dragon's unique kill step to edit only this source). No IDs/rates/loop markers touched. Privacy clean. Skeptic-confirmed.
