### PR TITLE
fix(data): Fishing (Swordfish) - correct barehand fishing requirements

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -30007,7 +30007,7 @@
     "travelTip": "Skills necklace -> Fishing Guild; or Camelot tele + run to Catherby",
     "guidanceSteps": [
       {
-        "description": "Bank for swordfish fishing. Bring a harpoon (or use barehand fishing at 55 Strength and Agility for higher XP). Fishing Guild entrance requires 68 Fishing (boostable from 63). Catherby works from 50 Fishing with no guild requirement.",
+        "description": "Bank for swordfish fishing. Bring a harpoon (or use barehand fishing - 70 Fishing and 50 Strength, no Agility requirement - for higher XP). Fishing Guild entrance requires 68 Fishing (boostable from 63). Catherby works from 50 Fishing with no guild requirement.",
         "worldX": 2573,
         "worldY": 3441,
         "worldPlane": 0,
@@ -30029,7 +30029,7 @@
         "section": "Travel"
       },
       {
-        "description": "Harpoon swordfish at harpoon spots. Each catch rolls the Heron pet and Big swordfish. Heron pet rate scales with Fishing level. Barehand fishing (55 Strength + Agility required) gives higher XP at the same drop rates. Guild bank is among the closest to a fishing spot in the game.",
+        "description": "Harpoon swordfish at harpoon spots. Each catch rolls the Heron pet and Big swordfish. Heron pet rate scales with Fishing level. Barehand fishing (70 Fishing and 50 Strength required, no Agility) gives higher XP at the same drop rates. Guild bank is among the closest to a fishing spot in the game.",
         "worldX": 2604,
         "worldY": 3414,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary
Corrects the barehand-fishing requirements in the Fishing (Swordfish) guidance (source tail audit).

The guidance said barehand fishing needs "55 Strength and Agility". Per the wiki:
- **No Agility requirement** exists for barehand fishing (Agility only affects heavy-rod fishing XP).
- Barehand **swordfish** specifically requires **70 Fishing and 50 Strength** (the "55" was the barehand-*tuna* Fishing level, not a Strength level).

Scope note: the "Fishing Guild boostable from 63" figure was left unchanged — it is arithmetically correct (base 63 + admiral pie's +5 boost = the 68 guild requirement), so the audit's suggested "62" change was not applied.

## Receipt (raw)
- Barbarian Training / barehand fishing (wiki): "No agility level is required for barehanded fishing." / "To barehand fish swordfish requires 70 Fishing and 50 Strength."
- Wiki: https://oldschool.runescape.wiki/w/Barbarian_Training

## Verification
- Single-source edit (two step descriptions). No IDs/rates/loop markers touched. Privacy clean. Skeptic-confirmed for the barehand requirements; lead declined the unsupported guild-boost sub-fix.
