### PR TITLE
fix(data): Sulphur Nagua - add missing Perilous Moons access gate

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -10845,6 +10845,9 @@
           "skill": "SLAYER",
           "level": 48
         }
+      ],
+      "quests": [
+        "PERILOUS_MOONS"
       ]
     },
     "items": [


### PR DESCRIPTION
## Problem
Sulphur Naguas spawn in the Ancient Prison within **Neypotzli** (beneath Cam Torum, Varlamore), only reachable after **partial completion of Perilous Moons**. The entry's `requirements` listed only **SLAYER 48** — a player who hasn't started Perilous Moons is told to travel there and cannot reach them.

## Fix
Added `requirements.quests: ["PERILOUS_MOONS"]`. The requirement checker treats a started/in-progress quest as access, so this correctly models the "partial completion" gate (not full completion).

## Source (cite-or-discard)
OSRS Wiki, Sulphur Nagua:
> Partial completion of Perilous Moons is required for access

Verified via WebFetch; survived a domain-skeptic refutation pass.

## Validation
`validate_drop_rates` (Sulphur Nagua): **passed, no issues** (PERILOUS_MOONS enum accepted).