### PR TITLE
fix(data): Hunter Guild - wiki-verified guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -19519,17 +19519,17 @@
     "travelTip": "Quetzal whistle -> Varlamore -> Hunter Guild",
     "guidanceSteps": [
       {
-        "description": "Travel to the Hunter Guild in Avium Savannah, Varlamore. Use the Quetzal whistle to teleport to Varlamore, then run south-west to the guild. Requires 46 Hunter and completion of Children of the Sun.",
+        "description": "Travel to the Hunter Guild in Avium Savannah, Varlamore. Use the Quetzal whistle to teleport straight to the landing zone in front of the guild (no running needed); the fairy ring is the only run-based route, north-west to the guild. Requires 46 Hunter and completion of Children of the Sun.",
         "worldX": 1579,
         "worldY": 3069,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 15,
-        "travelTip": "Quetzal whistle -> Varlamore -> run south-west to Hunter Guild",
+        "travelTip": "Quetzal whistle -> landing zone in front of Hunter Guild",
         "section": "Travel"
       },
       {
-        "description": "Complete Hunter Guild activities in the Avium Savannah. Track and catch creatures in the guild hunting grounds for Hunter Guild points. Spend points at the guild reward shop for guild-exclusive items. Higher Hunter levels unlock additional creature types and greater point rewards.",
+        "description": "Complete Hunters' Rumours from a Guild Hunter in the Avium Savannah. Each rumour tasks you with tracking and catching a specific creature, rewarding Hunter experience and a hunters' loot sack whose quality scales with the rumour tier. Guild-exclusive items (guild hunter outfit, huntsman's kit, quetzal whistles, Quetzin) come from loot sacks and rumour-milestone unlocks. Higher Hunter levels unlock higher rumour tiers (Adept, Expert, Master), which award higher-quality loot sacks.",
         "worldX": 1579,
         "worldY": 3069,
         "worldPlane": 0,


### PR DESCRIPTION
Wiki-verified guidance corrections for the Hunter Guild source. Prose-only edits to two `guidanceSteps` strings; no ids, coordinates, rates, or loop markers touched.

## Fixes

**Travel step (direction)**
- Was: "Use the Quetzal whistle to teleport to Varlamore, then run south-west to the guild."
- Now: whistle drops you at the landing zone in front of the guild (no running); the only run-based route is the fairy ring, north-west.
- Receipt (Hunter Guild wiki): "A quetzal whistle teleports players to the quetzal landing zone in front of the guild." / "Use the fairy ring and run north-west to reach the Hunters Guild."

**Activity step (fabricated points currency / reward shop)**
- Was: "catch creatures in the guild hunting grounds for Hunter Guild points. Spend points at the guild reward shop for guild-exclusive items."
- Now: complete Hunters' Rumours for Hunter XP and a hunters' loot sack (quality scales with rumour tier); guild-exclusive items come from loot sacks and rumour milestones.
- Receipt (Hunters' Rumours wiki): "Completing Hunters' Rumours rewards the player with additional Hunter experience and a hunters' loot sack, the quality of which depends on the tier of the rumour assigned. Hunter's loot sacks ... may also reward unique items like the guild hunter outfit and huntsman's kit, or Quetzin." No points currency or reward shop exists.

**Activity step (tier progression)**
- Was: "Higher Hunter levels unlock additional creature types and greater point rewards."
- Now: higher Hunter levels unlock higher rumour tiers (Adept/Expert/Master) awarding higher-quality loot sacks.
- Receipt (Hunters' Rumours wiki): "Players can choose four tiers of rumours, with each having their own unboostable Hunter level requirements: ... Novice / Adept / Expert / Master."

## Validation
- `validate_drop_rates --check cache_ids` (Hunter Guild): passed, no issues.
- `guidance_lint` (Hunter Guild): no errors (2 pre-existing INFO notes unchanged).
