### PR TITLE
fix(data): Vet'ion - add missing access gate and correct the prayer guidance

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -5311,6 +5311,11 @@
     "worldPlane": 0,
     "killTimeSeconds": 180,
     "ironKillTimeSeconds": 80,
+    "requirements": {
+      "diaries": [
+        "WILDERNESS_MEDIUM"
+      ]
+    },
     "items": [
       {
         "itemId": 27673,
@@ -5376,7 +5381,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to Vet'ion's Rest in the Wilderness with a crush weapon (Inquisitor's mace or Soulreaper axe), prayer potions, Saradomin brews, and a Voidwaker / DWH spec. Burning amulet to Chaos Temple, then run east",
+        "description": "Travel to Vet'ion's Rest in the Wilderness with a crush weapon (Inquisitor's mace or Soulreaper axe), prayer potions, Saradomin brews, and a Voidwaker / DWH spec. Entering the lair requires the medium Wilderness Diary, or an active Vet'ion boss Slayer task (a skeleton task does not bypass the diary). Burning amulet to Chaos Temple, then run east",
         "worldX": 3196,
         "worldY": 3776,
         "worldPlane": 0,
@@ -5399,7 +5404,7 @@
         "completionDistance": 5
       },
       {
-        "description": "Kill Vet'ion. Use Protect from Magic throughout - he attacks with magic only. Skeletal Hellhounds spawn at 50% HP in his first form; Greater Skeletal Hellhounds spawn at 50% HP in his enraged second form - kill them immediately as they grant him full damage immunity while alive. Use crush attacks since his stab and slash defence are very high",
+        "description": "Kill Vet'ion. His lightning is a dodgeable 3x3 AoE - move off the glowing tiles to avoid it (no overhead prayer fully blocks it; all his attacks can be dodged by moving). Skeletal Hellhounds spawn at 50% HP in his first form, and Greater Skeletal Hellhounds at 50% HP in his enraged second form - they attack with melee, so use Protect from Melee while they are up, and kill them immediately as they grant him full damage immunity while alive. Use crush attacks since his stab and slash defence are very high",
         "worldX": 3220,
         "worldY": 3783,
         "worldPlane": 0,


### PR DESCRIPTION
## Problem
1. **Access gate missing (blocker).** Entering Vet'ion's Rest requires the **medium Wilderness Diary, OR an active Vet'ion boss Slayer task** (a skeleton task does not bypass the diary). The entry had no `requirements` and no step mentioned the gate, so a player without either is told to travel there and then cannot enter the lair.
2. **Prayer wrong (high).** The combat step said *"Use Protect from Magic throughout - he attacks with magic only."* His lightning is a **dodgeable 3x3 AoE** (move off the glowing tiles; no overhead fully blocks it), and the Skeletal / Greater Skeletal Hellhounds attack with **melee** — so Protect from Melee is the prayer to use while they're up.

## Fix
- `requirements.diaries`: `["WILDERNESS_MEDIUM"]` (validated; resolves to `DIARY_WILDERNESS_MEDIUM`), plus a prose note in the prep step for the boss-task alternative (a structured requirement can't express the "diary OR task" disjunction).
- Rewrote the combat-step prayer guidance (dodge the lightning, Protect from Melee for the hellhounds).

## Source (cite-or-discard)
OSRS Wiki, Vet'ion + /Strategies:
> the player must have completed the medium Wilderness Diary tasks, OR they must have a Vet'ion boss Slayer task

> any tile that is about to be struck glows, giving players the chance to dodge

> [hellhounds] attack with melee, so activate Protect from Melee

Verified via WebFetch; both findings survived a domain-skeptic refutation pass.

## Validation
`validate_drop_rates` (Vet'ion): **passed, no issues** (diary enum accepted).