### PR TITLE
fix(data): Phosani's Nightmare - enter-sanctuary step auto-skipped (PLAYER_ON_PLANE already satisfied)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -3491,7 +3491,14 @@
         "worldPlane": 0,
         "objectId": 32637,
         "objectInteractAction": "Climb-down",
-        "completionCondition": "PLAYER_ON_PLANE"
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionZone": [
+          3770,
+          9690,
+          3850,
+          9810,
+          1
+        ]
       },
       {
         "description": "Drink from the Pool of Nightmare to enter Phosani's dream",


### PR DESCRIPTION
## Summary

Seventh fix in the "enter-dungeon step auto-skipped" class (root-cause writeup in #1060). Same Sisterhood Sanctuary as #1065 (The Nightmare).

Step 1 ("Climb down the stairs in Slepe church to enter the Sisterhood Sanctuary") used `PLAYER_ON_PLANE` with `worldPlane: 0`. The player is already on plane 0 in Slepe, so the condition was true on activation and the engine advanced straight past the step.

## Fix

Switch step 1 to `ARRIVE_AT_ZONE` over the Sisterhood Sanctuary (plane 1), matching #1065. The stairs highlight (`worldX/Y`, `objectId 32637`, `Climb-down`) is unchanged.

Zone `[3770, 9690, 3850, 9810, 1]` bounds the Sanctuary per spawn data — The Nightmare (npc 9460) spawns at `(3806, 9757, plane 1)`, matching the source's own s2/s3 coordinates.

## Verification

- `validate_drop_rates` (guidance): pass
- Static trace: at step 0 the player is on the Slepe surface (y 3302), outside the new plane-1 zone — the double-advance is eliminated.

Live re-sweep to follow (batched with the other instanced-class fixes); CI is the authoritative gate.
