### PR TITLE
fix(data): Boat Paints - gate at obtain floor (Sailing 1), drop spurious Construction req

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -18594,7 +18594,7 @@
         "section": "Travel"
       },
       {
-        "description": "Board your boat and earn boat paints through Sailing activities: port tasks (Shark paint, common), Barracuda Trials Marlin rank (Barracuda paint), Martial salvage (Salvor's paint, rare), kraken variant drops (Inky paint, rare). Deity paints require fully charting the corresponding ocean and completing an NPC hand-in. Apply paints at the Shipyard boat schematics board (25 Construction required).",
+        "description": "Board your boat and earn boat paints through Sailing activities: port tasks (Shark paint, common), Barracuda Trials Marlin rank (Barracuda paint), Martial salvage (Salvor's paint, rare), kraken variant drops (Inky paint, rare). Deity paints require fully charting the corresponding ocean and completing an NPC hand-in. Apply paints at the Shipyard boat schematics board (20 Construction required).",
         "worldX": 1824,
         "worldY": 3691,
         "worldPlane": 0,
@@ -18611,11 +18611,7 @@
       "skills": [
         {
           "skill": "SAILING",
-          "level": 28
-        },
-        {
-          "skill": "CONSTRUCTION",
-          "level": 25
+          "level": 1
         }
       ]
     }


### PR DESCRIPTION
## Summary
Changes the Boat Paints requirement from `SAILING 28 + CONSTRUCTION 25` to **`SAILING 1`** (Construction requirement removed), and corrects the guidance's apply-note from "25 Construction" to "20 Construction".

## Rationale
`Boat Paints` is a collection-log **source**: its requirement should be the level to start *obtaining* paints into the log, not to *apply* them to a boat.

- The easiest paint, **Shark paint**, drops from **port tasks at SAILING 1** (per the sibling `Port Tasks` source, listed as a mutually-exclusive source here).
- The stored `SAILING 28 + CONSTRUCTION 25` had no wiki basis:
  - Applying paints needs **Construction 20**, not 25 (wiki, identical across paint pages: *"Trimming a boat requires level 25 Sailing and 20 Construction"*).
  - **No Construction at all** is required to *obtain* paints — they are activity drops.

So the obtain floor for the source is SAILING 1, and the Construction requirement is dropped entirely. The guidance text's apply-note is corrected to 20 Construction for internal accuracy.

## Verification
- `validate_drop_rates --check all --source 'Boat Paints'`: passed.
- JSON parses clean. One source.

Sources: https://oldschool.runescape.wiki/w/Barracuda_paint , https://oldschool.runescape.wiki/w/Shark_paint