### PR TITLE
fix(data): Narwhal (Boat Combat) - Dragon nails drops at 1/75, not 1/150

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -30498,7 +30498,7 @@
       {
         "itemId": 31406,
         "name": "Dragon nails",
-        "dropRate": 0.006667,
+        "dropRate": 0.013333,
         "isPet": false,
         "wikiPage": "Dragon_nails"
       },


### PR DESCRIPTION
## Summary
Corrects the Narwhal (Boat Combat) **Dragon nails** drop rate from `0.006667` (1/150) to `0.013333` (1/75).

## Evidence
The OSRS Wiki Narwhal drop table lists a single per-kill row:
> `Dragon nails | qty: 3-7, 5-10 | rarity: 1/75`

with the note *"The quantity is increased to 5-10 while on a Narwhal bounty task."*

The bounty task modifies **quantity only**, not rarity. There is no aggregate, blended, variant, or account-type mechanic that produces 1/150 — the stored value was half the authoritative base rate (an auto-grab artifact).

## Verification
- `validate_drop_rates --check all --source Narwhal`: passed, no issues.
- JSON parses clean.
- One source, one field changed.

Source: https://oldschool.runescape.wiki/w/Narwhal