### PR TITLE
fix(data): Mithril Dragon - enter-cavern step auto-skipped (PLAYER_ON_PLANE already satisfied)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -31616,7 +31616,14 @@
           25275
         ],
         "objectInteractAction": "Dive-in",
-        "completionCondition": "PLAYER_ON_PLANE",
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionZone": [
+          1620,
+          5315,
+          1790,
+          5365,
+          1
+        ],
         "section": "Travel"
       },
       {


### PR DESCRIPTION
## Summary

The full guidance mechanical sweep (226 sources) surfaced a class of "enter dungeon/cavern" steps that the engine **silently auto-skips**, so the player never sees the instruction. Mithril Dragon is the first fix in that class.

Step 1 ("Dive into the whirlpool south of Otto's Grotto to enter the Ancient Cavern") used `PLAYER_ON_PLANE` with `worldPlane: 0`. The completion checker evaluates `PLAYER_ON_PLANE` as a pure state check:

```java
playerLocation.getPlane() == step.getWorldPlane()
```

Since the preceding travel step already leaves the player on plane 0, the condition is true the instant step 1 activates — the engine advances straight to step 2 and the dive instruction is never shown.

## Fix

Switch step 1 to `ARRIVE_AT_ZONE` over the upper Ancient Cavern floor (plane 1), where the mithril dragons spawn. The step now resolves only once the player has actually entered the cavern and reached the dragon level. The whirlpool highlight (`worldX/Y`, `objectIds`, `Dive-in`) is unchanged.

Zone `[1620, 5315, 1790, 5365, 1]` bounds both mithril-dragon rooms per spawn data (npc 2919: x 1627-1655 & 1755-1783, y 5326-5356, plane 1).

## Verification

- `validate_drop_rates` (guidance): pass
- `guidance_lint`: no new issues (3 pre-existing notes unrelated to this change)
- `audit_drop_rates.py --category OTHER`: 0 errors, Mithril Dragon not flagged
- Static trace: at step 0 the player is on plane 0, so the new plane-1 zone is not pre-satisfied — the double-advance is eliminated; the dive to plane 1 then completes the step.

Live re-sweep confirmation is pending a dev-client relaunch (the running client cached the pre-edit data); CI is the authoritative gate.
