### PR TITLE
fix(data): Fishy Salvage - Sailors' amulet reaches its marked ports (default The Pandemonium), not 'any port'

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -30948,7 +30948,7 @@
       }
     ],
     "locationDescription": "Sorting salvage obtained from Sailing voyages",
-    "travelTip": "Sailors' amulet to any port, board boat, sail to salvage",
+    "travelTip": "Sailors' amulet to The Pandemonium or nearest port, board boat, sail to salvage",
     "guidanceSteps": [
       {
         "description": "Travel to any Sailing port. Use Sailors' amulet for fast teleport, or walk to Port Sarim docks.",


### PR DESCRIPTION
Align this Sailing source's source-level travelTip with the corpus standard: `Sailors' amulet -> The Pandemonium or nearest port`. The OSRS Sailors' amulet teleports only to its 4 Sailors'-Marker ports — The Pandemonium (default), Port Roberts, Red Rock, Deepfin Point — not "any port". Receipt (live wiki 2026-06-13): the Sailors' amulet page lists exactly those 4 destinations, Pandemonium default-unlocked with a notice board + salvaging station + dock; 6 'Boat Combat' Sailing sources already use this phrasing. Detected by toolkit detector #89. Prose-only; travelTip-non-blank invariant preserved.