### PR TITLE
fix(data): Waterfiend - enter-cavern step auto-skipped (PLAYER_ON_PLANE already satisfied)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -32207,7 +32207,14 @@
           25275
         ],
         "objectInteractAction": "Dive-in",
-        "completionCondition": "PLAYER_ON_PLANE",
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionZone": [
+          1720,
+          5325,
+          1800,
+          5375,
+          0
+        ],
         "section": "Travel"
       },
       {


### PR DESCRIPTION
## Summary

Second fix in the "enter-cavern step auto-skipped" class found by the full guidance sweep (see #1060 for the root-cause writeup). Same Ancient Cavern, but anchored to the lower level.

Step 1 ("Dive into the whirlpool ... to enter the Ancient Cavern") used `PLAYER_ON_PLANE` with `worldPlane: 0`. Because the completion checker evaluates it as `playerLocation.getPlane() == step.getWorldPlane()` and the prior travel step already leaves the player on plane 0, the condition was true on activation — the engine advanced straight past the step and the dive instruction was never shown.

## Fix

Switch step 1 to `ARRIVE_AT_ZONE` over the **lower** Ancient Cavern floor (plane 0), where the waterfiends spawn. Completion now fires only once the player has descended to the waterfiend level. Whirlpool highlight unchanged.

Zone `[1720, 5325, 1800, 5375, 0]` bounds the lower-level waterfiend area per spawn data (npc 2916 cavern cluster: x 1738-1760, y 5340-5363, plane 0). Note this differs from the Mithril Dragon fix (#1060), which anchors to the **upper** floor (plane 1) where the mithril dragons are — the two sources share the cavern but target different levels.

## Verification

- `validate_drop_rates` (guidance): pass
- `guidance_lint`: no new issues (3 pre-existing notes unrelated to this change)
- `audit_drop_rates.py --category OTHER`: 0 errors, Waterfiend not flagged
- Static trace: at step 0 the player is on plane 0 at the whirlpool tile (outside the cavern zone), so the new zone is not pre-satisfied — the double-advance is eliminated.

Live re-sweep confirmation pending a dev-client relaunch (running client cached pre-edit data); CI is the authoritative gate.
