### PR TITLE
fix(data): Mastering Mixology - correct resin colours (Mox blue, Lye red)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -15715,7 +15715,7 @@
         "section": "Travel"
       },
       {
-        "description": "Mix potions at the Mixology station to earn Mox (orange), Aga (green), and Lye (blue) resin. Optimal cycle: grind the herb, add to vial, agitate at the correct station, then deposit the finished potion. Watch the order indicators - over-agitating turns the potion into paste (wasted XP).",
+        "description": "Mix potions at the Mixology station to earn Mox (blue), Aga (green), and Lye (red) resin. Optimal cycle: grind the herb, add to vial, agitate at the correct station, then deposit the finished potion. Watch the order indicators - over-agitating turns the potion into paste (wasted XP).",
         "worldX": 1393,
         "worldY": 2937,
         "worldPlane": 0,


### PR DESCRIPTION
## Problem (high)
The guidance labelled the resins *"Mox (orange), Aga (green), and Lye (blue)"*. **Mox is blue** and **Lye is red** (Aga green was correct). A player colour-matching the stations would target the wrong ones.

## Fix (prose-only)
"Mox (blue), Aga (green), and Lye (red)".

## Source (cite-or-discard)
OSRS Wiki paste examines — Mox: *"A sticky, blue, sweet-smelling substance"*; Aga: *"green"*; Lye: *"A sticky, red, acrid-smelling substance"*. Survived a domain-skeptic refutation pass.

## Validation
JSON valid; `validate_drop_rates` clean.