### PR TITLE
fix(data): Fishing Trawler - board-trawler step auto-skipped (PLAYER_ON_PLANE already satisfied)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -16162,8 +16162,14 @@
         "worldX": 2661,
         "worldY": 3164,
         "worldPlane": 0,
-        "completionCondition": "PLAYER_ON_PLANE",
-        "targetPlane": 1,
+        "completionCondition": "ARRIVE_AT_ZONE",
+        "completionZone": [
+          2658,
+          3158,
+          2680,
+          3180,
+          1
+        ],
         "section": "Activity"
       },
       {


### PR DESCRIPTION
## Summary

Eighth and final fix in the "enter-dungeon step auto-skipped" class found by the full guidance sweep (root-cause writeup in #1060).

Step 1 ("Talk to Murphy and board the trawler when the game is ready to depart") used `PLAYER_ON_PLANE` with `worldPlane: 0` and `targetPlane: 1`. The completion checker evaluates `PLAYER_ON_PLANE` against **`worldPlane`** (it does not read `targetPlane`):

```java
playerLocation.getPlane() == step.getWorldPlane()
```

The player is already on plane 0 at the Port Khazard dock, so the condition was true on activation and the engine advanced straight past the step — the board-the-trawler instruction was never shown.

## Fix

Switch step 1 to `ARRIVE_AT_ZONE` over the trawler deck (plane 1), so completion fires only once the player has boarded. The dock highlight (`worldX/Y`, plane 0) is unchanged; the now-unused `targetPlane` field is removed.

Zone `[2658, 3158, 2680, 3180, 1]` bounds the boat per spawn data — the on-boat Murphy variant (npc 10707) spawns at `(2671, 3172, plane 1)`, confirming the trawler deck is a static plane-1 area (not coordinate-shifted). The dock (plane 0) is outside the zone.

## Verification

- `validate_drop_rates` (guidance): the only flagged item ("last step is ARRIVE_AT_TILE") is pre-existing on master and unrelated to this step-1 change.
- Static trace: at step 0 the player is on the dock (plane 0), outside the new plane-1 zone — the double-advance is eliminated.

Live re-sweep to follow (batched with the other instanced-class fixes); CI is the authoritative gate.
