### PR TITLE
fix(data): The Whisperer - ranged volley barbs are grey, not purple

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -2079,7 +2079,7 @@
         "section": "Combat"
       },
       {
-        "description": "Kill The Whisperer. Switch Protect from Missiles for purple-barb ranged volleys and Protect from Magic for blue-orb magic volleys. During the Soul Siphon special attack, activate the blackstone fragment to enter the Shadow Realm and kill at least one full set of lost souls (grouped by chant phrase) before the 20-tick timer expires; failure deals 50 damage and heals her 100 HP. Keep your sanity bar above zero or you will die in 10 ticks.",
+        "description": "Kill The Whisperer. Switch Protect from Missiles for grey-barb ranged volleys and Protect from Magic for blue-orb magic volleys. During the Soul Siphon special attack, activate the blackstone fragment to enter the Shadow Realm and kill at least one full set of lost souls (grouped by chant phrase) before the 20-tick timer expires; failure deals 50 damage and heals her 100 HP. Keep your sanity bar above zero or you will die in 10 ticks.",
         "worldX": 3007,
         "worldY": 3477,
         "worldPlane": 0,


### PR DESCRIPTION
## Problem
The combat step described the ranged attack as *"purple-barb ranged volleys"*. The Whisperer's ranged attack is **grey barbs** (the magic attack is the cluster of blue orbs). The prayer mapping itself was already correct — only the colour cue was wrong. (The sibling "The Whisperer (Awakened)" entry already uses the correct "grey-barb" wording.)

## Fix (prose-only)
"purple-barb" → "grey-barb".

## Source (cite-or-discard)
OSRS Wiki, The Whisperer/Strategies:
> The ranged attacks consist of grey barbs, while the magic attacks consist of a cluster of three blue orbs

Verified via WebFetch; survived a domain-skeptic refutation pass.

## Validation
JSON valid; `validate_drop_rates` clean apart from the pre-existing advisory.