### PR TITLE
fix(data): Sailing Misc - Sailors' amulet reaches its marked ports (default The Pandemonium), not 'any port'

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -20262,7 +20262,7 @@
       }
     ],
     "locationDescription": "Various Sailing activities and island exploration",
-    "travelTip": "Sailors' amulet -> any port, board boat for various Sailing activities",
+    "travelTip": "Sailors' amulet -> The Pandemonium or nearest port, board boat for various Sailing activities",
     "guidanceSteps": [
       {
         "worldX": 1824,


### PR DESCRIPTION
Align this Sailing source's source-level travelTip with the corpus standard: `Sailors' amulet -> The Pandemonium or nearest port`. The OSRS Sailors' amulet teleports only to its 4 Sailors'-Marker ports — The Pandemonium (default), Port Roberts, Red Rock, Deepfin Point — not "any port". Receipt (live wiki 2026-06-13): the Sailors' amulet page lists exactly those 4 destinations, Pandemonium default-unlocked with a notice board + salvaging station + dock; 6 'Boat Combat' Sailing sources already use this phrasing. Detected by toolkit detector #89. Prose-only; travelTip-non-blank invariant preserved.