### PR TITLE
fix(data): Martial Salvage - correct Sailing level requirement to 73

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -31236,7 +31236,7 @@
       "skills": [
         {
           "skill": "SAILING",
-          "level": 65
+          "level": 73
         }
       ]
     }


### PR DESCRIPTION
## Summary
Martial Salvage requires **Sailing 73**, not 65 (source tail audit).

## Verification
- Single-source requirements edit. JSON parses. Privacy clean. Skeptic-confirmed.
