### PR TITLE
fix(data): Fishing (Swordfish) - correct Big swordfish rate 1/1200 -> 1/2500

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -29995,7 +29995,7 @@
       {
         "itemId": 7991,
         "name": "Big swordfish",
-        "dropRate": 0.000833,
+        "dropRate": 0.0004,
         "isPet": false,
         "wikiPage": "Big_swordfish"
       }


### PR DESCRIPTION
Closes #1008.

## What
Correct **Fishing (Swordfish)** → Big swordfish (7991) `dropRate` from `0.000833` (1/1200) to `0.0004` (**1/2500**).

## Why
The wiki rate is 1/2500 per raw swordfish caught (level-independent). The stored 1/1200 is ~2x too generous and self-contradicts our own data — the same item 7991 is already 0.0004 (1/2500) under the Miscellaneous source, and every sibling big-fish (Big shark 1/5000, Big bass 1/1000, Big harpoonfish 1/1600) uses the bare wiki rate. Rada's blessing / spirit-flakes doubling is explicitly clog-excluded, so it cannot justify the 2x. Domain-skeptic: SURVIVES (low).

## Verification
- RAW wiki receipt + WebFetch in #1008.
- JSON re-parses (226 sources); both 7991 entries now consistently 0.0004.
- No test pins this rate: `D4Batch3RegressionTest` only asserts Fishing (Swordfish) has `loopBackToStep > 0` (E4 loop marker), which is untouched.

One source per PR.
