### PR TITLE
fix(data): The Fight Caves - correct prayer assignments for cave monsters

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -24339,7 +24339,7 @@
         "section": "Travel"
       },
       {
-        "description": "Clear waves 1-62. Use Protect from Magic against Tz-Kih (level 22) and Yt-MejKot (180); Protect from Missiles against Tz-Kek (45) and Tok-Xil (90); Protect from Melee against Yt-HurKot (108) when healing Jad. Always pillar manip the larger spawns - stand so the pillar is between you and the new wave to control aggro stacking. Drop melee minions (Yt-MejKot, Ket-Zek) by tanking on the south pillar.",
+        "description": "Clear waves 1-62. Pray by each monster's attack style: Protect from Melee against Tz-Kih (level 22, drains prayer), Tz-Kek (45), Yt-MejKot (180), and the Yt-HurKot (108) healers; Protect from Missiles against Tok-Xil (90); Protect from Magic against Ket-Zek (360). Always pillar manip the larger spawns - stand so the pillar is between you and the new wave to control aggro stacking. Tank the melee minions (Tz-Kih, Yt-MejKot) on the south pillar, and keep Ket-Zek (magic) and Tok-Xil (ranged) at a distance.",
         "worldX": 2401,
         "worldY": 5093,
         "worldPlane": 0,


### PR DESCRIPTION
## Problem
The wave 1-62 guidance gave the **wrong protection prayer for 3 of the 4 monsters it named**, and mislabelled the magic attacker:

| Monster | Data said | Actual style | Correct prayer |
|---|---|---|---|
| Tz-Kih (22) | Protect from Magic | Melee (drains prayer) | **Protect from Melee** |
| Tz-Kek (45) | Protect from Missiles | Melee | **Protect from Melee** |
| Yt-MejKot (180) | Protect from Magic | Melee | **Protect from Melee** |
| Tok-Xil (90) | Protect from Missiles | Ranged | Protect from Missiles ✓ |
| Yt-HurKot (108) | Protect from Melee | Melee | Protect from Melee ✓ |
| Ket-Zek (360) | *(called a "melee minion")* | **Magic** | **Protect from Magic** |

A player following the old text prays Magic against two melee monsters and never prays Magic against the actual mager (Ket-Zek), taking heavy avoidable damage on a high-traffic Fire-cape grind.

## Fix (prose-only)
Rewrote the prayer list to be attack-style-based, and corrected the "drop melee minions (… Ket-Zek)" line (Ket-Zek is magic; keep it and Tok-Xil at distance).

## Source (cite-or-discard)
OSRS Wiki, TzHaar Fight Cave monster table: Tz-Kih / Tz-Kek / Yt-MejKot = **Melee**, Tok-Xil = **Ranged**, Ket-Zek = **Magic**. Verified via WebFetch; survived a domain-skeptic refutation pass.

## Validation
`validate_drop_rates` (The Fight Caves): clean apart from the pre-existing ARRIVE_AT_TILE last-step advisory.