### PR TITLE
fix(data): Crawling Hand - they spawn on the Slayer Tower ground floor, not the basement

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -10101,7 +10101,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Crawling Hands in the Slayer Tower basement. Very low combat - good for early slayer tasks",
+        "description": "Kill Crawling Hands on the Slayer Tower ground floor. Very low combat - good for early slayer tasks",
         "worldX": 3418,
         "worldY": 3543,
         "worldPlane": 0,


### PR DESCRIPTION
## Problem
The combat step said *"Kill Crawling Hands in the Slayer Tower **basement**"* — which contradicts the same entry's `locationDescription` ("Slayer Tower ground floor, Morytania"), its travel step ("Travel to Slayer Tower ground floor"), and `worldPlane: 0`. Crawling Hands spawn on the **ground floor**; the basement holds bloodvelds, gargoyles, nechryael, and abyssal demons. A player following "basement" goes to the wrong floor.

## Fix (prose-only)
"basement" → "ground floor".

## Source (cite-or-discard)
OSRS Wiki, Crawling Hand — location *"Slayer Tower (ground floor[UK]1st floor[US])"*. Verified via WebFetch; survived a domain-skeptic refutation pass.

## Validation
JSON valid; `validate_drop_rates` clean apart from the pre-existing advisory.