### PR TITLE
fix(data): Temple Trekking - Lumberjack outfit drops from undead lumberjacks, not a token trader

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -16305,7 +16305,7 @@
         "section": "Travel"
       },
       {
-        "description": "Choose the hardest route and weakest (hard-tier) follower (Rolayne Twickit) for the best Lumberjack outfit drop chance. Hard route, hard follower gives the highest token reward multiplier.",
+        "description": "The Lumberjack outfit is not tied to route difficulty or token rewards - each undead lumberjack in the bridge-repair event has a 25% chance to drop a piece (limit one piece per event). Do quick treks and fight the undead lumberjacks whenever the bridge-repair event appears.",
         "worldX": 3479,
         "worldY": 3241,
         "worldPlane": 0,
@@ -16323,7 +16323,7 @@
         "section": "Trek"
       },
       {
-        "description": "Claim your reward token at Paterdomus and exchange it with the token trader for a Lumberjack outfit piece. Hard treks yield more tokens per run.",
+        "description": "Claim your trek reward at Paterdomus. The Lumberjack outfit pieces are NOT bought here - they drop directly from the undead lumberjacks during the bridge-repair event (25% each, one piece per event). Other rewards scale with the trek's difficulty and length.",
         "worldX": 3477,
         "worldY": 3239,
         "worldPlane": 0,


### PR DESCRIPTION
## Problem (blocker + high)
The guidance described obtaining the **Lumberjack outfit** by claiming a reward token and exchanging it with a **"token trader"** — a **fabricated mechanic** (there is no token trader for the outfit). It also told players to pick the "hardest route … for the best Lumberjack outfit drop chance", but the drop is **independent of route difficulty**.

The Lumberjack outfit pieces are **dropped directly by the undead lumberjacks during the bridge-repair event** (25% chance each, one piece per event).

## Fix (prose-only)
Rewrote the two steps to the real drop mechanic and removed the difficulty-based advice.

## Source (cite-or-discard)
OSRS Wiki, Temple Trekking: "The undead lumberjacks in this event all have a **25% chance to drop a piece of the lumberjack outfit**, with a limit of one piece of the outfit per event." Survived a domain-skeptic refutation pass. (Note: I scoped the fix to the confirmed drop mechanic; I did not add the "Route One evade" fastest-method detail since the /Rewards page 404'd during verification.)

## Validation
JSON valid; `validate_drop_rates` clean.