### PR TITLE
fix(data): Prifddinas Rabbit - correct location to Gwenith Hunter cave

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -32333,7 +32333,7 @@
         "milestoneKills": 1
       }
     ],
-    "locationDescription": "Prifddinas, south-east corner (Ithell district)",
+    "locationDescription": "Elven rabbit cave, Gwenith Hunter area north of Prifddinas",
     "travelTip": "Teleport crystal or Moonclan teleport -> Prifddinas; or fairy ring AJS -> run north",
     "requirements": {
       "quests": [
@@ -32344,7 +32344,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to Prifddinas (requires Song of the Elves). Use a teleport crystal, Moonclan teleport, or fairy ring AJS. The rabbit spawns in the south-east corner of the city (Ithell district).",
+        "description": "Travel to Prifddinas (requires Song of the Elves). Use a teleport crystal, Moonclan teleport, or fairy ring AJS. The rabbit is in the Elven rabbit cave in the Gwenith Hunter area north of the city - exit through the northern gates and head north.",
         "worldX": 3267,
         "worldY": 6082,
         "worldPlane": 0,
@@ -32354,7 +32354,7 @@
         "section": "Travel"
       },
       {
-        "description": "Locate and kill the Prifddinas Rabbit in the south-east corner of the city. The rabbit has very low combat level (level 2) so any attack style works. This is a one-off guaranteed drop - only one Crystal grail exists.",
+        "description": "Locate and kill the Prifddinas Rabbit in the Elven rabbit cave (Gwenith Hunter area, north of the city). The rabbit has very low combat level (level 2) so any attack style works. This is a one-off guaranteed drop - only one Crystal grail exists.",
         "worldX": 3267,
         "worldY": 6082,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary
Corrects the Prifddinas Rabbit location prose (source tail audit).

The guidance placed the rabbit in the **south-east (Ithell) corner of the city**. It is actually in the **Elven rabbit cave in the Gwenith Hunter area, north of Prifddinas** (outside the city walls). Fixed locationDescription + both steps.

## Receipt (raw)
- Rabbit (Prifddinas) (wiki): "found in a cave in the Gwenith Hunter area north of Prifddinas ... not located in the south-east corner of the city. The cave itself is called the Elven rabbit cave."
- Wiki: https://oldschool.runescape.wiki/w/Rabbit_(Prifddinas)

## Verification
- Single-source, prose-only edit (locationDescription + 2 steps). **Coords not changed** — the step worldX/worldY (3267/6082, ~city centre) also appear inaccurate vs the cave spawn, but correcting actuation coordinates needs in-game verification, so they are intentionally left for a follow-up (flagged). No IDs/rates/loop markers touched. Privacy clean. Skeptic-confirmed.
