### PR TITLE
fix(data): Scurrius - Protect from Melee in phases 1-2, not Protect from Missiles

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -24228,7 +24228,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Scurrius. Stand under the boss for melee, dodge the falling rocks (red tiles), and kill the Giant rat spawns immediately to disrupt the fight. Scurrius heals from the Food Piles between phases (not from the rats), so push damage through the phase transitions. Use Protect from Missiles to negate his ranged-style auto. Easy first-boss fight that often drops the Scurrius' spine (rune pouch upgrade).",
+        "description": "Kill Scurrius. Stand under the boss for melee, dodge the falling rocks (red tiles), and kill the Giant rat spawns immediately to disrupt the fight. Scurrius heals from the Food Piles between phases (not from the rats), so push damage through the phase transitions. Use Protect from Melee for phases one and two - his Tail Swipe melee is his fastest and most accurate attack (Protect from Missiles only blocks the minor Flying Fur ranged hit). Easy first-boss fight that often drops the Scurrius' spine (rune pouch upgrade).",
         "worldX": 3299,
         "worldY": 9867,
         "worldPlane": 0,


### PR DESCRIPTION
## Problem
The combat step said *"Use Protect from Missiles to negate his ranged-style auto."* Scurrius's fastest and most accurate attack is the **melee Tail Swipe** (Attack level 300, +150 melee bonus), used throughout phases one and two; Protect from Missiles only blocks the minor **Flying Fur** ranged hit. The same step (correctly) tells the player to *"stand under the boss for melee"* — which leaves them taking the dominant Tail Swipe unprayed.

## Fix (prose-only)
Protect from Missiles → **Protect from Melee** for phases one and two, with a note that Protect from Missiles only blocks the minor Flying Fur.

## Source (cite-or-discard)
OSRS Wiki, Scurrius/Strategies:
> the player should use Protect from Melee, as it is Scurrius' fastest and most accurate attack, due to his Attack level of 300 and +150 melee attack bonus

Verified via WebFetch; survived a domain-skeptic refutation pass.

## Validation
`validate_drop_rates` (Scurrius): clean apart from the pre-existing ARRIVE_AT_TILE last-step advisory.