### PR TITLE
fix(data): Last Man Standing - wiki-verified guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -17347,7 +17347,7 @@
     "guidanceSteps": [
       {
         "section": "Travel",
-        "description": "Travel to Ferox Enclave via the Minigame teleport (Last Man Standing). The LMS lobby is on the island east of the enclave.",
+        "description": "Travel to Ferox Enclave via the Minigame teleport (Last Man Standing). The LMS lobby is at Ferox Enclave - speak to Lisa to enter a game.",
         "worldX": 3151,
         "worldY": 3634,
         "worldPlane": 0,
@@ -17356,7 +17356,7 @@
       },
       {
         "section": "Queue",
-        "description": "Enter the LMS lobby building and choose Competitive or Casual mode. Competitive earns more points per match but requires staking coins to enter.",
+        "description": "Enter the LMS lobby building and choose Competitive or Casual mode. Competitive earns more points per match but requires 750+ total level and 30+ quest points (or 1,500+ total level with fewer than 30 QP).",
         "worldX": 3151,
         "worldY": 3634,
         "worldPlane": 0,
@@ -17372,7 +17372,7 @@
       },
       {
         "section": "Round",
-        "description": "Scavenge weapons, armour, and food from supply crates on the island. Fight other players; the last player standing wins. Prioritise securing food and a weapon early; loot defeated players mid-game.",
+        "description": "Scavenge weapons and armour from supply crates on the island. Fight other players; the last player standing wins. Prioritise securing food and a weapon early; loot defeated players mid-game.",
         "worldX": 3151,
         "worldY": 3634,
         "worldPlane": 0,


### PR DESCRIPTION
Wiki-verified corrections to the Last Man Standing guidance prose. Data-only; no id, rate, coordinate, or loop-marker changes.

## Fixes

**Travel step** — lobby location
Was: "The LMS lobby is on the island east of the enclave."
Now: "The LMS lobby is at Ferox Enclave - speak to Lisa to enter a game."
Receipt (wiki_lookup 'Last Man Standing'): infobox `Location: Ferox Enclave`; image caption "The Last Man Standing lobby in Ferox Enclave". The island is only the match arena players are teleported to, not the lobby. (The step's own coordinates 3151,3634 already sit inside Ferox Enclave.)

**Queue step** — Competitive entry requirement
Was: "Competitive ... requires staking coins to enter."
Now: "Competitive ... requires 750+ total level and 30+ quest points (or 1,500+ total level with fewer than 30 QP)."
Receipt (wiki): "Participating in Competitive and High Stakes requires players to have a minimum total level of 750 and 30 Quest points, or a minimum total level of 1,500 if they have less than 30 Quest points." The 500,000-coin stake applies only to the separate High Stakes mode, not Competitive.

**Round step** — supply-crate contents
Was: "Scavenge weapons, armour, and food from supply crates ..."
Now: "Scavenge weapons and armour from supply crates ..."
Receipt (wiki Starting Loadout / Weapon & Armor Acquisition): food is the fixed starting loadout (10 sharks, 3 Saradomin brews, 2 Sanfew serums, etc.); island chests opened with bloody/bloodier keys roll only offensive/defensive gear loot tables. No food on any crate table.

## Validation
- `validate_drop_rates --check cache_ids` (Last Man Standing): passed, no issues.
- `guidance_lint` (Last Man Standing): only 2 pre-existing INFO notes, no new errors.
