### PR TITLE
fix(data): Brimhaven Agility Arena - wiki-verified guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -14182,7 +14182,7 @@
         "section": "Activity"
       },
       {
-        "description": "Exchange agility tickets with Cap'n Izzy No-Beard for Brimhaven Graceful recolours (250 tickets each piece) or the Pirate's hook (800 tickets). The full Graceful set takes 1500 tickets total",
+        "description": "Exchange agility tickets with Pirate Jackie the Fruit for Brimhaven Graceful recolours (250 vouchers for the full set) or the Pirate's hook (800 tickets).",
         "worldX": 2809,
         "worldY": 3194,
         "worldPlane": 0,


### PR DESCRIPTION
Wiki-verified corrections to the Brimhaven Agility Arena reward-exchange guidance step.

## Fixes
- **Reward NPC**: rewards are exchanged with **Pirate Jackie the Fruit**, not Cap'n Izzy No-Beard (who only collects the 200gp entry fee). This applies to both the Graceful recolour and the Pirate's hook.
  - Wiki (Brimhaven Agility Arena): "The tickets and vouchers can be traded in to Pirate Jackie the Fruit for Agility experience and a selection of items respectively." and "a 200 coins fee paid to Cap'n Izzy No-Beard before each entry."
  - Pirate's hook page: Seller "Pirate Jackie the Fruit", Cost "800 Brimhaven vouchers".
- **Graceful recolour cost**: it is a single **250 Brimhaven voucher** transaction for the full uncoloured outfit, not "250 each piece / 1500 total" (6x overstatement).
  - Wiki: "The graceful recolour costs 250 Brimhaven vouchers to recolour the full uncoloured graceful outfit."

The separate travel step correctly attributes the 200gp entry fee to Cap'n Izzy, so the NPC error was isolated to the reward step.

## Validation
- validate_drop_rates --check cache_ids: clean (no id changes).
- guidance_lint: no new issues (2 pre-existing INFO items on travel steps, unrelated).
