### PR TITLE
fix(data): Lava Strykewyrm - correct stale Dragon metal sheet rate 1/400 -> 1/115

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -11661,7 +11661,7 @@
       {
         "itemId": 31996,
         "name": "Dragon metal sheet",
-        "dropRate": 0.0025,
+        "dropRate": 0.008696,
         "isPet": false,
         "wikiPage": "Dragon_metal_sheet"
       }


### PR DESCRIPTION
Closes #1006.

## What
Correct **Lava Strykewyrm** → Dragon metal sheet (31996) `dropRate` from `0.0025` (1/400) to `0.008696` (**1/115**).

## Why
The stored 1/400 is the pre-Sailing rate. Sailing released 19 Nov 2025 and the Lava Strykewyrm changelog notes its dragon metal sheet drop rate was **increased**; the current OSRS Wiki drop table (NPC ID 15500, matching our `npcId`) lists it at **1/115**:
```
Dragon metal sheet | qty: 1 | rarity: 1/115
```
Kills are on-task-only (table rate = effective rate, no multi-roll/scaling). The item is legitimately multi-source, but 1/400 matches none of the other sources' rates — it's simply stale, not a misattribution. Domain-skeptic: SURVIVES (high).

## Verification
- RAW wiki receipt in #1006; cross-checked that the Sailing wiring on this source (Charred Island, 60 Sailing requirement) is correct live content (Sailing live since 2025-11-19).
- JSON re-parses (226 sources); only this one rate changed.
- No test pins this rate: `SailingSourceTriageTest` (category/steps/coords only) and `D4Batch6RegressionTest` (asserts ≥1 item with dropRate > 0; 0.008696 > 0) both still pass.

One source per PR.
