### PR TITLE
fix(data): Fishing Trawler - wiki-verified guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -16154,7 +16154,7 @@
         "section": "Activity"
       },
       {
-        "description": "During the 10-minute voyage, bail water from flooded sections (use bucket on water) and repair damaged nets with rope. Bailing continuously maximises your loot share. Two or more unrepaired nets will end the trip early",
+        "description": "During the 5-minute voyage, bail water from flooded sections (use bucket on water) and repair damaged nets with rope. Bailing continuously maximises your loot share. Torn nets simply catch no fish until repaired",
         "worldX": 2661,
         "worldY": 3164,
         "worldPlane": 1,
@@ -16166,7 +16166,7 @@
         "section": "Activity"
       },
       {
-        "description": "When the trawler returns to Port Khazard, collect your fish haul from Murphy. Each Angler outfit piece has approximately a 1-in-12 chance per completed voyage. Bank and board again for the next run",
+        "description": "When the trawler returns to Port Khazard, search the trawler net to collect your fish haul. Each Angler outfit piece has approximately a 1-in-12 chance per completed voyage. Bank and board again for the next run",
         "worldX": 2661,
         "worldY": 3164,
         "worldPlane": 0,


### PR DESCRIPTION
Wiki-verified guidance corrections for the Fishing Trawler minigame source. Three prose fixes, no id/coordinate/rate changes.

### Fixes

**1. Voyage duration: 10 minutes -> 5 minutes** (guidanceSteps[2])
> "Fishing Trawler is a Fishing minigame in which players must prevent Murphy's trawling boat from sinking for five minutes. ... a round takes roughly 6.5 minutes (5 minutes of trawling, 1 minute of docking ...)"

**2. Removed fabricated net-based loss condition** (guidanceSteps[2])
The data claimed "two or more unrepaired nets will end the trip early." The wiki frames the sole loss condition as the boat sinking (water level); nets are the fish-catching apparatus, not a trip-ending mechanic. Replaced with an accurate note that torn nets catch no fish until repaired.
> "players must prevent Murphy's trawling boat from sinking for five minutes. ... Leaks on the sides of the boat can be repaired using swamp paste."

**3. Reward collection interaction: search the trawler net, not Murphy** (guidanceSteps[3])
> "On return to the mainland, players who earned enough contribution points during the minigame may search the trawler net to receive an assortment of fish and Fishing experience, with a chance to receive pieces of the angler's outfit."

### Validation
- `validate_drop_rates --check cache_ids`: passed, no issues.
- `guidance_lint` (Fishing Trawler): no new errors; only pre-existing structural notes.

Held for manual review (no auto-merge).
