### PR TITLE
fix(data): Monkey Backpacks - wiki-verified guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -19770,7 +19770,7 @@
     "travelTip": "Fairy ring CLR -> Ape Atoll",
     "guidanceSteps": [
       {
-        "description": "Travel to the Ape Atoll Agility Course (fairy ring CLR, requires Monkey Madness II). Course starts at the top of the agility ladder.",
+        "description": "Travel to the Ape Atoll Agility Course (fairy ring CLR, requires Monkey Madness II). The course begins at the stepping-stone obstacle near Marim.",
         "worldX": 2764,
         "worldY": 2703,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Corrects the travel-step guidance prose for the Monkey Backpacks source (Ape Atoll Agility Course). The current text says the course "starts at the top of the agility ladder," but this course has no agility ladder.

## Fix

- guidanceSteps[0].description: replace "Course starts at the top of the agility ladder." with "The course begins at the stepping-stone obstacle near Marim."

## Authoritative basis

OSRS Wiki, Ape Atoll Agility Course: "The course consists of six obstacles that players can pass in return for Agility experience... All of the obstacles except for the stepping stones and the last tropical tree can be failed by the player." The stepping stones are the first (un-failable) obstacle and the lap's start point near Marim; no agility ladder appears anywhere in the obstacle set.

## Validation

- validate_drop_rates --check cache_ids: passed (no id changes; prose-only edit)
- guidance_lint (Monkey Backpacks): no new errors (one pre-existing INFO on step[1] is unrelated)