### PR TITLE
fix(data): Revenants - enter-caves step auto-skipped (PLAYER_ON_PLANE already satisfied)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -9993,7 +9993,14 @@
         "worldPlane": 0,
         "objectId": 31555,
         "objectInteractAction": "Enter",
-        "completionCondition": "PLAYER_ON_PLANE",
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionZone": [
+          3120,
+          10040,
+          3290,
+          10260,
+          0
+        ],
         "section": "Travel"
       },
       {


### PR DESCRIPTION
## Summary

Fifth fix in the "enter-dungeon step auto-skipped" class found by the full guidance sweep (root-cause writeup in #1060). This completes the non-instanced sources in the class.

Step 2 ("Pay the 100,000-coin entry fee and enter the Revenant Caves") used `PLAYER_ON_PLANE` with `worldPlane: 0`. The completion checker evaluates it as `playerLocation.getPlane() == step.getWorldPlane()`, and the player is already on plane 0 at the cave entrance — so the condition was true on activation and the engine advanced straight past the step.

## Fix

Switch step 2 to `ARRIVE_AT_ZONE` over the Revenant Caves interior (plane 0, y ~10040-10260), so completion fires only once the player has entered the caves. The entrance highlight (`worldX/Y`, `objectId 31555`, `Enter`) is unchanged.

Zone `[3120, 10040, 3290, 10260, 0]` bounds the cave interior per revenant spawn data (npc 7881 at 3214,10195 and 3199,10071, plane 0). The surface entrance (y 3672) sits outside the zone, so it is not pre-satisfied.

## Verification

- `validate_drop_rates` (guidance): pass
- `guidance_lint`: no new issues (2 pre-existing notes on the step-3 kill step)
- Static trace: at step 1 the player is at the surface entrance (y 3654), outside the new zone — the double-advance is eliminated; entering the caves (y ~10071) completes the step.

Live re-sweep pending a dev-client relaunch; CI is the authoritative gate.
