### PR TITLE
fix(data): Brimhaven Agility Arena - correct reward currency (tickets -> XP, items via vouchers)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -14234,7 +14234,7 @@
         "section": "Activity"
       },
       {
-        "description": "Exchange agility tickets with Pirate Jackie the Fruit for Brimhaven Graceful recolours (250 vouchers for the full set) or the Pirate's hook (800 tickets).",
+        "description": "Trade in with Pirate Jackie the Fruit: Agility Arena tickets are exchanged for Agility XP, while the item rewards use the separate Brimhaven voucher currency - the Graceful recolour is 250 vouchers for the full set and the Pirate's hook is 800 vouchers.",
         "worldX": 2809,
         "worldY": 3194,
         "worldPlane": 0,


### PR DESCRIPTION
## Problem (low)
The reward step said items were bought with **"agility tickets"** and priced the Pirate's hook at "800 **tickets**". Post-update, Agility Arena **tickets** are traded for **Agility XP**; the item rewards (Graceful recolour, Pirate's hook) use the separate **Brimhaven voucher** currency. The Pirate's hook costs **800 vouchers**.

## Fix (prose-only)
Corrected the currency (tickets → XP; items → vouchers; hook 800 vouchers).

## Deferred (separate finding)
The structured graceful `pointCost` (250 on each of 6 pieces = 1500, vs the real **whole-set 250**) is a real 6× overstatement, but fixing it needs a plugin **set-recolour modeling** decision (whole purchase unlocks all 6). **Deferred for an operator call** — noted in the ledger. The prose already (correctly) says "250 vouchers for the full set".

## Source (cite-or-discard)
OSRS Wiki, Brimhaven Agility Arena: "tickets and vouchers can be traded in to Pirate Jackie the Fruit for Agility experience and a selection of items respectively"; Pirate's hook = 800 vouchers. Survived a domain-skeptic refutation pass.

## Validation
JSON valid; `validate_drop_rates` clean.