### PR TITLE
fix(data): Vampyre Kraken (Boat Combat) - correct two drop rates to wiki base

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -30770,7 +30770,7 @@
       {
         "itemId": 31996,
         "name": "Dragon metal sheet",
-        "dropRate": 0.001953,
+        "dropRate": 0.006667,
         "isPet": false,
         "wikiPage": "Dragon_metal_sheet"
       },
@@ -30784,7 +30784,7 @@
       {
         "itemId": 31949,
         "name": "Bottled storm",
-        "dropRate": 0.001953,
+        "dropRate": 0.003333,
         "isPet": false,
         "wikiPage": "Bottled_storm"
       },


### PR DESCRIPTION
## Summary
Corrects two Vampyre Kraken (Boat Combat) drop rates to the wiki per-creature base rates:

| Item | Before | After |
|---|---|---|
| Dragon metal sheet | 0.001953 (1/512) | **0.006667 (1/150)** |
| Bottled storm | 0.001953 (1/512) | **0.003333 (1/300)** |

## Evidence
The Vampyre Kraken drop table (NPC 15212) raw wikitext:
> `{{DropsLine|name=Dragon metal sheet|quantity=1-2|rarity=1/150|altrarity=~1/75|...}}`
> `{{DropsLine|name=Bottled storm|quantity=1|rarity=1/300|altrarity=~1/150|...}}`

The plugin stores **base** rates; `altrarity` is the bounty-task multiplier (commoner, not rarer). Both stored values were an identical `1/512` — matching neither the base nor the bounty rate for either item (an auto-grab placeholder). Confirmed against the creature's own per-creature table, not an item-page aggregate.

Note: `Dragon metal sheet` (31996) and `Bottled storm` (31949) also appear under other Sailing sources at their own rates — that multi-source overlap is intentional and untouched here.

## Verification
- `validate_drop_rates --check all --source 'Vampyre Kraken'`: passed.
- JSON parses clean. One source, two fields.

Source: https://oldschool.runescape.wiki/w/Vampyre_kraken