### PR TITLE
fix(data): Basilisk Knight - correct impossible Lunar Isle teleport travel

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -11516,12 +11516,12 @@
       }
     ],
     "locationDescription": "Jormungand's Prison, Island of Stone",
-    "travelTip": "Lunar Isle tele -> Rellekka",
+    "travelTip": "Fremennik sea boots or Enchanted lyre -> Rellekka, then Haskell's boat to the Island of Stone",
     "npcId": 9293,
     "interactAction": "Attack",
     "guidanceSteps": [
       {
-        "description": "Travel to Jormungand's Prison, Island of Stone.",
+        "description": "Travel to Jormungand's Prison on the Island of Stone: reach Rellekka (Fremennik sea boots or Enchanted lyre), then take Haskell's boat north of Yrsa's Accoutrements to the Island of Stone.",
         "worldX": 2456,
         "worldY": 4240,
         "worldPlane": 0,


### PR DESCRIPTION
## Problem
The `travelTip` said *"Lunar Isle tele → Rellekka"*. The Lunar/Moonclan teleport lands on **Lunar Isle**, not Rellekka, so it isn't a valid route to Jormungand's Prison on the **Island of Stone**. The Island of Stone is reached by **Haskell's boat from Rellekka**, so the player must reach Rellekka first.

Surfaced by **cross-source consistency** — same Lunar-teleport class as the Dagannoth Prime/Rex and Vorkath fixes — after the per-source verifier returned Basilisk Knight CLEAN (the third Lunar-teleport miss; a noted verifier blind spot).

## Fix (travel-prose only)
`travelTip` and the travel step now route via Fremennik sea boots / Enchanted lyre → Rellekka, then Haskell's boat to the Island of Stone. No "Lunar" reference remains.

## Source (cite-or-discard)
OSRS Wiki, Island of Stone:
> It can be reached by boarding Haskell's boat directly north of Yrsa's Accoutrements

and the Lunar Isle teleport "gets you to Lunar Isle" (not Rellekka). Verified via WebFetch.

## Validation
JSON valid; `validate_drop_rates` clean apart from the pre-existing advisory.