### PR TITLE
fix(data): Champion's Challenge - wiki-verified guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -18732,12 +18732,7 @@
         "section": "Combat"
       }
     ],
-    "rewardType": "MIXED",
-    "requirements": {
-      "quests": [
-        "DRAGON_SLAYER_I"
-      ]
-    }
+    "rewardType": "MIXED"
   },
   {
     "name": "Chompy Bird Hunting",


### PR DESCRIPTION
## Summary

Removes the `DRAGON_SLAYER_I` quest prerequisite from the **Champion's Challenge** source's `requirements`. This source had `requirements.quests = ["DRAGON_SLAYER_I"]`; since that was the only quest, the now-empty `requirements` block is dropped.

The only eligibility gate for the Champions' Challenge is membership + 32 quest points — there is no quest prerequisite. Dragon Slayer I starts at the Champions' Guild and itself needs 32 QP to begin, but completing it is not required for the Challenge. Requiring DSI over-gated eligible accounts that reached 32 QP through other quests.

## Authoritative basis

`wiki_lookup("Champions' Challenge")`, verbatim:

> The Champions' Challenge is a Distraction and Diversion found in the basement of the Champions' Guild. ... In order to be eligible to receive a champion's scroll, a player must be on a members server and have at least 32 quest points.

The page's infobox and body enumerate no quest prerequisite; Dragon Slayer I is not listed as a requirement anywhere.

## Validation

- `validate_drop_rates --check cache_ids`: no Champion's Challenge issues (pre-existing warnings in other sources only).
- `guidance_lint` (Champion's Challenge): only pre-existing INFO notes; no new errors.

## Notes

Branch name differs from the usual `-guidance` convention because that branch already existed on the remote pointing at a stale, pre-rebase commit (it would have reverted an unrelated, already-merged fix). This branch is based on current `master` and contains only the single-line requirements change.
