### PR TITLE
fix(data): The Hueycoatl - correct pillar mechanic and travel

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -23272,7 +23272,7 @@
       }
     ],
     "locationDescription": "The Darkfrost, Hailstorm Mountains in Varlamore",
-    "travelTip": "Quetzal whistle -> Hueycoatl arena, or Civitas illa Fortis lodestone",
+    "travelTip": "Quetzal whistle -> Hueycoatl arena, or Quetzal Transport System -> Quetzacalli Gorge -> run to the Darkfrost",
     "npcId": 14009,
     "interactAction": "Attack",
     "guidanceSteps": [
@@ -23291,17 +23291,17 @@
         "section": "Bank"
       },
       {
-        "description": "Travel to the Hueycoatl Arena in the Hailstorm Mountains, Varlamore. Use the quetzal whistle for the fastest route, or Civitas illa Fortis lodestone and run west",
+        "description": "Travel to the Hueycoatl arena (the Darkfrost) in the Hailstorm Mountains, Varlamore. Use the quetzal whistle for the fastest route, or take the Quetzal Transport System to Quetzacalli Gorge and run to the Darkfrost (the pendant of ates teleports directly once unlocked)",
         "worldX": 1509,
         "worldY": 3290,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
-        "travelTip": "Quetzal whistle -> Hueycoatl, or Civitas illa Fortis lodestone -> run west",
+        "travelTip": "Quetzal whistle -> Hueycoatl, or Quetzal Transport System -> Quetzacalli Gorge -> run to the Darkfrost",
         "section": "Travel"
       },
       {
-        "description": "Kill The Hueycoatl. The fight cycles across 4 anchor pillars - Hueycoatl rams a different pillar each phase. Run to the active pillar and DPS the head while it is bound. Dodge red tiles (fire breath / tail slam), kill the egg nest adds before they hatch, and use Protect from Magic on the final phase enrage. Dragon hunter wand or dragon hunter crossbow are the meta picks.",
+        "description": "Kill The Hueycoatl. Three pillars stand west of the head - blue (Protect from Magic), red (Protect from Melee), and green (Protect from Missiles). Charge them by praying the protection prayer matching each pillar's colour; once all three are charged the path opens and the head can be attacked. Dodge red tiles (fire breath / tail slam), kill the egg nest adds before they hatch, and use Protect from Magic on the final phase enrage. Dragon hunter wand or dragon hunter crossbow are the meta picks.",
         "worldX": 1509,
         "worldY": 3290,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary
Corrects the fight mechanic and travel for The Hueycoatl (source tail audit + lodestone class).

- **Mechanic:** the fight uses **three colour-coded pillars** west of the head — **blue (Protect from Magic), red (Protect from Melee), green (Protect from Missiles)** — charged by praying the matching protection prayer to open the path to the head. The guidance described "4 anchor pillars" the boss "rams". Rewritten.
- **Travel:** removed "Civitas illa Fortis lodestone" (OSRS has **no lodestone network** — RS3 mechanic) from all three travel lines, replaced with the wiki's **Quetzal Transport System -> Quetzacalli Gorge** route (pendant of ates teleports directly once unlocked).

## Receipt (raw)
- The Hueycoatl/Strategies (wiki): "the three pillars located west of the head" / "Players can charge the blue, red, and green pillars by praying Protect from Magic, Protect from Melee, and Protect from Missiles respectively" / "Once the path to the summit opens, the Hueycoatl can be attacked directly."
- Travel (wiki): "Using the Quetzal Transport System to reach Quetzacalli Gorge, then running ... around the mountain"; lodestones are RS3-only (`/w/Lodestone` -> Waystone).
- Wiki: https://oldschool.runescape.wiki/w/The_Hueycoatl/Strategies

## Verification
- Single-source edit (source travelTip + 2 step descriptions + 1 step travelTip). JSON parses; no lodestone remains in the source. No IDs/rates/loop markers touched. Privacy clean. Skeptic-confirmed.
