### PR TITLE
fix(data): Tithe Farm - wiki-verified guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -15950,7 +15950,7 @@
     "guidanceSteps": [
       {
         "section": "Travel",
-        "description": "Travel to Tithe Farm in Hosidius via Xeric's talisman (Xeric's Heart) or fairy ring CIR then walk south. Requires 34% Hosidius favour and 34 Farming.",
+        "description": "Travel to Tithe Farm in Hosidius via Xeric's talisman (Xeric's Glade) or fairy ring AKR then walk south. Requires 34 Farming.",
         "worldX": 1791,
         "worldY": 3504,
         "worldPlane": 0,
@@ -15959,7 +15959,7 @@
       },
       {
         "section": "Setup",
-        "description": "Bring seeds scaled to your Farming level (Golovanova at 34+, Logavano at 54+, Bologano at 74+), a watering can or Gricoller's can, and stamina potions for long sessions.",
+        "description": "Bring seeds scaled to your Farming level (Golovanova at 34+, Bologano at 54+, Logavano at 74+), a watering can or Gricoller's can, and stamina potions for long sessions.",
         "worldX": 1791,
         "worldY": 3504,
         "worldPlane": 0,
@@ -15974,7 +15974,7 @@
       },
       {
         "section": "Skilling",
-        "description": "Plant seeds in patches, water them before the timer expires (watch the plant stage indicator above each patch), and harvest when fully grown. Higher-tier seeds give more points per hour; aim for 74+ Tithe Farm points per round to trigger bonus rewards.",
+        "description": "Plant seeds in patches, water them before the timer expires (watch the plant stage indicator above each patch), and harvest when fully grown. Higher-tier seeds give more points per hour; deposit all 100 fruit per round (bonus experience begins at the 75th fruit deposited).",
         "worldX": 1791,
         "worldY": 3504,
         "worldPlane": 0,


### PR DESCRIPTION
Wiki-verified corrections to the Tithe Farm guidance prose. Edits are confined to three `description` strings in this source; no ids, coords, rates, or loop markers touched.

### Fixes

1. **Xeric's talisman destination** (Travel step): `Xeric's Heart` -> `Xeric's Glade`.
   - Wiki raw: "Use a Xeric's talisman to teleport to Xeric's Glade and go south-east". Xeric's Heart is the Kourend Castle teleport, central Great Kourend, not the Hosidius Tithe Farm.

2. **Fairy ring code** (Travel step): `CIR` -> `AKR`.
   - Wiki raw: fairy code `akr` (Hosidius Vinery, then go south). CIR is the Mount Karuulm code.

3. **Access gate** (Travel step): removed `34% Hosidius favour and`.
   - Wiki raw: "The Tithe Farm can now be accessed starting at level 34 Farming as Kourend Favour has been removed." (10 January 2024). Sole gate is now 34 Farming.

4. **Seed Farming levels** (Setup step): `Logavano at 54+, Bologano at 74+` -> `Bologano at 54+, Logavano at 74+`.
   - Wiki raw SCP values: Golovanova 34, Bologano 54, Logavano 74. The data had Bologano and Logavano inverted.

5. **Bonus-reward trigger** (Skilling step): replaced `aim for 74+ Tithe Farm points per round to trigger bonus rewards` with the real mechanic - deposit all 100 fruit per round, bonus experience begins at the 75th fruit.
   - Wiki raw: points are "1 point per 3 plants ... +2 per 100 plants", capping a 100-fruit round near 35 points, so 74+ per round is arithmetically unreachable.

### Validation
- `validate_drop_rates --check cache_ids` (Tithe Farm): passed, no issues.
- `guidance_lint` (Tithe Farm): no new errors; only pre-existing INFO notes about MANUAL-step completion distances.
