### PR TITLE
fix(data): Mahogany Homes - wiki-verified guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -15490,7 +15490,7 @@
         "section": "Bank prep"
       },
       {
-        "description": "Travel to Amy in Falador east of the Falador shield shop to pick up your starting contract. Higher Construction levels unlock the Carpenter (Adept 20+, Expert 50+, Master 70+) tiers - each pays more points per contract.",
+        "description": "Travel to Amy in Falador east of the Falador shield shop to pick up your starting contract. Higher Construction levels unlock the Carpenter (Novice 20+, Adept 50+, Expert 70+) tiers - each pays more points per contract.",
         "worldX": 2954,
         "worldY": 3369,
         "worldPlane": 0,
@@ -15500,7 +15500,7 @@
         "section": "Travel"
       },
       {
-        "description": "Talk to Amy and accept a contract. She will direct you to Falador, Varrock, Hosidius, or East Ardougne - teleport directly to the contract city. Higher tiers (Adept / Expert / Master) ignore the starter Falador-only contracts.",
+        "description": "Talk to Amy and accept a contract. She will direct you to Falador, Varrock, Hosidius, or East Ardougne - teleport directly to the contract city. Higher tiers (Novice / Adept / Expert) ignore the starter Falador-only contracts.",
         "worldX": 2954,
         "worldY": 3369,
         "worldPlane": 0,
@@ -15509,7 +15509,7 @@
         "section": "Travel"
       },
       {
-        "description": "At the contract house, repair every broken hotspot in the order shown. Right-click each broken object and use the correct plank tier (Master = Mahogany only). Use the Crystal saw boost if your Construction level is borderline. Reporting to the owner finishes the contract and credits the carpenter's points.",
+        "description": "At the contract house, repair every broken hotspot in the order shown. Right-click each broken object and use the correct plank tier (Expert = Mahogany only). Use the Crystal saw boost if your Construction level is borderline. Reporting to the owner finishes the contract and credits the carpenter's points.",
         "worldX": 2954,
         "worldY": 3369,
         "worldPlane": 0,
@@ -15533,7 +15533,7 @@
         "section": "Reward"
       },
       {
-        "description": "Teleport back to a bank to restock planks when your inventory runs low. Falador east bank is closest to Amy; West Ardougne bank is closest to Ardougne contracts.",
+        "description": "Teleport back to a bank to restock planks when your inventory runs low. Falador east bank is closest to Amy; East Ardougne bank is closest to Ardougne contracts.",
         "worldX": 2965,
         "worldY": 3382,
         "worldPlane": 0,


### PR DESCRIPTION
Corrects four factual errors in the Mahogany Homes guidance prose. Edits are limited to `description` strings for this one source; no ids, coordinates, or loop markers touched.

## Fixes (wiki-verified)

**1. Travel step - contract tier names (high)**
`(Adept 20+, Expert 50+, Master 70+)` -> `(Novice 20+, Adept 50+, Expert 70+)`
Wiki: "Beginner contracts can be started at level 1, Novice at level 20, Adept at level 50 and Expert at level 70." The data shifted every name by one level and invented a non-existent "Master" tier.

**2. Accept-contract step - tier names (medium)**
`(Adept / Expert / Master)` -> `(Novice / Adept / Expert)`
Same four-tier scheme; "Master" is not a Mahogany Homes tier.

**3. Repair step - highest plank tier (medium)**
`Master = Mahogany only` -> `Expert = Mahogany only`
Wiki: highest tier is Expert (level 70), which uses mahogany planks. The plank association was right; only the tier label was fabricated.

**4. Bank/restock step - Ardougne bank (high)**
`West Ardougne bank` -> `East Ardougne bank`
Wiki infobox locates Mahogany Homes contracts in East Ardougne ("throughout East Ardougne"). West Ardougne is a separate walled city; routing players there for banking is a navigation error.

## Validation
- `validate_drop_rates --check cache_ids` (Mahogany Homes): clean, no issues.
- `guidance_lint` (Mahogany Homes): no new errors introduced (remaining warnings are pre-existing structural items unrelated to this prose change).

Held for manual review (no auto-merge).
