### PR TITLE
fix(data): Soul Wars - wiki-verified guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -17021,7 +17021,7 @@
       },
       {
         "section": "Round",
-        "description": "Kill enemies to collect soul fragments, then offer them at the Soul obelisk to weaken the opposing Avatar. When the Avatar reaches 0 soul fragments, attack and kill it. Use Protect from Magic when fighting the Avatar directly.",
+        "description": "Kill enemies to collect soul fragments, then offer them at the Soul obelisk to weaken the opposing Avatar. When the Avatar reaches 0 soul fragments, attack and kill it. Use Protect from Melee when fighting the Avatar directly.",
         "worldX": 2210,
         "worldY": 2858,
         "worldPlane": 0,
@@ -17034,7 +17034,7 @@
       },
       {
         "section": "Reward",
-        "description": "Collect Zeal tokens from Nomad after each game. Spend on the Ectoplasmator (2500), Soul cape (2500), or Unsired shards. The Lil' creator pet has a 1/400 drop rate from the reward chest.",
+        "description": "Collect Zeal tokens from Nomad after each game. Spend on the Ectoplasmator (250), Soul cape (2500). The Lil' creator pet has a 1/400 drop rate from spoils of war (30 Zeal each from Nomad).",
         "worldX": 2210,
         "worldY": 2858,
         "worldPlane": 0,


### PR DESCRIPTION
Wiki-verified guidance corrections for the Soul Wars source (prose only; no ids, rates, or coordinates touched).

### Round step — Avatar prayer
Avatars use a melee attack. Advise Protect from Melee, not Protect from Magic.
> wiki Avatar of Creation / Avatar of Destruction: "Praying Protect from Melee negates both the Hitpoints and Prayer drain."

### Reward step — Ectoplasmator cost
Corrected from 2500 to 250 Zeal Tokens.
> wiki Ectoplasmator: "Requiring 40 Prayer, it can be purchased from Nomad on the Isle of Souls for 250 Zeal Tokens."

### Reward step — fabricated "Unsired shards"
Removed. No such item exists; the only Unsired (item 25624) is an Abyssal Sire drop placed at the Font of Consumption, unrelated to Nomad's shop. Not listed in any Soul Wars reward.

### Reward step — Lil' creator pet source
Changed "from the reward chest" to "from spoils of war (30 Zeal each from Nomad)".
> wiki Spoils of war: "It can be purchased from Nomad on the Isle of Souls for 30 Zeal Tokens."
> wiki Avatar of Creation: "A pet version of the Avatar of Creation, Lil' creator, can be obtained as a possible reward from opening spoils of war."

Validation: `validate_drop_rates --check cache_ids` clean for Soul Wars; `guidance_lint` shows only pre-existing INFO notes (no new issues).
