### PR TITLE
fix(data): Ocean Encounters - wiki-verified guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -20136,7 +20136,7 @@
         "section": "Travel"
       },
       {
-        "description": "Board your boat and sail. Ocean encounters spawn randomly while sailing (even turning in place). Types include lost crates (loot), giant clams (pearl crafting), lost caskets (clue reward rolls), castaway rescues (XP), and clue turtles (clue scrolls). Encounters despawn after 60 seconds without interaction. A keg filled with kraken ink stout increases encounter rate by 4%.",
+        "description": "Board your boat and sail. Ocean encounters spawn randomly while sailing. Types include lost crates (loot), giant clams (pearl crafting), lost caskets (clue reward rolls), castaway rescues (XP), and clue turtles (clue scrolls). Encounters despawn after 60 seconds without interaction. A keg filled with kraken ink stout increases encounter rate by 4%.",
         "worldX": 1824,
         "worldY": 3691,
         "worldPlane": 0,


### PR DESCRIPTION
Corrects one wiki-verified inaccuracy in the Ocean Encounters sailing activity step.

## Fix
- **Activity step description**: removed the "(even turning in place)" parenthetical.

## Authoritative basis
OSRS Wiki — Ocean encounters (https://oldschool.runescape.wiki/w/Ocean_encounters):

> When a boat is moving, a 120 tick (72 second) timer counts down, and when it hits zero, an event has a 1/6 chance to spawn. ... The timer pauses if a boat is stationary ... The timer only counts down if the boat has moved to a new tile.

Turning in place yields no tile translation, so no encounters spawn while turning. The
parenthetical was a flat-false mechanic claim, not advice. `wiki_updates` shows 0 edits to
the page since 2026-01-01, so no staleness favors the old text.

Validation: `validate_drop_rates --check cache_ids` clean for this source; `guidance_lint`
reports only the two pre-existing INFO notes (unchanged by this edit).
