### PR TITLE
fix(data): Fishing Trawler - add the swamp-paste leak-sealing task

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -16183,7 +16183,7 @@
     },
     "guidanceSteps": [
       {
-        "description": "Travel to Port Khazard. Use the Minigame Grouping teleport (Fishing Trawler) for the fastest route, or fairy ring DJP then run south. Bring bailing buckets and rope for repairs",
+        "description": "Travel to Port Khazard. Use the Minigame Grouping teleport (Fishing Trawler) for the fastest route, or fairy ring DJP then run south. Bring a bailing bucket, swamp paste (to seal leaks), and rope (to repair torn nets)",
         "worldX": 2661,
         "worldY": 3164,
         "worldPlane": 0,
@@ -16212,7 +16212,7 @@
         "section": "Activity"
       },
       {
-        "description": "During the 5-minute voyage, bail water from flooded sections (use bucket on water) and repair damaged nets with rope. Bailing continuously maximises your loot share. Torn nets simply catch no fish until repaired",
+        "description": "During the 5-minute voyage, keep three tasks up: bail water with the bucket, seal the hull leaks with swamp paste (the leaks are the source of the incoming water), and repair torn nets with rope. Staying on top of leaks and bailing maximises your loot share; torn nets simply catch no fish until repaired",
         "worldX": 2661,
         "worldY": 3164,
         "worldPlane": 1,


### PR DESCRIPTION
## Problem (low)
The guidance listed only bailing (bucket) and net repair (rope), omitting the **swamp-paste leak-sealing** task. The hull springs leaks that are the *source* of the incoming water; they're sealed with swamp paste.

## Fix (prose-only)
Added swamp paste to the prep and voyage steps (full task set: bail, seal leaks, repair nets).

## Source (cite-or-discard)
OSRS Wiki, Fishing Trawler: "Leaks on the sides of the boat can be repaired using **swamp paste**." Survived a domain-skeptic refutation pass.

## Validation
JSON valid; `validate_drop_rates` clean.