### PR TITLE
fix(data): Skeletal Wyvern - drop wrong objectId 30100 from AID trapdoor step

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -12016,8 +12016,6 @@
         "worldX": 3008,
         "worldY": 3150,
         "worldPlane": 0,
-        "objectId": 30100,
-        "objectInteractAction": "Climb-down",
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 8,
         "section": "Travel"


### PR DESCRIPTION
Closes #1004.

## What
Remove the wrong `objectId: 30100` (+ its `objectInteractAction`) from **Skeletal Wyvern** `guidanceSteps[2]` ("Enter the Asgarnian Ice Dungeon trapdoor").

## Why
The game cache resolves objectId 30100 to **"Armed Forces Report"** — a Varlamore readable document, no actions, sole spawn at (1538, 10224) — not a trapdoor, and nowhere near the Port Sarim AID entrance at the step's own coord (3008, 3150). The id appears only here; it was introduced in #644.

The step is `ARRIVE_AT_TILE` (completionDistance 8), so the objectId only drives the highlight overlay — a wrong id mis-highlights but completion still works. No cache/mejrs-confirmed AID-trapdoor id exists at that tile to substitute (the project rule forbids assigning an id the cache can't confirm), so removal is the conservative fix; it matches the source's sibling steps, which carry no objectId.

## Verification
- `object_lookup(30100)` → `"Armed Forces Report" — Actions: none — (1538,10224)` (RAW cache receipt in #1004).
- JSON re-parses (226 sources); step count unchanged (6 steps), so `D3Batch5RegressionTest` (asserts `guidanceSteps >= 5`) still passes.
- `guidance_lint Skeletal Wyvern`: no new critical/warning; one benign INFO ("description implies object interaction, no objectId") that already exists identically on step[5] ("Climb back up the ladder") in this same source.
- Domain-skeptic refutation pass: SURVIVES.

One source per PR.
