### PR TITLE
fix(data): Port Tasks - Sailors' amulet reaches its marked ports (default The Pandemonium), not 'any port'

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -32282,7 +32282,7 @@
       }
     ],
     "locationDescription": "Port tasks from sailing ports",
-    "travelTip": "Sailors' amulet -> any port -> notice board",
+    "travelTip": "Sailors' amulet -> The Pandemonium or nearest port -> notice board",
     "guidanceSteps": [
       {
         "description": "Travel to any Sailing port. Use the Sailors' amulet for fast teleportation, or walk to Port Sarim docks. Accept tasks from the Port Notice Board at the port.",
@@ -32291,7 +32291,7 @@
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
-        "travelTip": "Sailors' amulet -> any port; or walk to Port Sarim",
+        "travelTip": "Sailors' amulet -> The Pandemonium or nearest port; or walk to Port Sarim",
         "section": "Travel"
       },
       {


### PR DESCRIPTION
Align this Sailing source's source-level travelTip with the corpus standard: `Sailors' amulet -> The Pandemonium or nearest port`. The OSRS Sailors' amulet teleports only to its 4 Sailors'-Marker ports — The Pandemonium (default), Port Roberts, Red Rock, Deepfin Point — not "any port". Receipt (live wiki 2026-06-13): the Sailors' amulet page lists exactly those 4 destinations, Pandemonium default-unlocked with a notice board + salvaging station + dock; 6 'Boat Combat' Sailing sources already use this phrasing. Detected by toolkit detector #89. Prose-only; travelTip-non-blank invariant preserved.