### PR TITLE
fix(data): Sea Treasures - wiki-verified guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -20454,7 +20454,7 @@
         "section": "Travel"
       },
       {
-        "description": "Board your boat and navigate to the marked sea treasure location. Interact with the treasure spot to collect Medallion fragments (1-8, combine to form Sailors' amulet (inert)) and rare antique junk: Rusty locket, Mouldy block, Dull knife, Broken compass, Rusty coin, Broken sextant, Mouldy doll, Smashed mirror. Higher Sailing levels unlock better treasure voyages.",
+        "description": "Board your boat and navigate to the marked sea treasure location. Interact with the treasure spot to collect Medallion fragments (1-8, combine to form Medallion of the Deep) and rare antique junk: Rusty locket, Mouldy block, Dull knife, Broken compass, Rusty coin, Broken sextant, Mouldy doll, Smashed mirror. Higher Sailing levels unlock better treasure voyages.",
         "worldX": 1824,
         "worldY": 3691,
         "worldPlane": 0,


### PR DESCRIPTION
Corrects one wiki-verified prose error in the Sea Treasures guidance.

### Activity step (guidanceSteps[1].description)
The eight Medallion fragments combine into the **Medallion of the Deep**, not the Sailors' amulet (inert).

- Changed "combine to form Sailors' amulet (inert)" -> "combine to form Medallion of the Deep".
- The Sailors' amulet (inert) is a separate salvaging reward and stays listed independently in this source; only the fragment-assembly product was misnamed.

Wiki receipt (`Medallion fragment`):
> Medallion fragments are items found on various islands accessed via the Sailing skill... There are eight of these fragments, which are assembled into the Medallion of the Deep, an item that allows the wielder to breathe underwater.

### Validation
- `validate_drop_rates --check cache_ids` (Sea Treasures): passed, no issues.
- `guidance_lint` (Sea Treasures): no new errors (only pre-existing INFO notes, unrelated to this prose edit).
