### PR TITLE
fix(data): Cave Kraken - add missing 50 Magic assignment requirement

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -12888,6 +12888,10 @@
         {
           "skill": "SLAYER",
           "level": 87
+        },
+        {
+          "skill": "MAGIC",
+          "level": 50
         }
       ]
     },


### PR DESCRIPTION
## Problem
Cave kraken assignment requires **87 Slayer AND 50 Magic** (they're immune to melee and Ranged deals only 1/7 damage, so Magic is the only reliable style — hence the Magic gate). The entry's `requirements.skills` listed only **SLAYER 87**, omitting the Magic gate.

## Fix
Added `{ "skill": "MAGIC", "level": 50 }` to `requirements.skills`.

## Source (cite-or-discard)
OSRS Wiki, Cave kraken:
> To be assigned cave krakens, players require level 87 Slayer and 50 Magic

Verified via WebFetch; survived a domain-skeptic refutation pass.

## Validation
`validate_drop_rates` (Cave Kraken): **passed, no issues.**