### PR TITLE
fix(data): Custodian Stalker - travel direction, 59 Agility gate, and junk gear id

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -12336,12 +12336,12 @@
       }
     ],
     "locationDescription": "Stalker Den, beneath Custodia Pass, Varlamore",
-    "travelTip": "Fairy ring AIS -> Auburnvale -> run south to Stalker Den entrance",
+    "travelTip": "Fairy ring AIS -> Auburn Valley -> run north-west to the southern Stalker Den entrance (59 Agility), or fairy ring BLS -> Kebos Lowlands for the northern entrance (no Agility)",
     "npcId": 14704,
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to the Stalker Den entrance south of Custodia Pass, Varlamore (fairy ring AIS to Auburnvale, run south). Requires Shadows of Custodia quest. Bring melee gear and food; Elder Custodian Stalkers apply a Bleed via a targeted spore attack - no key required to enter",
+        "description": "Travel to the Stalker Den entrance near Custodia Pass, Varlamore (fairy ring AIS to Auburn Valley, then run north-west). Requires Shadows of Custodia quest. The southern squeeze-through entrance also needs 59 Agility; if you lack it, use the northern entrance via fairy ring BLS to Kebos Lowlands instead. Bring melee gear and food; Elder Custodian Stalkers apply a Bleed via a targeted spore attack - no key required to enter",
         "worldX": 1324,
         "worldY": 3364,
         "worldPlane": 0,
@@ -12353,11 +12353,11 @@
           9870,
           0
         ],
-        "travelTip": "Fairy ring AIS -> Auburnvale -> run south to Stalker Den",
+        "travelTip": "Fairy ring AIS -> Auburn Valley -> run north-west to the Stalker Den",
         "section": "Travel"
       },
       {
-        "description": "Squeeze through the cave entrance to enter the Stalker Den",
+        "description": "Squeeze through the southern cave entrance to enter the Stalker Den (requires 59 Agility; otherwise use the northern entrance)",
         "worldX": 1324,
         "worldY": 3364,
         "worldPlane": 0,
@@ -12379,7 +12379,7 @@
         "recommendedItemIds": [
           4151,
           4087,
-          392
+          391
         ]
       }
     ]


### PR DESCRIPTION
## Problem
Three defects on the Custodian Stalker entry:
1. **Travel direction (high).** The source `travelTip`, step-1 description, and step-1 `travelTip` all said *"fairy ring AIS → Auburnvale, run **south**"*. Fairy ring AIS lands in **Auburn Valley**, and the southern Stalker Den entrance is reached by running **north-west**, not south.
2. **Access gate (high).** The southern (AIS / squeeze-through) entrance the guidance routes through requires **59 Agility**. Noted it, with the **northern BLS entrance** (no Agility) as the alternative for sub-59 accounts. Left as prose rather than a hard structured requirement, since the northern entrance bypasses the gate (so 59 Agility isn't a true clog requirement).
3. **Junk gear id (Tier-0, detector #96).** `recommendedItemIds` contained `392` — the **noted** form of Manta ray (null cache name; passes `cache_ids` but renders as junk in the overlay). Corrected to `391` (Manta ray).

## Source (cite-or-discard)
OSRS Wiki, Stalker Den:
> Fairy ring AIS to Auburn Valley, then run north-west

> Southern entrance requiring 59 Agility

Travel + agility verified via WebFetch (survived domain-skeptic). The id fix is deterministic (item-id-plausibility detector + `runelite_id_lookup`: 391 = MANTARAY).

## Validation
`validate_drop_rates --check cache_ids` (Custodian Stalker): **passed** (junk id resolved).