### PR TITLE
fix(data): Barbarian Assault - wiki-verified guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -18190,7 +18190,7 @@
       },
       {
         "section": "Reward",
-        "description": "Spend honour points at Commander Connad's shop: Fighter torso (1500 pts), Penance skirt (1500 pts), role hats (1100 pts each). Buy Gambles (500 pts) for a chance at the Pet penance queen (1/1000 per gamble).",
+        "description": "Spend honour points at Commander Connad's shop: Fighter torso (1500 pts), Penance skirt (1500 pts), role hats (1100 pts each). Buy Gambles (500 pts + 1 Penance Queen kill) for a chance at the Pet penance queen (1/1000 per gamble).",
         "worldX": 2519,
         "worldY": 3571,
         "worldPlane": 0,


### PR DESCRIPTION
Wiki-verified guidance correction for the Barbarian Assault source. Prose-only edit to `guidanceSteps[3]` (Reward step) in `drop_rates.json`; no ids, rates, coordinates, or loop markers touched.

## Fix
- **Reward step gamble cost**: appended the documented prerequisite for the High (500-point) gamble. Was `Buy Gambles (500 pts)`, now `Buy Gambles (500 pts + 1 Penance Queen kill)`.

### Authoritative basis
From the live wiki Gambles table (https://oldschool.runescape.wiki/w/Barbarian_Assault/Gambles), the gamble levels and costs:

| Level | Honour points needed | Required wave |
|-------|----------------------|---------------|
| Low | 200 | 3 or higher |
| Medium | 400 | 6 or higher |
| High | 500 and 1 queen kill | 1 or higher |

The 500-point gamble is the High tier, whose cost is listed verbatim as "500 and 1 queen kill". The preceding Round step already has the player defeat the Penance Queen, so this is a prose-completeness fix.

## Validation
- `validate_drop_rates --check cache_ids` (Barbarian Assault): passed, no issues.
- `guidance_lint` (Barbarian Assault): only pre-existing INFO notes; no new issues from this edit.
