### PR TITLE
fix(data): Mage Training Arena - Emir's Arena not 'Duel Arena ruins'

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -14654,7 +14654,7 @@
     },
     "guidanceSteps": [
       {
-        "description": "Travel to the Mage Training Arena north-east of Al Kharid. Ring of dueling to Emir's Arena is fastest; alternatively teleport to Al Kharid and run north-east past the Duel Arena ruins",
+        "description": "Travel to the Mage Training Arena north-east of Al Kharid. Ring of dueling to Emir's Arena is fastest; alternatively teleport to Al Kharid and run north-east past Emir's Arena",
         "worldX": 3363,
         "worldY": 3316,
         "worldPlane": 0,


### PR DESCRIPTION
## What

Mage Training Arena travel step's alternative walking route referenced the **"Duel Arena ruins"**. Two problems:

1. The Duel Arena was renamed **Emir's Arena** on 13 July 2022.
2. It is not "ruins" — the complex was restored ("once again being used as a fighting ground").

`description`: `run north-east past the Duel Arena ruins` → `run north-east past Emir's Arena`

The same step already correctly names "Emir's Arena" for the ring-of-dueling method; this aligns the walking landmark. Geography unchanged: running NE from the Al Kharid teleport toward the MTA passes the Emir's Arena.

## Receipt

OSRS Wiki, [Emir's Arena](https://oldschool.runescape.wiki/w/Emir's_Arena): *"...the arena once again being used as a fighting ground, with increased control and heightened security"* — a restored complex that **replaced the Duel Arena**.

## Scope / safety

- One source (Mage Training Arena), description text only — no ids/rates/requirements/loop markers.
- `D4Batch12a2aRegressionTest` asserts structural properties (step counts, arrive-step, loop, section labels), not this string.
- Second and final source in the "Duel Arena → Emir's Arena" class sweep (sibling: Beginner Treasure Trails #977). Corpus has **0** remaining "Duel Arena" refs after both merge.