### PR TITLE
fix(data): Chaos Elemental - replace junk noted-burning-amulet gear id (Tier-0 #96)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -4933,7 +4933,7 @@
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 8,
         "requiredItemIds": [
-          21167,
+          21166,
           11941,
           1704,
           385,


### PR DESCRIPTION
## Problem (Tier-0, detector #96)
`requiredItemIds` listed **21167** — the **noted** form of Burning amulet (5). Noted items have a null cache name, so it passes `validate_drop_rates --check cache_ids` but renders as a junk/blank entry in the required-items overlay. The new `item-id-plausibility` detector (#96, enabled by the 2026-06-30 toolkit update) flags it.

The burning amulet is the wilderness travel item the guidance already names ("Burning amulet → …").

## Fix (deterministic)
`21167` → **21166** (unnoted `BURNING_AMULET_5`). Confirmed via `runelite_id_lookup` (21166 = BURNING_AMULET_5).

This is the first of 5 Wilderness sources carrying the same systematic noted-amulet error (Chaos Elemental, Scorpia, Chaos Fanatic, Crazy archaeologist, Revenants).

## Validation
`validate_drop_rates --check cache_ids` (Chaos Elemental): **passed** (junk id resolved).