### PR TITLE
fix(data): Port Tasks - shark paint is a port task reward, not salvage

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -32295,7 +32295,7 @@
         "section": "Travel"
       },
       {
-        "description": "Accept and complete port tasks from the Port Notice Board. Completing tasks rewards Sailing XP and occasionally unique items: Soup (1/4,500 task reward) and Shark paint (1/36 salvage reward). Tasks are repeatable and vary by port and Sailing level.",
+        "description": "Accept and complete port tasks from the Port Notice Board. Completing tasks rewards Sailing XP and occasionally unique items: Soup (1/4,500 task reward) and Shark paint (port task reward). Tasks are repeatable and vary by port and Sailing level.",
         "worldX": 3055,
         "worldY": 3245,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary
Corrects the shark paint source label in the Port Tasks guidance (source tail audit).

Shark paint was labelled a "salvage reward". It comes from **completing port tasks**, not salvage. Corrected to "port task reward". (The boat-paints source elsewhere already attributes Shark paint to port tasks.)

## Receipt (raw)
- Boat paints (wiki/in-game): Shark paint is a port task reward. The numeric rate is out of scope for this prose-label fix.

## Verification
- Single-source, single-line prose edit. No IDs/rates/loop markers touched. Privacy clean. Skeptic-confirmed.
