### PR TITLE
fix(data): Large Salvage - correct Sailing level requirement to 53

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -31099,7 +31099,7 @@
       "skills": [
         {
           "skill": "SAILING",
-          "level": 45
+          "level": 53
         }
       ]
     }


### PR DESCRIPTION
## Summary
Corrects the Sailing level requirement for Large Salvage (source tail audit). Large Salvage requires **Sailing 53**, not 45.

## Receipt
- Salvage / Sailing (wiki): Large Salvage tier requires Sailing 53.

## Verification
- Single-source requirements edit (one level field). JSON parses. No other fields touched. Privacy clean. Skeptic-confirmed.
