### PR TITLE
fix(data): Albatross (Boat Combat) - Sailing requirement is 50, not 55

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -30519,7 +30519,7 @@
       "skills": [
         {
           "skill": "SAILING",
-          "level": 55
+          "level": 50
         }
       ]
     }


### PR DESCRIPTION
## Problem (high)
The Sailing requirement was **55**. The Albatross may be assigned as a Boat Combat bounty task starting at **50 Sailing** (55 appears nowhere on the wiki page). This matches the sibling convention already in the data (Narwhal = SAILING 62, per its wiki "bounty task starting at 62 Sailing").

## Fix
`requirements.skills` SAILING 55 → **50**.

## Source (cite-or-discard)
OSRS Wiki, Albatross: "They may be assigned as a bounty task starting at **50 Sailing**." Verified via WebFetch; survived a domain-skeptic refutation pass.

## Validation
JSON valid; `validate_drop_rates` clean.