### PR TITLE
fix(data): Pest Control - wiki-verified guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -14485,7 +14485,7 @@
       },
       {
         "section": "Queue",
-        "description": "Board the lander matching your combat level (Novice <100, Intermediate 100-150, Veteran 150+). Wait for the lander to fill and depart to the island.",
+        "description": "Board the lander matching your combat level (Novice 40+, Intermediate 70+, Veteran 100+). Wait for the lander to fill and depart to the island.",
         "worldX": 2659,
         "worldY": 2676,
         "worldPlane": 0,
@@ -14498,7 +14498,7 @@
       },
       {
         "section": "Round",
-        "description": "Destroy all 4 portals while defending the Void Knight. Use Protect from Melee when swarmed by spinners near the Void Knight. Prioritise portals over kills - the game ends instantly if the Void Knight falls.",
+        "description": "Destroy all 4 portals while defending the Void Knight. Kill Spinners at each portal once its immunity drops - they repair the portals; Shifters, Defilers, Ravagers and Torchers are the pests that attack the Void Knight. Prioritise portals over kills - the game ends instantly if the Void Knight falls.",
         "worldX": 2659,
         "worldY": 2676,
         "worldPlane": 0,


### PR DESCRIPTION
Wiki-verified guidance corrections for the Pest Control source. Two prose-only edits to `drop_rates.json` guidance steps; no ids, rates, coordinates, or loop markers touched.

## Fixes

### 1. Lander combat-level thresholds (Queue step)
Was: `(Novice <100, Intermediate 100-150, Veteran 150+)` — invented upper caps and shifted the lower bounds.
Now: `(Novice 40+, Intermediate 70+, Veteran 100+)`.

> The only requirement to participate in Pest Control is a combat level of 40, 70 or 100 for Novice, Intermediate and Veteran games respectively.

The brackets are minimums, not ranges: a level-100+ player can still board Novice.

### 2. Spinner / Void Knight behaviour (Round step)
Was: "Use Protect from Melee when swarmed by spinners near the Void Knight." — conflates Spinners with the pests that attack the Void Knight.
Now: Spinners repair the portals (kill them at each portal once immunity drops); Shifters, Defilers, Ravagers and Torchers are the pests that reach the Void Knight.

> When at the portals, Spinners will spawn and begin repairing the portal. ... Shifters, Defilers, Ravagers and Torchers often make it into range of the Void Knight, and if he is allowed to die, the round will end prematurely.

## Validation
- `validate_drop_rates --check cache_ids` (Pest Control): passed, no issues.
- `guidance_lint` (Pest Control): no errors/warnings; only pre-existing INFO notes, unchanged by this PR.

Held for manual review (no auto-merge).
