### PR TITLE
fix(data): Prifddinas Elf - correct Ardougne cloak tier and dodgy necklace

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -32122,7 +32122,7 @@
         "section": "Travel"
       },
       {
-        "description": "Pickpocket elves in Prifddinas (85 Thieving). Each successful pickpocket has a 1/1024 chance of yielding an enhanced crystal teleport seed. Wearing the Ardougne cloak 4 or a dodgy necklace reduces failure rate significantly.",
+        "description": "Pickpocket elves in Prifddinas (85 Thieving). Each successful pickpocket has a 1/1024 chance of yielding an enhanced crystal teleport seed. The Ardougne cloak 3 (Hard Diary reward) gives a 10% increased pickpocket success chance; a dodgy necklace gives a 25% chance to avoid the stun and damage when a pickpocket fails.",
         "worldX": 3279,
         "worldY": 6072,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary
Two corrections to the Prifddinas Elf (Thieving) guidance (source tail audit).

- **Ardougne cloak tier:** the +10% global pickpocket success boost is a **Hard** Ardougne Diary reward (Ardougne cloak **3**), not cloak 4. The Elite diary (cloak 4) grants no additional Thieving bonus.
- **Dodgy necklace:** it does **not** reduce the failure rate. It gives a **25% chance to avoid the stun and damage** when a pickpocket fails.

## Receipt (raw)
- Ardougne Diary (wiki): the Hard diary grants a 10% increased pickpocketing success rate (via Ardougne cloak 3); applies to pickpocketing everywhere.
- Dodgy necklace (wiki): "has a 25% chance of preventing the damage and stun from a failed pickpocket."
- Wiki: https://oldschool.runescape.wiki/w/Dodgy_necklace

## Verification
- Single-source, single-line prose edit. No IDs/rates/loop markers touched. Privacy clean. Skeptic-confirmed.
