### PR TITLE
fix(data): Beginner Treasure Trails - Emir's Arena not Duel arena

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -9775,7 +9775,7 @@
     "locationDescription": "Grand Exchange",
     "guidanceSteps": [
       {
-        "description": "Travel to the Grand Exchange with a Spade, a charged Ring of duelling for Castle Wars / Duel arena teleports, and a Stamina potion. The RuneLite Clue Scroll plugin will guide each individual step in-game; no combat gear is needed for beginner clues.",
+        "description": "Travel to the Grand Exchange with a Spade, a charged Ring of duelling for Castle Wars / Emir's Arena teleports, and a Stamina potion. The RuneLite Clue Scroll plugin will guide each individual step in-game; no combat gear is needed for beginner clues.",
         "worldX": 3165,
         "worldY": 3487,
         "worldPlane": 0,


### PR DESCRIPTION
## What

Beginner-clue travel step labelled the ring-of-dueling destination as "Duel arena". The Duel Arena was renamed **Emir's Arena** (Al Kharid PvP Arena) in the 13 July 2022 update; the ring of dueling teleport now lands the player at Emir's Arena.

`description`: `Castle Wars / Duel arena teleports` → `Castle Wars / Emir's Arena teleports`

## Receipt

OSRS Wiki, [Emir's Arena](https://oldschool.runescape.wiki/w/Emir's_Arena): *"The Emir's Arena, also known as the Al Kharid PvP Arena, is a minigame that replaced the Duel Arena... Players will arrive here if they use the ring of dueling teleport."*

## Scope / safety

- One source (Beginner Treasure Trails), description text only — no item ids, rates, requirements, or loop markers touched.
- `D3Batch6RegressionTest` / `ClueCompletionEstimatorTest` assert structural properties (step counts, arrive-step, section labels), not this string.
- Part of the retroactive "Duel Arena → Emir's Arena" class sweep (sibling: Mage Training Arena).