### PR TITLE
fix(data): Stronghold of Security - wiki-verified guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -20726,7 +20726,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill monsters on each floor for skull sceptre pieces: Floor 1 (Vault of War) - minotaurs drop the right skull half; Floor 2 (Catacomb of Famine) - flesh crawlers and other monsters drop the left skull half; Floor 3 (Pit of Pestilence) - catablepons drop the top of sceptre; Floor 4 (Sepulchre of Death) - ankous drop the bottom of sceptre.",
+        "description": "Kill monsters on each floor for skull sceptre pieces: Floor 1 (Vault of War) - minotaurs drop the right skull half; Floor 2 (Catacomb of Famine) - flesh crawlers drop the bottom of sceptre; Floor 3 (Pit of Pestilence) - catablepons drop the top of sceptre; Floor 4 (Sepulchre of Death) - ankous drop the left skull half.",
         "worldX": 3230,
         "worldY": 9844,
         "worldPlane": 0,


### PR DESCRIPTION
Corrects two mislabelled Skull sceptre pieces in the Stronghold of Security floor-by-floor guidance prose. Edits only the guidance `description` string; no ids, rates, coordinates, or loop markers touched.

### Fixes

- **Floor 2 (Catacomb of Famine):** flesh crawlers drop the **bottom of sceptre**, not the "left skull half".
  - Wiki (Flesh Crawler drop table, https://oldschool.runescape.wiki/w/Flesh_Crawler): `Bottom of sceptre | qty: 1 | rarity: 3/100` — the only sceptre piece on their table; no "left skull half".
- **Floor 4 (Sepulchre of Death):** ankous drop the **left skull half**, not the "bottom of sceptre".
  - Wiki (Ankou drop table, https://oldschool.runescape.wiki/w/Ankou): `Left skull half | qty: 1 | rarity: 3/100` — the only sceptre piece on their table; no "bottom of sceptre".

The two pieces were inverted; this restores the correct floor-to-piece mapping.

### Validation
- `validate_drop_rates --check cache_ids` for the source: passed, no issues.
- `guidance_lint` for the source: no new errors (only pre-existing INFO notes).
