### PR TITLE
fix(data): Pyramid Plunder - wiki-verified guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -20609,7 +20609,7 @@
     "travelTip": "Pharaoh's sceptre -> Jalsavrah",
     "guidanceSteps": [
       {
-        "description": "Bank and prepare: Pharaoh's sceptre (charged), lockpick, superantipoisons, prayer potions, and food. Bring 43+ Prayer for Protect from Melee to ignore mummy and scarab damage. Completion of Contact! is strongly recommended for nearby banking. Need 71 Thieving minimum to access the grand gold chest (the only Pharaoh's sceptre source).",
+        "description": "Bank and prepare: Pharaoh's sceptre (charged), lockpick, superantipoisons, prayer potions, and food. Bring 43+ Prayer for Protect from Melee to ignore mummy and scarab damage. Completion of Contact! is strongly recommended for nearby banking. Need 21 Thieving to enter the minigame; higher levels (up to 91) unlock the more valuable rooms with better sceptre odds. The Pharaoh's sceptre can drop from the golden chests and sarcophagi.",
         "worldX": 3288,
         "worldY": 2801,
         "worldPlane": 0,
@@ -20638,7 +20638,7 @@
         "section": "Travel"
       },
       {
-        "description": "Rush through rooms 1-7, looting urns and sarcophagi only. Use Protect from Melee to ignore mummies and scarabs. At room 8 (requires 91 Thieving), loot the grand gold chest which exclusively yields the Pharaoh's sceptre. Recharge the sceptre at the Guardian Mummy between runs.",
+        "description": "Rush through rooms 1-7, looting urns and sarcophagi only. Use Protect from Melee to ignore mummies and scarabs. At room 8 (requires 91 Thieving), loot the golden chest; it and the sarcophagi mostly yield artefacts but rarely give the Pharaoh's sceptre, with the best odds in the highest rooms. Recharge the sceptre at the Guardian Mummy between runs.",
         "worldX": 3289,
         "worldY": 2799,
         "worldPlane": 2,


### PR DESCRIPTION
Wiki-verified guidance-prose corrections for the Pyramid Plunder source. Two prose strings in `guidanceSteps`; no ids, rates, coordinates, or loop markers touched.

## Fixes

**Step 0 (Bank) - Thieving gate + "only source"**
Old: "Need 71 Thieving minimum to access the grand gold chest (the only Pharaoh's sceptre source)."
Both halves wrong: 71 is room 6's entry, not a chest-access floor, and the sceptre is not single-sourced.
> Pyramid Plunder (wiki): "At least 21 Thieving is necessary to start the game. Every ten levels thereafter will grant entrance to the more valuable rooms, up to level 91. Note that these levels cannot be boosted."
> Pharaoh's sceptre (wiki): "found during the Pyramid Plunder minigame in Sophanem, from the golden chests and sarcophagi."

**Step 2 (Run) - "exclusively yields"**
Old: "loot the grand gold chest which exclusively yields the Pharaoh's sceptre."
The chest mostly yields artefacts; the sceptre is a rare, room-scaled outcome, and sarcophagi are a second source.
> Pharaoh's sceptre (wiki): "Pharaoh's sceptres are a very rare reward received from the golden chests and sarcophagi during the Pyramid Plunder minigame. The chance of receiving a pharaoh's sceptre scales depending on the room."

## Validation
- validate_drop_rates --check cache_ids: passed, no issues
- guidance_lint (Pyramid Plunder): no new errors (only pre-existing INFO notes about MANUAL/objectId, unrelated to these prose edits)
