### PR TITLE
fix(data): Bryophyta - Growthlings require a woodcutting axe or magic secateurs

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -3978,7 +3978,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Bank in Varrock west bank. Required: Mossy key (farmed from Moss giants in Varrock Sewers or Brimhaven Dungeon at 1/150, or 1/75 on a moss giant Slayer task). Bring melee gear, super combat, food, prayer potions, and an Amulet of glory for the return teleport",
+        "description": "Bank in Varrock west bank. Required: Mossy key (farmed from Moss giants in Varrock Sewers or Brimhaven Dungeon at 1/150, or 1/75 on a moss giant Slayer task). Bring melee gear, super combat, food, prayer potions, and an Amulet of glory for the return teleport. Also bring a woodcutting axe or magic secateurs to kill the Growthlings (a bronze axe is available from the log pile in the lair if you have neither)",
         "worldX": 3185,
         "worldY": 3439,
         "worldPlane": 0,
@@ -4017,7 +4017,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Bryophyta. Activate Protect from Magic before entering or immediately on entry. All melee styles are equally effective (no elevated stab defence; 50% fire magic weakness). Kill Growthlings the moment they spawn - Bryophyta is immune to all damage (except poison and venom) while any Growthling is alive",
+        "description": "Kill Bryophyta. Activate Protect from Magic before entering or immediately on entry. All melee styles are equally effective (no elevated stab defence; 50% fire magic weakness). Kill the Growthlings the moment they spawn by attacking them with a woodcutting axe or magic secateurs, which one-shot them - normal weapons, battleaxes, and the zombie axe cannot damage them. Bryophyta is immune to all damage (except poison and venom) while any Growthling is alive",
         "worldX": 3174,
         "worldY": 3435,
         "worldPlane": 0,


### PR DESCRIPTION
## Problem
Bryophyta is immune to all damage (except poison/venom) while any Growthling is alive. The Growthlings can **only** be killed by attacking them with a woodcutting axe or magic secateurs (which one-shot them) — normal weapons, battleaxes, and the zombie axe cannot damage them.

The entry's recommended gear listed only a whip (no axe / secateurs), and the combat step said "Kill Growthlings the moment they spawn" without a method — so following the guidance, the kill is impossible (boss permanently immune behind un-killable Growthlings).

## Fix (prose-only)
- Prep step: bring a woodcutting axe or magic secateurs (bronze axe available from the log pile in the lair as a fallback).
- Combat step: state the Growthling kill method explicitly.

No itemId, dropRate, coord, `loopBackToStep`, or `loopCount` touched.

## Source (cite-or-discard)
OSRS Wiki, Bryophyta:
> they must be attacked with a woodcutting axe or magic secateurs, one-shotting the growthlings

> other types of axes, such as battleaxes or the zombie axe, cannot be used to kill the growthlings

Verified via WebFetch of `oldschool.runescape.wiki/w/Bryophyta`; survived a domain-skeptic refutation pass.

## Validation
`validate_drop_rates` / `guidance_lint` (Bryophyta): only pre-existing by-design warnings; nothing introduced by this change.