### PR TITLE
fix(data): Cyclopes - defender tier progression is leave-and-re-enter, not holding

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -22243,7 +22243,7 @@
         "section": "Travel"
       },
       {
-        "description": "Kill Cyclopes for defender drops. Warrior guild tokens are spent on entry (10) and another 10 each minute inside the room - bring a large supply. Hold the current tier defender in inventory to unlock the next tier. Protect from Melee recommended.",
+        "description": "Kill Cyclopes for defender drops. Warrior guild tokens are spent on entry (10) and another 10 each minute inside the room - bring a large supply. Tier progression is gated by LEAVING and re-entering: after you get a defender, leave the room (re-showing it to Kamfreena) and re-enter, and the next tier can then drop even if the defender is banked. Holding the current defender only lets you obtain duplicates of the SAME tier. Protect from Melee recommended.",
         "perItemStepDescription": {
           "8844": "Kill Cyclopes (no prerequisite) to receive a Bronze defender and start the chain.",
           "8845": "Kill Cyclopes while holding a Bronze defender in inventory to receive an Iron defender.",


### PR DESCRIPTION
## Problem (low)
The combat step said to *"hold the current tier defender in inventory to unlock the next tier"*. That's wrong: tier progression is gated by **leaving the Cyclops room and re-entering** (re-showing the defender to Kamfreena), after which the next tier can drop **even if the defender is banked**. Holding the current defender only lets you obtain **duplicates of the same tier**. A player who stays in the room holding a bronze defender would never get the iron defender.

## Fix (prose-only)
Corrected the combat step to the leave-and-re-enter mechanic.

## Source (cite-or-discard)
OSRS Wiki, Defender: "After obtaining the first defender of each metal, the player must **leave the room and re-enter** before the next tier defender can drop … the next defender will still drop regardless of whether it is in the player's inventory." Survived a domain-skeptic refutation pass.

## Validation
JSON valid; `validate_drop_rates` clean.