### PR TITLE
fix(data): Shellbane Gryphon - remove impossible Quetzal-whistle travel to The Great Conch

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -24079,7 +24079,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Bank in Civitas illa Fortis (Varlamore). Requires an active gryphon Slayer task - the boss cannot be attacked off-task. Required: 51 Slayer and 'Troubled Tortugans' quest complete. Bring strong melee gear, a Tortugan shield (REQUIRED - heavy damage without it), equipped weight >= 40kg to counter the knockback special, prayer potions, food, Slayer helmet (i) on-task, and a Quetzal whistle for the return teleport",
+        "description": "Bank in Civitas illa Fortis (Varlamore). Requires an active gryphon Slayer task - the boss cannot be attacked off-task. Required: 51 Slayer and 'Troubled Tortugans' quest complete. Bring strong melee gear, a Tortugan shield (REQUIRED - heavy damage without it), equipped weight >= 40kg to counter the knockback special, prayer potions, food, Slayer helmet (i) on-task, and a way back to a fairy ring or charter ship for the return trip",
         "worldX": 1626,
         "worldY": 3093,
         "worldPlane": 0,
@@ -24094,7 +24094,7 @@
         "section": "Bank"
       },
       {
-        "description": "Travel to The Great Conch and locate the Shellbane Gryphon Cave entrance in the centre of the island, north of fairy ring CJQ. Take fairy ring CJQ or a Quetzal whistle to The Great Conch, then head north to the cave entrance",
+        "description": "Travel to The Great Conch and locate the Shellbane Gryphon Cave entrance in the centre of the island, north of fairy ring CJQ. Take fairy ring CJQ (or a charter ship, or sail there) to The Great Conch, then head north to the cave entrance",
         "worldX": 3176,
         "worldY": 2477,
         "worldPlane": 0,
@@ -24132,7 +24132,7 @@
         ]
       },
       {
-        "description": "Pick up the Gryphon feathers (7-10 guaranteed per kill) and any rares, then exit the cave and teleport via Quetzal whistle to restock. Belle's folly (tarnished) is the main unique chase at 1/256",
+        "description": "Pick up the Gryphon feathers (7-10 guaranteed per kill) and any rares, then exit the cave and return via fairy ring CJQ or a charter ship to restock. Belle's folly (tarnished) is the main unique chase at 1/256",
         "worldX": 1626,
         "worldY": 3093,
         "worldPlane": 0,


### PR DESCRIPTION
## Problem
Three guidance steps recommended a **Quetzal whistle** to travel to / return from **The Great Conch** (the Shellbane Gryphon's island). The Quetzal whistle is a **Varlamore-only** transport and does not reach The Great Conch, which is a **Sailing island**. Following the guidance, the player cannot get there or back by that method.

## Fix (prose-only)
Replaced the Quetzal-whistle travel/return references with the island's actual transports — **fairy ring CJQ, charter ship, or Sailing**. (The `travelTip` was already correct: fairy ring CJQ.)

The "low" companion finding about a "run east" cave direction was **dropped** — the current data already says the cave is "north of fairy ring CJQ" and to "head north", so there was nothing to fix there.

## Source (cite-or-discard)
OSRS Wiki, The Great Conch — Transportation:
> Using the fairy ring CJQ / Taking a charter ship / Sailing to the docking point on the south side of the island

A Quetzal whistle is not listed. Verified via WebFetch; survived a domain-skeptic refutation pass.

## Validation
`validate_drop_rates` (Shellbane Gryphon): clean apart from the pre-existing ARRIVE_AT_TILE last-step advisory.