### PR TITLE
fix(data): Pickpocketing Darkmeyer Vyre - wrong disguise item ids (Blood pint/null) and pickpocket target

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -32430,7 +32430,7 @@
     },
     "guidanceSteps": [
       {
-        "description": "Travel to Darkmeyer via Drakan's medallion (Sins of the Father required). Equip vyre noble clothing (top, legs, shoes) before entering - without it Vyrewatch Sentinels will attack rather than let you pickpocket them.",
+        "description": "Travel to Darkmeyer via Drakan's medallion (Sins of the Father required). Equip the full Vyrewatch outfit (top, legs, shoes - the 'vyre noble' disguise) before entering - without it the Vyres turn hostile instead of letting you pickpocket them.",
         "worldX": 3631,
         "worldY": 3325,
         "worldPlane": 0,
@@ -32438,14 +32438,14 @@
         "completionDistance": 20,
         "travelTip": "Drakan's medallion -> Darkmeyer; or Kharyrll teleport -> Canifis then travel south-east",
         "requiredItemIds": [
-          24774,
-          24775,
-          24776
+          9634,
+          9636,
+          9638
         ],
         "section": "Travel"
       },
       {
-        "description": "Pickpocket Vyrewatch Sentinels (82 Thieving required). Wear vyre noble robes to avoid aggression. Blood shards drop at approximately 1/5000 per pickpocket. Rogue's outfit doubles pickpocket loot. Use Dodgy necklace to avoid stun/damage on failure.",
+        "description": "Pickpocket Vyres in Darkmeyer (82 Thieving required). Wear the full Vyrewatch outfit to blend in. Blood shard drops at approximately 1/5000 per pickpocket. Rogue's outfit doubles pickpocket loot. Use a Dodgy necklace to avoid stun/damage on failure.",
         "worldX": 3631,
         "worldY": 3325,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary

Accuracy-sample fix (random-sample verification pass). Two errors in the Darkmeyer Vyre pickpocketing source:

1. **Wrong disguise item ids (blocker).** `requiredItemIds` was `[24774, 24775, 24776]` — the game cache resolves `24774` to **"Blood pint"** and `24775`/`24776` to **null**. None are the disguise. Replaced with the Vyrewatch outfit the activity requires: `9634/9636/9638` (cache: **"Vyrewatch top/legs/shoes"** — the "vyre noble" disguise worn to pickpocket in Darkmeyer).
2. **Wrong pickpocket target.** Both steps said **"Vyrewatch Sentinels"**, but those are a separate combat (slayer) NPC that is *killed*, not pickpocketed. The Blood shard comes from pickpocketing **Vyres** in Darkmeyer. Reworded the target to "Vyres" while keeping the Vyrewatch outfit as the disguise. 82 Thieving and the ~1/5000 rate are unchanged (both re-confirmed).

## Receipts

- `cross_check_ids`: `24774 -> "Blood pint"`, `24775/24776 -> null`, `9634/9636/9638 -> "Vyrewatch top/legs/shoes"`.
- OSRS wiki (Blood shard): pickpocket target "Vyre", "82" Thieving, rate "1/5,000", "The effect of the rogue equipment does apply to this item when pickpocketing".

## Verification

`validate_drop_rates` (all): pass. CI is the authoritative gate for data.
