### PR TITLE
fix(data): Aerial Fishing - wiki-verified guidance corrections

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -18431,7 +18431,7 @@
         "section": "Travel"
       },
       {
-        "description": "Collect king worms on the island or use fish offcuts as bait. Equip the cormorant glove from Alry the Angler, then send the cormorant at nearby fishing pools. Aim for pools within 3 tiles (1 catch per tick maximum). Cut caught fish with a knife for stackable fish offcuts (3 Cooking XP each) to use as bait.",
+        "description": "Collect king worms on the island or use fish offcuts as bait. Equip the cormorant glove from Alry the Angler, then send the cormorant at nearby fishing pools. Aim for pools directly adjacent (within the player's 3x3 reach / 1 tile) for 1 catch per tick maximum. Cut caught fish with a knife for stackable fish offcuts (Cooking XP varies by fish: 3.5 bluegill, 10 common tench, 20 mottled eel, 25 greater siren) to use as bait.",
         "worldX": 1379,
         "worldY": 3634,
         "worldPlane": 0,
@@ -18446,7 +18446,7 @@
         "loopCount": 0
       },
       {
-        "description": "Trade caught fish with Alry the Angler for Molch pearls (bluegill=1, common tench=2, violet perch=3, cerulean twitch=4). Spend pearls at his shop for Angler outfit (100 each), Pearl rods (100-150), or Fish sack (1000). Golden tench drops directly while fishing.",
+        "description": "Molch pearls drop randomly alongside your catches (about 1/100 to 1/75, scaling with your Fishing and Hunter levels); the four fish caught are bluegill, common tench, mottled eel, and greater siren. You can also exchange a golden tench with Alry the Angler for 100 Molch pearls. Spend pearls at his shop for the Angler outfit (100 each), Pearl rods (100-150), or the Fish sack (1000).",
         "worldX": 1379,
         "worldY": 3634,
         "worldPlane": 0,


### PR DESCRIPTION
Corrects three guidance-prose inaccuracies in the Aerial Fishing source. Each fix is confirmed against a fresh OSRS Wiki receipt; no ids, coordinates, rates, or loop markers were touched.

### Fixes

**1. Optimal pool range (Fish step, low)**
Was: "Aim for pools within 3 tiles (1 catch per tick maximum)". The 1-catch-per-tick benefit only applies inside the player's 3x3 reach; "within 3 tiles" describes a 7x7 area.
Wiki (Aerial fishing): "The shortest wait occurs after targeting a fishing spot within the player's 3x3 reach (i.e. directly adjacent to the player) whereby the Cormorant will be available again on the next tick."

**2. Cooking XP per offcut (Fish step, low)**
Was: flat "(3 Cooking XP each)". Cutting XP scales by species.
Wiki (Lake Molch fish table): bluegill 3.5, common tench 10, mottled eel 20, greater siren 25.

**3. Fish names + Molch pearl mechanic (Reward step, blocker)**
Was: "Trade caught fish with Alry the Angler for Molch pearls (bluegill=1, common tench=2, violet perch=3, cerulean twitch=4)".
- "violet perch" and "cerulean twitch" are not OSRS species (no wiki page); the 3rd/4th aerial-fishing fish are mottled eel and greater siren.
- The mechanic was inverted. Wiki (Molch pearl): "Each catch has a 1/100 to 1/75 chance of giving Molch pearls in addition to the player's catch, which scales based on the player's Fishing and Hunter levels. Players can also exchange a golden tench with Alry the Angler for 100 Molch pearls... Molch pearls can be traded to Alry in his shop... for equipable versions of fishing rods, pieces of the Angler's outfit, as well as for the fish sack."

### Validation
- validate_drop_rates --check cache_ids (Aerial Fishing): passed, no issues.
- guidance_lint (Aerial Fishing): no new errors; remaining items are pre-existing INFO (by-design loop marker, completionDistance hints).
