### PR TITLE
fix(data): Pickpocketing Darkmeyer Vyre - fix Kharyrll fallback direction

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -32387,7 +32387,7 @@
       }
     ],
     "locationDescription": "Darkmeyer, Morytania",
-    "travelTip": "Drakan's medallion -> Darkmeyer; or Kharyrll teleport (Ancient Magicks) -> run north",
+    "travelTip": "Drakan's medallion -> Darkmeyer; or Kharyrll teleport (Ancient Magicks) -> Canifis then travel south-east",
     "requirements": {
       "quests": [
         "SINS_OF_THE_FATHER"
@@ -32407,7 +32407,7 @@
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
-        "travelTip": "Drakan's medallion -> Darkmeyer; or Kharyrll teleport -> run north",
+        "travelTip": "Drakan's medallion -> Darkmeyer; or Kharyrll teleport -> Canifis then travel south-east",
         "requiredItemIds": [
           24774,
           24775,


### PR DESCRIPTION
## Summary
Corrects the Kharyrll travel fallback direction in the Pickpocketing Darkmeyer Vyre guidance (source tail audit).

Kharyrll Teleport lands in **Canifis** (north-west Morytania). Darkmeyer is to the **south-east** (reached via Meiyerditch). Running **north** from Canifis leads to the Slayer Tower, not Darkmeyer. Corrected both travelTips. (Drakan's medallion remains the primary, correct route.)

## Receipt (raw)
- Kharyrll Teleport (wiki): teleports to Canifis.
- Darkmeyer is in the south-east of Morytania (Sanguinesti region), reached from Canifis via Mort Myre / Meiyerditch — i.e. south-east; north of Canifis is the Slayer Tower.
- Wiki: https://oldschool.runescape.wiki/w/Darkmeyer

## Verification
- Single-source edit (source travelTip + step travelTip). No IDs/rates/loop markers touched. Privacy clean. Skeptic-confirmed.
