### PR TITLE
fix(data): Vorkath - remove impossible Lunar Isle teleport travel to Rellekka

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -909,18 +909,18 @@
       }
     ],
     "locationDescription": "Rellekka docks (boat to island)",
-    "travelTip": "Lunar Isle teleport -> Rellekka, or Fremennik sea boots -> Rellekka",
+    "travelTip": "Fremennik sea boots -> Rellekka, or Enchanted lyre / Rellekka house portal",
     "npcId": 8061,
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to Rellekka docks, sail to Ungael Island via Torfinn. Use lunar isle teleport or Fremennik sea boots",
+        "description": "Travel to Rellekka docks, sail to Ungael Island via Torfinn. Use Fremennik sea boots (or an Enchanted lyre / Rellekka house portal) to reach Rellekka",
         "worldX": 2641,
         "worldY": 3697,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 15,
-        "travelTip": "Lunar Isle teleport + talk to banker, Rellekka house portal, or Fremennik sea boots",
+        "travelTip": "Fremennik sea boots, Rellekka house portal, or Enchanted lyre",
         "conditionalAlternatives": [
           {
             "requirements": {


### PR DESCRIPTION
## Problem
The source `travelTip`, step-1 description, and step-1 `travelTip` all listed **"Lunar Isle teleport -> Rellekka"**. The Lunar Isle (Moonclan) teleport drops the player on **Lunar Isle**, which is connected to Rellekka only by Lokar Searunner's boat — it does not bring you to Rellekka, so it isn't a valid route to the Torfinn/Ungael docks. (Same teleport-destination class as the Dagannoth Prime/Rex fix.)

## Fix (travel-prose only)
Replaced the Lunar Isle teleport references with valid Rellekka teleports: **Fremennik sea boots**, **Enchanted lyre**, and the **Rellekka house portal**. No "Lunar" reference remains in the source.

## Source (cite-or-discard)
OSRS Wiki — the Lunar/Moonclan teleport "Teleports you to the gate to the village on Lunar Isle" (not Rellekka). Verified via WebFetch; survived a domain-skeptic refutation pass.

## Validation
JSON valid; `validate_drop_rates` clean apart from the pre-existing advisory.