### PR TITLE
fix(data): Gryphon - remove junk noted-runite-bar gear id (Tier-0 #96)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -11141,8 +11141,7 @@
         "section": "Combat",
         "recommendedItemIds": [
           4151,
-          4087,
-          2364
+          4087
         ]
       }
     ]


### PR DESCRIPTION
## Problem (Tier-0, detector #96)
`recommendedItemIds` listed **2364** — the noted form of Runite bar (null cache name → blank overlay entry).

## Fix (deterministic)
**Removed** `2364`. A runite bar isn't a Gryphon loadout item, and the unnoted `2363` is equally nonsensical as gear, so the junk id is removed rather than guessing an intended item. Remaining gear (whip, dragon platelegs) unchanged.

This was the only open finding holding Gryphon back from V1 — it can be stamped once merged.

## Validation
`validate_drop_rates --check cache_ids` (Gryphon): **passed.**