### PR TITLE
fix(data): Kalphite Queen - remove fabricated stomp, walk under in phase 2, fix prayer

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -1506,7 +1506,7 @@
         "completionCondition": "MANUAL"
       },
       {
-        "description": "Kill the Kalphite Queen - Phase 1 (510 HP halved at 255). She rotates Magic and Ranged hits that ALWAYS land but can roll 0 damage; her Ranged attack drains 1 prayer point on a non-zero hit. Use Protect from Missiles (Ranged hits are more frequent and drain prayer) and tank her Magic. Fight her in melee range with crush gear (Bandos godsword spec, abyssal bludgeon, or Osmumten's fang) - standing in melee triggers her to use her melee attack 50% of the time, lowering her DPS. Bring an antidote++ or serpentine helm against the Kalphite Guardian poison on the way in",
+        "description": "Kill the Kalphite Queen - Phase 1 (510 HP halved at 255). She rotates Magic and Ranged hits that ALWAYS land but can roll 0 damage; her Ranged attack drains 1 prayer point on a non-zero hit. Keep one overhead up - it does not matter much whether you pray Protect from Missiles or Protect from Magic since she attacks with both (Protect from Magic is slightly preferred in case another player crashes you). Fight her in melee range with crush gear (Bandos godsword spec, abyssal bludgeon, or Osmumten's fang) - standing in melee triggers her to use her melee attack 50% of the time, lowering her DPS. Bring an antidote++ or serpentine helm against the Kalphite Guardian poison on the way in",
         "worldX": 3471,
         "worldY": 9506,
         "worldPlane": 0,
@@ -1517,7 +1517,7 @@
         "completionNpcId": 965
       },
       {
-        "description": "Phase 2: when KQ flashes/shape-shifts at 50% HP she gains a wing-like form and her attack styles swap priorities - switch to Protect from Magic and use Ranged (twisted bow, blowpipe, or zaryte crossbow with Armadyl/Crystal armour). Stay outside melee range during phase 2 to avoid her stomp. Bring a few extra Saradomin brews if soloing without prayer flicks; the kill is over in 30-60 seconds with t-bow",
+        "description": "Phase 2: when KQ flashes/shape-shifts at 50% HP she gains a wing-like form - keep your overhead up (no forced prayer switch is needed) and continue with Ranged (twisted bow, blowpipe, or zaryte crossbow with Armadyl/Crystal armour). Walk under her (stand adjacent) as soon as phase 2 begins - she has no stomp or AoE attack, and standing away just gives her a free extra attack. Bring a few extra Saradomin brews if soloing without prayer flicks; the kill is over in 30-60 seconds with t-bow",
         "worldX": 3471,
         "worldY": 9506,
         "worldPlane": 0,


### PR DESCRIPTION
## Problem
Two errors in the Kalphite Queen combat guidance:

1. **Fabricated "stomp" + inverted positioning.** Phase 2 said *"Stay outside melee range during phase 2 to avoid her stomp."* KQ has **no stomp or AoE attack** — only stab/melee, Ranged, and Magic. The correct play is to **walk under her** (stand adjacent) as soon as phase 2 begins; standing away just gives her a free extra attack.
2. **Unnecessary forced prayer switch.** The entry told players to pray Protect from Missiles in phase 1 and **switch** to Protect from Magic in phase 2. She uses Magic and Ranged simultaneously in both forms, so one overhead only ever blocks one style — it doesn't matter much which you pray (Protect from Magic slightly preferred for crash-bounce), and no phase-tied switch is required.

## Fix (prose-only)
- Phase-1 step: reframe the overhead choice (either works; Magic slightly preferred).
- Phase-2 step: walk under her / no stomp; drop the forced switch.

No itemId, dropRate, coord, `loopBackToStep`, or `loopCount` touched.

## Source (cite-or-discard)
OSRS Wiki, Kalphite Queen/Strategies:
> Players should walk under her as soon as this phase begins, otherwise she will get an extra attack on you first

> it generally does not matter whether you pray Protect from Magic or Protect from Missiles

KQ's attacks are limited to melee, ranged, and magic. Verified via WebFetch; both findings survived a domain-skeptic refutation pass.

## Validation
`validate_drop_rates` (Kalphite Queen): clean apart from the pre-existing multi-form npcId 965 carve-out WARN (unrelated to this prose change).