### PR TITLE
fix(data): Mage Training Arena - wiki-verified guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -14634,7 +14634,7 @@
       }
     ],
     "locationDescription": "Mage Training Arena, north-east of Al Kharid",
-    "travelTip": "Ring of dueling -> Emir's Arena, then run north-east",
+    "travelTip": "Ring of dueling -> Emir's Arena, then run north",
     "requirements": {
       "skills": [
         {
@@ -14651,11 +14651,11 @@
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
-        "travelTip": "Ring of dueling -> Emir's Arena, run north-east",
+        "travelTip": "Ring of dueling -> Emir's Arena, run north",
         "section": "Travel"
       },
       {
-        "description": "Enter one of the four training rooms. Telekinetic: move statues with Telekinetic Grab. Alchemy: High Alch the correct items. Enchanting: Lvl-1 Enchant jewelry. Graveyard (needs Bones to Peaches unlocked): convert bones. Each room awards its own coloured pizazz points",
+        "description": "Enter one of the four training rooms. Telekinetic: move statues with Telekinetic Grab. Alchemy: High Alch the correct items. Enchanting: Lvl-1 Enchant jewelry. Graveyard: convert bones. Each room awards its own coloured pizazz points",
         "worldX": 3374,
         "worldY": 3316,
         "worldPlane": 0,
@@ -14676,7 +14676,7 @@
         "section": "Activity"
       },
       {
-        "description": "When you have enough pizazz points, visit the reward shop inside the arena to purchase Infinity armour pieces, wands, Mage's book, or Bones to Peaches. The Master wand (17 pizazz of each type) and Mage's book are the primary targets",
+        "description": "When you have enough pizazz points, visit the reward shop inside the arena to purchase Infinity armour pieces, wands, Mage's book, or Bones to Peaches. The Master wand (240 Telekinetic, 240 Alchemist, 2400 Enchantment, 240 Graveyard pizazz with the Teacher wand; about 480/530/4800/480 from scratch) and Mage's book are the primary targets",
         "worldX": 3363,
         "worldY": 3316,
         "worldPlane": 0,


### PR DESCRIPTION
Three wiki-verified guidance corrections for the Mage Training Arena source. Prose/travelTip only; no ids, coordinates, rates, or loop markers touched.

### 1. Travel direction (travelTip x2, low)
The Ring of dueling leg from Emir's Arena to the arena runs due north, not north-east.
Wiki (Mage Training Arena): "A ring of dueling teleport to the Al Kharid Emir's Arena and running north." Infobox location: "North of the Emir's Arena."
"north-east of Al Kharid" in locationDescription is correct and left unchanged.

### 2. Graveyard room access (Activity step, low)
Removed the "(needs Bones to Peaches unlocked)" parenthetical. The Creature Graveyard accepts Bones To Bananas (a standard-spellbook spell), so the room is enterable and completable with no minigame unlock.
Wiki: spells listed for the room are "Bones To Bananas or Bones To Peaches."

### 3. Master wand cost (Reward step, blocker)
Replaced "(17 pizazz of each type)" with the real cost. The internal pointCost value (17) was leaking into player-facing prose.
Wiki (Master wand): with the teacher wand equipped/in inventory the cost is 240 Telekinetic / 240 Alchemist / 2400 Enchantment / 240 Graveyard pizazz; from scratch (wand + 3 prerequisites) 480 / 530 / 4800 / 480.

Validation: validate_drop_rates --check cache_ids clean; guidance_lint introduces no new errors (remaining INFO notes are pre-existing MANUAL-step structural notes).
