### PR TITLE
fix(data): Venenatis - add missing access gate (medium Wilderness Diary or boss task)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -5214,6 +5214,11 @@
     "worldPlane": 0,
     "killTimeSeconds": 120,
     "ironKillTimeSeconds": 72,
+    "requirements": {
+      "diaries": [
+        "WILDERNESS_MEDIUM"
+      ]
+    },
     "items": [
       {
         "itemId": 27670,
@@ -5272,7 +5277,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to the Silk Chasm cave entrance in the Wilderness with anti-pk gear, a Voidwaker / DWH spec weapon if available, and at least one super combat plus restore. Use Wilderness crabs teleport (fastest) or Waka canoe (57 Woodcutting)",
+        "description": "Travel to the Silk Chasm cave entrance in the Wilderness with anti-pk gear, a Voidwaker / DWH spec weapon if available, and at least one super combat plus restore. Entering the lair requires the medium Wilderness Diary, or an active Venenatis boss Slayer task (a spider task does not bypass the diary). Use Wilderness crabs teleport (fastest) or Waka canoe (57 Woodcutting)",
         "worldX": 3321,
         "worldY": 3794,
         "worldPlane": 0,


### PR DESCRIPTION
## Problem
Entering Venenatis' lair (the **Silk Chasm**) requires the **medium Wilderness Diary, OR an active Venenatis boss Slayer task** (a spider task does not bypass the diary). The entry had no `requirements` and no step mentioned the gate, so a player without either is told to travel to and enter the Silk Chasm — and cannot.

## Fix
- `requirements.diaries`: `["WILDERNESS_MEDIUM"]` (validated), plus a prose note in the prep step for the boss-task alternative (the "diary OR task" disjunction can't be expressed structurally).

## Source (cite-or-discard)
OSRS Wiki, Venenatis:
> In order to enter Venenatis' lair, the player must have completed the medium Wilderness Diary tasks, OR they must have a Venenatis boss Slayer task (a spider Slayer task does not bypass the diary requirement)

Verified via WebFetch; survived a domain-skeptic refutation pass.

## Validation
`validate_drop_rates` (Venenatis): **passed, no issues.**