### PR TITLE
fix(data): Elite Treasure Trails - no double-agents; geode source; guards

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -27899,7 +27899,7 @@
     "locationDescription": "Grand Exchange",
     "guidanceSteps": [
       {
-        "description": "Travel to the Grand Exchange with a spade, a Stethoscope, a sextant + watch + chart (for coordinate clues), light-imbuable teleport jewellery, a Stamina potion, and combat gear for the elite double-agents and demi-boss fights",
+        "description": "Travel to the Grand Exchange with a spade, a Stethoscope, a sextant + watch + chart (for coordinate clues), light-imbuable teleport jewellery, a Stamina potion, and combat gear for the Armadylean/Bandosian guards (coordinate clues) and demi-boss fights",
         "worldX": 3165,
         "worldY": 3487,
         "worldPlane": 0,
@@ -27912,7 +27912,7 @@
         "section": "Travel"
       },
       {
-        "description": "Obtain an elite clue scroll from a boss drop (Vorkath, Zulrah, Cerberus, Hydra, Barrows reward casket), a slayer monster, or by opening Dragon impling jars (1/50 per jar). Elite clues also drop from elite clue geodes while mining gem rocks and motherlode mine",
+        "description": "Obtain an elite clue scroll from a boss drop (Vorkath, Zulrah, Cerberus, Hydra, Barrows reward casket), a slayer monster, or by opening Dragon impling jars (1/50 per jar). Elite clues also drop from elite clue geodes while mining gem rocks and ore rocks (gold, mithril, adamantite, runite)",
         "worldX": 3165,
         "worldY": 3487,
         "worldPlane": 0,
@@ -27922,7 +27922,7 @@
         "loopCount": 1
       },
       {
-        "description": "Complete all clue steps with the RuneLite Clue Scroll plugin. Elite clues add cryptic chains, hot/cold coordinates, dual cryptic clues with two locations per step, and level 84-210 elite double-agents - bring Protect from Melee and a Ranged or Magic weapon",
+        "description": "Complete all clue steps with the RuneLite Clue Scroll plugin. Elite clues add cryptic chains, hot/cold coordinates, dual cryptic clues with two locations per step, and Armadylean or Bandosian guards on coordinate clues (elite clues have no double-agents) - bring Protect from Melee and a Ranged or Magic weapon",
         "worldX": 0,
         "worldY": 0,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary
Three corrections to the Elite Treasure Trails guidance (source tail audit).

- **No elite double-agents:** the double-agent mechanic is for **hard** (level 65/108) and **master** (level 141) clues. Elite coordinate clues instead spawn **Armadylean or Bandosian guards**. Fixed both the gear-prep step and the clue-types step (the "level 84-210 elite double-agents" figure was fabricated).
- **Clue geode source:** elite clue geodes come from mining **gem and ore rocks** (gold/mithril/adamantite/runite), **not the Motherlode Mine**.

## Receipt (raw)
- Treasure Trails / Double agent (wiki): "level 108 for hard clues outside of the Wilderness and 65 within ... level 141 for master clues. Level 141 Double agents were added to the cache, presumably to appear when doing Elite clue scrolls, but were unused." Elite coordinate clues "require the player to fight an Armadylean guard or a Bandosian guard."
- Clue geode (elite) (wiki): obtained from Mining (gem rocks, gold/mithril/adamantite/runite rocks) — Motherlode Mine not listed.
- Wiki: https://oldschool.runescape.wiki/w/Clue_scroll_(elite)

## Verification
- Single-source edit (three step descriptions). JSON parses. No IDs/rates/loop markers touched. Privacy clean. Skeptic-confirmed.
