### PR TITLE
fix(data): The Whisperer (Awakened) - replace fabricated shield mechanic with Soul Siphon

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -2789,7 +2789,7 @@
         "section": "Combat"
       },
       {
-        "description": "Kill The Whisperer (Awakened). Switch Protect from Missiles for grey-barb ranged volleys and Protect from Magic for blue-orb magic volleys. Use the blackstone fragment to hop into the Shadow Realm and break the four shadow tiles before her shield resets - missing one resets her shield to full and extends the kill 30 seconds. Never let your sanity bar fully deplete; full depletion causes near-instant death within 10 ticks - teleport immediately if this occurs. Awakened-mode: more tentacles (7 in X formation, 6 in + formation vs 4 in base); Soul Siphon has 16 souls (up from 12) with a 21-second timer. Switch prayers a tick early on every volley.",
+        "description": "Kill The Whisperer (Awakened). Switch Protect from Missiles for grey-barb ranged volleys and Protect from Magic for blue-orb magic volleys. When she casts Soul Siphon, use the blackstone fragment to enter the Shadow Realm and kill a full set of souls chanting the same phrase before the chant completes - failing it deals 50 damage to you and heals her for 100. Never let your sanity bar fully deplete; full depletion causes near-instant death within 10 ticks - teleport immediately if this occurs. Awakened-mode: more tentacles (7 in X formation, 6 in + formation vs 4 in base); Soul Siphon has 16 souls (up from 12) with a 21-second timer. Switch prayers a tick early on every volley.",
         "worldX": 3007,
         "worldY": 3477,
         "worldPlane": 0,


### PR DESCRIPTION
## Problem
The combat step described a **non-existent mechanic**: *"Use the blackstone fragment to hop into the Shadow Realm and break the four shadow tiles before her shield resets - missing one resets her shield to full and extends the kill 30 seconds."* The Whisperer has **no shield**, **no shadow tiles to break**, and **no 30-second kill extension**.

The real Shadow Realm objective is **Soul Siphon**: enter via the blackstone fragment and kill a full set of same-chant souls before the chant completes; failing it deals 50 damage to the player and heals her 100. (The step already references the Awakened-scaled "16 souls / 21-second timer" Soul Siphon later — so the fabricated sentence directly contradicted the same step.)

## Fix (prose-only)
Replaced the fabricated shield/shadow-tiles sentence with the correct Soul Siphon action + failure consequence.

## Source (cite-or-discard)
OSRS Wiki, The Whisperer/Strategies:
> Players must activate their blackstone fragment to enter the Shadow Realm and kill at least one set of souls chanting the same phrase. If the player fails to kill a full set of souls within the time limit, the chant will complete, dealing 50 damage to the player and heals her for 100 health

Verified via WebFetch; survived a domain-skeptic refutation pass.

## Validation
JSON valid; `validate_drop_rates` clean apart from the pre-existing ARRIVE_AT_TILE advisory.