### PR TITLE
fix(data): Forestry - wiki-verified guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -19174,7 +19174,7 @@
         "independent": true
       }
     ],
-    "locationDescription": "Seers' Village oak south of bank (W444 meta), NOT Woodcutting Guild",
+    "locationDescription": "Seers' Village maple north of bank (W444 meta), NOT Woodcutting Guild",
     "travelTip": "Camelot teleport -> Seers' Village",
     "waypoints": [
       {
@@ -19189,7 +19189,7 @@
         }
       },
       {
-        "name": "Seers' Village oak south of bank (W444 meta)",
+        "name": "Seers' Village maple north of bank (W444 meta)",
         "worldX": 2725,
         "worldY": 3490,
         "worldPlane": 0
@@ -19197,17 +19197,17 @@
     ],
     "guidanceSteps": [
       {
-        "description": "Travel to a Forestry-active woodcutting area. Seers' Village oak trees south of the bank on a W444 Forestry world are the most common hub. Use the Camelot teleport and run south-east from the bank.",
+        "description": "Travel to a Forestry-active woodcutting area. Seers' Village maple trees north of the bank on a W444 Forestry world are the most common hub. Use the Camelot teleport and run north from the bank.",
         "worldX": 2725,
         "worldY": 3490,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 15,
-        "travelTip": "Camelot teleport -> run south-east to Seers' Village oaks",
+        "travelTip": "Camelot teleport -> run north to Seers' Village maples",
         "section": "Travel"
       },
       {
-        "description": "Chop trees on a Forestry world. Events spawn periodically (pheasant, flower, poacher, tree spirit, bee hive, roots). Participate in each event for Anima-infused bark and Forestry points. Spend points at the Forestry Shop for lumberjack and Forestry outfit pieces, log basket, and log brace. Rare unique drops (fox whistle, golden pheasant egg, petal garland) come directly from events.",
+        "description": "Chop trees on a Forestry world. Events spawn periodically (pheasant, flower, poacher, bee hive, roots). Participate in each event for Anima-infused bark. Spend Anima-infused bark at the Forestry Shop for lumberjack and Forestry outfit pieces, log basket, and log brace. Rare unique drops (fox whistle, golden pheasant egg, petal garland) come directly from events.",
         "worldX": 2725,
         "worldY": 3490,
         "worldPlane": 0,


### PR DESCRIPTION
Wiki-verified guidance corrections for the Forestry collection-log source. Data only; no id/coordinate/loop-marker changes.

### Fixes

1. **Seers' Village tree type / sub-location** (locationDescription, waypoint name, travel step): was "oak trees south of the bank" -> now "maple trees north of the bank".
   - wiki_lookup("Forestry") locations table: `Oak: Draynor village - East side of the bank`; `Maple: Seers village - North of the bank, there are 4 trees`; `Yew: Seers village - In the church court yard entrance`. No oak trees exist at Seers' Village.

2. **Travel direction** (travel description + travelTip): "run south-east from the bank" -> "run north". The only official Forestry trees at Seers' Village (maple, yew) are north / north-west of the bank, not south-east.

3. **Non-existent event removed**: dropped "tree spirit" from the event list.
   - WebFetch https://oldschool.runescape.wiki/w/Forestry enumerates nine events (Rising Roots, Struggling Sapling, Flowering Tree, Woodcutting Leprechaun, Beehive, Friendly Ent, Poachers, Enchantment Ritual, Pheasant Control); none is named "tree spirit" (that is a legacy Woodcutting random event).

4. **Currency wording**: "Anima-infused bark and Forestry points" / "Spend points" -> "Anima-infused bark" / "Spend Anima-infused bark".
   - wiki_lookup("Anima-infused bark"): `Anima-infused bark is the primary currency used in the Forestry Shop, ... earned by completing Forestry events`. There is no separate "Forestry points" currency.

### Validation
- `validate_drop_rates --check cache_ids` (Forestry): passed, no issues.
- `guidance_lint` (Forestry): no new errors (only pre-existing INFO notes about objectId/completionDistance, untouched by these prose edits).
