### PR TITLE
fix(data): Barracuda Trials - add Sailing requirement and correct the Soup rate

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -18260,6 +18260,14 @@
     "worldPlane": 0,
     "killTimeSeconds": 480,
     "afkLevel": 1,
+    "requirements": {
+      "skills": [
+        {
+          "skill": "SAILING",
+          "level": 30
+        }
+      ]
+    },
     "items": [
       {
         "itemId": 31732,
@@ -18342,7 +18350,7 @@
       {
         "itemId": 31283,
         "name": "Soup",
-        "dropRate": 0.000444,
+        "dropRate": 0.000333,
         "isPet": false,
         "wikiPage": "Soup_(item)",
         "independent": true
@@ -18352,7 +18360,7 @@
     "travelTip": "Sailing port -> trial",
     "guidanceSteps": [
       {
-        "description": "Travel to Sailing trial locations across the seas.",
+        "description": "Travel to the Sailing trial locations across the seas. The three trials unlock by Sailing level (not boostable): The Tempor Tantrum at 30, The Jubbly Jive at 55, and The Gwenith Glide at 72; The Gwenith Glide also requires the Regicide quest. Only skiffs may be used.",
         "worldX": 1823,
         "worldY": 3691,
         "worldPlane": 0,


### PR DESCRIPTION
## Problem
1. **Missing Sailing requirement.** The entry had no `requirements`, yet its reward items span all three trials, which unlock at **Sailing 30 / 55 / 72** (not boostable); The Gwenith Glide (72) also requires **Regicide**. A level-1 Sailing account can access none of them.
2. **Soup pet rate wrong.** `0.000444` (1/2252) is **higher than any achievable single Barracuda rank** — the best is Gwenith Glide Marlin at **1/3000**. An impossible per-source rate.

## Fix
- Added `requirements.skills: SAILING 30` (the access gate; validated — SAILING enum already used by Boat Paints) + a prose note on the 30/55/72 tiers and the Gwenith-Glide Regicide gate.
- Soup `dropRate` 0.000444 → **0.000333** (1/3000).

## Source (cite-or-discard)
OSRS Wiki, Barracuda Trials: trials "unlocked at level 30 … 55 … 72"; "The level requirement is not boostable"; Gwenith Glide row lists Regicide. Soup: best Barracuda rate "1/3,000". Verified via WebFetch; survived a domain-skeptic refutation pass.

## Validation
`validate_drop_rates` (Barracuda Trials): **passed, no issues.**