### PR TITLE
fix(data): The Inferno - correct protection prayers for cave monsters (blocker)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -24473,7 +24473,7 @@
         "section": "Travel"
       },
       {
-        "description": "Clear waves 1-66. Stack-up positioning is the entire game: pillar 4 (NW) and pillar 1 (S) are the standard anchors. Pray Magic vs Jal-Zek (mages) and Jal-Xil (rangers), Ranged vs Jal-Imkot (melee meleers) and Jal-AkRek-Mej, and Melee vs Jal-MejRah (bats) when adjacent. Blob (Jal-Xil) shots split into mage+range halves - 1-tick prayer flick to drop both. Healers (Jal-AkRek-Ket) come in twos and stack heals on Zuk - drag them off-screen. Always keep at least 4 brews + 4 restores in the bag entering wave 67.",
+        "description": "Clear waves 1-66. Stack-up positioning is the entire game: pillar 4 (NW) and pillar 1 (S) are the standard anchors. Pray by each monster's attack style: Protect from Magic vs Jal-Zek (mager) and Jal-AkRek-Mej (magic blob); Protect from Missiles vs Jal-Xil (ranger) and Jal-MejRah (bats); Protect from Melee vs Jal-Imkot (meleer) when adjacent. The Jal-Ak blob shots split into mage+range halves - 1-tick prayer flick to drop both. Healers come in twos and stack heals on Zuk - drag them off-screen. Always keep at least 4 brews + 4 restores in the bag entering wave 67.",
         "worldX": 2273,
         "worldY": 5341,
         "worldPlane": 0,


### PR DESCRIPTION
## Problem (blocker)
The wave 1-66 guidance gave the **wrong protection prayer for 4 of the 5 monsters it named** — on the hardest PvM content in the game, where a wrong prayer is fatal:

| Monster | Data said | Actual style | Correct prayer |
|---|---|---|---|
| Jal-Zek | Protect from Magic | Magic | Protect from Magic ✓ |
| Jal-Xil | Protect from Magic | **Ranged** | **Protect from Missiles** |
| Jal-Imkot | Protect from Missiles | **Melee (Slash)** | **Protect from Melee** |
| Jal-AkRek-Mej | Protect from Missiles | **Magic** | **Protect from Magic** |
| Jal-MejRah | Protect from Melee | **Ranged** | **Protect from Missiles** |

It also labelled the splitting blob "Jal-Xil" (that's the ranger; the blob is **Jal-Ak**) and named the wrong healer.

## Fix (prose-only)
Rewrote the prayer list to attack-style-based, fixed the blob name, dropped the incorrect healer name.

## Source (cite-or-discard)
OSRS Wiki, The Inferno monster table: Jal-Zek = Magic, Jal-Xil = Ranged, Jal-Imkot = Melee (Slash), Jal-AkRek-Mej = Magic, Jal-MejRah = Ranged. Verified via WebFetch; survived a domain-skeptic refutation pass.

## Validation
JSON valid; `validate_drop_rates` clean apart from the pre-existing ARRIVE_AT_TILE advisory.