### PR TITLE
fix(data): Dagannoth Rex - correct Lunar teleport route to Waterbirth Island

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -4205,7 +4205,7 @@
       }
     ],
     "locationDescription": "Waterbirth Island, Rellekka",
-    "travelTip": "Lunar Isle tele -> Rellekka",
+    "travelTip": "Waterbirth Teleport (Lunar spellbook) -> Waterbirth Island",
     "mutuallyExclusiveSources": [
       "Dagannoth Prime",
       "Dagannoth Supreme"
@@ -4214,7 +4214,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to Waterbirth Island via Rellekka docks (pay 1,000 gp without The Fremennik Trials, free after) or Lunar Isle teleport",
+        "description": "Travel to Waterbirth Island via Rellekka docks (pay 1,000 gp without The Fremennik Trials, free after) or Waterbirth Teleport (Lunar spellbook)",
         "worldX": 2521,
         "worldY": 3740,
         "worldPlane": 0,


### PR DESCRIPTION
## Problem
Identical defect to the companion Dagannoth Prime PR. `travelTip` and step 1 said **"Lunar Isle tele -> Rellekka"** — the Lunar Isle Teleport spell lands on Lunar Isle (not Rellekka) and is not the route to the Dagannoth Kings. The correct Lunar-spellbook option is the **Waterbirth Teleport** spell (already used by the Dagannoth Supreme entry).

This entry was surfaced by cross-source consistency (Prime, Rex, and Supreme share the same lair; Supreme already had the correct form).

## Fix
- `travelTip`: `Lunar Isle tele -> Rellekka` → `Waterbirth Teleport (Lunar spellbook) -> Waterbirth Island`.
- Step 1: "or Lunar Isle teleport" → "or Waterbirth Teleport (Lunar spellbook)".

Travel-prose only.

## Source (cite-or-discard)
OSRS Wiki, Waterbirth Teleport:
> Teleports you to Waterbirth Island

## Validation
`validate_drop_rates` (Dagannoth Rex): **passed, no issues.**