### PR TITLE
fix(data): Cyclopes - Dragon defender drops only from level-106 Warriors' Guild basement Cyclopes

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -22227,7 +22227,7 @@
           "8848": "Kill Cyclopes while holding a Black defender in inventory to receive a Mithril defender.",
           "8849": "Kill Cyclopes while holding a Mithril defender in inventory to receive an Adamant defender.",
           "8850": "Kill Cyclopes while holding an Adamant defender in inventory to receive a Rune defender.",
-          "12954": "Kill Cyclopes while holding a Rune defender in inventory to receive the Dragon defender."
+          "12954": "Only the level 106 Cyclopes in the Warriors' Guild basement drop the Dragon defender (1/100). After obtaining the Rune defender, show it to Lorelai (one-time) to unlock basement access via the ladder west of the guild's back door, then kill the level 106 Cyclopes there."
         },
         "worldX": 2849,
         "worldY": 3543,


### PR DESCRIPTION
Accuracy-sample fix. The Dragon defender per-item step said to kill any Cyclopes; it only drops from the level-106 Cyclopes in the Warriors' Guild basement (1/100), accessed by showing a Rune defender to Lorelai. Corrected the perItemStepDescription.

Receipt: wiki Dragon defender - 'can only be obtained from the stronger level 106 Cyclopes found exclusively in the Warrior Guild's basement.' validate_drop_rates: pass. CI is the gate.