### PR TITLE
fix(data): Scroll Cases - wiki-verified guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -16532,7 +16532,7 @@
       },
       {
         "section": "Earning Cases",
-        "description": "Complete clue scrolls of all tiers. Minor cases unlock at 50 completions per tier; major cases unlock at tier-specific higher thresholds. Cases are awarded automatically upon reaching the milestone.",
+        "description": "Complete clue scrolls of all tiers. Minor cases unlock at 50 (Beginner/Hard/Elite), 100 (Easy/Medium), or 25 (Master) completions depending on the tier; major cases unlock at tier-specific higher thresholds. Cases are awarded automatically upon reaching the milestone.",
         "worldX": 3213,
         "worldY": 3424,
         "worldPlane": 0,


### PR DESCRIPTION
## Scroll Cases — guidance correction

Fixes one wiki-verified factual error in the "Earning Cases" guidance step.

### Minor scroll case unlock thresholds (per-tier, not uniform)
The step claimed minor cases "unlock at 50 completions per tier", implying a uniform threshold. The minor-case threshold actually varies by clue tier.

Updated prose: "Minor cases unlock at 50 (Beginner/Hard/Elite), 100 (Easy/Medium), or 25 (Master) completions depending on the tier."

Raw receipt — OSRS Wiki, Scroll case (https://oldschool.runescape.wiki/w/Scroll_case):
> "Minor and major scroll cases are rewarded upon reaching the following treasure trail completion milestones for each tier:"

Milestone table, Minor Case column (tier order Beginner / Easy / Medium / Hard / Elite / Master): 50 / 100 / 100 / 50 / 50 / 25. This also matches the source entry's own per-item `milestoneKills` (Minor master scroll case = 25).

Only the guidance prose for this source changed — no ids, rates, coordinates, or loop markers touched.
