### PR TITLE
fix(data): Shellbane Gryphon - correct placeholder coords to The Great Conch entrance

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -24009,8 +24009,8 @@
   {
     "name": "Shellbane Gryphon",
     "category": "BOSSES",
-    "worldX": 13993,
-    "worldY": 9901,
+    "worldX": 3176,
+    "worldY": 2477,
     "worldPlane": 0,
     "killTimeSeconds": 36,
     "requirements": {
@@ -24078,8 +24078,8 @@
       },
       {
         "description": "Travel to The Great Conch and locate the Shellbane Gryphon Cave entrance in the centre of the island, north of fairy ring CJQ. Take fairy ring CJQ or a Quetzal whistle to The Great Conch, then head north to the cave entrance",
-        "worldX": 13993,
-        "worldY": 9901,
+        "worldX": 3176,
+        "worldY": 2477,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
@@ -24088,8 +24088,8 @@
       },
       {
         "description": "Enter the cave to descend to the Shellbane Gryphon arena. The cave is instanced, so no other players will interfere with the fight",
-        "worldX": 13993,
-        "worldY": 9901,
+        "worldX": 3176,
+        "worldY": 2477,
         "worldPlane": 0,
         "objectId": 58439,
         "objectInteractAction": "Enter",
@@ -24098,8 +24098,8 @@
       },
       {
         "description": "Kill the Shellbane Gryphon. Active gryphon Slayer task required. Use Protect from Melee; the gryphon is primarily weak to melee - attack with your best melee setup. Keep the Tortugan shield equipped at all times (heavy damage without it). Maintain >= 40kg equipped weight to counter the knockback special attack. Respond to the corrosive spit (move) and whirlwind (move) specials as they occur. Slayer helmet (i) on-task for the damage bonus",
-        "worldX": 13993,
-        "worldY": 9901,
+        "worldX": 3176,
+        "worldY": 2477,
         "worldPlane": 0,
         "npcId": 14860,
         "interactAction": "Attack",


### PR DESCRIPTION
## Summary

The `Shellbane Gryphon` source carried the out-of-bounds placeholder coordinate `(13993, 9901)` in all four of its `worldX`/`worldY` slots (the source-level coord plus guidance steps 2–4). `travel_path_verify` flagged the three step coords as *"outside legal OSRS world bounds (x 900..4500, y 1100..13500)"* (high severity, ×3).

## Fix

Corrected all four to `(3176, 2477, plane 0)`.

## Evidence

- **Game cache:** `object_lookup(58439)` — the cave-entrance object the Enter-cave step already references (`objectId: 58439`, morphs to `58440` "Cave entrance") — has exactly one placed spawn at `(3176, 2477, plane 0)`.
- **Geography:** the wiki places The Great Conch in the Unquiet Ocean *south of Menaphos*; `(3176, 2477)` sits ~343 tiles south of Sophanem and validates as a legal surface tile.
- The instanced kill step (`npcId 14860`, `ACTOR_DEATH`) is anchored to the same entrance tile; completion is NPC-driven, not tile-driven, so the anchor is cosmetic but must still be in-bounds.

## Validation

`travel_path_verify` now reports `ok: true` with zero findings. `build`/`test` and the data lints are green locally; CI is the authoritative gate.
