### PR TITLE
fix(data): Amoxliatl - remove mis-attributed Huasca seed (membership)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -23824,13 +23824,6 @@
         "isPet": true,
         "wikiPage": "Moxi",
         "independent": true
-      },
-      {
-        "itemId": 30088,
-        "name": "Huasca seed",
-        "dropRate": 0.017241,
-        "isPet": false,
-        "wikiPage": "Huasca_seed"
       }
     ],
     "locationDescription": "Ruins of Tapoyauik, Varlamore",


### PR DESCRIPTION
Closes (see linked issue).

## What
Remove **Huasca seed (30088)** from the **Amoxliatl** `items` list — it is not an Amoxliatl collection-log item.

## Why
RAW TempleOSRS membership: `"amoxliatl": [30154,29889,29892,29895]` (Moxi, Glacial temotli, Pendant of ates inert, Frozen tear) — no Huasca seed; `"hueycoatl": [...,30088]` — Huasca seed belongs to Hueycoatl, and stays under the repo's "The Hueycoatl" source. Amoxliatl drops huasca seeds as a regular herb-seed drop, but a non-clog drop must not sit in the clog `items` list. abextm confirms 30088 = "Huasca seed". Domain-skeptic: SURVIVES.

## Verification
- RAW Temple receipts in the linked issue.
- JSON re-parses (226 sources); Amoxliatl items now `[29889,29892,29895,30154]` (the Temple 4-item set); Hueycoatl still has 30088.
- No test pins Amoxliatl membership: D3Batch1RegressionTest only asserts `guidanceSteps >= 5`.

One source per PR.
