### PR TITLE
fix(data): Barrows - prep step combat-style guidance was inverted (named each brother's own style, not its weakness)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -8294,7 +8294,7 @@
     "travelTip": "Barrows teleport (Arceuus 83 Magic), Barrows teleport tablet, or Fairy ring BKR",
     "guidanceSteps": [
       {
-        "description": "Teleport to Barrows with a spade, food, prayer potions, and a weapon for each style (Magic for Ahrim, Ranged for Karil, Melee for the four Melee brothers). Verac ignores Protect prayers - bring high-defence armour for him",
+        "description": "Teleport to Barrows with a spade, food, prayer potions, and a weapon for each style (Magic for the four melee brothers - Dharok, Guthan, Torag, Verac - and for Karil; Ranged or Melee for Ahrim). Verac ignores Protect prayers - bring high-defence armour for him",
         "worldX": 3565,
         "worldY": 3298,
         "worldPlane": 0,


### PR DESCRIPTION
Found via live in-client guidance validation.

The Barrows prep step contradicted the per-brother steps and was inverted - it listed each brother's OWN attack type instead of the style to counter it with:
- was: "Magic for Ahrim, Ranged for Karil, Melee for the four Melee brothers"
- now: "Magic for the four melee brothers (Dharok, Guthan, Torag, Verac) and for Karil; Ranged or Melee for Ahrim"

**Wiki receipts:**
- Dharok/Guthan/Torag/Verac: "use[s] melee equipment, which makes [them] vulnerable to Magic attacks" (Magic defence -11)
- Ahrim: "wears robes, which make him vulnerable to Ranged as well as Melee attacks"
- Karil: "is weak to both melee attacks and magic attacks, and in particular to air spells"

The per-brother steps were already correct; only the prep step is changed. Prose-only; `validate_drop_rates` clean, no new `guidance_lint` issues.