### PR TITLE
fix(data): Shades of Mort'ton - wiki-verified guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -15016,7 +15016,7 @@
         ]
       },
       {
-        "description": "Pick up your shade key from the reward pillar inside the temple.",
+        "description": "Pick up your shade key from the pedestal next to the funeral pyre.",
         "worldX": 3495,
         "worldY": 3298,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Wiki-verified guidance correction for the Shades of Mort'ton minigame.

### Fix
- **Shade key pickup step** — changed the description from "Pick up your shade key from the reward pillar inside the temple." to "Pick up your shade key from the pedestal next to the funeral pyre." The cremation reward (a key or a stack of coins) spawns at the funeral pyre where the shade remains were burned, not inside the Flamtaer temple (a separate structure north of town).

### Authoritative basis
- OSRS Wiki, *Shades of Mort'ton (minigame)*: "An animation of a shade's spirit will float up into the air, then either a key or a stack of coins will appear on the pedestal nearby."
- OSRS Wiki, *Mort'ton*: "On the south and west sides of the town are funeral pyres for burning shade remains." and "North of the town is the Flamtaer temple, which players rebuild in the Shades of Mort'ton minigame."

Prose-only change: one line, no ids/coordinates/rates touched.
