### PR TITLE
fix(data): Scorpia - replace junk noted-burning-amulet gear id (Tier-0 #96)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -5048,7 +5048,7 @@
         ],
         "travelTip": "Burning amulet -> Lava Maze, run south-west to Scorpion Pit",
         "requiredItemIds": [
-          21167,
+          21166,
           5952,
           1704,
           385,


### PR DESCRIPTION
## Problem (Tier-0, detector #96)
`requiredItemIds` listed **21167** (noted Burning amulet (5); null cache name → junk overlay entry).

## Fix (deterministic)
`21167` → **21166** (`BURNING_AMULET_5`). 2nd of 5 Wilderness sources with the same systematic error.

## Validation
`cache_ids` passes (same fix verified on #1116).