### PR TITLE
fix(data): Sarachnis - remove fabricated magic attack and colour-glow prayer tells

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -3828,7 +3828,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Sarachnis. Use a crush weapon - her stab and slash defence is huge. Flick prayers: Protect from Magic when her body glows red, Protect from Ranged when she glows yellow. Prioritise killing the magic-using spawn; the melee spawn can be tanked if your defensive bonuses are sufficient. All remaining spawns die automatically when Sarachnis is killed. Standing on tiles directly adjacent to walls puts you out of her melee range; pray Protect from Missiles there to nullify all her damage, though spawn damage is unaffected by wall positioning.",
+        "description": "Kill Sarachnis. Use a crush weapon - her stab and slash defence is huge. She has no magic attack: pray Protect from Melee when adjacent to her and Protect from Missiles when out of melee range (she uses ranged when she cannot reach you). Kill the Spawn of Sarachnis that appear during the fight; they can be tanked if your defensive bonuses are sufficient. All remaining spawns die automatically when Sarachnis is killed. Standing on tiles directly adjacent to walls puts you out of her melee range; pray Protect from Missiles there to nullify all her damage, though spawn damage is unaffected by wall positioning.",
         "worldX": 1847,
         "worldY": 9910,
         "worldPlane": 0,


### PR DESCRIPTION
## Problem
The combat step said: *"Flick prayers: Protect from Magic when her body glows red, Protect from Ranged when she glows yellow."* Sarachnis has **no magic attack** and **no colour-glow tells**. She uses melee when a player is adjacent and ranged when out of reach. The step also referenced a "magic-using spawn" that isn't documented.

## Fix (prose-only)
Replaced the fabricated magic/colour-glow instruction with the correct distance-based prayers (Protect from Melee adjacent, Protect from Missiles at range) and neutralised the unverified "magic-using spawn" claim. The existing (correct) wall-positioning + Protect from Missiles note is retained.

## Source (cite-or-discard)
OSRS Wiki, Sarachnis — attack styles **"Melee, Ranged"**:
> Players should use Protect from Missiles when Sarachnis shoots the web to block her next ranged attack, then quickly close to melee range and switch back to Protect from Melee

No magic attack or colour tell is documented. Verified via WebFetch; survived a domain-skeptic refutation pass.

## Validation
`validate_drop_rates` (Sarachnis): clean apart from the pre-existing ARRIVE_AT_TILE last-step advisory.