### PR TITLE
fix(data): Ogress Shaman - correct placeholder coords to Corsair Cove Dungeon

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -31842,9 +31842,9 @@
   {
     "name": "Ogress Shaman",
     "category": "OTHER",
-    "worldX": 2459,
-    "worldY": 9488,
-    "worldPlane": 2,
+    "worldX": 2002,
+    "worldY": 8989,
+    "worldPlane": 1,
     "killTimeSeconds": 14,
     "afkLevel": 2,
     "items": [
@@ -31877,18 +31877,18 @@
     "guidanceSteps": [
       {
         "description": "Travel to the Corsair Cove (spirit tree or charter ship from Port Sarim). Head south to the cave dungeon entrance.",
-        "worldX": 2459,
-        "worldY": 9488,
-        "worldPlane": 2,
+        "worldX": 2523,
+        "worldY": 2861,
+        "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
         "section": "Travel"
       },
       {
         "description": "Enter the Corsair Cove Dungeon through the cave entrance south of the cove.",
-        "worldX": 2459,
-        "worldY": 9488,
-        "worldPlane": 2,
+        "worldX": 2523,
+        "worldY": 2861,
+        "worldPlane": 0,
         "objectId": 31791,
         "objectInteractAction": "Enter",
         "completionCondition": "ARRIVE_AT_TILE",
@@ -31897,9 +31897,9 @@
       },
       {
         "description": "Kill Ogress Shamans in the Corsair Cove Dungeon. They use Magic attacks -- Protect from Magic strongly recommended. Shaman mask is the rare cosmetic drop.",
-        "worldX": 2459,
-        "worldY": 9488,
-        "worldPlane": 2,
+        "worldX": 2002,
+        "worldY": 8989,
+        "worldPlane": 1,
         "npcId": 7991,
         "interactAction": "Attack",
         "completionCondition": "ACTOR_DEATH",


### PR DESCRIPTION
Corrects the `Ogress Shaman` source, whose anchor and all three guidance steps used the placeholder `(2459,9488,plane 2)` — a tile that holds no Ogress Shaman and is on the wrong plane.

### Evidence (raw, from the runelite-dev MCP)
- `npc_spawns(7991)` → 16 spawns, all at `(1962–2035, 8965–9080, plane 1)`; none within ~400 tiles of the old coord.
- `npc_spawns` over box `(2300–2700, 9300–9700, plane 2)` → no ogress spawns at the old coord.
- `object_lookup(31791)` (the Enter step's "cave entrance") = "Hole" at `(2523,2861, plane 0)`.
- Plane: mejrs-plane == repo data-plane (calibrated against Cave Horror `(3740,9373,p0)`, mejrs p0); ogress spawns are mejrs p1, so the dungeon plane is **1**, not the stored 2.

### Fix (per-step)
| Step | Old | New |
|---|---|---|
| Travel | (2459,9488,p2) | (2523,2861,p0) surface entrance |
| Enter (obj 31791) | (2459,9488,p2) | (2523,2861,p0) surface entrance |
| Combat (npc 7991) | (2459,9488,p2) | (2002,8989,p1) ogress spawn tile |
| Source anchor | (2459,9488,p2) | (2002,8989,p1) ogress spawn tile |

Same class as #998 (Shellbane Gryphon). Bounds guard (`travel_path_verify`) clean; gated through the domain-skeptic (survives). The guidance_lint INFO about step[1] being 6150 tiles from the source anchor is expected — it reflects the intentional surface-entrance vs underground-combat split.

In-game plane is worth a seam spot-check, but the mejrs calibration makes p1 well-supported.

Closes #1002
