### PR TITLE
fix(data): Ocean Encounters - Sailing requirement is 40, not 28

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -20202,7 +20202,7 @@
       "skills": [
         {
           "skill": "SAILING",
-          "level": 28
+          "level": 40
         }
       ]
     }


### PR DESCRIPTION
## Summary
Ocean Encounters' Sailing requirement was `28`; corrected to `40`.

Every collection-log item in this source is a giant-clam pearl (Tiny pearl `31770` through Radiant pearl `31800`). Giant clams are the only ocean-encounter type that yields these pearls, and per the wiki they appear only from **Sailing 40** (below 40, a player can interact only as a passenger on another player's boat). A solo player at Sailing 28 cannot obtain any of these clog items, so the honest gating requirement is 40. The prior `28` was not sourced to any wiki threshold.

## Citation
Wiki — [Giant clam](https://oldschool.runescape.wiki/w/Giant_clam):
> The giant clam is an ocean encounter that can appear anywhere on the ocean while the boat is moving, starting at level 40 Sailing. It is possible to interact with them before level 40 as a passenger on the boat of a player who does have the level.

## Verification
- `validate_drop_rates(Ocean Encounters)` → passed.
- `D4Batch11RegressionTest` asserts only that a SAILING requirement entry is present (not a specific level), so this change is test-safe.
- One-field change; coordinates untouched.