### PR TITLE
fix(data): Zulrah - red/magma form is a typeless tail attack, not Protect from Melee

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -827,7 +827,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Zulrah. Prayer rotates per form: green (Ranged form) -> Protect from Missiles, blue (Magic form) -> Protect from Magic, red (Melee form) -> Protect from Melee, jad phase -> swap each attack. Bring a blowpipe + magic setup, swap gear on the rotation, and avoid the toxic clouds Zulrah summons",
+        "description": "Kill Zulrah. Prayer matches the form's attack style: green (Ranged form) -> Protect from Missiles, blue (Magic form) -> Protect from Magic. In its red (magma) form Zulrah does NOT use a melee attack - it whips its tail at your current tile for a typeless hit that no prayer reduces, so move two tiles away to dodge it rather than praying Melee. During the jad phase swap your overhead each attack. Bring a blowpipe + magic setup, swap gear on the rotation, and avoid the toxic clouds Zulrah summons",
         "worldX": 2268,
         "worldY": 3069,
         "worldPlane": 0,


### PR DESCRIPTION
## Problem
The combat step said *"red (Melee form) -> Protect from Melee"*. Zulrah's **red/magma form has no melee attack**: it whips its tail at the player's current tile for a **typeless** hit that **no protection prayer reduces**. Praying Protect from Melee gives zero mitigation; the correct response is to **move two tiles away** to dodge it. On a high-traffic boss this misleads players into tanking heavy damage + stun every red phase.

## Fix (prose-only)
Rewrote the red-form guidance to "move two tiles away (typeless tail attack, unblockable)". The green (Missiles), blue (Magic), and jad-phase guidance is unchanged and correct.

## Source (cite-or-discard)
OSRS Wiki, Zulrah/Strategies:
> When Zulrah is red, it uses a typeless attack wherein it swings its tail at the player's position, which can be avoided by moving two tiles away; if it hits, it will deal heavy damage and stun the player

Verified via WebFetch; survived a domain-skeptic refutation pass.

## Validation
JSON valid; `validate_drop_rates` clean apart from the pre-existing advisory.