### PR TITLE
fix(data): Mithril Dragon - correct Dragon full helm rate 1/8192 -> 1/32768

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -31412,7 +31412,7 @@
       {
         "itemId": 11335,
         "name": "Dragon full helm",
-        "dropRate": 0.000122,
+        "dropRate": 0.0000305,
         "isPet": false,
         "wikiPage": "Dragon_full_helm"
       },


### PR DESCRIPTION
Closes #1010.

## What
Correct **Mithril Dragon** → Dragon full helm (11335) `dropRate` from `0.000122` (1/8192) to `0.0000305` (**1/32768**).

## Why
A 2^13-vs-2^15 transcription error — the wiki drop table lists `Dragon full helm | qty: 1 | rarity: 1/32768`, but the stored 1/8192 is ~4x too generous. The source's other rates are correct (Draconic visage 1/10000, rare-table Shield left half / Dragon spear), so this is an isolated typo, not an effective-rate convention. No multi-roll / RDT / variant / staleness path yields 1/8192. Domain-skeptic: SURVIVES (high).

## Verification
- RAW wiki receipt in #1010.
- JSON re-parses (226 sources); 0.0000305 round-trips to 1/32787 (0.06% off 1/32768, well within the file's rate tolerance — cf. Chewed bones 0.76%).
- No test pins this rate: `D4Batch9RegressionTest` references the source only in its batch-shape list, with no per-item rate assertion.

One source per PR.
