### PR TITLE
feat(overlay): nearest-only object highlight for unfiltered gather-loop steps (F4)

### DIFF
--- a/src/main/java/com/collectionloghelper/overlay/ObjectHighlightOverlay.java
+++ b/src/main/java/com/collectionloghelper/overlay/ObjectHighlightOverlay.java
@@ -43,6 +43,7 @@ import net.runelite.client.callback.ClientThread;
 import net.runelite.api.DecorativeObject;
 import net.runelite.api.GameObject;
 import net.runelite.api.GroundObject;
+import net.runelite.api.Player;
 import net.runelite.api.Point;
 import net.runelite.api.Scene;
 import net.runelite.api.Tile;
@@ -301,11 +302,24 @@ public class ObjectHighlightOverlay extends Overlay
 		final List<TileObject> objects = this.matchedObjects;
 		final String action = this.objectInteractAction;
 		final String tipText = this.tooltipText;
+		final List<WorldPoint> exactTiles = this.filterTiles;
+		final int maxDist = this.filterMaxDistance;
 
 		if (objects.isEmpty() || !config.showOverlays())
 		{
 			return null;
 		}
+
+		// Nearest-only highlight: when the step pinned no explicit tiles
+		// (objectFilterTiles) and no distance window (objectMaxDistance), a target
+		// objectId can match every scene instance (e.g. 70+ funeral pyres / braziers
+		// on a gather-loop step). Highlight only the instance nearest the player so
+		// guidance points at the next actionable object rather than cluttering the
+		// scene. Steps that pin tiles or a distance window keep their full set.
+		final boolean nearestOnly = (exactTiles == null || exactTiles.isEmpty())
+			&& maxDist <= 0
+			&& objects.size() > 1;
+		final TileObject nearest = nearestOnly ? nearestObject(objects, playerLocalLocation()) : null;
 
 		Color overlayColor = config.overlayColor();
 		final ObjectHighlightStyle style = config.objectHighlightStyle();
@@ -315,6 +329,10 @@ public class ObjectHighlightOverlay extends Overlay
 
 		for (TileObject obj : objects)
 		{
+			if (nearestOnly && obj != nearest)
+			{
+				continue;
+			}
 			LocalPoint localPoint = obj.getLocalLocation();
 			if (style == ObjectHighlightStyle.OUTLINE_GLOW)
 			{
@@ -338,6 +356,49 @@ public class ObjectHighlightOverlay extends Overlay
 		}
 
 		return null;
+	}
+
+	private LocalPoint playerLocalLocation()
+	{
+		Player local = client.getLocalPlayer();
+		return local != null ? local.getLocalLocation() : null;
+	}
+
+	/**
+	 * Returns the object nearest the player by squared local distance. Allocation-free
+	 * (single pass, no comparator) so it is safe on the render path. Falls back to the
+	 * first object when the player location is unavailable, so an unfiltered single-
+	 * instance highlight still draws.
+	 */
+	static TileObject nearestObject(List<TileObject> objects, LocalPoint player)
+	{
+		if (objects == null || objects.isEmpty())
+		{
+			return null;
+		}
+		if (player == null)
+		{
+			return objects.get(0);
+		}
+		TileObject best = null;
+		long bestDistSq = Long.MAX_VALUE;
+		for (TileObject obj : objects)
+		{
+			LocalPoint lp = obj.getLocalLocation();
+			if (lp == null)
+			{
+				continue;
+			}
+			long dx = (long) lp.getX() - player.getX();
+			long dy = (long) lp.getY() - player.getY();
+			long distSq = dx * dx + dy * dy;
+			if (distSq < bestDistSq)
+			{
+				bestDistSq = distSq;
+				best = obj;
+			}
+		}
+		return best != null ? best : objects.get(0);
 	}
 
 	/**

--- a/src/test/java/com/collectionloghelper/overlay/ObjectHighlightOverlayNearestTest.java
+++ b/src/test/java/com/collectionloghelper/overlay/ObjectHighlightOverlayNearestTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.overlay;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import net.runelite.api.TileObject;
+import net.runelite.api.coords.LocalPoint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import org.junit.jupiter.api.Test;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ObjectHighlightOverlayNearestTest
+{
+	private static TileObject objectAt(int x, int y)
+	{
+		TileObject obj = mock(TileObject.class);
+		when(obj.getLocalLocation()).thenReturn(new LocalPoint(x, y));
+		return obj;
+	}
+
+	@Test
+	void picksTheClosestInstanceToThePlayer()
+	{
+		TileObject far = objectAt(1000, 1000);
+		TileObject near = objectAt(120, 100);
+		TileObject mid = objectAt(400, 400);
+		List<TileObject> objects = new ArrayList<>(List.of(far, mid, near));
+
+		TileObject result = ObjectHighlightOverlay.nearestObject(objects, new LocalPoint(100, 100));
+
+		assertSame(near, result, "should pick the instance with the smallest squared distance");
+	}
+
+	@Test
+	void returnsNullForEmptyOrNullInput()
+	{
+		assertNull(ObjectHighlightOverlay.nearestObject(Collections.emptyList(), new LocalPoint(0, 0)));
+		assertNull(ObjectHighlightOverlay.nearestObject(null, new LocalPoint(0, 0)));
+	}
+
+	@Test
+	void fallsBackToFirstWhenPlayerLocationUnavailable()
+	{
+		TileObject first = objectAt(500, 500);
+		TileObject second = objectAt(10, 10);
+		List<TileObject> objects = List.of(first, second);
+
+		// Null player location (e.g. mid-teleport) must still yield a drawable target.
+		assertSame(first, ObjectHighlightOverlay.nearestObject(objects, null));
+	}
+
+	@Test
+	void skipsObjectsWithNoLocalLocation()
+	{
+		TileObject noLoc = mock(TileObject.class);
+		when(noLoc.getLocalLocation()).thenReturn(null);
+		TileObject located = objectAt(300, 300);
+		List<TileObject> objects = new ArrayList<>(List.of(noLoc, located));
+
+		assertEquals(located, ObjectHighlightOverlay.nearestObject(objects, new LocalPoint(290, 290)));
+	}
+}


### PR DESCRIPTION
## Summary

Implements the **nearest-only object highlight** (F4) — the one actionable CLH item surfaced by the P3 corpus-detector sweep's `over-highlight-risk` class (9 findings: Shades of Mort'ton, Wintertodt, Trouble Brewing, Motherlode Mine).

`ObjectHighlightOverlay` rendered **every** scene instance matching a target `objectId`. On gather-loop steps that pin neither `objectFilterTiles` nor `objectMaxDistance`, this lit 70+ objects simultaneously (e.g. every funeral pyre at Shades, every brazier at Wintertodt), cluttering the scene rather than pointing at the next actionable target.

## Fix

When a step sets **no** exact-tile filter and **no** distance window, highlight only the instance **nearest the player**. Steps that pin explicit tiles or a distance window are unchanged, so intentional multi-object highlights still draw in full. This matches the over-highlight detector's exact condition ("no `objectFilterTiles` / `objectMaxDistance`").

- `nearestObject(...)` is a single allocation-free pass (squared local distance, no comparator/stream) — safe on the render path per the project's hot-path rules.
- Falls back to the first object when the player location is unavailable (mid-teleport), so an unfiltered single-instance highlight still draws.

## Verification

- New unit test `ObjectHighlightOverlayNearestTest` (closest pick, empty/null input, null-player fallback, skips objects with no local location).
- `./gradlew build` (full compile + test + data lint): green.
