### PR TITLE
fix(data): Opulent Salvage - correct Sailing level requirement to 87

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -31387,7 +31387,7 @@
       "skills": [
         {
           "skill": "SAILING",
-          "level": 80
+          "level": 87
         }
       ]
     }


### PR DESCRIPTION
## Summary
Opulent Salvage requires **Sailing 87**, not 80 (source tail audit).

## Verification
- Single-source requirements edit. JSON parses. Privacy clean. Skeptic-confirmed.
