### PR TITLE
fix(data): Sailing Misc - wiki-verified guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -20257,12 +20257,12 @@
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
-        "description": "Use Sailors' amulet to teleport to The Pandemonium or your nearest activated port.",
+        "description": "Use Sailors' amulet to teleport to a chosen unlocked port (The Pandemonium by default; Port Roberts, Red Rock, or Deepfin Point each require inspecting that dock's Sailors' Marker).",
         "travelTip": "Sailors' amulet -> The Pandemonium (default unlock)",
         "section": "Travel"
       },
       {
-        "description": "Board your boat and participate in Sailing activities: shipwreck salvaging (dragon materials, Boat bottle, Facility bottle), boat combat encounters (Dragon nails, Dragon cannon barrel, Bottled storm), and ocean encounters (Echo pearl). Higher Sailing levels unlock better shipwrecks and stronger sea encounters with improved rare drop rates.",
+        "description": "Board your boat and participate in Sailing activities: shipwreck salvaging (dragon materials, Boat bottle, Facility bottle), boat combat encounters (Dragon nails, Dragon cannon barrel, Bottled storm, Echo pearl from dolphins/orcas), and ocean encounters. Higher Sailing levels unlock better shipwrecks and stronger sea encounters with improved rare drop rates.",
         "worldX": 1824,
         "worldY": 3691,
         "worldPlane": 0,


### PR DESCRIPTION
Wiki-verified guidance prose corrections for the **Sailing Misc** source. Two prose-only edits; no item IDs, drop rates, coordinates, or loop markers touched.

## Fixes

**1. Travel step — Sailors' amulet destinations (low)**
The amulet teleports to four fixed, individually-unlocked named ports selected from a menu, not a dynamic "nearest activated port".
- Raw wiki (Sailors' amulet): "The amulet allows the player to teleport to the Pandemonium, Port Roberts, Red Rock, and Deepfin Point. ... The teleport to The Pandemonium is unlocked by default. To use the teleports to Port Roberts, Red Rock, and Deepfin Point, the player must first inspect the Sailors' Marker on their docks."

**2. Activity step — Echo pearl miscategorised (high)**
Echo pearl is a boat-combat drop, not an ocean-encounter reward; moved it into the boat-combat clause.
- Raw wiki (Echo pearl): "An echo pearl is an item dropped by dolphins and orcas."
- The Ocean encounters reward table lists Strong winds / Mysterious glow / Lost crate / Castaway / Giant clam — no Echo pearl. The source's own mutuallyExclusiveSources lists "Orcas (Boat Combat)", corroborating boat-combat origin.

## Validation
- `validate_drop_rates --check cache_ids` (Sailing Misc): passed, no issues.
- `guidance_lint` (Sailing Misc): no new errors (two pre-existing INFO notes only).
