### PR TITLE
fix(data): Volcanic Mine - Dragon pickaxe (broken) is a 1/100 ore-pack roll, not a 4000-point buy

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -15817,7 +15817,7 @@
       {
         "itemId": 27695,
         "name": "Dragon pickaxe (broken)",
-        "dropRate": 1.0,
+        "dropRate": 0.01,
         "isPet": false,
         "wikiPage": "Dragon_pickaxe_(broken)",
         "pointCost": 4000
@@ -15904,7 +15904,7 @@
         ]
       },
       {
-        "description": "Exit the mine after the round ends to bank your points and ores. Spend points at Petrified Pete's shop for Prospector pieces (boots 21k, legs 34k, jacket 39k, helmet 26k each), Dragon pickaxe broken (4000), Volcanic mine teleport (200), Large water container (10000), or Ash covered tome (40000).",
+        "description": "Exit the mine after the round ends to bank your points and ores. Spend points at Petrified Pete's shop for Prospector pieces (boots 21k, legs 34k, jacket 39k, helmet 26k each), Volcanic mine teleport (200), Large water container (10000), or Ash covered tome (40000). The Dragon pickaxe (broken) is not bought directly - it is a 1/100 roll from Ore packs, which cost 4000 points each (expected ~400k points).",
         "worldX": 3815,
         "worldY": 3807,
         "worldPlane": 0,


### PR DESCRIPTION
## Problem (high)
The **Dragon pickaxe (broken)** was modeled as a guaranteed direct shop purchase (`dropRate 1.0, pointCost 4000`), and the reward step listed it as "Dragon pickaxe broken (4000)". It is **not** bought directly: 4,000 points buys **one Ore pack**, and the broken pickaxe is a **1/100 roll from opening ore packs** (expected ~400,000 points).

## Fix (structural)
- `dropRate` 1.0 → **0.01** (the 1/100 per-pack chance). `pointCost` 4000 kept (the ore-pack cost).
- Corrected the reward-shop guidance step to describe the ore-pack mechanic.

## Source (cite-or-discard)
OSRS Wiki, Ore pack (Volcanic Mine): "The ore pack costs **4,000 points** … drop at a rate of **1/100 openings**". Verified via WebFetch; survived a domain-skeptic refutation pass.

## Validation
`validate_drop_rates` (Volcanic Mine): clean apart from the pre-existing ARRIVE_AT_TILE advisory. CI regression suite is the authoritative gate for the rate change.