### PR TITLE
fix(data): Chompy Bird Hunting - wiki-verified guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -18917,13 +18917,13 @@
         "independent": true
       }
     ],
-    "locationDescription": "Feldip Hills, south of Rantz",
+    "locationDescription": "Feldip Hills, west of Rantz",
     "travelTip": "Fairy ring AKS -> Feldip",
     "npcId": 1475,
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to the Feldip Hills south of Rantz (fairy ring AKS). Bank for ogre bellows and an ogre bow (or comp ogre bow) before travelling. Bring bloated toads as bait.",
+        "description": "Travel to the Feldip Hills west of Rantz (fairy ring AKS). Bank for ogre bellows and an ogre bow (or comp ogre bow) before travelling. Bring bloated toads as bait.",
         "worldX": 2387,
         "worldY": 3040,
         "worldPlane": 0,


### PR DESCRIPTION
Corrects the directional prose for the fairy ring AKS chompy hunting location.

## Fix
- `locationDescription` and `guidanceSteps[0].description`: "south of Rantz" -> "west of Rantz".

## Receipt
Wiki Locations section (https://oldschool.runescape.wiki/w/Chompy_bird_hunting):
"3 ponds in the Feldip Hills west of Rantz (fairy ring code AKS)".

The routed waypoint (2387, 3040) is ~243 tiles west of Rantz at (2630, 2981), confirming west. The waypoint already routes correctly; only the descriptive word was wrong (low severity).

## Validation
- `validate_drop_rates --check cache_ids`: no new issues (pre-existing hat-label name-mismatch warnings are unrelated to this prose change).
- `guidance_lint`: no new errors (the single ACTOR_DEATH completion-distance warning is pre-existing).
