### PR TITLE
fix(data): Motherlode Mine - upper level 57 Mining; prospector leg/boot costs

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -22614,7 +22614,7 @@
         "dropRate": 1.0,
         "isPet": false,
         "wikiPage": "Prospector_legs",
-        "pointCost": 40,
+        "pointCost": 50,
         "independent": true
       },
       {
@@ -22623,7 +22623,7 @@
         "dropRate": 1.0,
         "isPet": false,
         "wikiPage": "Prospector_boots",
-        "pointCost": 40,
+        "pointCost": 30,
         "independent": true
       },
       {
@@ -22649,7 +22649,7 @@
     "travelTip": "Skills necklace -> Mining Guild entrance, run east into Dwarven Mine",
     "guidanceSteps": [
       {
-        "description": "Bank for Motherlode Mine. Bring your best pickaxe (dragon or crystal), a coal bag and gem bag if unlocked, and stamina potions. 30 Mining required; upper level needs 72 Mining and 100 golden nuggets one-time.",
+        "description": "Bank for Motherlode Mine. Bring your best pickaxe (dragon or crystal), a coal bag and gem bag if unlocked, and stamina potions. 30 Mining required; upper level needs 57 Mining and 100 golden nuggets one-time.",
         "worldX": 3013,
         "worldY": 3355,
         "worldPlane": 0,
@@ -22698,7 +22698,7 @@
         ]
       },
       {
-        "description": "Deposit pay-dirt into the hopper. Wait at the sack near Prospector Percy for cleaned ores and golden nuggets. Upper level hopper needs 72 Mining and 100 nuggets one-time unlock, and gives roughly 10% more nuggets per hour.",
+        "description": "Deposit pay-dirt into the hopper. Wait at the sack near Prospector Percy for cleaned ores and golden nuggets. Upper level hopper needs 57 Mining and 100 nuggets one-time unlock, and gives roughly 10% more nuggets per hour.",
         "worldX": 3748,
         "worldY": 5666,
         "worldPlane": 0,
@@ -22710,7 +22710,7 @@
         "loopCount": 0
       },
       {
-        "description": "Spend golden nuggets at Prospector Percy shop: helmet (40), jacket (60), legs (40), boots (40), coal bag (100), gem bag (100). Prioritise coal bag and gem bag for immediate efficiency gains. Bank chest beside Percy is accessible without requirements.",
+        "description": "Spend golden nuggets at Prospector Percy shop: helmet (40), jacket (60), legs (50), boots (30), coal bag (100), gem bag (100). Prioritise coal bag and gem bag for immediate efficiency gains. Bank chest beside Percy is accessible without requirements.",
         "worldX": 3728,
         "worldY": 5693,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary
Corrects the Motherlode Mine upper-level requirement and Prospector shop costs (source tail audit).

- **Upper level:** requires **57 Mining**, not 72. The requirement was reduced from 72 to 57 in the 8 May 2024 update; the data was stale (two places).
- **Prospector legs:** cost **50** golden nuggets (data said 40) — fixed both the guidance prose and the `pointCost` field.
- **Prospector boots:** cost **30** golden nuggets (data said 40) — fixed both the prose and the `pointCost` field.

## Receipt (raw)
- Motherlode Mine (wiki): "Unlocking the upper level of the mine requires base Mining 57, and a one-time fee of 100 golden nuggets." Update history (8 May 2024): "The Mining level required to unlock the upper level has been decreased from 72 to 57."
- Prospector kit (wiki): legs 50 nuggets, boots 30 nuggets (set total 180 = helmet 40 + jacket 60 + legs 50 + boots 30).
- Wiki: https://oldschool.runescape.wiki/w/Motherlode_Mine , https://oldschool.runescape.wiki/w/Prospector_kit

## Verification
- Single-source edit. Loop markers (`loopCount`/`loopBackToStep`) untouched — confirmed via diff (D4Batch3 E4 loop guard for Motherlode intact). The two `pointCost` fields and the matching shop-cost prose are fixed together (same layer). JSON parses. Privacy clean. Skeptic-confirmed.
