### PR TITLE
fix(data): Soul Wars - Ectoplasmator costs 250 Zeal Tokens, not 2500

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -17014,7 +17014,7 @@
         "dropRate": 1.0,
         "isPet": false,
         "wikiPage": "Ectoplasmator",
-        "pointCost": 2500,
+        "pointCost": 250,
         "independent": true
       },
       {


### PR DESCRIPTION
## Problem (high)
The Ectoplasmator's `pointCost` was **2500** — a 10× overstatement that also contradicts the entry's own reward guidance step ("Spend on the Ectoplasmator (250)").

## Fix
`pointCost` 2500 → **250** Zeal Tokens.

## Source (cite-or-discard)
OSRS Wiki, Ectoplasmator: "purchased from Nomad on the Isle of Souls for **250 Zeal Tokens**". Survived a domain-skeptic refutation pass.

## Validation
JSON valid; `validate_drop_rates` clean.