### PR TITLE
fix(data): Stingray (Boat Combat) - wiki-verified guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -30370,7 +30370,7 @@
         "section": "Travel"
       },
       {
-        "description": "Board your boat and sail into open water. Stingrays are sea encounters requiring a cannon facility (28 Sailing) with cannonballs loaded. No special mechanics -- fire cannon until dead, then Harvest the carcass for Ray barbs (1/30). Repair at a Shipwright when hull is damaged.",
+        "description": "Board your boat and sail to the Stingrays in the Unquiet, Sunset, or Shrouded Oceans. They are directly-attackable sea monsters (combat level 92) -- Attack them, safespotting across the nearby rock formations where possible. Harvest the carcass for Ray barbs (1/30). Repair at a Shipwright when your hull is damaged.",
         "worldX": 1824,
         "worldY": 3691,
         "worldPlane": 0,


### PR DESCRIPTION
Corrects the in-game guidance prose for the Stingray (Boat Combat) collection-log source. One confirmed wiki-verified fix.

### Combat step - remove fabricated cannon framing (high)
The step claimed Stingrays are "sea encounters requiring a cannon facility ... fire cannon until dead." Fresh wiki receipt:

> wiki_lookup("Stingray") infobox: Combat level 92, Hitpoints 106, NPC ID 15218. Drop table: Ray barbs 1/30.
> "Stingrays are monsters that can be found in the Unquiet Ocean, Sunset Ocean, and Shrouded Ocean."
> "Stingrays west of the Colossal Wyrm Remains can be safespotted across many of the nearby rock formations..."
> The word "cannon" does not appear in the article.

Stingrays are directly-attackable monsters (the entry's own structured fields already use interactAction `Attack`, completionCondition `ACTOR_DEATH`, completionNpcId `15218`, with no cannonballs in the item lists). Reworded the prose to: sail to them in the named oceans, Attack and safespot across nearby rock formations, harvest the carcass for Ray barbs (1/30).

### Validation
- validate_drop_rates --check cache_ids: passed (no issues).
- guidance_lint: no new errors (pre-existing completionDistance WARNING / step[0] INFO unchanged, unrelated to this prose edit).

Only the `description` prose was changed; no ids, rates, coordinates, or loop markers touched.
