### PR TITLE
fix(data): Fossil Island Notes - wiki-verified guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -19334,7 +19334,7 @@
         "section": "Travel"
       },
       {
-        "description": "Search the House on the Hill displays and complete activities for fossil notes.",
+        "description": "Search the stone chests in the House on the Hill (numulites required, 100 per search) and complete activities for fossil notes.",
         "worldX": 3774,
         "worldY": 3819,
         "worldPlane": 0,


### PR DESCRIPTION
Wiki-verified guidance correction for the Fossil Island Notes collection-log source.

## Fix
- **guidanceSteps[1] ("Collect notes") description**: changed "Search the House on the Hill displays" to "Search the stone chests in the House on the Hill (numulites required, 100 per search)". "displays" is not a real game object; the note items come from the House's five searchable stone chests.

## Raw receipt
wiki_lookup("House on the Hill") — https://oldschool.runescape.wiki/w/House_on_the_Hill

> Within both floors of the House, there are five stone chests with a search option. Searching the stone chest will ask for a numulite. After inserting the numulite, the chest will give the search option to insert 100 numulites into the hole. The chests have a chance of having nothing happen, dealing damage, or giving one of various notes. The notes can be added to the player's Fossil island note book.

## Validation
- `validate_drop_rates --check cache_ids` (Fossil Island Notes): passed, no issues.
- `guidance_lint` (Fossil Island Notes): no new errors (only pre-existing INFO notes).
