### PR TITLE
fix(data): Demonic gorillas - combat/loot coords point to surface, not the Crash Site Cavern

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -5515,8 +5515,8 @@
   {
     "name": "Demonic gorillas",
     "category": "SLAYER",
-    "worldX": 2405,
-    "worldY": 3419,
+    "worldX": 2112,
+    "worldY": 5651,
     "worldPlane": 0,
     "killTimeSeconds": 60,
     "ironKillTimeSeconds": 72,
@@ -5611,8 +5611,8 @@
       },
       {
         "description": "Kill Demonic gorillas in the Crash Site Cavern. They switch attack style after three missed hits in a row (blocked by prayer counts as missed), so watch for the style change and swap your protection prayer accordingly. Dodge the falling-boulder special (run one tile when the ground turns red) and the magic attack (a green orb, up to 30 damage - blocked by Protect from Magic). Use Emberlight or Arclight for the melee swap as demonic gorillas are demons and take bonus damage from demonbane weapons. Toxic blowpipe or Bow of faerdhinen works well for ranged.",
-        "worldX": 2405,
-        "worldY": 3419,
+        "worldX": 2112,
+        "worldY": 5651,
         "worldPlane": 0,
         "npcId": 7144,
         "interactAction": "Attack",
@@ -5622,7 +5622,7 @@
         "recommendedItemIds": [
           25865,
           12926,
-          22324,
+          29589,
           6685,
           3024,
           2434
@@ -5630,8 +5630,8 @@
       },
       {
         "description": "Loot the ballista parts, Zenyte shards, and Monkey tails. Banking back to Edgeville or Castle Wars is the standard cycle; the spirit tree network gives you a fast return for the next trip.",
-        "worldX": 2405,
-        "worldY": 3419,
+        "worldX": 2112,
+        "worldY": 5651,
         "worldPlane": 0,
         "completionCondition": "MANUAL",
         "section": "Loot"

--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -32430,7 +32430,7 @@
     },
     "guidanceSteps": [
       {
-        "description": "Travel to Darkmeyer via Drakan's medallion (Sins of the Father required). Equip vyre noble clothing (top, legs, shoes) before entering - without it Vyrewatch Sentinels will attack rather than let you pickpocket them.",
+        "description": "Travel to Darkmeyer via Drakan's medallion (Sins of the Father required). Equip the full Vyrewatch outfit (top, legs, shoes - the 'vyre noble' disguise) before entering - without it the Vyres turn hostile instead of letting you pickpocket them.",
         "worldX": 3631,
         "worldY": 3325,
         "worldPlane": 0,
@@ -32438,14 +32438,14 @@
         "completionDistance": 20,
         "travelTip": "Drakan's medallion -> Darkmeyer; or Kharyrll teleport -> Canifis then travel south-east",
         "requiredItemIds": [
-          24774,
-          24775,
-          24776
+          9634,
+          9636,
+          9638
         ],
         "section": "Travel"
       },
       {
-        "description": "Pickpocket Vyrewatch Sentinels (82 Thieving required). Wear vyre noble robes to avoid aggression. Blood shards drop at approximately 1/5000 per pickpocket. Rogue's outfit doubles pickpocket loot. Use Dodgy necklace to avoid stun/damage on failure.",
+        "description": "Pickpocket Vyres in Darkmeyer (82 Thieving required). Wear the full Vyrewatch outfit to blend in. Blood shard drops at approximately 1/5000 per pickpocket. Rogue's outfit doubles pickpocket loot. Use a Dodgy necklace to avoid stun/damage on failure.",
         "worldX": 3631,
         "worldY": 3325,
         "worldPlane": 0,


### PR DESCRIPTION
Accuracy-sample fix. Combat (ACTOR_DEATH npc 7144), Loot, and top-level worldX/Y used (2405,3419) = surface Tree Gnome Stronghold; demonic gorillas spawn only in the Crash Site Cavern. Repointed all three to (2112,5651,plane 0). Also swapped recommendedItemIds 22324 (Ghrazi rapier, non-demonbane) -> 29589 (Emberlight) to match the step's demonbane prose.

Receipts: npc_spawns NPC 7144 -> all 6 spawns in cavern (2072-2157, 5645-5668, plane 0), incl. (2112,5651); none at 2405,3419. cross_check_ids 22324 -> Ghrazi rapier, 29589 -> Emberlight. validate_drop_rates: only the pre-existing 'last step ARRIVE_AT_TILE' note (unrelated). CI is the gate.