### PR TITLE
fix(data): Fishing Trawler - wrong bucket item id (empty bucket 1925 -> bailing bucket 583)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -16166,7 +16166,7 @@
         "completionDistance": 20,
         "travelTip": "Minigame tele -> Fishing Trawler, or fairy ring DJP -> run south",
         "requiredItemIds": [
-          1925,
+          583,
           954
         ],
         "section": "Travel"
@@ -16193,7 +16193,7 @@
         "worldPlane": 1,
         "completionCondition": "MANUAL",
         "recommendedItemIds": [
-          1925,
+          583,
           954
         ],
         "section": "Activity"


### PR DESCRIPTION
Accuracy-sample fix. requiredItemIds (Travel) and recommendedItemIds (bailing step) listed 1925 = BUCKET_EMPTY, which does nothing in the minigame. The water-removal item is the Bailing bucket (583). Changed both 1925 -> 583; rope (954) unchanged.

Receipts: cross_check_ids 583 -> 'Bailing bucket'; RuneLite BUCKET_BAILING=583 vs BUCKET_EMPTY=1925; wiki: 'Item ID: 583 ... used in the Fishing Trawler minigame ... bail water out of the trawler.' validate: only pre-existing 'last step ARRIVE_AT_TILE' note. CI is the gate.