### PR TITLE
fix(data): Gnome Restaurant (Seed Pods) - wiki-verified guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -30293,7 +30293,7 @@
         "section": "Travel"
       },
       {
-        "description": "Ask Gianne jnr. for a hard delivery (11-minute time limit). If the assigned customer is not Wingstone, Penwie, Brambickle, or Prof. Manglethorp, decline and wait 5m30s or complete an easy order. Only these four customers give Mint cake or Grand seed pod.",
+        "description": "Ask Gianne jnr. for a hard delivery (11-minute time limit). If the assigned customer is not Wingstone, Penwie, Brambickle, or Prof. Manglethorp, decline and wait 5m30s or complete an easy order. All four give Grand seed pod, but only Wingstone, Penwie, and Brambickle also give Mint cake (Prof. Manglethorp gives no Mint cake).",
         "worldX": 2436,
         "worldY": 3500,
         "worldPlane": 0,
@@ -30322,7 +30322,7 @@
         "section": "Reward"
       },
       {
-        "description": "Return to Gianne jnr. for the next hard order. Re-roll orders until Wingstone, Penwie, Brambickle, or Prof. Manglethorp is assigned to maximise seed pod and mint cake drop rate.",
+        "description": "Return to Gianne jnr. for the next hard order. Re-roll orders until Wingstone, Penwie, Brambickle, or Prof. Manglethorp is assigned to maximise Grand seed pod rate. For Mint cake, only Wingstone, Penwie, and Brambickle qualify (Prof. Manglethorp gives no Mint cake).",
         "worldX": 2436,
         "worldY": 3500,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Wiki-verified correction to the Gnome Restaurant (Seed Pods) guidance prose. The customer-reward steps grouped all four "hard delivery" customers as giving both Mint cake and Grand seed pod. The wiki shows Mint cake is restricted to three of them.

## Fix

- **Order step (step 2):** changed "Only these four customers give Mint cake or Grand seed pod." to clarify all four give Grand seed pod, but only Wingstone, Penwie, and Brambickle also give Mint cake (Prof. Manglethorp gives no Mint cake).
- **Re-roll step (step 5):** clarified that re-rolling for any of the four maximises Grand seed pod rate, while only Wingstone, Penwie, and Brambickle qualify for Mint cake.

Only prose `description` strings changed; no itemId, dropRate, coordinate, npcId, or loop marker touched.

## Authoritative basis

OSRS Wiki raw drop tables, `https://oldschool.runescape.wiki/w/Gnome_Restaurant?action=raw` (fetched 2026-06-28):

- Grand seed pod: `raritynotes=...Only available from Wingstone, Penwie, Brambickle, and Professor Manglethorp.`
- Mint cake: `raritynotes=...Only available from Wingstone, Penwie, and Brambickle.`

## Validation

- `validate_drop_rates --check cache_ids` — clean (no id changes)
- `guidance_lint` — no new issues (pre-existing INFO/WARNING unchanged)
