### PR TITLE
fix(data): Rogues' Den - overstated drop rate (0.625) and junk recommended items

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -16327,7 +16327,7 @@
       {
         "itemId": 5554,
         "name": "Rogue mask",
-        "dropRate": 0.625,
+        "dropRate": 0.392,
         "isPet": false,
         "wikiPage": "Rogue_mask",
         "independent": true
@@ -16335,7 +16335,7 @@
       {
         "itemId": 5553,
         "name": "Rogue top",
-        "dropRate": 0.625,
+        "dropRate": 0.392,
         "isPet": false,
         "wikiPage": "Rogue_top",
         "independent": true
@@ -16343,7 +16343,7 @@
       {
         "itemId": 5555,
         "name": "Rogue trousers",
-        "dropRate": 0.625,
+        "dropRate": 0.392,
         "isPet": false,
         "wikiPage": "Rogue_trousers",
         "independent": true
@@ -16351,7 +16351,7 @@
       {
         "itemId": 5556,
         "name": "Rogue gloves",
-        "dropRate": 0.625,
+        "dropRate": 0.392,
         "isPet": false,
         "wikiPage": "Rogue_gloves",
         "independent": true
@@ -16359,7 +16359,7 @@
       {
         "itemId": 5557,
         "name": "Rogue boots",
-        "dropRate": 0.625,
+        "dropRate": 0.392,
         "isPet": false,
         "wikiPage": "Rogue_boots",
         "independent": true
@@ -16402,14 +16402,6 @@
           3060,
           4990,
           1
-        ],
-        "recommendedItemIds": [
-          13237,
-          13238,
-          13239,
-          13240,
-          13241,
-          13242
         ],
         "section": "Activity"
       },


### PR DESCRIPTION
Accuracy-sample fix (corrected after CI caught a mis-targeted edit). All 5 Rogue pieces had dropRate 0.625 (matches no level); the per-run chance is the equipment-crate chance (crate lets you pick the piece) = 39.2% at the lvl-50 requirement up to 46.9% at 99. Set all to 0.392. Also removed the Activity (maze) step's recommendedItemIds [13237-13242] - those are the Brimhaven Graceful recolour piece ids copy-pasted in by mistake; the Rogues' Den maze strips all carried items so there are no recommended items.

Brimhaven Agility Arena's activityObtainableItemIds (the rightful owner of 13237-13242) is untouched. Receipts: wiki crate-chance table '50|39.2% ... 99|46.9%' + 'may alternatively choose to get a rogue kit'. ActivityObtainableItemsTest passes locally; validate: only pre-existing 'last step ARRIVE_AT_TILE'. CI is the gate.