### PR TITLE
fix(data): Cave Horror - correct the witchwood icon scream mechanic

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -11402,7 +11402,7 @@
         ]
       },
       {
-        "description": "Kill Cave Horrors in the Mos Le Harmless cave. Without a witchwood icon equipped, the scream special attack always deals 10% of base HP as damage; wearing the icon converts the scream into a regular attack roll (58 Slayer)",
+        "description": "Kill Cave Horrors in the Mos Le Harmless cave (58 Slayer). The scream special always deals 10% of your base Hitpoints level on hit; without a witchwood icon equipped the horror always screams. Wearing the witchwood icon does not stop the scream - it makes the horror alternate randomly between a melee kick (every 4 ticks) and a scream (every 5), so it only partially reduces the special. The special is fully negated only by Protect from Melee",
         "worldX": 3740,
         "worldY": 9373,
         "worldPlane": 0,


### PR DESCRIPTION
## Problem
The combat step said *"wearing the icon converts the scream into a regular attack roll"*. That's inaccurate — the witchwood icon does **not** make the scream accuracy-rolled. It makes the horror **alternate randomly between a melee kick (every 4 ticks) and a scream (every 5)**, which only partially reduces how often the special lands. The scream always deals **10% of base Hitpoints level** on hit and is **fully negated only by Protect from Melee**. (The 10%-base-HP clause and the 58 Slayer requirement were already correct.)

## Fix (prose-only, low severity)
Rewrote the witchwood-icon mechanic to match the wiki.

## Source (cite-or-discard)
OSRS Wiki, Cave horror — special *"always deals damage equal to 10% of the player's base Hitpoints level"*; *"completely nullified by having Protect from Melee activated"*; with the icon, they *"alternate randomly between kicking every 4 ticks, and screaming every 5"*. Verified via WebFetch; survived a domain-skeptic refutation pass.

## Validation
JSON valid; `validate_drop_rates` clean apart from the pre-existing advisory.