### PR TITLE
fix(data): Yama - correct prayer (dynamic switching) and adds (void flares, not imps)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -23458,7 +23458,7 @@
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Bank for Yama. Bring Saradomin brews, super restores, prayer pots, and ranged-tank gear (Karil's top + Masori, Bowfa or Zaryte crossbow). Yama is melee-and-magic style hybrid; Protect from Magic is the primary prayer. Bring a chasm teleport scroll for repeat trips.",
+        "description": "Bank for Yama. Bring Saradomin brews, super restores, prayer pots, and ranged-tank gear (Karil's top + Masori, Bowfa or Zaryte crossbow). Yama uses all three styles: flick Protect from Missiles and Protect from Magic to match his ranged and magic attacks - his melee pierces prayer (a 3-tile hit), so keep your distance. Bring a chasm teleport scroll for repeat trips.",
         "worldX": 1641,
         "worldY": 3673,
         "worldPlane": 0,
@@ -23491,7 +23491,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Yama. Protect from Magic, dodge the floor-fire patches and the demonic tallow slams, kill the spawned imps fast. On the enrage phase Yama leaps to a new chasm tile - reposition immediately or eat through the unprotected hit. Scythe of Vitur or Soulreaper axe for melee DPS; Bowfa or Tbow for ranged tank role.",
+        "description": "Kill Yama. Flick between Protect from Missiles and Protect from Magic to match his ranged and magic attacks (in phase 3 he alternates them every attack); his melee hits through prayer in a 3-tile radius, so keep your distance. Dodge the floor-fire patches and shadow waves, and destroy the void flares before they fully charge - they damage you and heal Yama if left alive. On the enrage phase Yama leaps to a new chasm tile - reposition immediately or eat through the unprotected hit. Scythe of Vitur or Soulreaper axe for melee DPS; Bowfa or Tbow for ranged tank role.",
         "worldX": 1503,
         "worldY": 10091,
         "worldPlane": 0,


### PR DESCRIPTION
## Problem
Two confirmed defects in the Yama guidance (2025 boss):
1. **Prayer.** The entry said *"Yama is melee-and-magic style hybrid; Protect from Magic is the primary prayer"* and the combat step just said *"Protect from Magic"*. Yama uses **melee, ranged, AND magic** with **dynamic switching** — in phase 3 he alternates ranged and magic every attack (flick Protect from Missiles / Protect from Magic), and his melee **pierces prayer** in a 3-tile radius (keep distance).
2. **Adds.** *"demonic tallow slams"* and *"spawned imps"* are not real mechanics. Yama's hazards are **void flares** (destroy before they charge — they damage you and heal Yama) and shadow waves.

## Deferred (not in this PR)
The **Oathplate shards** drop rate (currently 1/30) is also suspect, but the wiki value is **ambiguous between 1/15 and a displayed 1/17.07** in my sources. Rather than guess, I'm deferring it to a separate, precisely-sourced rate fix. Logged in the verification ledger.

## Source (cite-or-discard)
OSRS Wiki, Yama: phase 3 "every auto-attack switches between styles"; melee "penetrate[s] prayer and hit[s] all players within three tiles"; void flares "will damage players and heal Yama if not destroyed". Verified via WebFetch; survived a domain-skeptic refutation pass.

## Validation
`validate_drop_rates` (Yama): clean apart from the pre-existing ARRIVE_AT_TILE advisory.