### PR TITLE
fix(data): Callisto - correct inverted prayer guidance (Protect from Melee, not Magic)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -5492,7 +5492,7 @@
         "travelTip": "Burning amulet -> Chaos Temple + run north"
       },
       {
-        "description": "Arrive at Callisto's Den and pre-pot Divine ranging potion. Turn on Rigour (or Eagle Eye) and Protect from Magic before engaging; melee combat is not advised as Callisto deals very high melee damage even through Protect from Melee",
+        "description": "Arrive at Callisto's Den and pre-pot Divine ranging potion. Turn on Rigour (or Eagle Eye) and keep Protect from Melee up - it reduces his high-damage AoE melee (his primary threat) by ~50%. Flick Protect from Magic only when he launches the white orb knockback",
         "worldX": 3291,
         "worldY": 3849,
         "worldPlane": 0,
@@ -5500,7 +5500,7 @@
         "completionDistance": 5
       },
       {
-        "description": "Kill Callisto with ranged using Protect from Magic. Callisto uses melee, ranged (if out of reach), and a slow magic attack - Protect from Magic fully negates the magic attack and prevents the knockback/stun. At 66% and 33% HP Callisto deploys bear traps that snare and damage if stepped on. Protect from Melee only reduces his melee damage by ~50% so stay at range",
+        "description": "Kill Callisto with ranged. Keep Protect from Melee up as the standing prayer - his high-damage AoE melee swipe is the main threat and is reduced ~50% by it. He also uses a ranged crescent attack when out of melee reach (Protect from Magic does NOT block this). When he launches the white orb at you, flick Protect from Magic to avoid the knockback and up to 50 damage. At 66% and 33% HP Callisto deploys bear traps that snare and damage if stepped on",
         "worldX": 3291,
         "worldY": 3849,
         "worldPlane": 0,


### PR DESCRIPTION
## Problem
The Callisto entry told players to stand on **Protect from Magic** and explicitly disparaged Protect from Melee ("melee combat is not advised… deals very high melee damage even through Protect from Melee" / "Protect from Melee only reduces his melee damage by ~50% so stay at range").

This inverts the actual mechanics:
- Callisto's primary, highest-damage attack is his **AoE melee swipe**, which Protect from Melee reduces by ~50% — so it is the standing prayer.
- Protect from Magic is relevant **only** for the white orb knockback (flick it when the orb is launched).
- Protect from Magic does not block his ranged crescent attack either, so "stay at range under Protect from Magic" left players exposed.

## Fix (prose-only)
- Arrival step: stand on Protect from Melee; flick Magic for the white orb.
- Combat step: rewrite prayer usage; keep the bear-trap mechanic.

No itemId, dropRate, coord, `loopBackToStep`, or `loopCount` touched.

## Source (cite-or-discard)
OSRS Wiki, Callisto/Strategies:
> using Protect from Melee reduces the damage by ~50%

> Callisto will occasionally launch a white orb at his target, of which they should switch on Protect from Magic or risk taking up to 50 damage

Verified via WebFetch of `oldschool.runescape.wiki/w/Callisto/Strategies`; survived a domain-skeptic refutation pass.

## Validation
`validate_drop_rates` (Callisto): **passed, no issues**. `guidance_lint`: only the pre-existing ACTOR_DEATH completionDistance advisory.