### PR TITLE
fix(data): Deranged Archaeologist - remove junk noted gear id (Tier-0 #96)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -24594,7 +24594,6 @@
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 8,
         "requiredItemIds": [
-          23713,
           12695,
           6685,
           2434,


### PR DESCRIPTION
## Problem (Tier-0, detector #96)
`requiredItemIds` listed **23713** — a noted item with a null cache name (junk overlay entry; the unnoted `23712` has no RuneLite constant, so it can't be resolved to a meaningful item).

## Fix (deterministic)
**Removed** `23713`. It's not a hard requirement for the fight — the Digsite pendant the step mentions is a travel convenience, not a gate (Fossil Island is reachable by boat). Remaining required items (super combat, Saradomin brew, prayer potion, Slayer helmet) unchanged.

## Validation
`validate_drop_rates --check cache_ids` (Deranged Archaeologist): **passed.**