### PR TITLE
fix(data): Armoured Zombie - correct coordinates and travel (Zemouregal's Fort, far north)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -31973,8 +31973,8 @@
   {
     "name": "Armoured Zombie",
     "category": "OTHER",
-    "worldX": 3566,
-    "worldY": 3390,
+    "worldX": 2780,
+    "worldY": 10277,
     "worldPlane": 0,
     "killTimeSeconds": 7,
     "afkLevel": 2,
@@ -32016,7 +32016,7 @@
       }
     ],
     "locationDescription": "Zemouregal's Fort, in the far north (Troll Country, near Ghorrock)",
-    "travelTip": "Varrock teleport -> north to fort",
+    "travelTip": "No direct teleport - Weiss (icy basalt) or Trollheim teleport, then the tunnel on Trollweiss Mountain peak",
     "npcId": 14113,
     "interactAction": "Attack",
     "requirements": {
@@ -32026,9 +32026,9 @@
     },
     "guidanceSteps": [
       {
-        "description": "Travel to Zemouregal's Fort in the far north of Troll Country (near Ghorrock). Requires The Curse of Arrav quest.",
-        "worldX": 3566,
-        "worldY": 3390,
+        "description": "Travel to Zemouregal's Fort in the far north (Troll Country, between Weiss and the Ice Path, Ghorrock to the east). There is no direct teleport - use Weiss (icy basalt) or a Trollheim teleport and reach the fort via the tunnel on the peak of Trollweiss Mountain. Requires The Curse of Arrav quest.",
+        "worldX": 2780,
+        "worldY": 10277,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
@@ -32036,8 +32036,8 @@
       },
       {
         "description": "Kill Armoured Zombies at Zemouregal's Fort. Use Crumble Undead or melee. Broken zombie axe, Broken zombie helmet, and Champion scroll (zombie) are the rare drops.",
-        "worldX": 3566,
-        "worldY": 3390,
+        "worldX": 2780,
+        "worldY": 10277,
         "worldPlane": 0,
         "npcId": 14113,
         "interactAction": "Attack",


### PR DESCRIPTION
## Problem (blocker + high)
The source and **both** guidance steps used worldX/Y **3566,3390** — which is at **Darkmeyer, Morytania** (84 tiles away per coordinate_helper), flatly contradicting the entry's own `locationDescription` ("Zemouregal's Fort, far north, Troll Country"). The `ARRIVE_AT_TILE` travel step could never resolve near the actual fort. (npcId 14113 = Armoured zombie, Zemouregal's Fort — confirmed by the drop table: Broken zombie helmet/axe 1/600, Zombie champion scroll 1/5000.)

Also the `travelTip` "Varrock teleport → north to fort" is wrong — that points at the unrelated Zemouregal's Base near Varrock.

## Fix (blocker coord + high travel)
- Coords `3566,3390` → **`2780,10277`** (region 11168, underground fort tunnels; matches the wiki spawn cluster 2758–2809, 10256–10285) on the source and both steps.
- `travelTip` / travel step: the fort has **no direct teleport** — reached via the **tunnel on the peak of Trollweiss Mountain** (Weiss icy basalt / Trollheim teleport).

## Source (cite-or-discard)
OSRS Wiki, Zemouregal's Fort: "located in the North", accessed via "a tunnel found on the peak of Trollweiss Mountain", "Teleports: No". Survived a domain-skeptic refutation pass. *Note: `npc_spawns` had no mejrs data for this quest-instanced NPC; the coord is from the wiki spawn receipt and region-verified (11168 = underground fort tunnels).*

## Validation
`validate_drop_rates` (Armoured Zombie): **passed, no issues.**