### PR TITLE
fix(data): Castle Wars - wiki-verified guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -16923,7 +16923,7 @@
       },
       {
         "section": "Round",
-        "description": "Capture the enemy flag from their castle and return it to your own base to score tickets. Bring explosives to destroy barricades or use a catapult to slow attackers. Each successful capture earns 1 Castle Wars ticket.",
+        "description": "Capture the enemy flag from their castle and return it to your own base to score a point for your team. Bring explosives to destroy barricades or use a catapult to slow attackers. The team with the most points after 20 minutes wins; Castle Wars tickets are awarded at the end of the game based on the result (more for a win, fewer for a draw).",
         "worldX": 2440,
         "worldY": 3089,
         "worldPlane": 0,


### PR DESCRIPTION
Corrects the Castle Wars "Round" guidance step, which mis-stated the reward economy.

## Fix
- The prose claimed "Each successful capture earns 1 Castle Wars ticket." A flag capture actually scores **one point toward the team's score**, and Castle Wars tickets are handed out **at the end of the 20-minute game** based on the match result (more for a win, fewer for a draw) - not per capture.

## Authoritative basis
OSRS Wiki, Castle Wars page (https://oldschool.runescape.wiki/w/Castle_Wars):

> "The aim of the game is to take the enemy's standard (flag) from their castle and return it to the standard in your own castle, gaining one point each time... Each game lasts for 20 minutes, and the team with the most points at the end of the game is declared the winner. You will gain some rewards, as explained in the next section."

## Scope
Single-line prose edit to the guidance `description`. No id, rate, coordinate, or loop-marker changes. `validate_drop_rates --check cache_ids` and `guidance_lint` for this source stay clean (only pre-existing INFO notes remain).
