### PR TITLE
fix(data): Scorpia - correct travel direction from Lava Maze (north-east, not south-west)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -5034,7 +5034,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Bank in Ferox Enclave then travel to the Scorpion Pit in deep Wilderness (level ~53). Bring anti-venom+, a high-tier stab weapon, prayer potions, food, and a Wilderness-cheap kit (Karil's leathertop / Black d'hide) - Scorpia's guardians inflict poison starting at 6 damage and burn through brews quickly. Burning amulet -> Lava Maze then run south-west; or web-walk down via the Chaos Elemental ladder. Scorpia is in multi-combat so a PKer team will land specs together - swap to a one-click logout if you spot dots on the minimap",
+        "description": "Bank in Ferox Enclave then travel to the Scorpion Pit in deep Wilderness (level ~53). Bring anti-venom+, a high-tier stab weapon, prayer potions, food, and a Wilderness-cheap kit (Karil's leathertop / Black d'hide) - Scorpia's guardians inflict poison starting at 6 damage and burn through brews quickly. Burning amulet -> Lava Maze then run north-east to the Scorpion Pit; or web-walk down via the Chaos Elemental ladder. Scorpia is in multi-combat so a PKer team will land specs together - swap to a one-click logout if you spot dots on the minimap",
         "worldX": 3231,
         "worldY": 3936,
         "worldPlane": 0,


### PR DESCRIPTION
## Problem
The prep step said *"Burning amulet -> Lava Maze then run south-west"*. Scorpia's **Scorpion Pit is in the north-east Wilderness** (~3231,3936); the burning amulet "Lava Maze" teleport lands to the west and south (~3028,3843). The player must run **north-east**, not south-west — the old direction points away from the boss, into the wrong part of deep (PvP) Wilderness.

## Fix (prose-only)
"run south-west" → "run north-east to the Scorpion Pit".

## Source (cite-or-discard)
OSRS Wiki, Scorpia:
> Cave in the Scorpion Pit (north-east Wilderness)

Vector from the Lava Maze landing to the pit is +east/+north (north-east), and Wilderness level rising 41→53 confirms the pit is north. Verified via WebFetch; survived a domain-skeptic refutation pass.

## Validation
`validate_drop_rates` (Scorpia): passed.