### PR TITLE
fix(data): Boat Paints - Sailors' amulet reaches its marked ports (default The Pandemonium), not 'any port'

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -18581,7 +18581,7 @@
       }
     ],
     "locationDescription": "Port Sarim docks, obtained via various Sailing activities",
-    "travelTip": "Sailors' amulet -> any port, complete port tasks or salvage for paints",
+    "travelTip": "Sailors' amulet -> The Pandemonium or nearest port, complete port tasks or salvage for paints",
     "guidanceSteps": [
       {
         "worldX": 1824,


### PR DESCRIPTION
Align travelTip with corpus standard 'Sailors' amulet -> The Pandemonium or nearest port'. Wiki: amulet reaches Pandemonium/Port Roberts/Red Rock/Deepfin Point only; Pandemonium is default. Detected by toolkit detector #89.