### PR TITLE
fix(data): Chaos Fanatic - replace junk noted-burning-amulet gear id (Tier-0 #96)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -5141,7 +5141,7 @@
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 8,
         "requiredItemIds": [
-          21167,
+          21166,
           11941,
           1704,
           385,


### PR DESCRIPTION
Tier-0 detector #96: requiredItemIds had **21167** (noted Burning amulet (5), null cache name). Fixed to **21166** (BURNING_AMULET_5). 3rd of 5 Wilderness sources with this systematic error. cache_ids passes.