### PR TITLE
fix(data): Runecrafting (Fire Runes) - wrong required item id (6527 Tzhaar weapon) and banking destination

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -30108,7 +30108,7 @@
     },
     "guidanceSteps": [
       {
-        "description": "Travel to the Fire Altar north-east of Al Kharid. Bring a fire tiara (wear it to enter freely) or a fire talisman. Equip a large pouch and medium pouch to carry more essence per trip. Ring of dueling to Emir's Arena is the standard banking method - use it to teleport to the Castle Wars or Ferox Enclave bank between trips.",
+        "description": "Travel to the Fire Altar north-east of Al Kharid (west of Emir's Arena). Bring a fire tiara (wear it to enter freely) or a fire talisman. Equip a large pouch and medium pouch to carry more essence per trip. Ring of dueling to Emir's Arena is the standard banking method - the arena bank is a short run from the altar ruins.",
         "worldX": 2583,
         "worldY": 4838,
         "worldPlane": 0,
@@ -30116,12 +30116,12 @@
         "completionDistance": 15,
         "travelTip": "Ring of dueling -> Emir's Arena -> run north-east to fire altar ruins",
         "requiredItemIds": [
-          6527
+          1442
         ],
         "section": "Travel"
       },
       {
-        "description": "Craft fire runes at the altar (14 Runecrafting required). Click the altar to craft all essence in inventory and pouches. Use Ring of dueling to teleport to Castle Wars bank, refill essence, then repeat. Rift guardian pet chance applies each time you craft runes. Lava rune crafting (via combo rune method) is faster XP but requires Earth runes.",
+        "description": "Craft fire runes at the altar (14 Runecrafting required). Click the altar to craft all essence in inventory and pouches. Use Ring of dueling to teleport back to Emir's Arena, refill essence at the bank, then run to the altar and repeat. Rift guardian pet chance applies each time you craft runes. Lava rune crafting (via combo rune method) is faster XP but requires Earth runes.",
         "worldX": 2583,
         "worldY": 4838,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Accuracy-sample fix (random-sample verification pass). Two errors in the Fire Runes runecrafting source:

1. **Wrong required item (blocker).** `requiredItemIds` was `[6527]` = **Tzhaar-ket-em** (a TzHaar melee weapon) per the game cache — the activity uses no such item. Replaced with **fire talisman `1442`**, which actually gates entry to the Fire altar (the prose already names "a fire tiara ... or a fire talisman").
2. **Wrong banking destination.** Both steps told players to teleport to the **Castle Wars / Ferox Enclave** bank, but the standard fire-rune method — and this source's own `travelTip` ("Ring of dueling -> Emir's Arena -> run ... to fire altar") — uses the **Emir's Arena** ring-of-dueling bank, a short run from the altar ruins. Both descriptions aligned to Emir's Arena.

## Receipts

- `cross_check_ids`: `6527 -> "Tzhaar-ket-em"`, `1442 -> "Fire talisman"`.
- OSRS wiki (Fire altar): enter by "use a fire talisman on the ruins, or click 'Enter' ... while wearing a fire tiara"; "Crafting fire runes with a ring of dueling is one of the fastest ways to 44 Runecraft."

## Verification

`validate_drop_rates` (all): pass. CI is the authoritative gate for data.
