### PR TITLE
fix(data): Fishy Salvage - requires Sailing 26, not 25

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -30976,7 +30976,7 @@
       "skills": [
         {
           "skill": "SAILING",
-          "level": 25
+          "level": 26
         }
       ]
     }


### PR DESCRIPTION
## Summary
Corrects the Fishy Salvage requirement from `SAILING 25` to `SAILING 26`.

## Evidence
OSRS Wiki Fishy salvage page:
> *"Level 26 Sailing is required to salvage these, granting 17 experience."*

The data convention for salvage tiers is the wiki's *"Level X Sailing is required to salvage these"* number, and every other tier already matches exactly (Small 15, Barracuda 35, Large 53, Plundered 64, Martial 73, Fremennik 80, Opulent 87). Fishy was the lone off-by-one. `wiki_updates` shows the page unchanged since launch — not a staleness artifact; salvaging gates are unboostable hard requirements.

## Verification
- `validate_drop_rates --check all --source 'Fishy Salvage'`: passed.
- JSON parses clean. One source, one field.

Source: https://oldschool.runescape.wiki/w/Fishy_salvage