### PR TITLE
fix(data): Grotesque Guardians - remove mis-attributed Granite maul (membership)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -3086,13 +3086,6 @@
         "isPet": true,
         "wikiPage": "Noon",
         "independent": true
-      },
-      {
-        "itemId": 4153,
-        "name": "Granite maul",
-        "dropRate": 0.004,
-        "isPet": false,
-        "wikiPage": "Granite_maul"
       }
     ],
     "locationDescription": "Slayer Tower rooftop, Morytania",


### PR DESCRIPTION
Closes (see linked issue).

## What
Remove **Granite maul (4153)** from the **Grotesque Guardians** `items` list — it is not a GG collection-log item.

## Why
RAW TempleOSRS membership for `grotesque_guardians` is `[21748,21730,21736,21739,21742,21745,21726]` (Noon, Black tourmaline core, Granite gloves/ring/hammer, Jar of stone, Granite dust) — no Granite maul. Granite maul is a Gargoyle clog item and stays under the repo's Gargoyle source (~1/256), so multi-source membership is preserved. abextm confirms 4153 = "Granite maul". Domain-skeptic: SURVIVES.

## Verification
- RAW Temple receipt in the linked issue.
- JSON re-parses (226 sources); GG items now `[21726,21736,21739,21742,21730,21745,21748]` (the Temple 7-item set); Gargoyle still has 4153.
- No test pins GG membership/count to 4153: the slayer/efficiency tests reference GG for guidance shape / task-only status / mocked data (the mock already models Granite maul under Gargoyle).

One source per PR.
