### PR TITLE
fix(data): Temple Trekking - wiki-verified guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -16227,7 +16227,7 @@
       }
     ],
     "locationDescription": "Temple Trekking, between Burgh de Rott and Paterdomus",
-    "travelTip": "Drakan's medallion -> Burgh de Rott, or Minigame tele -> Temple Trekking; fallback: fairy ring BKR (Canifis) then run south-west",
+    "travelTip": "Drakan's medallion -> Ver Sinhaza, then run south-west to Burgh de Rott, or Minigame tele -> Temple Trekking; fallback: fairy ring CKS (Canifis) then run south-west",
     "guidanceSteps": [
       {
         "description": "Travel to Burgh de Rott and speak to Rolayne Twickit (hard) to begin a trek. Bring food, combat gear, and a bow or staff for ranged puzzle events.",
@@ -16236,7 +16236,7 @@
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
-        "travelTip": "Drakan's medallion -> Burgh de Rott is fastest; Minigame tele also works; fallback: fairy ring BKR (Canifis) run south-west",
+        "travelTip": "Drakan's medallion -> Ver Sinhaza, then run south-west to Burgh de Rott is fastest; Minigame tele also works; fallback: fairy ring CKS (Canifis) run south-west",
         "npcId": 1563,
         "interactAction": "Talk-to",
         "recommendedItemIds": [
@@ -16247,7 +16247,7 @@
         "section": "Travel"
       },
       {
-        "description": "Choose the hardest route and strongest follower (Rolayne Twickit) for the best Lumberjack outfit drop chance. Hard route, hard follower gives the highest token reward multiplier.",
+        "description": "Choose the hardest route and weakest (hard-tier) follower (Rolayne Twickit) for the best Lumberjack outfit drop chance. Hard route, hard follower gives the highest token reward multiplier.",
         "worldX": 3479,
         "worldY": 3241,
         "worldPlane": 0,


### PR DESCRIPTION
Wiki-verified corrections to three guidance-prose errors in the Temple Trekking source. Only `description` / `travelTip` strings changed; no ids, rates, coordinates, or loop markers touched.

### Fixes

**1. Drakan's medallion destination (both travelTips)**
`Drakan's medallion -> Burgh de Rott` was wrong; the medallion has no Burgh de Rott teleport. Changed to `Drakan's medallion -> Ver Sinhaza, then run south-west to Burgh de Rott`.
> wiki (Drakan's medallion): "allows unlimited teleportation to Ver Sinhaza, Darkmeyer ... and the Sisterhood Sanctuary under Slepe"
> wiki (Temple Trekking, ways to reach Burgh de Rott): "Drakan's medallion to Ver Sinhaza"

**2. Canifis fairy ring code (both fallback travelTips)**
`fairy ring BKR (Canifis)` mislabelled; BKR lands in Mort Myre Swamp, not Canifis. Changed to `fairy ring CKS (Canifis)`.
> wiki (Fairy ring): BKR -> "Mort Myre Swamp, south of Canifis"; CKS -> "Canifis"
> wiki (Temple Trekking): "Code CKS - Takes you to Canifis"

**3. Follower difficulty wording (Setup step)**
`strongest follower (Rolayne Twickit)` inverted the mechanic. Changed to `weakest (hard-tier) follower`.
> cache npc 1563 = "Rolayne Twickit (hard)"
> wiki (Temple Trekking): "Escorting weaker followers means a greater number of monsters will attack" (weaker follower = harder trek = more reward tokens)

### Validation
- `validate_drop_rates --check cache_ids` (Temple Trekking): passed, no issues
- `guidance_lint` (Temple Trekking): no new errors (only pre-existing structural WARNING/INFO unrelated to these prose edits)
