### PR TITLE
fix(data): Revenants - fix burning-amulet id and remove junk magic-logs gear ids (Tier-0 #96)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -9983,12 +9983,11 @@
         "completionDistance": 10,
         "requiredItemIds": [
           21816,
-          21167
+          21166
         ],
         "recommendedItemIds": [
           12926,
           21816,
-          1514,
           391,
           2434,
           2444
@@ -10049,7 +10048,6 @@
         "recommendedItemIds": [
           12926,
           21816,
-          1514,
           391,
           2434,
           2444


### PR DESCRIPTION
## Problem (Tier-0, detector #96)
Two junk noted-item ids (null cache names, pass `cache_ids` but render as blank overlay entries):
- `requiredItemIds` **21167** — noted Burning amulet (5).
- `recommendedItemIds` **1514** — noted Magic logs (appears in both the prep and combat gear lists).

## Fix (deterministic)
- `21167` → **21166** (`BURNING_AMULET_5`) — the wilderness travel item the guidance names.
- **Removed** `1514` from both gear lists. Magic logs aren't a Revenants loadout item, and the unnoted `1513` is equally nonsensical as gear, so the junk id is removed rather than guessing an intended item. Remaining gear (blowpipe, Bracelet of ethereum, manta ray, prayer/ranging potions) is unchanged.

5th of 5 Wilderness sources with the noted-burning-amulet error.

## Validation
`validate_drop_rates --check cache_ids` (Revenants): **passed.**