### PR TITLE
fix(data): Barrows - climb-into-tunnel step auto-skipped (PLAYER_ON_PLANE already satisfied)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -8405,8 +8405,14 @@
         "worldX": 3565,
         "worldY": 3298,
         "worldPlane": 0,
-        "completionCondition": "PLAYER_ON_PLANE",
-        "completionPlane": 0,
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionZone": [
+          3520,
+          9660,
+          3585,
+          9720,
+          0
+        ],
         "section": "Loot"
       },
       {


### PR DESCRIPTION
## Summary

Fourth fix in the "enter-dungeon step auto-skipped" class found by the full guidance sweep (root-cause writeup in #1060).

Step 7 ("Find the brother whose crypt has a tunnel entrance and climb down into the tunnels") used `PLAYER_ON_PLANE` with `worldPlane: 0`. The completion checker evaluates it as `playerLocation.getPlane() == step.getWorldPlane()`, and the player is already on plane 0 at the mounds — so the condition was true on activation and the engine advanced straight to the loot step. The climb-down instruction was never shown.

## Fix

Switch step 7 to `ARRIVE_AT_ZONE` over the Barrows tunnels (plane 0, y ~9700), so completion fires only once the player has climbed into the tunnels.

Zone `[3520, 9660, 3585, 9720, 0]` bounds the tunnel maze around the central chest tile (3551,9694) used by step 8. The surface mounds (y ~3280) sit outside the zone, so it is not pre-satisfied. The now-unused `completionPlane` field is removed (the engine reads `worldPlane`, not `completionPlane`).

## Verification

- `validate_drop_rates` (guidance): pass
- `guidance_lint`: no new issues (9 pre-existing INFO notes)
- Static trace: at step 6 the player is at Guthan's mound (y 3283), outside the new zone — the double-advance is eliminated; climbing into the tunnels (y ~9694) completes the step.

Live re-sweep pending a dev-client relaunch; CI is the authoritative gate.
