### PR TITLE
fix(data): Creature Creation (Spidine) - fix wrong ingredient id (raw sardine, not raw salmon)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -23031,7 +23031,7 @@
         "completionDistance": 20,
         "requiredItemIds": [
           223,
-          331
+          327
         ],
         "section": "Travel"
       },


### PR DESCRIPTION
## Problem (high)
The travel step's `requiredItemIds` were `[223, 331]`. The description correctly says **"raw sardine"**, but item **331 = Raw salmon** — the wrong ingredient. The required-items overlay would highlight raw salmon.

## Fix
`[223, 331]` → **`[223, 327]`** (223 = Red spiders' eggs, **327 = Raw sardine**).

## Source (cite-or-discard)
`runelite_id_lookup`: 331 = `RAW_SALMON`, 327 = `RAW_SARDINE`; the Spidine is created from red spiders' eggs + raw sardine.

## Validation
`validate_drop_rates --check cache_ids` (Creature Creation (Spidine)): **passed.**