### PR TITLE
fix(data): Phantom Muspah - relabel lair (southern crevice, not the Ancient Prison)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -1591,7 +1591,7 @@
         "independent": true
       }
     ],
-    "locationDescription": "Ancient Prison entrance, Weiss",
+    "locationDescription": "Phantom Muspah lair (southern crevice of Ghorrock Dungeon), via Weiss",
     "travelTip": "Icy basalt teleport -> Weiss, or Ring of shadows",
     "npcId": 12077,
     "interactAction": "Attack",
@@ -1605,7 +1605,7 @@
         "completionDistance": 20
       },
       {
-        "description": "Run south through Ghorrock Dungeon and step onto the Ancient Prison entrance tile",
+        "description": "Run south through Ghorrock Dungeon to the crevice leading to the Phantom Muspah's lair (the Ghorrock Prison entrance is a separate location in the north-west)",
         "worldX": 3338,
         "worldY": 10303,
         "worldPlane": 0,


### PR DESCRIPTION
## Problem
The entry's `locationDescription` was *"Ancient Prison entrance, Weiss"* and step 2 told the player to *"step onto the Ancient Prison entrance tile"*. The Phantom Muspah is actually fought in its own lair reached through a **crevice at the south** of Ghorrock Dungeon. The Ghorrock/Ancient Prison is a **distinct entrance in the north-west** — that's the Duke Sucellus (DT2) location. The "run south" direction was already correct; only the landmark name was wrong (low severity, but it names a different boss's location).

## Fix (prose-only)
- `locationDescription`: → "Phantom Muspah lair (southern crevice of Ghorrock Dungeon), via Weiss".
- Step 2: reference the southern crevice to the Muspah lair, noting the Ghorrock Prison is a separate NW location.

## Source (cite-or-discard)
OSRS Wiki, Ghorrock Dungeon:
> At the south of the dungeon through a crevice is the lair of the Phantom Muspah

> In the northwest is the entrance to the Ghorrock Prison

Verified via WebFetch; survived a domain-skeptic refutation pass.

## Validation
`validate_drop_rates` (Phantom Muspah): **passed, no issues.**