### PR TITLE
fix(data): ToA 500 Invocation - model the Masori/Menaphite kits as guaranteed challenge rewards

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -7696,10 +7696,11 @@
       {
         "itemId": 27255,
         "name": "Menaphite ornament kit",
-        "dropRate": 0.02,
+        "dropRate": 1.0,
         "isPet": false,
         "wikiPage": "Menaphite_ornament_kit",
-        "independent": true
+        "independent": true,
+        "milestoneKills": 1
       },
       {
         "itemId": 27248,
@@ -7713,10 +7714,11 @@
       {
         "itemId": 27372,
         "name": "Masori crafting kit",
-        "dropRate": 0.02,
+        "dropRate": 1.0,
         "isPet": false,
         "wikiPage": "Masori_crafting_kit",
-        "independent": true
+        "independent": true,
+        "milestoneKills": 1
       },
       {
         "itemId": 27377,


### PR DESCRIPTION
## Problem (low)
In the **Tombs of Amascut (500 Invocation)** entry, the **Masori crafting kit** (27372) and **Menaphite ornament kit** (27255) were modeled as **1/50 (0.02) random drops**. They are actually **deterministic challenge rewards**:
- Masori crafting kit — given at **raid level 350+**, zero deaths, 1500+ points ("Always" rarity).
- Menaphite ornament kit — given at **raid level 425+**, zero deaths ("Always" rarity).

At 500 invocation both thresholds are met, so both are **guaranteed on a first eligible deathless clear** — exactly like the **Cursed phalanx** and the five **Remnants** in this same entry, which already use `dropRate 1.0 + milestoneKills 1`.

## Fix
Changed both kits to `dropRate 1.0 + milestoneKills 1`, matching the sibling challenge-reward pattern, so the collection-log efficiency ranker shows them as guaranteed at this tier instead of 1/50. **Scoped to the 500 entry only** — the ToA-normal and ToA-300 entries (where raid level can be below 350/425) were not flagged and are unchanged.

## Source (cite-or-discard)
OSRS Wiki — Masori crafting kit: *"complete a raid at level 350+ with zero deaths … at least 1500 points"* (Always rarity); Menaphite ornament kit: *"complete a raid at level 425 (or higher) with zero deaths"* (Always rarity). Verified via WebFetch; survived a domain-skeptic refutation pass.

## Validation
`validate_drop_rates` (ToA 500 Invocation): **passed, no issues.** CI regression suite is the authoritative gate.