### PR TITLE
fix(data): Vyrewatch Sentinel - correct Blood shard rate in guidance text (1/1500)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -13359,7 +13359,7 @@
         ]
       },
       {
-        "description": "Loot Blood shards (1/5000 drop rate). Charge an Amulet of fury into an Amulet of blood fury at 1000 Blood shards or sell shards directly for GP.",
+        "description": "Loot Blood shards (1/1500 drop rate). Charge an Amulet of fury into an Amulet of blood fury at 1000 Blood shards or sell shards directly for GP.",
         "worldX": 3631,
         "worldY": 3325,
         "worldPlane": 0,


### PR DESCRIPTION
## Problem
The loot step said Blood shards drop at **"1/5000"** — which contradicts the source's own (correct) `dropRate` field of `0.000667` (1/1500) **and** the wiki. The 1/5000 figure is the **Darkmeyer Vyre pickpocketing** rate (a separate, mutually-exclusive Thieving source). Combat Vyrewatch Sentinels drop the Blood shard at **1/1500**. The wrong text overstates the grind by ~3.3×.

## Fix (prose-only)
Guidance text `1/5000` → `1/1500`. The machine-readable `dropRate` was already correct and is unchanged.

## Source (cite-or-discard)
OSRS Wiki, Blood shard / Vyrewatch Sentinel drops table:
> Vyrewatch Sentinel (combat): 1/1,500 … Vyre (pickpocketing): 1/5,000

Verified via WebFetch + the source's own `dropRate` field; survived a domain-skeptic refutation pass. (Also matches a prior verification-log note confirming 1/1500.)

## Validation
JSON valid; `validate_drop_rates` clean apart from the pre-existing advisory.