### PR TITLE
fix(data): Vale Totems - reward items are bought with vale research points, not offerings directly

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -17529,7 +17529,7 @@
         "section": "Activity"
       },
       {
-        "description": "Collect vale offerings from completed totems after ent visits. Exchange offerings at the reward trader for Bow string spool, Fletching knife, Ent branch, or Greenman mask.",
+        "description": "Collect vale offerings from completed totems after ent visits. Vale offerings are an intermediate currency: rummage every 100 offerings for one vale research point (plus a random reward). Spend vale research points at the Vale Research Exchange (run by Ranulph) on the Bow string spool, Fletching knife, Ent branch, or Greenman mask.",
         "worldX": 1452,
         "worldY": 3128,
         "worldPlane": 0,


### PR DESCRIPTION
## Problem (low)
The reward step said to *"exchange offerings at the reward trader"* for the clog items. That skips a step: **vale offerings are an intermediate currency** — every 100 offerings can be rummaged for **one vale research point** (plus a random reward), and the **research points** are what's spent at the **Vale Research Exchange** (run by Ranulph).

## Fix (prose-only)
Corrected the reward flow (offerings → rummage for research points → spend at the Vale Research Exchange).

## Source (cite-or-discard)
OSRS Wiki, Vale Totems: "For every 100 vale offerings the player collects, they can rummage through them for one research point … Earned vale research points can be spent at Vale Research Exchange". Survived a domain-skeptic refutation pass.

## Validation
JSON valid; `validate_drop_rates` clean.