### PR TITLE
fix(data): Medium Treasure Trails - remove fabricated wizard fights, fix instrument NPCs

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -26453,7 +26453,7 @@
         ]
       },
       {
-        "description": "Complete all clue steps with the RuneLite Clue Scroll plugin. Medium clues introduce coordinate clues (Spade required), puzzle boxes, and mid-level wizard fights (level 27 Saradomin / Zamorak / Guthix wizards) - use Protect from Magic when one spawns. Always carry a Sextant / Watch / Chart from Trinitus before the clue starts for instant coordinate solves.",
+        "description": "Complete all clue steps with the RuneLite Clue Scroll plugin. Medium clues introduce coordinate clues (Spade required) and puzzle boxes (no antagonist fights - combat steps start at hard clues). A Sextant (Murphy at Port Khazard), Watch (Brother Kojo at the Clock Tower), and Chart (the Observatory professor) solve coordinate clues, though the plugin handles them automatically.",
         "worldX": 3165,
         "worldY": 3487,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary
Two corrections to the Medium Treasure Trails guidance (source tail audit).

- **No wizard fights:** medium clues have **no antagonist combat** — fights begin at hard clues. Removed the fabricated "mid-level wizard fights (level 27 Saradomin/Zamorak/Guthix wizards)" claim.
- **Navigation instruments:** the sextant, watch, and chart are **not** from "Trinitus". Sextant from **Murphy** (Port Khazard), Watch from **Brother Kojo** (Clock Tower), Chart from the **Observatory professor**.

## Receipt (raw)
- Treasure Trails (wiki): "In hard and higher-levelled Treasure Trails, some steps will require the player to fight a random enemy" — medium clues list N/A for antagonists.
- Navigation (wiki): "A chart can be obtained from the Observatory professor at the Observatory"; sextant from Murphy (Port Khazard); watch from Brother Kojo (Clock Tower).
- Wiki: https://oldschool.runescape.wiki/w/Treasure_Trails

## Verification
- Single-source, single-line prose edit. No IDs/rates/loop markers touched. Privacy clean. Skeptic-confirmed.
