### PR TITLE
fix(data): Earthen Nagua - add missing The Final Dawn quest access gate

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -10923,6 +10923,9 @@
           "skill": "SLAYER",
           "level": 48
         }
+      ],
+      "quests": [
+        "THE_FINAL_DAWN"
       ]
     },
     "items": [
@@ -10949,7 +10952,7 @@
         "section": "Bank"
       },
       {
-        "description": "Use the quetzal whistle to travel to Kastori in Varlamore, then run west to the Tonali Cavern entrance beneath the Crypt of Tonali",
+        "description": "Use the quetzal whistle to travel to Kastori in Varlamore, then run west to the Tonali Cavern entrance beneath the Crypt of Tonali (accessible only after completing The Final Dawn quest)",
         "worldX": 1309,
         "worldY": 3104,
         "worldPlane": 0,


### PR DESCRIPTION
## Problem
Earthen Naguas are found in the **Tonali Cavern**, which is only reachable **after completing The Final Dawn quest**. The entry's `requirements` listed only **SLAYER 48** and the guidance routed straight to the cavern with no quest mentioned — so a player who hasn't done The Final Dawn is told to travel there and cannot reach them.

## Fix
- `requirements.quests`: added `THE_FINAL_DAWN` (verified to be a valid `net.runelite.api.Quest` constant in the api jar the project builds against, alongside `CHILDREN_OF_THE_SUN` / `PERILOUS_MOONS`).
- Travel step: prose note that the cavern is accessible only after The Final Dawn.

## Source (cite-or-discard)
OSRS Wiki, Earthen Nagua:
> They are found in the Tonali Cavern after completion of the The Final Dawn quest

Verified via WebFetch; survived a domain-skeptic refutation pass.

## Validation
`validate_drop_rates` (Earthen Nagua): **passed, no issues.** Quest enum confirmed present in `runelite-api-1.12.26.3`.