### PR TITLE
fix(data): Warped Creature - only partial completion of The Path of Glouphrie is needed

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -11330,7 +11330,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Warped Creatures in the Poison Waste Dungeon, Tirannwn. Requires completion of The Path of Glouphrie.",
+        "description": "Kill Warped Creatures in the Poison Waste Dungeon, Tirannwn. Requires partial completion of The Path of Glouphrie (plus 56 Slayer and a crystal chime in inventory).",
         "worldX": 2032,
         "worldY": 4636,
         "worldPlane": 0,


### PR DESCRIPTION
## Problem (low)
The guidance said *"Requires **completion** of The Path of Glouphrie"*, implying full completion. Only **partial completion** is needed to kill the warped creatures (plus 56 Slayer and a crystal chime in inventory). A player mid-quest can already fight them.

(The structured `requirements.quests: THE_PATH_OF_GLOUPHRIE` is already partial-aware — the checker treats an in-progress quest as access — so only the prose overstated the gate.)

## Fix (prose-only)
"Requires completion" → "Requires partial completion … (plus 56 Slayer and a crystal chime in inventory)".

## Source (cite-or-discard)
OSRS Wiki, Warped terrorbird:
> requiring partial completion of The Path of Glouphrie

Verified via WebFetch; survived a domain-skeptic refutation pass.

## Validation
JSON valid; `validate_drop_rates` clean apart from the pre-existing advisory.