### PR TITLE
fix(data): Barbarian Assault - Granite body is a 95k-coin purchase, not a 1000-point buy

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -18170,7 +18170,7 @@
         "dropRate": 1.0,
         "isPet": false,
         "wikiPage": "Granite_body",
-        "pointCost": 1000
+        "milestoneKills": 1
       },
       {
         "itemId": 12703,
@@ -18240,7 +18240,7 @@
       },
       {
         "section": "Reward",
-        "description": "Spend honour points at Commander Connad's shop: Fighter torso (1500 pts), Penance skirt (1500 pts), role hats (1100 pts each). Buy Gambles (500 pts + 1 Penance Queen kill) for a chance at the Pet penance queen (1/1000 per gamble).",
+        "description": "Spend honour points at Commander Connad's shop: Fighter torso (1500 pts), Penance skirt (1500 pts), role hats (1100 pts each). Buy Gambles (500 pts + 1 Penance Queen kill) for a chance at the Pet penance queen (1/1000 per gamble). The Granite body is the only reward not bought with honour points - it costs 95,000 coins from Commander Connad after your first Penance Queen kill.",
         "worldX": 2519,
         "worldY": 3571,
         "worldPlane": 0,


### PR DESCRIPTION
## Problem (high)
The **Granite body** had a fabricated `pointCost: 1000`, modeling it as an honour-point purchase. It's the **only Barbarian Assault reward not bought with honour points** — it costs **95,000 coins** from Commander Connad after killing the Penance Queen.

## Fix (structural + prose)
- Removed the fabricated `pointCost 1000`; modeled as a guaranteed reward gated on one qualifying game (`dropRate 1.0 + milestoneKills 1`, matching other one-time-guaranteed rewards).
- Noted the 95k-coin / Penance Queen gate in the reward step.

## Source (cite-or-discard)
OSRS Wiki, Granite body: "Players who have killed the Penance Queen can purchase it from Commander Connad … for **95,000 coins**. It is the only reward … not obtained with honour points." Verified via WebFetch; survived a domain-skeptic refutation pass.

## Validation
JSON valid; `validate_drop_rates` clean.