### PR TITLE
feat(maintenance): toolkit-independent drift detector + data-maintenance workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ __pycache__/
 # Generated audit reports (written by scripts/audit_drop_rates.py)
 audit-report-*.json
 audit-report-*.md
+
+# drift_check.mjs local state cache
+.drift-cache/

--- a/docs/data-maintenance-workflow.md
+++ b/docs/data-maintenance-workflow.md
@@ -1,0 +1,93 @@
+# Data maintenance & drift workflow
+
+How we keep `drop_rates.json` accurate over time — both **validating the metas we already
+have** and **catching new content** the game ships, so the plugin can be updated retroactively.
+
+There are two loops. The first proves what we ship is correct *now*; the second tells us
+*when* reality has moved and what to re-check. They share one trigger (the abextm cache
+revision) so we re-validate exactly when there is new game data, not on a blind timer.
+
+---
+
+## Loop A — sustained accuracy validation (all metas, all items)
+
+**Goal:** every source's guidance reflects the *current* obtaining meta (location, travel,
+requirements, gear/prayer, drop mechanics & rates), not just that it drives mechanically.
+
+**Why a fan-out, not one-at-a-time:** a single source takes a full wiki/cache cross-check;
+serially that is ~225 long turns. Fanning out N independent verifiers (one per source) runs
+the expensive verification in parallel — the proven pattern from the 2026-06-29 sample run
+(17 sources, ~5 min wall-clock, found 2 blockers + 16 highs).
+
+**Mechanism (the accuracy-sample / fix-spec Workflow):**
+1. Pick a batch — a stratified random sample for a confidence estimate, or a full sweep in
+   slices of ~20 to march through all 226.
+2. `pipeline(sources, verifier)` — each verifier agent:
+   - reads the source's `guidanceSteps` / `requiredItemIds` / `items` from `drop_rates.json`,
+   - establishes current ground truth from the OSRS wiki (+ spawn/cache for ids/coords),
+   - returns a structured verdict (`ACCURATE` | `ISSUES`) with **cite-or-discard** receipts
+     and a domain-skeptic gate (legitimate mechanics are never flagged).
+3. Triage the scorecard: blockers/highs become one-source-per-PR fixes (each re-verified,
+   `validate_drop_rates` + `guidance_lint`, CI-gated); lows are batched/deferred.
+4. A second `fix-spec` fan-out can turn confirmed findings into exact, receipt-backed edits.
+
+**Confidence definition:** the corpus is "confident" when a fresh random sample returns a
+low blocker/high rate (target: 0 blockers, <1 high per ~20). Track the rate per sweep in
+`docs/data-verification-log.md`; re-sweep after each fix batch and after any cache-revision
+drift (Loop B).
+
+**Cadence:** march the full corpus in slices between releases; on a cache-revision bump
+(Loop B), re-validate the categories most likely touched by the update first.
+
+> The Workflow scripts live under the session's `workflows/scripts/` (e.g.
+> `clh-guidance-accuracy-sample`, `clh-accuracy-fix-spec`). They are the reusable templates —
+> change the source list / batch slice and re-run.
+
+---
+
+## Loop B — toolkit-independent drift detection (new content & ids)
+
+**Goal:** know when new game data lands and what new collection-log items/ids to add — using
+**only plain HTTPS to the same upstreams the toolkit wraps**, so it runs with no MCP, in CI,
+on a cron, or anywhere Node can fetch.
+
+Implemented in [`scripts/drift_check.mjs`](../scripts/drift_check.mjs) (read-only; persists
+markers under `.drift-cache/`, gitignored).
+
+### Data sources (all direct, no runelite-dev-toolkit)
+
+| Need | Source | Endpoint |
+|------|--------|----------|
+| Authoritative item/NPC ids (what the plugin uses) | **abextm/osrs-cache** | `api.github.com/repos/abextm/osrs-cache/commits/master` (revision/freshness) + `raw.githubusercontent.com/abextm/osrs-cache/<sha>/<n>.flatcache` (bytes, parsed via the `@abextm/cache2` npm package) |
+| Semantics: new items, rates, requirements, clog membership | **OSRS Wiki** | `oldschool.runescape.wiki/api.php` (MediaWiki: `recentchanges`, `search`, `parse` for item-infobox ids) |
+| Spawn coordinates | **mejrs/data_osrs** | `raw.githubusercontent.com/mejrs/data_osrs/.../master` |
+| Official patch notes | **OSRS news** | `oldschool.runescape.com/news` (fetch) |
+
+The abextm commit message carries the **cache revision** string (e.g.
+`Cache version 2026-06-25-rev239`). A changed revision == a game update shipped new/changed
+cache data — the precise, low-noise trigger for both loops.
+
+### What `drift_check.mjs` does
+
+1. Fetch the latest abextm cache revision; diff against the last-seen marker. Changed ⇒
+   **NEW CACHE REVISION** verdict (re-run Loop A on the likely-affected categories).
+2. Pull wiki `recentchanges` since the last run, filter to clog-relevant titles
+   (collection log / pet / jar / relic / medallion / vestige / …).
+3. Load the plugin's covered item ids (currently 226 sources / 1701 distinct ids) to diff
+   against new-item candidates.
+4. Emit a drift report + candidate list (`--json` for machine consumption) and persist
+   `.drift-cache/last-seen.json` (gitignored) so the next run is a true diff.
+
+### Turning drift into updates
+
+New cache revision **or** new clog item on the wiki → resolve the item id (wiki infobox, or
+parse abextm flatcache with `@abextm/cache2` for exact id↔name) → feed the candidate into the
+`add-source` / `drop-rate-entry` authoring pipeline → the new/changed source then flows
+through Loop A's verification before it ships. The two loops compose: **B finds what changed,
+A proves the fix is right.**
+
+### Suggested automation
+
+- Schedule `node scripts/drift_check.mjs` (cron / CI weekly + post-patch-Wednesday). On a
+  NEW-CACHE verdict, open a tracking issue with the candidate list and kick Loop A.
+- It needs no secrets and no MCP — only outbound HTTPS — so it is safe to run headless.

--- a/scripts/drift_check.mjs
+++ b/scripts/drift_check.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+// drift_check.mjs - toolkit-independent drift detector for Collection Log Helper.
+//
+// Purpose: surface when new OSRS game data lands so the plugin's drop_rates.json
+// can be updated retroactively - WITHOUT depending on the runelite-dev-toolkit MCP.
+// It talks directly to the same upstreams the toolkit wraps, over plain HTTPS:
+//
+//   1. abextm/osrs-cache (GitHub)      - authoritative item/NPC ids the plugin uses.
+//        commits API -> latest cache REVISION string ("Cache version YYYY-MM-DD-revN").
+//        A new revision == a game update dropped new/changed data.
+//   2. OSRS Wiki MediaWiki API          - semantics: new items, drop rates, requirements.
+//        recentchanges + search -> pages touched since we last looked.
+//   3. (optional) raw abextm flatcache  - exact id<->name, parsed via @abextm/cache2.
+//
+// It is read-only: it reports a drift verdict + candidate work, and persists the
+// last-seen markers under .drift-cache/ (gitignored) so the next run is a diff. Wire it to a
+// schedule (or run on demand); feed its candidate list into the add-source pipeline.
+//
+// Usage: node scripts/drift_check.mjs [--since YYYY-MM-DDTHH:MM:SSZ] [--json]
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const DROP_RATES = join(ROOT, "src/main/resources/com/collectionloghelper/drop_rates.json");
+const STATE_DIR = join(ROOT, ".drift-cache");
+const STATE_FILE = join(STATE_DIR, "last-seen.json");
+const UA = "collection-log-helper-drift-check/1.0 (data maintenance)";
+
+const argv = process.argv.slice(2);
+const asJson = argv.includes("--json");
+const sinceArg = (() => { const i = argv.indexOf("--since"); return i >= 0 ? argv[i + 1] : null; })();
+
+async function httpJson(url) {
+  const res = await fetch(url, { headers: { "User-Agent": UA, Accept: "application/json" } });
+  if (!res.ok) throw new Error(`${res.status} ${url}`);
+  return res.json();
+}
+
+function loadState() {
+  if (existsSync(STATE_FILE)) {
+    try { return JSON.parse(readFileSync(STATE_FILE, "utf8")); } catch { /* fall through */ }
+  }
+  return { cacheRev: null, lastRunIso: null };
+}
+
+function saveState(s) {
+  mkdirSync(STATE_DIR, { recursive: true });
+  writeFileSync(STATE_FILE, JSON.stringify(s, null, 2));
+}
+
+// 1. abextm cache revision (the freshness gate - matches what the plugin's ids use).
+async function abextmRevision() {
+  const c = await httpJson("https://api.github.com/repos/abextm/osrs-cache/commits/master");
+  const msg = c.commit?.message ?? "";
+  const rev = (msg.match(/Cache version[^\n]*/) || [msg.split("\n")[0]])[0].trim();
+  return { sha: c.sha, rev, date: c.commit?.committer?.date };
+}
+
+// 2. Wiki pages touched recently (the semantics signal). Filters to mainspace and to
+//    titles that look collection-log relevant; broaden as needed.
+async function wikiRecentChanges(sinceIso) {
+  const params = new URLSearchParams({
+    action: "query", list: "recentchanges", rcnamespace: "0", rclimit: "200",
+    rcprop: "title|timestamp", rctype: "edit|new", format: "json",
+  });
+  if (sinceIso) params.set("rcend", sinceIso);
+  const d = await httpJson(`https://oldschool.runescape.wiki/api.php?${params}`);
+  return d.query?.recentchanges ?? [];
+}
+
+// 3. Plugin's currently-covered item ids (what we already guide for).
+function pluginItemIds() {
+  const data = JSON.parse(readFileSync(DROP_RATES, "utf8"));
+  const ids = new Set();
+  let items = 0;
+  for (const src of data) {
+    for (const it of src.items ?? []) { if (typeof it.itemId === "number") { ids.add(it.itemId); items++; } }
+  }
+  return { ids, items, sources: data.length };
+}
+
+async function main() {
+  const state = loadState();
+  const [rev, plugin] = await Promise.all([abextmRevision(), Promise.resolve(pluginItemIds())]);
+
+  const cacheChanged = state.cacheRev && state.cacheRev !== rev.rev;
+  const since = sinceArg || state.lastRunIso || null;
+  let wiki = [];
+  let wikiErr = null;
+  try { wiki = await wikiRecentChanges(since); } catch (e) { wikiErr = String(e); }
+
+  // Heuristic interest filter: wiki edits whose title hints at new/clog content.
+  const INTEREST = /(collection log|\bpet\b|jar of|\brelic\b|\bmedallion\b|\bvestige\b|\bward\b|\bicon\b)/i;
+  const flagged = wiki.filter(c => INTEREST.test(c.title)).slice(0, 40);
+
+  const report = {
+    generatedFrom: { abextm: rev, wikiSince: since, wikiChanges: wiki.length },
+    drift: {
+      cacheRevisionChanged: !!cacheChanged,
+      previousCacheRev: state.cacheRev,
+      currentCacheRev: rev.rev,
+      verdict: cacheChanged
+        ? "NEW CACHE REVISION - a game update landed; re-validate drift candidates and check for new clog items/ids."
+        : (state.cacheRev ? "no cache change since last run" : "first run - baseline recorded"),
+    },
+    plugin: { sources: plugin.sources, coveredItemIds: plugin.ids.size, totalItemEntries: plugin.items },
+    wikiCandidates: flagged.map(c => ({ title: c.title, timestamp: c.timestamp })),
+    wikiError: wikiErr,
+  };
+
+  saveState({ cacheRev: rev.rev, lastRunIso: new Date().toISOString().replace(/\.\d+/, "") });
+
+  if (asJson) { console.log(JSON.stringify(report, null, 2)); return; }
+  console.log(`abextm cache: ${rev.rev}  (${rev.date}, sha ${rev.sha.slice(0, 10)})`);
+  console.log(`plugin: ${report.plugin.sources} sources, ${report.plugin.coveredItemIds} distinct item ids`);
+  console.log(`drift verdict: ${report.drift.verdict}`);
+  console.log(`wiki changes since ${since || "(no baseline)"}: ${report.generatedFrom.wikiChanges}` + (wikiErr ? ` (ERROR: ${wikiErr})` : ""));
+  if (report.wikiCandidates.length) {
+    console.log(`clog-relevant wiki edits to review (${report.wikiCandidates.length}):`);
+    for (const c of report.wikiCandidates) console.log(`  - ${c.title}  (${c.timestamp})`);
+  }
+}
+
+main().catch(e => { console.error("drift_check failed:", e); process.exit(1); });


### PR DESCRIPTION
## Summary

Adds a sustainable way to keep `drop_rates.json` accurate as the game changes — two composing loops, documented in `docs/data-maintenance-workflow.md`.

### Loop B — `scripts/drift_check.mjs` (toolkit-independent)

A read-only drift detector that talks **directly** to the same upstreams the dev-toolkit wraps, over plain HTTPS — **no MCP dependency**, so it runs headless in CI or on a cron:

- **abextm/osrs-cache** (GitHub commits API) → the authoritative cache **revision** string. A new revision == a game update shipped new/changed item/NPC data — the precise trigger.
- **OSRS Wiki** (MediaWiki API) → recent changes filtered to collection-log-relevant titles (semantics: new items, rates, requirements).
- Loads the plugin's covered item ids and persists last-seen markers under `.drift-cache/` (gitignored) so each run is a true diff.

Verified: `node scripts/drift_check.mjs` reports the current cache revision (rev239), plugin coverage (226 sources / 1701 distinct item ids), and baselines the markers. New item ids resolve via the wiki infobox or the abextm flatcache (`@abextm/cache2`).

### Loop A — sustained accuracy validation (documented)

The fan-out verifier Workflow (one verifier per source, current-wiki cross-check, cite-or-discard + domain-skeptic) used for the 2026-06-29 accuracy pass that found and fixed the recent backlog. Run as a stratified sample for a confidence estimate, or in slices to march the whole corpus; re-run on a drift signal.

**They compose: B finds what changed, A proves the fix is right.**

## Notes

Pure tooling/docs — no `drop_rates.json` or plugin-code changes. `.drift-cache/` added to `.gitignore`.
