### PR TITLE
fix(data): Catacombs of Kourend - enter-catacombs step auto-skipped (PLAYER_ON_PLANE already satisfied)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -20824,7 +20824,14 @@
         "worldPlane": 0,
         "objectId": 27785,
         "objectInteractAction": "Investigate",
-        "completionCondition": "PLAYER_ON_PLANE",
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionZone": [
+          1620,
+          9990,
+          1690,
+          10100,
+          0
+        ],
         "section": "Travel"
       },
       {


### PR DESCRIPTION
## Summary

Third fix in the "enter-dungeon step auto-skipped" class found by the full guidance sweep (root-cause writeup in #1060).

Step 1 ("Investigate the Statue of King Rada I in the castle courtyard to enter the Catacombs of Kourend") used `PLAYER_ON_PLANE` with `worldPlane: 0`. The completion checker evaluates it as `playerLocation.getPlane() == step.getWorldPlane()`, and the player is already on plane 0 in the courtyard — so the condition was true on activation and the engine advanced straight past the step.

## Fix

Switch step 1 to `ARRIVE_AT_ZONE` over the Catacombs underground (plane 0, y ~10000), so completion fires only once the player has actually entered. The statue highlight (`worldX/Y`, `objectId 27785`, `Investigate`) is unchanged.

Zone `[1620, 9990, 1690, 10100, 0]` matches the existing step-0 `completionZone` underground extent (maxY 10070) and the step-3 kill tile (1664,10050). The courtyard (y 3673) sits outside the zone, so it is not pre-satisfied.

## Verification

- `validate_drop_rates` (guidance): pass
- `guidance_lint`: no new issues (3 pre-existing INFO notes about surface-vs-underground coordinate distance)
- Static trace: at step 0 the player is in the courtyard (y 3673), outside the new zone — the double-advance is eliminated; entering the catacombs (y ~10050) completes the step.

Live re-sweep pending a dev-client relaunch; CI is the authoritative gate.
