### PR TITLE
fix(data): Great White Shark (Boat Combat) - correct two drop rates to wiki base

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -30670,7 +30670,7 @@
       {
         "itemId": 31996,
         "name": "Dragon metal sheet",
-        "dropRate": 0.000651,
+        "dropRate": 0.005,
         "isPet": false,
         "wikiPage": "Dragon_metal_sheet"
       },
@@ -30684,7 +30684,7 @@
       {
         "itemId": 31961,
         "name": "Broken dragon hook",
-        "dropRate": 0.000978,
+        "dropRate": 0.002,
         "isPet": false,
         "wikiPage": "Broken_dragon_hook"
       },


### PR DESCRIPTION
## Summary
Corrects two Great White Shark (Boat Combat) drop rates to the wiki per-creature base rates:

| Item | Before | After |
|---|---|---|
| Dragon metal sheet | 0.000651 (1/1536) | **0.005 (1/200)** |
| Broken dragon hook | 0.000978 (1/1022) | **0.002 (1/500)** |

## Evidence
The Great White Shark drop table (NPC 15200, matching this source's `npcId`) lists:
> `Dragon metal sheet | qty: 1-2 | rarity: 1/200` (raw: `~1/200; ~1/100`, footnote *"drop rate is increased on a bounty task"*)
> `Broken dragon hook | qty: 1 | rarity: 1/500` (raw: `1/500; 1/250`)

Both stored values were **rarer than the wiki base rate**, and the only documented modifier (bounty tasks) makes drops *commoner*, not rarer — so no game mechanic explains them. Confirmed against the creature's own per-creature table (NPC-ID matched), not an item-page aggregate.

## Verification
- `validate_drop_rates --check all --source 'Great White Shark'`: passed.
- JSON parses clean. One source, two fields.

Source: https://oldschool.runescape.wiki/w/Great_white_shark