### PR TITLE
fix(data): Gnome Restaurant (Seed Pods) - Gianne jnr is on the 1st floor, not the ground floor

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -30334,7 +30334,7 @@
     ],
     "guidanceSteps": [
       {
-        "description": "Travel to the Grand Tree in Tree Gnome Stronghold. Talk to Gianne jnr. on the west end of the ground floor to get a hard delivery order.",
+        "description": "Travel to the Grand Tree in Tree Gnome Stronghold and climb up to the 1st floor [UK] / 2nd floor [US]. Talk to Aluft Gianne jnr. at the west end of that floor (north-west, just west of the cafe) to get a hard delivery order.",
         "worldX": 2436,
         "worldY": 3500,
         "worldPlane": 0,
@@ -30357,7 +30357,7 @@
         "section": "Order"
       },
       {
-        "description": "Cook the required gnome dish using the range and ingredients on the Grand Tree ground floor. Use the recipe book in your inventory if unsure of the recipe. Deliver the finished dish to the assigned customer within the 11-minute time limit. Customer locations vary across Gielinor - check the delivery box for the destination.",
+        "description": "Cook the required gnome dish using the range and ingredient shops on the Grand Tree 1st floor [UK] / 2nd floor [US] (same floor as Gianne jnr.). Use the recipe book in your inventory if unsure of the recipe. Deliver the finished dish to the assigned customer within the 11-minute time limit. Customer locations vary across Gielinor - check the delivery box for the destination.",
         "worldX": 2436,
         "worldY": 3500,
         "worldPlane": 0,


### PR DESCRIPTION
## Problem (high)
The guidance placed **Aluft Gianne jnr.**, the cooking range, and the ingredient shops on the Grand Tree **"ground floor"**. They're on the **1st floor [UK] / 2nd floor [US]** — the player must climb up from the base. "Ground floor" misdirects them to the wrong level (there's no range/Gianne there).

## Fix (prose-only)
Corrected the start and cook steps to the 1st floor [UK]. (Left the step coords/plane as the arrival base — I don't have verified 1st-floor tile coords, and the steps represent where you arrive before climbing.)

## Source (cite-or-discard)
OSRS Wiki, Gnome Restaurant: "talk to Gianne jnr. on the west end of the **1st floor[UK]2nd floor[US]** of the Grand Tree". Verified via WebFetch; survived a domain-skeptic refutation pass.

## Validation
JSON valid; `validate_drop_rates` clean.