### PR TITLE
fix(data): Cutting Squid - jumbo squid require Fishing 69

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -32029,7 +32029,7 @@
     "travelTip": "Port Piscarilius sailing dock -> sail to squid fishing spots",
     "guidanceSteps": [
       {
-        "description": "Bank for squid cutting. Bring a knife for hand-cutting (most beak rolls per squid) or use the boat chum station for faster throughput. Jumbo squid give 1/512 per cut; swordtip squid give 1/1024. Sailing 47 and Fishing 52 required (lantern harpooning). Spirit flakes or rada's blessing can double catches.",
+        "description": "Bank for squid cutting. Bring a knife for hand-cutting (most beak rolls per squid) or use the boat chum station for faster throughput. Jumbo squid give 1/512 per cut; swordtip squid give 1/1024. Sailing 47 and Fishing 52 are required for swordtip squid; jumbo squid require Fishing 69 (lantern harpooning). Spirit flakes or rada's blessing can double catches.",
         "worldX": 1824,
         "worldY": 3691,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary
Clarifies the squid Fishing requirements in the Cutting Squid guidance (source tail audit).

The step listed "Sailing 47 and Fishing 52 required" for both squid types. **Jumbo squid require Fishing 69**; Fishing 52 is the requirement for **swordtip** squid. Reworded to separate the two.

## Receipt (raw)
- Squid / lantern harpooning (wiki): swordtip squid Fishing 52; jumbo squid Fishing 69.

## Verification
- Single-source, single-line prose edit. No IDs/rates/loop markers touched. Privacy clean. Skeptic-confirmed.
