### PR TITLE
fix(data): Vale Totems - wiki-verified guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -17471,7 +17471,7 @@
         "section": "Setup"
       },
       {
-        "description": "Run between the 8 totem sites around the valley maintaining and decorating totems. Activate ent trails (step on both trail markers) to double offerings on the next ent visit and gain 4 boosted XP actions. Totems deplete after each ent visit and must be rebuilt with 1 log plus 4 fletched decorations.",
+        "description": "Run between the 8 totem sites around the valley maintaining and decorating totems. Activate ent trails (step on both trail markers) to double offerings on the next ent visit and gain 4 boosted XP actions. Totems lose 1 durability per ent visit and only need rebuilding (1 log plus 4 fletched decorations) once fully depleted; higher-tier logs survive more visits before depleting.",
         "worldX": 1452,
         "worldY": 3128,
         "worldPlane": 0,


### PR DESCRIPTION
Corrects the Vale Totems Activity-step guidance prose to match the documented totem durability mechanic.

## Fix

**Totem depletion mechanic** (`guidanceSteps` Activity step, `medium`)
- Before: "Totems deplete after each ent visit and must be rebuilt with 1 log plus 4 fletched decorations."
- After: "Totems lose 1 durability per ent visit and only need rebuilding (1 log plus 4 fletched decorations) once fully depleted; higher-tier logs survive more visits before depleting."
- The old wording told players to rebuild every single ent cycle, which is wrong: totems lose only one durability per ent visit and survive multiple visits (more for higher-tier logs) before needing a rebuild.

### Wiki receipt
> Totems will lose one durability for each ent that visits and will need to be rebuilt once the totem is depleted. [...] Each complete totem requires five logs (one to build the totem and four fletched items for decorations).

(wiki_lookup "Vale Totems"; staleness check: no page changes since 2026-01-01.)

## Validation
- `validate_drop_rates --check cache_ids` (Vale Totems): passed, no issues.
- `guidance_lint` (Vale Totems): no new errors (only pre-existing INFO notes about MANUAL-step completionDistance, untouched here).
