### PR TITLE
fix(data): Port Tasks - Soup is the Sailing skilling pet (isPet + wikiPage)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -32323,8 +32323,8 @@
         "itemId": 31283,
         "name": "Soup",
         "dropRate": 0.000222,
-        "isPet": false,
-        "wikiPage": "Soup_(item)"
+        "isPet": true,
+        "wikiPage": "Soup"
       },
       {
         "itemId": 32090,


### PR DESCRIPTION
## Summary
Soup (`31283`) is the Sailing **skilling pet**, but the Port Tasks entry marked it `isPet:false`, misclassifying a collection-log pet. Set `isPet:true`. Also corrected its `wikiPage`: `Soup_(item)` returns HTTP 404; the canonical live page is `Soup`.

## Citation
Wiki — [Soup](https://oldschool.runescape.wiki/w/Soup):
> Soup is a skilling pet that can be obtained while training the Sailing skill.

## Verification
- `validate_drop_rates(Port Tasks)` → passed.
- Item-field change only; the source's Piscarilius coordinates and guidance steps are untouched (the `SailingSourceTriageTest` Port-Piscarilius anchor for Port Tasks is unaffected).

## Follow-up (out of scope for this PR)
The same item Soup (`31283`) is also present in **Barracuda Trials** with the identical `isPet:false` / `wikiPage:"Soup_(item)"` misclassification. That is a separate source in a different batch; it will be corrected when that source is verified, to keep this PR one-source-scoped.