### PR TITLE
fix(data): Gnome Restaurant (Scarfs) - wiki-verified guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -16025,7 +16025,7 @@
     ],
     "guidanceSteps": [
       {
-        "description": "Travel to the Grand Tree in Tree Gnome Stronghold. Talk to Gianne jnr. on the west end of the ground floor to get a hard delivery order.",
+        "description": "Travel to the Grand Tree in Tree Gnome Stronghold. Talk to Gianne jnr. on the west end of the 1st floor (US 2nd floor) / one level above ground to get a hard delivery order.",
         "worldX": 2436,
         "worldY": 3500,
         "worldPlane": 0,
@@ -16048,7 +16048,7 @@
         "section": "Order"
       },
       {
-        "description": "Cook the required gnome dish using the range and ingredients on the Grand Tree ground floor. Use the recipe book in your inventory if unsure of the recipe. Deliver the finished dish to Captain Ninto (south-west of the Stronghold gate) or Captain Daerkin (Gnome stronghold entrance) within the time limit.",
+        "description": "Cook the required gnome dish using the range and ingredients on the Grand Tree 1st floor (US 2nd floor) / one level above ground. Use the recipe book in your inventory if unsure of the recipe. Deliver the finished dish to Captain Ninto (in the dwarf bar / White Wolf Tunnel beneath White Wolf Mountain) or Captain Daerkin (at Emir's Arena, south-western arena viewing area) within the time limit.",
         "worldX": 2436,
         "worldY": 3500,
         "worldPlane": 0,


### PR DESCRIPTION
Wiki-verified guidance prose corrections for the Gnome Restaurant (Scarfs) source. No ids, rates, coordinates, or loop markers touched.

## Fixes

**1. Floor label (Gianne jnr. step + cooking-range step)** — low
"ground floor" -> "1st floor (US 2nd floor) / one level above ground".
Receipt: wiki_lookup("Gnome Restaurant") infobox: `Location: Grand Tree, {{FloorNumber|uk=1}}` (UK 1st / US 2nd floor, one level above ground). The cooking range is on that same platform ("north of Aluft Gianne snr.").

**2. Captain Ninto location** — high
"(south-west of the Stronghold gate)" -> "(in the dwarf bar / White Wolf Tunnel beneath White Wolf Mountain)".
Receipt: npc_lookup("Captain Ninto") -> abextm cache NPC id 2569; wiki location: White Wolf Tunnel. The Stronghold-gate placement would misdirect the player to the wrong region and fail the timed delivery.

**3. Captain Daerkin location** — high
"(Gnome stronghold entrance)" -> "(at Emir's Arena, south-western arena viewing area)".
Receipt: npc_lookup("Captain Daerkin") -> abextm cache NPC id 2570; wiki location: Emir's Arena (desert arena near Al Kharid), a separate region from the Tree Gnome Stronghold.

## Validation
- validate_drop_rates --check cache_ids: passed, no issues.
- guidance_lint: no new errors (remaining warnings/infos are pre-existing structural notes unrelated to this prose change).
