### PR TITLE
fix(data): Woodcutting (Teak Trees) - correct 2-tick method description

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -29843,7 +29843,7 @@
     "travelTip": "Fairy ring BJP -> Isle of Souls (no req); or Ape Atoll tele for 2-tick",
     "guidanceSteps": [
       {
-        "description": "Bank for teak chopping. Bring your best axe (dragon or crystal for highest success rate). 35 Woodcutting required. Isle of Souls is best with no extra requirements. Ape Atoll or Prifddinas are optimal for 2-tick manipulation (bring a knife and kebbit claws or karambwanji for the tick cycle).",
+        "description": "Bank for teak chopping. Bring your best axe (dragon or crystal for highest success rate). 35 Woodcutting required. Isle of Souls is best with no extra requirements. Ape Atoll/Isle of Souls (birds) or Prifddinas (rabbits) are optimal for 2-tick manipulation, where you auto-retaliate to a monster hitting you every 2 ticks while clicking the tree.",
         "worldX": 2200,
         "worldY": 2858,
         "worldPlane": 0,
@@ -29866,7 +29866,7 @@
         "section": "Travel"
       },
       {
-        "description": "Chop teak logs. AFK method: stand between two trees and click the other when one falls (each respawns in 9 seconds). 2-tick method at Ape Atoll or Prifddinas: use knife on bait on tick 1, click tree on tick 2. Bird nests drop to the ground (1/256 chance) and despawn after 2 minutes - collect for bonus value.",
+        "description": "Chop teak logs. AFK method: stand between two trees and click the other when one falls (each respawns in 9 seconds). 2-tick method at Ape Atoll or Prifddinas: let a monster attack you every 2 ticks (birds at Ape Atoll, rabbits at Prifddinas) and click the tree on auto-retaliate. Bird nests drop to the ground (1/256 chance) and despawn after 2 minutes - collect for bonus value.",
         "worldX": 2770,
         "worldY": 2700,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary
Corrects the 2-tick teak method description in the Woodcutting (Teak Trees) guidance (source tail audit).

The guidance described the 2-tick method as "use knife on bait on tick 1, click tree on tick 2" (and "bring a knife and kebbit claws or karambwanji"). That is the **1.5-tick** (3-tick-cycle) technique. The **2-tick** method at Ape Atoll/Isle of Souls (birds) and Prifddinas (rabbits) works by **auto-retaliating to a monster hitting you every 2 ticks while clicking the tree**. Corrected both step descriptions.

## Receipt (raw)
- Pay-to-play Woodcutting training (wiki): "2-tick woodcutting is done by auto-retaliating to being attacked every two ticks and clicking on a tree" ... "get two monsters attacking you such that a hitsplat appears every two ticks". Birds at Ape Atoll/Isle of Souls, rabbits at Prifddinas.
- The knife/kebbit-claw actions are 3-tick-cycle builders for the 1.5-tick method (Fossil Island).
- Wiki: https://oldschool.runescape.wiki/w/Pay-to-play_Woodcutting_training

## Verification
- Single-source edit (two step descriptions). Loop markers untouched (D4Batch3 E4 loop guard intact). No IDs/rates touched. Privacy clean. Skeptic-confirmed.
