### PR TITLE
fix(data): Mining (Gemstone Rocks) - add diary req, fix gloves teleport, gem bag

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -29932,13 +29932,13 @@
         "section": "Bank prep"
       },
       {
-        "description": "Travel to Shilo Village underground mine. Teleport to Shilo Village via Karamja gloves 3/4, then enter the underground mine on the south side. Brimhaven cart ride also works.",
+        "description": "Travel to the Shilo Village underground gem mine (requires the Medium Karamja Diary to enter). Karamja gloves 3 (Hard Karamja Diary) or 4 teleport directly into the underground mine; otherwise reach Shilo Village (Brimhaven cart ride) and climb down to the underground level.",
         "worldX": 2842,
         "worldY": 9381,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 15,
-        "travelTip": "Karamja gloves 3/4 tele to Shilo Village; or Brimhaven cart ride",
+        "travelTip": "Karamja gloves 3/4 -> directly into the underground mine; or Brimhaven cart ride to Shilo Village",
         "section": "Travel"
       },
       {
@@ -29958,7 +29958,7 @@
         "loopCount": 0
       },
       {
-        "description": "Bank gems once your inventory is full. The gem bag holds up to 60 uncut gems to delay banking. Shilo Village bank is immediately above the underground mine entrance.",
+        "description": "Bank gems once your inventory is full. The gem bag holds up to 60 of each uncut gem type (300 total) to delay banking. Shilo Village bank is immediately above the underground mine entrance.",
         "worldX": 2852,
         "worldY": 2954,
         "worldPlane": 0,
@@ -29971,6 +29971,9 @@
     "requirements": {
       "quests": [
         "SHILO_VILLAGE"
+      ],
+      "diaries": [
+        "KARAMJA_MEDIUM"
       ],
       "skills": [
         {


### PR DESCRIPTION
## Summary
Three corrections to the Mining (Gemstone Rocks) guidance — this source is the Shilo Village *underground* gem mine (source tail audit).

- **Requirement:** entering the underground gem mine requires the **Medium Karamja Diary**. Added `"diaries": ["KARAMJA_MEDIUM"]` to `requirements` (schema-supported; resolves to `Varbits.DIARY_KARAMJA_MEDIUM`).
- **Teleport:** **Karamja gloves 3** (a **Hard** Karamja Diary reward) teleport **directly into the underground mine**, not "to Shilo Village" town. Corrected step 2 + travelTip. (Note: the audit's suggested-fix text mislabelled gloves 3 as a Medium-diary reward — it is Hard; corrected here.)
- **Gem bag:** holds **60 of each** uncut gem type (**300 total**), not "60 uncut gems".

## Receipt (raw)
- Shilo Village mine (wiki): "Players who have completed the Medium Karamja Diary are able to access the underground portion of the gem mine ... Players now only require completion of the medium Karamja Diary to enter the underground portion."
- Karamja gloves 3 (wiki): "Free, unlimited teleportation to the underground portion of the Shilo Village mine" ... "the reward for completing all of the hard Karamja Diary tasks."
- Gem bag (wiki): "It can hold 60 of each (300 total) uncut gems".
- Wiki: https://oldschool.runescape.wiki/w/Shilo_Village_mine , https://oldschool.runescape.wiki/w/Gem_bag

## Verification
- Single-source edit. `requirements` change validated (JSON parses; `KARAMJA_MEDIUM` is a recognised diary enum). No item IDs / drop rates / loop markers touched. Privacy clean. Skeptic-confirmed; lead corrected the gloves-3 diary tier (Hard, not Medium).
