### PR TITLE
fix(data): Forestry - Golden pheasant egg rate updated to the current ~1/50 per event

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -19033,7 +19033,7 @@
       {
         "itemId": 28663,
         "name": "Golden pheasant egg",
-        "dropRate": 0.003704,
+        "dropRate": 0.02,
         "isPet": false,
         "wikiPage": "Golden_pheasant_egg",
         "independent": true


### PR DESCRIPTION
## Problem (high)
The Golden pheasant egg `dropRate` was **0.003704 (1/270)** — a **stale pre-February 2025 value**. The 5 Feb 2025 update adjusted the rate; the current effective rate is **~1 in 50 per event**.

## Fix
`dropRate` 0.003704 → **0.02** (1/50). I used the wiki's corrected effective rate (~1/50), not the 1/30 news-post figure, because the wiki explicitly notes the real rate is ~1/50 (action-based, not a single per-event roll). The entry models per-event (`killTimeSeconds` 120 ≈ one event).

## Source (cite-or-discard)
OSRS Wiki, Golden pheasant egg (Changes): "Drop rates for the Golden Pheasant Egg have been adjusted to 1 in 30 per event … **the real rate is ~1 in 50 per event** due to being based on actions instead". Verified via WebFetch; survived a domain-skeptic refutation pass (the skeptic specifically corrected the 1/30 figure to ~1/50).

## Validation
JSON valid; `validate_drop_rates` clean. CI regression suite is the authoritative gate for the rate change.