### PR TITLE
fix(data): Shellbane Gryphon - fix step travelTip (no Quetzal whistle, cave is north)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -24100,7 +24100,7 @@
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
-        "travelTip": "Quetzal whistle -> The Great Conch, run east to the cave mouth",
+        "travelTip": "Fairy ring CJQ -> The Great Conch, run north to the cave mouth",
         "section": "Travel"
       },
       {


### PR DESCRIPTION
## Problem
Follow-up to #1094. That PR corrected the step descriptions and the source-level `travelTip`, but missed a **per-step `travelTip`** on the travel step, which still read:

> Quetzal whistle -> The Great Conch, run east to the cave mouth

Both parts are wrong: the Quetzal whistle (Varlamore-only) does not reach The Great Conch (a Sailing island), and the cave is **north** of fairy ring CJQ, not east (the step's own description already says "head north"). This was the "low" finding from the batch-3 verifier that I initially mis-judged as stale — it lives in a step-level `travelTip` field, not the description.

## Fix
`"Quetzal whistle -> The Great Conch, run east to the cave mouth"` → `"Fairy ring CJQ -> The Great Conch, run north to the cave mouth"`. No "Quetzal" reference now remains in the source.

## Source (cite-or-discard)
OSRS Wiki, The Great Conch — transports are fairy ring CJQ / charter ship / Sailing; the cave is north of fairy ring CJQ.

## Validation
JSON valid; `validate_drop_rates` clean apart from the pre-existing ARRIVE_AT_TILE advisory.