### PR TITLE
fix(data): Glough's Experiments - Crash Site Cavern is in Kandarin, not beneath Ape Atoll

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -19458,7 +19458,7 @@
         "wikiPage": "Monkey_tail"
       }
     ],
-    "locationDescription": "Crash Site Cavern beneath Ape Atoll",
+    "locationDescription": "Crash Site Cavern, north of the Tree Gnome Stronghold (Kandarin)",
     "travelTip": "Spirit tree -> Stronghold",
     "npcId": 7144,
     "interactAction": "Attack",


### PR DESCRIPTION
## Problem (high)
The `locationDescription` said *"Crash Site Cavern beneath Ape Atoll"* — the **wrong continent**. The Crash Site Cavern (Monkey Madness II demonic gorillas) is **north of the Tree Gnome Stronghold / north-west of the Grand Tree, in Kandarin**. The entry's own coords (2130,5647) and guidance steps ("north-west of the Grand Tree") already reflect Kandarin, and the sibling **Demonic gorillas** entry (same npcId 7144) correctly says "Crash Site Cavern, Gnome Stronghold" — so the `locationDescription` was the lone stale outlier.

## Fix (prose-only)
→ "Crash Site Cavern, north of the Tree Gnome Stronghold (Kandarin)".

## Source (cite-or-discard)
OSRS Wiki, Crash Site Cavern: "a cave located a very short distance **north of the Tree Gnome Stronghold** … **north-west of the Grand Tree**"; leagueRegion Kandarin. Survived a domain-skeptic refutation pass.

## Validation
JSON valid; `validate_drop_rates` clean.