### PR TITLE
fix(data): Hallowed Sepulchre - wiki-verified guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -13740,7 +13740,7 @@
         "section": "Bank prep"
       },
       {
-        "description": "Use Drakan's medallion to teleport to Darkmeyer. Head to the Mausoleum Door in the south-east of Darkmeyer (south of the bank, near the canal).",
+        "description": "Use Drakan's medallion to teleport to Darkmeyer. Head to the Mausoleum Door in the north-east of Darkmeyer (north-east of the bank, near the canal).",
         "worldX": 3654,
         "worldY": 3385,
         "worldPlane": 0,
@@ -13760,7 +13760,7 @@
         "section": "Travel"
       },
       {
-        "description": "Run the floors in order: 1, 2, 3, 4 (then 5 at 72+ Agility). Loot every brown coffin you pass for Hallowed marks. Strange old lockpick / Ring of endurance / Dark dye / Dark acorn rare drops only roll on floor 5 grand coffins, so prioritise getting to floor 5 every run once you can.",
+        "description": "Run the floors in order: 1, 2, 3, 4 (then 5 at 92+ Agility). Loot every brown coffin you pass for Hallowed marks. Strange old lockpick drops from coffins on every floor (better odds the higher you go); only the Ring of endurance is exclusive to floor-5 grand coffins, so prioritise getting to floor 5 every run once you can. Dark dye and Dark acorn are bought from the reward shop with marks, not dropped.",
         "worldX": 3654,
         "worldY": 3385,
         "worldPlane": 0,


### PR DESCRIPTION
Wiki-verified guidance corrections for the Hallowed Sepulchre source. Three prose-only edits to `guidanceSteps`; no ids, rates, coordinates, or loop markers touched.

### Fixes

**1. Floor 5 Agility gate (blocker): 72 -> 92**
The floor-5 gate was understated by 20 levels; 72 is actually the floor-3 requirement, so a player at 72 cannot reach floor 5 at all.
> Floor 1: 52 Agility - Floor 2: 62 Agility - Floor 3: 72 Agility - Floor 4: 82 Agility - Floor 5: 92 Agility. The Agility requirements are not boostable. (oldschool.runescape.wiki/w/Hallowed_Sepulchre)

**2. Floor-loot acquisition (high)**
Three of the four listed items were mischaracterised as floor-5 grand-coffin-only drops. Only Ring of endurance is floor-5 exclusive.
> Strange old lockpick: "The drop rate is 1/200 for the 1st floor, 1/120 for the 2nd floor, 1/90 for the 3rd floor, 1/60 for the 4th floor and 1/40 for the 5th floor."
> Dark dye: "It can be purchased from the Mysterious Hallowed Goods shop for 300 hallowed marks."
> Dark acorn: purchased from the Mysterious Hallowed Goods shop for 3,000 hallowed marks.
This also resolves an internal contradiction: step[5] already lists Dark dye/Dark acorn as mark purchases.

**3. Entrance direction (high): south-east -> north-east**
> "The Hallowed Sepulchre is located on the north east side of Darkmeyer." (oldschool.runescape.wiki/w/Hallowed_Sepulchre)
Coordinate cross-check confirms the entrance (3654,3385) is north and east of the Darkmeyer bank (3637,3370).

### Validation
- `validate_drop_rates --check cache_ids`: clean (no id changes).
- `guidance_lint`: no new issues; remaining warnings/info are pre-existing structural notes unrelated to these prose edits.
