### PR TITLE
fix(data): Deep Sea Fishing - wiki-verified guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -20538,7 +20538,7 @@
     "travelTip": "Port Roberts dock -> sail to trawling shoal (69 Fishing + Sailing required)",
     "guidanceSteps": [
       {
-        "description": "Bank for deep sea trawling. Bring a trawling net (from Netmaster or Sailing shops), stamina potions, and food. 69 Fishing and basic Sailing required. Speak to Netmaster Kellan at the Rolling Tide pub in Port Roberts for an introduction.",
+        "description": "Bank for deep sea trawling. Your boat must have a trawling net facility built via Construction at a hotspot before heading out; carry stamina potions and food. 69 Fishing and basic Sailing required. Speak to Netmaster Kellan at the Rolling Tide pub in Port Roberts for an introduction (he is informational, not a vendor).",
         "worldX": 1565,
         "worldY": 3420,
         "worldPlane": 0,


### PR DESCRIPTION
Wiki-verified guidance correction for the Deep Sea Fishing source (one prose edit to `guidanceSteps[0].description`).

## Fix
The bank-prep step framed the trawling net as a carried item bought "(from Netmaster or Sailing shops)". A trawling net is actually a boat **facility** built via Construction at a hotspot, and Netmaster Kellan is informational, not a vendor. Reworded to direct players to build the trawling net facility before heading out.

## Authoritative basis
- `wiki_lookup("Trawling net")`: "A trawling net is a type of facility that can be installed on player-owned skiffs and sloops... used for deep sea trawling at shoals." Materials table lists Sailing **and Construction** levels with build materials/XP per tier — nets are built, not bought.
- `wiki_lookup("Deep sea trawling")`: "Netmaster Kellan, a retired trawler found at the Rolling Tide pub in Port Roberts, provides an in-game explanation on the basics of deep sea trawling." No shop selling pre-made trawling nets is described.

## Validation
- `validate_drop_rates --check cache_ids` (Deep Sea Fishing): passed, no issues.
- `guidance_lint` (Deep Sea Fishing): no new errors (only pre-existing INFO notes).

No ids, rates, coordinates, or loop markers touched — single prose-string edit.
