### PR TITLE
fix(data): Catacombs of Kourend - dark totem drop is HP-dependent, not a flat 1/500

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -20908,7 +20908,7 @@
         "section": "Bank"
       },
       {
-        "description": "Kill monsters in the Catacombs for dark totem pieces (base, middle, top - each 1/500 from any monster). Burying bones restores Prayer. Popular Slayer tasks here include abyssal demons, nechryaels, hellhounds, and brutal black dragons. Combine Slayer trips with totem piece hunting for efficient farming.",
+        "description": "Kill monsters in the Catacombs for the dark totem pieces (base, middle, top). The drop is not a flat 1/500 and not from every monster: the rate is HP-dependent, 1/(500 - the monster's Hitpoints), so higher-HP monsters drop pieces more often (e.g. a 205 HP monster is ~1/295). Ghosts never drop them, and Superior Slayer monsters give a guaranteed piece. Burying bones restores Prayer. Popular Slayer tasks here include abyssal demons, nechryaels, hellhounds, and brutal black dragons - combine Slayer trips with totem hunting.",
         "worldX": 1664,
         "worldY": 10050,
         "worldPlane": 0,


### PR DESCRIPTION
## Problem (low)
The guidance said dark totem pieces drop *"each 1/500 from any monster"*. Two errors: the rate is **not flat** — it's HP-dependent, **1/(500 − the monster's Hitpoints)** (so higher-HP monsters drop pieces more often, always better than 1/500) — and it's **not from any monster** (ghosts never drop them; Superior Slayer monsters give a guaranteed piece). The entry's own item `dropRate` (0.00339 ≈ 1/295) already implies a ~205-HP monster, contradicting the "1/500" prose.

## Fix (prose-only)
Corrected to the HP formula + the ghost/superior carve-outs.

## Source (cite-or-discard)
OSRS Wiki, Dark totem base: obtained "from monsters found within the Catacombs of Kourend (**excluding ghosts**)"; "The exact formula is **1/(500 − hitpoints)**". Survived a domain-skeptic refutation pass.

## Validation
JSON valid; `validate_drop_rates` clean.