### PR TITLE
fix(data): Champion's Challenge - gatekeeper is Larxus, and the cape needs all 11 champions

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -18750,7 +18750,7 @@
         "dropRate": 1.0,
         "isPet": false,
         "wikiPage": "Champion%27s_cape",
-        "milestoneKills": 10
+        "milestoneKills": 11
       }
     ],
     "locationDescription": "Champions' Guild south of Varrock",
@@ -18776,7 +18776,7 @@
         "section": "Travel"
       },
       {
-        "description": "Challenge a champion in the arena by handing a champion scroll to Larxia. Each champion uses a specific combat style - use appropriate protection prayer. Defeat all 10 champions to unlock the Champions' cape and the Champion of Champions fight.",
+        "description": "Challenge a champion in the arena by handing a champion scroll to Larxus. Each champion uses a specific combat style - use the appropriate protection prayer. Defeating all 10 race champions unlocks the Champion of Champions fight against Leon d'Cour; the Champion's cape is only awarded after you also defeat Leon d'Cour (all 11 champions).",
         "worldX": 3191,
         "worldY": 3356,
         "worldPlane": 0,


### PR DESCRIPTION
## Problem (high + low)
1. **Wrong NPC name (high).** The gatekeeper is **Larxus**, not "Larxia" — you give champion scrolls to Larxus.
2. **Cape champion count (low).** The **Champion's cape** is awarded after defeating **all 11 champions** (the 10 race champions **plus Leon d'Cour**, the Champion of Champions), not 10. Defeating the 10 race champions only *unlocks* the Leon d'Cour fight.

## Fix
- Prose: Larxia → Larxus; clarified the 10-race-champions → Leon d'Cour → cape (11) progression.
- `Champion's cape` `milestoneKills` 10 → **11**.

## Source (cite-or-discard)
OSRS Wiki, Champion's Challenge: "Once players defeat **all 11 champions**, they receive Leon d'Cour's champion's cape"; gatekeeper is Larxus. Verified via WebFetch; survived a domain-skeptic refutation pass.

## Validation
JSON valid; `validate_drop_rates` clean.