### PR TITLE
fix(data): Hallowed Sepulchre - Strange old lockpick drops on every floor, not just floor 5

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -13835,7 +13835,7 @@
         "section": "Sepulchre"
       },
       {
-        "description": "Spend Hallowed marks at the reward shop near the entrance. The Ring of endurance and Strange old lockpick come from the floor-5 grand coffins; everything else is bought with marks (Hallowed grapple/focus/symbol/hammer 100 marks, Hallowed ring 250 marks, Dark dye 300, Dark acorn 3000).",
+        "description": "Spend Hallowed marks at the reward shop near the entrance. The Strange old lockpick drops from regular coffins on every floor (better odds the higher the floor: ~1/200 on floor 1 up to ~1/40 on floor 5); the Ring of endurance is exclusive to the floor-5 Grand Hallowed Coffin. Everything else is bought with marks (Hallowed grapple/focus/symbol/hammer 100 marks, Hallowed ring 250 marks, Dark dye 300, Dark acorn 3000).",
         "worldX": 3654,
         "worldY": 3385,
         "worldPlane": 0,


### PR DESCRIPTION
## Problem (low)
The reward step said the **Strange old lockpick** comes from the floor-5 grand coffins. It actually drops from **regular coffins on every floor (1–5)**, with better odds the higher the floor (~1/200 floor 1 up to ~1/40 floor 5). Only the **Ring of endurance** is exclusive to the floor-5 Grand Hallowed Coffin.

## Fix (prose-only)
Corrected the lockpick source (all floors, scaling odds) and kept the Ring of endurance as floor-5-exclusive.

## Source (cite-or-discard)
OSRS Wiki, Hallowed Sepulchre — Strange old lockpick floor drop rates: 1/200, 1/120, 1/90, 1/60, 1/40 (floors 1–5). Survived a domain-skeptic refutation pass.

## Validation
JSON valid; `validate_drop_rates` clean.