### PR TITLE
fix(data): Doom of Mokhaiotl - ranged primary style + projectile-colour prayers

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -23593,7 +23593,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Bank for a Mokhaiotl delve. Bring a Mokhaiotl waystone, full Saradomin brews, super restores, prayer pots, super combat potion, and your best melee setup (Scythe is BiS for the boss but Soulreaper axe works). Bring chinchompas or magic for the early-depth swarm phases.",
+        "description": "Bank for a Mokhaiotl delve. Bring a Mokhaiotl waystone, full Saradomin brews, super restores, prayer pots, and ranging potions. Ranged is the primary style: a twisted bow is BiS given Doom's very high Magic level (275), and the scorching bow is the budget alternative. Bring a crystal halberd (or other melee weapon) only as a switch for the melee-punish mechanic at deeper delves - melee is unfriendly as a main weapon.",
         "worldX": 1593,
         "worldY": 3091,
         "worldPlane": 0,
@@ -23627,7 +23627,7 @@
         "section": "Combat"
       },
       {
-        "description": "Fight through the depth floors. Each depth has a different mechanic rotation (slam, projectile, shadow tiles). Protect from Magic for shadow phases, Protect from Melee when Doom closes the gap. Watch for the shadow-clone phase from depth 5+ and pre-pot before each floor's boss segment. Doom of Mokhaiotl is the depth-end fight - kill it to claim the delve reward.",
+        "description": "Fight through the depth floors. The Doom's standard attack is a single projectile whose colour tells you which prayer to use: blue = Protect from Magic, green = Protect from Missiles, red = Protect from Melee (red only appears from depth 2+). Damage is calculated on impact, so you can flick the correct prayer after the projectile launches. Watch for the shadow-clone phase from depth 5+ and pre-pot before each floor's boss segment. Doom of Mokhaiotl is the depth-end fight - kill it to claim the delve reward.",
         "worldX": 1311,
         "worldY": 9520,
         "worldPlane": 0,
@@ -23637,8 +23637,8 @@
         "completionNpcId": 14707,
         "section": "Combat",
         "recommendedItemIds": [
-          22325,
-          27277,
+          20997,
+          23987,
           6685,
           3024,
           2434


### PR DESCRIPTION
## Problem
Two current-meta errors in the Doom of Mokhaiotl entry (2025 Varlamore boss):

1. **Gear/style inverted.** The prep step recommended melee as the primary style — *"your best melee setup (Scythe is BiS for the boss but Soulreaper axe works)"* — and the recommended-item overlay highlighted the scythe + Soulreaper axe. This is the classic crush-weakness trap: the boss has high crush defence and a Magic level of 275, so **ranged is primary** (twisted bow BiS, scorching bow budget). Melee is only a switch for the melee-punish mechanic at deeper delves.
2. **Prayers framed as phase-based.** The combat step said *"Protect from Magic for shadow phases, Protect from Melee when Doom closes the gap"* and omitted the ranged style. In reality the standard attack is a single projectile whose **colour** tells you which prayer to use (blue = magic, green = ranged/missiles, red = melee from depth 2+), and you can flick after it launches.

## Fix
- Prep step: ranged-primary gear (twisted bow BiS / scorching bow budget; crystal halberd only as a melee-punish switch).
- Combat step: rewrite to the projectile-colour prayer mechanic.
- `recommendedItemIds`: `22325` (scythe) + `27277` (soulreaper) → `20997` (twisted bow) + `23987` (crystal halberd). Both new IDs verified against the game cache (`validate_drop_rates --check cache_ids` passed).

## Source (cite-or-discard)
OSRS Wiki, Doom of Mokhaiotl/Strategies:
> The twisted bow is the best weapon to use, given Doom's Magic level of 275

> the fight has many mechanics which make melee unfriendly, especially at deeper delves

> The Doom's standard attack consists of a single projectile, with its colour and shape indicating the combat style to pray against: blue for magic, green for ranged, and red for melee

Verified via WebFetch; both findings survived a domain-skeptic refutation pass.

## Validation
`validate_drop_rates` + `cache_ids` (Doom): **passed** (only the pre-existing ARRIVE_AT_TILE last-step advisory).