### PR TITLE
fix(data): Giants' Foundry - wiki-verified guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -14300,7 +14300,7 @@
     "travelTip": "Grouping tele -> Giants' Foundry",
     "guidanceSteps": [
       {
-        "description": "Travel to Giants' Foundry. Bring 28 of your highest-tier metal bars (steel and above; mithril or higher recommended for faster reputation) plus an Ammo mould if you want bonus reputation. No combat gear needed. Sleeping Giants quest + 15 Smithing required to enter. Use the Grouping teleport for the fastest route; Falador tele + run south-east is the unquested fallback.",
+        "description": "Travel to Giants' Foundry. Bring 28 of your highest-tier metal bars (steel and above; mithril or higher recommended for faster reputation). No combat gear needed. Sleeping Giants quest + 15 Smithing required to enter. Use the Grouping teleport for the fastest route; Falador tele + run south-east is the unquested fallback.",
         "worldX": 3360,
         "worldY": 3151,
         "worldPlane": 0,


### PR DESCRIPTION
Corrects the Giants' Foundry travel-step guidance.

## Fix
Removed the clause "plus an Ammo mould if you want bonus reputation" from `guidanceSteps[0].description`. The transaction direction was inverted: the (Double) ammo mould is a **reward purchased from** the Foundry shop, not an item carried in to earn reputation.

Raw wiki receipt (wiki_lookup):

> Double ammo mould: "It can be purchased from the Giants' Foundry reward shop for 2,000 Foundry Reputation if Dwarf Cannon is complete."

> Giants' Foundry required items: "Metal bars or metal equipment which can be made at anvils from at least two bars" and "A bucket (can be obtained at The Giants' Foundry) or Ice gloves to pick up moulded weapons"

The minigame's required-items list contains no ammo mould. Step 4 of this same source already correctly lists the Double ammo mould (2000) as a reward purchase, so this removes an internal contradiction.

## Validation
- `validate_drop_rates --check cache_ids` (Giants' Foundry): passed, no issues.
- `guidance_lint` (Giants' Foundry): no new issues; remaining INFO/WARNING notes are pre-existing structural items unrelated to this prose change.
