### PR TITLE
fix(guidance): hint on MANUAL loop / recurring-gather steps so they do not read as stuck (#822)

### DIFF
--- a/src/main/java/com/collectionloghelper/guidance/GuidanceSequencer.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceSequencer.java
@@ -248,6 +248,32 @@ public class GuidanceSequencer
 	}
 
 	/**
+	 * #822: a short user-facing hint for the active step when it is an intentional
+	 * WAIT step — a recurring-gather step (auto-advance deliberately suppressed) or a
+	 * MANUAL loop terminal — so the deliberate pause is not mistaken for a hang.
+	 * Returns {@code null} for a one-off MANUAL step or an event-driven step (those
+	 * advance on their own or on a single Next, so they never read as stuck).
+	 * Keyed off the loop/recurring condition, so every loop source benefits at once.
+	 */
+	public String getActiveStepHint()
+	{
+		GuidanceStep step = getCurrentStep();
+		if (step == null || step.getCompletionCondition() != CompletionCondition.MANUAL)
+		{
+			return null;
+		}
+		if (isRecurringGatherSequence())
+		{
+			return "Keep gathering - press Next when done (the loop re-enters this step).";
+		}
+		if (step.getLoopBackToStep() > 0 && step.getLoopCount() > 0)
+		{
+			return "Repeat until done - press Next to continue, or Stop to finish.";
+		}
+		return null;
+	}
+
+	/**
 	 * Returns the raw current step without bank routing substitution,
 	 * but with conditional alternatives resolved.
 	 */

--- a/src/main/java/com/collectionloghelper/guidance/StepChangeHandler.java
+++ b/src/main/java/com/collectionloghelper/guidance/StepChangeHandler.java
@@ -117,6 +117,11 @@ public class StepChangeHandler
 					+ "/" + guidanceSequencer.getCumulativeTrackThreshold()
 					+ " actions tracked";
 			}
+			final String infoBoxHint = guidanceSequencer.getActiveStepHint();
+			if (infoBoxHint != null)
+			{
+				tooltip += "\n" + infoBoxHint;
+			}
 			in.activeInfoBox.setTooltipText(tooltip);
 			if (current == total)
 			{
@@ -128,7 +133,9 @@ public class StepChangeHandler
 		{
 			final int current = guidanceSequencer.getCurrentIndex() + 1;
 			final int total = guidanceSequencer.getTotalSteps();
-			final String desc = step.resolveDescription(in.activeTargetItemId);
+			final String stepHint = guidanceSequencer.getActiveStepHint();
+			final String baseDesc = step.resolveDescription(in.activeTargetItemId);
+			final String desc = stepHint != null ? baseDesc + "\n" + stepHint : baseDesc;
 			final boolean isManual = step.getCompletionCondition() == CompletionCondition.MANUAL;
 			final GuidanceStep rawStep = guidanceSequencer.getRawCurrentStep();
 			final CollectionLogSource stepChangeSource = guidanceSequencer.getActiveSource();

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerRestockTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerRestockTest.java
@@ -194,6 +194,24 @@ public class GuidanceSequencerRestockTest
 			"highlight target should remain the recurring key");
 	}
 
+	/**
+	 * #822: the recurring-gather MANUAL step deliberately suppresses auto-advance, which
+	 * reads as "stuck". {@code getActiveStepHint()} must surface a "Keep gathering - press
+	 * Next" hint on that step so the deliberate pause is not mistaken for a hang.
+	 */
+	@Test
+	public void recurringGatherStepSurfacesKeepGatheringHint() throws Exception
+	{
+		AtomicReference<GuidanceStep> lastStep = new AtomicReference<>();
+		sequencer.setPlayerLocation(new WorldPoint(0, 0, 0));
+		sequencer.startSequence(makeSource(gatherLoopSteps()), lastStep::set, () -> { });
+
+		assertEquals(0, sequencer.getCurrentIndex(), "precondition: on the recurring gather step");
+		String hint = sequencer.getActiveStepHint();
+		assertTrue(hint != null && hint.contains("Keep gathering"),
+			"recurring-gather MANUAL step should surface a 'Keep gathering' hint (#822), got: " + hint);
+	}
+
 	// ---- Scenario helpers ----
 
 	private void startAtLoopStep(AtomicReference<GuidanceStep> lastStep)


### PR DESCRIPTION
Fixes #822.

Recurring-gather and MANUAL loop-terminal steps intentionally suppress auto-advance, which reads as "stuck". Adds `GuidanceSequencer.getActiveStepHint()` (one source of truth) returning a short cue for intentional wait steps:
- recurring-gather (`isRecurringGatherSequence()`): "Keep gathering - press Next when done"
- plain MANUAL loop terminal (`loopBackToStep`/`loopCount`): "Repeat until done - press Next to continue, or Stop to finish"
- one-off MANUAL / event-driven: `null` (unchanged)

`StepChangeHandler` appends it to the InfoBox tooltip + side-panel description. Keyed off the loop/recurring condition, so all 14 MANUAL-loop sources benefit, not just Shades (retroactive, per live calibration triage).

**Validation:** new unit test (recurring-gather step surfaces the hint) + full guidance suite green. Live seam validation (driving Wintertodt/Shades and asserting `state.read.stepHint`) to follow on the next dev-client relaunch.

Structural guidance-engine change - no auto-merge; for review.