### PR TITLE
fix(data): Waterfiend - Ancient Cavern needs Barbarian Firemaking

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -32211,7 +32211,7 @@
     "travelTip": "Barbarian Outpost -> dive into whirlpool",
     "guidanceSteps": [
       {
-        "description": "Travel to Otto's Grotto, south of the Barbarian Outpost (games necklace). Barbarian Fishing training is required to dive into the whirlpool.",
+        "description": "Travel to Otto's Grotto, south of the Barbarian Outpost (games necklace). Barbarian Firemaking training (the pyre-ship part of the Barbarian Training miniquest) is required to dive into the whirlpool.",
         "worldX": 2512,
         "worldY": 3509,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary
Corrects the Ancient Cavern access requirement in the Waterfiend guidance (source tail audit).

Diving the whirlpool at Otto's Grotto to reach the Ancient Cavern requires **Barbarian Firemaking** training (the pyre-ship part of the Barbarian Training miniquest), not "Barbarian Fishing training".

## Receipt (raw)
- Ancient Cavern (wiki): whirlpool access requires the Firemaking part of Barbarian Training (build a pyre ship).
- Wiki: https://oldschool.runescape.wiki/w/Ancient_Cavern

## Verification
- Single-source edit (one step description; anchored to Waterfiend's unique kill step since the whirlpool block is shared with the Mithril Dragon source). No IDs/rates/loop markers touched. Privacy clean. Skeptic-confirmed.
