### PR TITLE
fix(data): The Hueycoatl - quetzal whistle does not reach the Darkfrost directly

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -23292,7 +23292,7 @@
       }
     ],
     "locationDescription": "The Darkfrost, Hailstorm Mountains in Varlamore",
-    "travelTip": "Quetzal whistle -> Hueycoatl arena, or Quetzal Transport System -> Quetzacalli Gorge -> run to the Darkfrost",
+    "travelTip": "Pendant of ates -> the Darkfrost (direct), or Quetzal Transport System / quetzal whistle -> Quetzacalli Gorge then run to the Darkfrost",
     "npcId": 14009,
     "interactAction": "Attack",
     "guidanceSteps": [
@@ -23311,13 +23311,13 @@
         "section": "Bank"
       },
       {
-        "description": "Travel to the Hueycoatl arena (the Darkfrost) in the Hailstorm Mountains, Varlamore. Use the quetzal whistle for the fastest route, or take the Quetzal Transport System to Quetzacalli Gorge and run to the Darkfrost (the pendant of ates teleports directly once unlocked)",
+        "description": "Travel to the Hueycoatl arena (the Darkfrost) in the Hailstorm Mountains, Varlamore. The pendant of ates teleports directly to the Darkfrost (once unlocked) for the fastest route; otherwise the quetzal whistle or Quetzal Transport System only lands at Quetzacalli Gorge (the Darkfrost is not a landing site), so run to the Darkfrost from there",
         "worldX": 1509,
         "worldY": 3290,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
-        "travelTip": "Quetzal whistle -> Hueycoatl, or Quetzal Transport System -> Quetzacalli Gorge -> run to the Darkfrost",
+        "travelTip": "Pendant of ates -> the Darkfrost (direct), or Quetzal Transport System / quetzal whistle -> Quetzacalli Gorge then run",
         "section": "Travel"
       },
       {


### PR DESCRIPTION
## Problem
The source `travelTip`, step-2 description, and step-2 `travelTip` billed the **quetzal whistle** as a direct / *"fastest route"* to the Hueycoatl arena (the **Darkfrost**). The quetzal whistle and Quetzal Transport System only reach **built landing sites**, and the Darkfrost is **not** one of the 14 sites (nearest is Quetzacalli Gorge), so the player still has to run. The only direct teleport is the **pendant of ates** (which the entry already noted parenthetically).

## Fix (travel-prose only, low severity)
Reframed the routes: pendant of ates is the direct/fastest option; the whistle / Transport System land at Quetzacalli Gorge and you run from there.

## Source (cite-or-discard)
OSRS Wiki — the quetzal whistle takes players "to any built Quetzal Transport System landing site" (14 sites, the Darkfrost not among them); the pendant of ates teleports directly to "The Darkfrost". Verified via WebFetch; survived a domain-skeptic refutation pass.

## Validation
JSON valid; `validate_drop_rates` clean apart from the pre-existing advisory.