### PR TITLE
fix(data): Guardians of the Rift - wiki-verified guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -13957,7 +13957,7 @@
       }
     ],
     "locationDescription": "Temple of the Eye, accessed via portal in Wizards' Tower basement",
-    "travelTip": "Arceuus teleport -> Temple",
+    "travelTip": "Minigame Teleport / Amulet of the eye -> Temple of the Eye",
     "npcId": 12179,
     "interactAction": "Talk-to",
     "dialogOptions": [
@@ -13966,7 +13966,7 @@
     ],
     "guidanceSteps": [
       {
-        "description": "Bank for Guardians of the Rift. Bring all four pouches (giant / large / medium / small) for essence carrying, a chisel for cutting guardian fragments, a Pickaxe (rune or better) for mining the altar fragments, and a few teleports home. No combat gear needed.",
+        "description": "Bank for Guardians of the Rift. Bring all four pouches (giant / large / medium / small) for essence carrying, a chisel for cutting guardian fragments, any pickaxe for mining the altar fragments, and a few teleports home. No combat gear needed.",
         "worldX": 3185,
         "worldY": 3436,
         "worldPlane": 0,
@@ -13982,13 +13982,13 @@
         "section": "Bank prep"
       },
       {
-        "description": "Travel to Temple of the Eye via the portal in Wizards' Tower basement. Arceuus library teleport + run south-west or Mind altar teleport is also viable.",
+        "description": "Travel to Temple of the Eye via the portal in Wizards' Tower basement. Minigame Teleport or necklace of passage to Wizards' Tower is also viable.",
         "worldX": 3109,
         "worldY": 3168,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
-        "travelTip": "Arceuus library tele -> Temple of the Eye, or Mind altar tele",
+        "travelTip": "Minigame Teleport / necklace of passage -> Wizards' Tower -> Temple of the Eye",
         "section": "Travel"
       },
       {
@@ -14002,7 +14002,7 @@
         "section": "Travel"
       },
       {
-        "description": "Mine the central guardian altar fragments, cut them with the chisel to make guardian stones, deposit stones into the elemental and catalytic pillars to earn rift points, then craft runes at the rift each round. Aim for 150+ total points per round to roll the unique table; high MVP score (3000+) maximises Abyssal pearl gain.",
+        "description": "Mine the central guardian altar fragments, cut them with the chisel to make guardian stones, deposit stones into the elemental and catalytic pillars to earn rift points, then craft runes at the rift each round. Aim for 300+ total points per round to roll the unique table; high MVP score (3000+) maximises Abyssal pearl gain.",
         "worldX": 3614,
         "worldY": 9484,
         "worldPlane": 0,
@@ -14022,7 +14022,7 @@
         ]
       },
       {
-        "description": "Hand in any Intricate pouches you obtained to receive bonus rewards (Abyssal pearls / rare uniques). Then spend Abyssal pearls at the reward guardian for the Hat / Robe top / Robe bottoms / Boots / Ring of the elements / Guardian's eye.",
+        "description": "Hand in any Intricate pouches you obtained to receive bonus rewards (tarnished locket / lost bag / runes / dragon items / hard clue). Then spend Abyssal pearls at the reward guardian for the Hat / Robe top / Robe bottoms / Boots / Ring of the elements / Guardian's eye.",
         "worldX": 3624,
         "worldY": 9486,
         "worldPlane": 0,


### PR DESCRIPTION
Wiki-verified guidance corrections for the Guardians of the Rift source. Prose-only edits to `description`/`travelTip` strings; no ids, rates, coordinates, or loop markers touched.

## Fixes (with authoritative basis)

1. **Bank prep pickaxe tier** — "a Pickaxe (rune or better)" -> "any pickaxe".
   - Wiki requirements: *"Any pickaxe; A chisel (only if crafting guardians)"*. The old text wrongly told players with lower pickaxes their tool was inadequate.

2. **Top-level travelTip** — "Arceuus teleport -> Temple" -> "Minigame Teleport / Amulet of the eye -> Temple of the Eye".
   - Wiki travel methods: amulet of the eye; Minigame Teleport; necklace of passage to Wizards' Tower; fairy ring to Wizards' Tower; etc. No Arceuus teleport is listed — the route was fabricated.

3. **Travel step (Arceuus library)** — removed "Arceuus library teleport + run south-west" clause.
   - Arceuus library teleport lands in Great Kourend, nowhere near Wizards' Tower; not among the listed travel methods.

4. **Travel step (Mind altar)** — removed "or Mind altar tele" from both the description and the travelTip.
   - Mind altar teleport deposits the player north of Falador, far from Wizards' Tower; not a listed method.

5. **Minigame points threshold** — "150+ total points per round" -> "300+ total points per round".
   - Wiki changelog: *"The minimum points threshold required to receive the large experience drop at the end of the minigame has been increased from 150 to 300."* (Nov 2024).

6. **Intricate pouch rewards** — removed "Abyssal pearls" from the pouch reward parenthetical; corrected to tarnished locket / lost bag / runes / dragon items / hard clue.
   - Wiki Intricate pouch reward list contains no Abyssal pearls (those come from the Rewards Guardian, not the pouch).

## Validation
- `validate_drop_rates --check cache_ids`: clean (only a pre-existing multi-form npcId WARN, unrelated to these prose edits).
- `guidance_lint`: no new errors; remaining warnings/info are pre-existing and concern fields not touched here.
