### PR TITLE
fix(data): Araxxor - add missing 92 Slayer requirement and Slayer-task lock

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -9169,6 +9169,12 @@
     "requirements": {
       "quests": [
         "SINS_OF_THE_FATHER"
+      ],
+      "skills": [
+        {
+          "skill": "SLAYER",
+          "level": 92
+        }
       ]
     },
     "items": [
@@ -9254,7 +9260,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Bank for Araxxor. Bring Saradomin brews, super restores, and combat potions. Use melee (scythe, Inquisitor's mace, or Soulreaper axe) or ranged; bring a halberd for mirrorback araxytes. Saradomin brews and super restores for sustain.",
+        "description": "Bank for Araxxor. Requires 92 Slayer, and he can only be killed while on a spider or araxyte Slayer task (Konar can also assign Araxxor). Bring Saradomin brews, super restores, and combat potions. Use melee (scythe, Inquisitor's mace, or Soulreaper axe) or ranged; bring a halberd for mirrorback araxytes. Saradomin brews and super restores for sustain.",
         "worldX": 3087,
         "worldY": 3493,
         "worldPlane": 0,


### PR DESCRIPTION
## Problem
The Araxxor entry listed only the Sins of the Father quest in `requirements`. It was missing two real access gates:

1. **92 Slayer** — required to kill Araxxor at all.
2. **On-task lock** — as a Slayer boss, Araxxor can only be killed while on a spider or araxyte Slayer task (Konar may also assign it).

A player below 92 Slayer, or off-task, would complete Sins of the Father, travel to the lair, and be unable to engage the boss.

## Fix
- `requirements`: add `skills: [{ skill: SLAYER, level: 92 }]` (same shape Cerberus/Hydra/Grotesque Guardians use).
- Prep guidance step: note the 92 Slayer + on-task access gate.

Prose/requirement-only — no itemId, dropRate, coord, `loopBackToStep`, or `loopCount` touched.

## Source (cite-or-discard)
OSRS Wiki, Araxxor:
> requiring level 92 Slayer and access to Morytania to kill

> As a Slayer boss, he may only be killed while on a spider or araxyte Slayer task

Verified via WebFetch of `oldschool.runescape.wiki/w/Araxxor`; survived a domain-skeptic refutation pass.

## Validation
- `validate_drop_rates` (Araxxor): clean apart from the pre-existing corpus-wide ARRIVE_AT_TILE last-step advisory.
- `guidance_lint` (Araxxor): only pre-existing by-design warnings; nothing introduced by this change.