### PR TITLE
fix(data): Fremennik Salvage - correct Sailing level requirement to 80

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -31294,7 +31294,7 @@
       "skills": [
         {
           "skill": "SAILING",
-          "level": 70
+          "level": 80
         }
       ]
     }


### PR DESCRIPTION
## Summary
Fremennik Salvage requires **Sailing 80**, not 70 (source tail audit).

## Verification
- Single-source requirements edit. JSON parses. Privacy clean. Skeptic-confirmed.
