### PR TITLE
fix(data): Lost Schematics - coords point to Port Piscarilius, should be Port Sarim

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -19599,8 +19599,8 @@
   {
     "name": "Lost Schematics",
     "category": "OTHER",
-    "worldX": 1824,
-    "worldY": 3691,
+    "worldX": 3044,
+    "worldY": 3193,
     "worldPlane": 0,
     "killTimeSeconds": 600,
     "afkLevel": 1,
@@ -19719,8 +19719,8 @@
     "guidanceSteps": [
       {
         "description": "Sail to discoverable islands via Port Sarim docks. Higher Sailing level unlocks more islands and schematic types.",
-        "worldX": 1824,
-        "worldY": 3691,
+        "worldX": 3044,
+        "worldY": 3193,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 20,
@@ -19728,8 +19728,8 @@
       },
       {
         "description": "Find lost schematics while exploring islands during Sailing voyages.",
-        "worldX": 1824,
-        "worldY": 3691,
+        "worldX": 3044,
+        "worldY": 3193,
         "worldPlane": 0,
         "completionCondition": "MANUAL",
         "section": "Find schematics"


### PR DESCRIPTION
## Problem (high)
The source and both guidance steps used coords **1824,3691 = Port Piscarilius sailing dock** (Kourend, region 7225) — which requires **15 Sailing** and is ~1200 tiles from Port Sarim. This contradicts the entry's own `travelTip` ("Port Sarim docks → sail"), both step descriptions ("via Port Sarim docks"), and its **Sailing level-1** requirement. The `ARRIVE_AT_TILE` step would send the player to the wrong port (one above the stated level gate).

## Fix (coord)
Coords `1824,3691` → **`3044,3193`** (Port Sarim docks area, region 12081 — the canonical level-1 Sailing departure) on the source and both steps.

## Source (cite-or-discard)
OSRS Wiki, Sailing: Port Sarim / The Pandemonium is the level-1 start; "Players can dock at Port Piscarilius with **level 15 Sailing**". `coordinate_helper`: 1824,3691 = Port Piscarilius; 3044,3193 = Port Sarim. Survived a domain-skeptic refutation pass.

## Validation
JSON valid; `validate_drop_rates` clean.