### PR TITLE
fix(data): Shayzien Armour - 5 defeats per tier, not 40; add Defence 20 req

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -22361,7 +22361,7 @@
         "isPet": false,
         "wikiPage": "Shayzien_helm_(1)",
         "independent": true,
-        "milestoneKills": 40
+        "milestoneKills": 5
       },
       {
         "itemId": 13361,
@@ -22370,7 +22370,7 @@
         "isPet": false,
         "wikiPage": "Shayzien_platebody_(1)",
         "independent": true,
-        "milestoneKills": 40
+        "milestoneKills": 5
       },
       {
         "itemId": 13360,
@@ -22379,7 +22379,7 @@
         "isPet": false,
         "wikiPage": "Shayzien_greaves_(1)",
         "independent": true,
-        "milestoneKills": 40
+        "milestoneKills": 5
       },
       {
         "itemId": 13357,
@@ -22388,7 +22388,7 @@
         "isPet": false,
         "wikiPage": "Shayzien_gloves_(1)",
         "independent": true,
-        "milestoneKills": 40
+        "milestoneKills": 5
       },
       {
         "itemId": 13358,
@@ -22397,7 +22397,7 @@
         "isPet": false,
         "wikiPage": "Shayzien_boots_(1)",
         "independent": true,
-        "milestoneKills": 40
+        "milestoneKills": 5
       },
       {
         "itemId": 13364,
@@ -22406,7 +22406,7 @@
         "isPet": false,
         "wikiPage": "Shayzien_helm_(2)",
         "independent": true,
-        "milestoneKills": 80
+        "milestoneKills": 10
       },
       {
         "itemId": 13366,
@@ -22415,7 +22415,7 @@
         "isPet": false,
         "wikiPage": "Shayzien_platebody_(2)",
         "independent": true,
-        "milestoneKills": 80
+        "milestoneKills": 10
       },
       {
         "itemId": 13365,
@@ -22424,7 +22424,7 @@
         "isPet": false,
         "wikiPage": "Shayzien_greaves_(2)",
         "independent": true,
-        "milestoneKills": 80
+        "milestoneKills": 10
       },
       {
         "itemId": 13362,
@@ -22433,7 +22433,7 @@
         "isPet": false,
         "wikiPage": "Shayzien_gloves_(2)",
         "independent": true,
-        "milestoneKills": 80
+        "milestoneKills": 10
       },
       {
         "itemId": 13363,
@@ -22442,7 +22442,7 @@
         "isPet": false,
         "wikiPage": "Shayzien_boots_(2)",
         "independent": true,
-        "milestoneKills": 80
+        "milestoneKills": 10
       },
       {
         "itemId": 13369,
@@ -22451,7 +22451,7 @@
         "isPet": false,
         "wikiPage": "Shayzien_helm_(3)",
         "independent": true,
-        "milestoneKills": 120
+        "milestoneKills": 15
       },
       {
         "itemId": 13371,
@@ -22460,7 +22460,7 @@
         "isPet": false,
         "wikiPage": "Shayzien_platebody_(3)",
         "independent": true,
-        "milestoneKills": 120
+        "milestoneKills": 15
       },
       {
         "itemId": 13370,
@@ -22469,7 +22469,7 @@
         "isPet": false,
         "wikiPage": "Shayzien_greaves_(3)",
         "independent": true,
-        "milestoneKills": 120
+        "milestoneKills": 15
       },
       {
         "itemId": 13367,
@@ -22478,7 +22478,7 @@
         "isPet": false,
         "wikiPage": "Shayzien_gloves_(3)",
         "independent": true,
-        "milestoneKills": 120
+        "milestoneKills": 15
       },
       {
         "itemId": 13368,
@@ -22487,7 +22487,7 @@
         "isPet": false,
         "wikiPage": "Shayzien_boots_(3)",
         "independent": true,
-        "milestoneKills": 120
+        "milestoneKills": 15
       },
       {
         "itemId": 13374,
@@ -22496,7 +22496,7 @@
         "isPet": false,
         "wikiPage": "Shayzien_helm_(4)",
         "independent": true,
-        "milestoneKills": 160
+        "milestoneKills": 20
       },
       {
         "itemId": 13376,
@@ -22505,7 +22505,7 @@
         "isPet": false,
         "wikiPage": "Shayzien_platebody_(4)",
         "independent": true,
-        "milestoneKills": 160
+        "milestoneKills": 20
       },
       {
         "itemId": 13375,
@@ -22514,7 +22514,7 @@
         "isPet": false,
         "wikiPage": "Shayzien_greaves_(4)",
         "independent": true,
-        "milestoneKills": 160
+        "milestoneKills": 20
       },
       {
         "itemId": 13372,
@@ -22523,7 +22523,7 @@
         "isPet": false,
         "wikiPage": "Shayzien_gloves_(4)",
         "independent": true,
-        "milestoneKills": 160
+        "milestoneKills": 20
       },
       {
         "itemId": 13373,
@@ -22532,7 +22532,7 @@
         "isPet": false,
         "wikiPage": "Shayzien_boots_(4)",
         "independent": true,
-        "milestoneKills": 160
+        "milestoneKills": 20
       },
       {
         "itemId": 13379,
@@ -22541,7 +22541,7 @@
         "isPet": false,
         "wikiPage": "Shayzien_helm_(5)",
         "independent": true,
-        "milestoneKills": 200
+        "milestoneKills": 25
       },
       {
         "itemId": 13381,
@@ -22550,7 +22550,7 @@
         "isPet": false,
         "wikiPage": "Shayzien_body_(5)",
         "independent": true,
-        "milestoneKills": 200
+        "milestoneKills": 25
       },
       {
         "itemId": 13380,
@@ -22559,7 +22559,7 @@
         "isPet": false,
         "wikiPage": "Shayzien_greaves_(5)",
         "independent": true,
-        "milestoneKills": 200
+        "milestoneKills": 25
       },
       {
         "itemId": 13377,
@@ -22568,7 +22568,7 @@
         "isPet": false,
         "wikiPage": "Shayzien_gloves_(5)",
         "independent": true,
-        "milestoneKills": 200
+        "milestoneKills": 25
       },
       {
         "itemId": 13378,
@@ -22577,7 +22577,7 @@
         "isPet": false,
         "wikiPage": "Shayzien_boots_(5)",
         "independent": true,
-        "milestoneKills": 200
+        "milestoneKills": 25
       }
     ],
     "locationDescription": "Shayzien Combat Ring, Great Kourend",
@@ -22594,31 +22594,31 @@
       {
         "description": "Kill soldiers in the Shayzien Combat Ring to earn tier 5 Shayzien armour.",
         "perItemStepDescription": {
-          "13359": "Kill tier 1 soldiers in the Shayzien Combat Ring to earn tier 1 Shayzien armour (40 kills).",
-          "13361": "Kill tier 1 soldiers in the Shayzien Combat Ring to earn tier 1 Shayzien armour (40 kills).",
-          "13360": "Kill tier 1 soldiers in the Shayzien Combat Ring to earn tier 1 Shayzien armour (40 kills).",
-          "13357": "Kill tier 1 soldiers in the Shayzien Combat Ring to earn tier 1 Shayzien armour (40 kills).",
-          "13358": "Kill tier 1 soldiers in the Shayzien Combat Ring to earn tier 1 Shayzien armour (40 kills).",
-          "13364": "Kill tier 2 soldiers in the Shayzien Combat Ring to earn tier 2 Shayzien armour (80 kills).",
-          "13366": "Kill tier 2 soldiers in the Shayzien Combat Ring to earn tier 2 Shayzien armour (80 kills).",
-          "13365": "Kill tier 2 soldiers in the Shayzien Combat Ring to earn tier 2 Shayzien armour (80 kills).",
-          "13362": "Kill tier 2 soldiers in the Shayzien Combat Ring to earn tier 2 Shayzien armour (80 kills).",
-          "13363": "Kill tier 2 soldiers in the Shayzien Combat Ring to earn tier 2 Shayzien armour (80 kills).",
-          "13369": "Kill tier 3 soldiers in the Shayzien Combat Ring to earn tier 3 Shayzien armour (120 kills).",
-          "13371": "Kill tier 3 soldiers in the Shayzien Combat Ring to earn tier 3 Shayzien armour (120 kills).",
-          "13370": "Kill tier 3 soldiers in the Shayzien Combat Ring to earn tier 3 Shayzien armour (120 kills).",
-          "13367": "Kill tier 3 soldiers in the Shayzien Combat Ring to earn tier 3 Shayzien armour (120 kills).",
-          "13368": "Kill tier 3 soldiers in the Shayzien Combat Ring to earn tier 3 Shayzien armour (120 kills).",
-          "13374": "Kill tier 4 soldiers in the Shayzien Combat Ring to earn tier 4 Shayzien armour (160 kills).",
-          "13376": "Kill tier 4 soldiers in the Shayzien Combat Ring to earn tier 4 Shayzien armour (160 kills).",
-          "13375": "Kill tier 4 soldiers in the Shayzien Combat Ring to earn tier 4 Shayzien armour (160 kills).",
-          "13372": "Kill tier 4 soldiers in the Shayzien Combat Ring to earn tier 4 Shayzien armour (160 kills).",
-          "13373": "Kill tier 4 soldiers in the Shayzien Combat Ring to earn tier 4 Shayzien armour (160 kills).",
-          "13379": "Kill tier 5 soldiers in the Shayzien Combat Ring to earn tier 5 Shayzien armour (200 kills).",
-          "13381": "Kill tier 5 soldiers in the Shayzien Combat Ring to earn tier 5 Shayzien armour (200 kills).",
-          "13380": "Kill tier 5 soldiers in the Shayzien Combat Ring to earn tier 5 Shayzien armour (200 kills).",
-          "13377": "Kill tier 5 soldiers in the Shayzien Combat Ring to earn tier 5 Shayzien armour (200 kills).",
-          "13378": "Kill tier 5 soldiers in the Shayzien Combat Ring to earn tier 5 Shayzien armour (200 kills)."
+          "13359": "Kill tier 1 soldiers in the Shayzien Combat Ring to earn tier 1 Shayzien armour (5 kills).",
+          "13361": "Kill tier 1 soldiers in the Shayzien Combat Ring to earn tier 1 Shayzien armour (5 kills).",
+          "13360": "Kill tier 1 soldiers in the Shayzien Combat Ring to earn tier 1 Shayzien armour (5 kills).",
+          "13357": "Kill tier 1 soldiers in the Shayzien Combat Ring to earn tier 1 Shayzien armour (5 kills).",
+          "13358": "Kill tier 1 soldiers in the Shayzien Combat Ring to earn tier 1 Shayzien armour (5 kills).",
+          "13364": "Kill tier 2 soldiers in the Shayzien Combat Ring to earn tier 2 Shayzien armour (10 kills).",
+          "13366": "Kill tier 2 soldiers in the Shayzien Combat Ring to earn tier 2 Shayzien armour (10 kills).",
+          "13365": "Kill tier 2 soldiers in the Shayzien Combat Ring to earn tier 2 Shayzien armour (10 kills).",
+          "13362": "Kill tier 2 soldiers in the Shayzien Combat Ring to earn tier 2 Shayzien armour (10 kills).",
+          "13363": "Kill tier 2 soldiers in the Shayzien Combat Ring to earn tier 2 Shayzien armour (10 kills).",
+          "13369": "Kill tier 3 soldiers in the Shayzien Combat Ring to earn tier 3 Shayzien armour (15 kills).",
+          "13371": "Kill tier 3 soldiers in the Shayzien Combat Ring to earn tier 3 Shayzien armour (15 kills).",
+          "13370": "Kill tier 3 soldiers in the Shayzien Combat Ring to earn tier 3 Shayzien armour (15 kills).",
+          "13367": "Kill tier 3 soldiers in the Shayzien Combat Ring to earn tier 3 Shayzien armour (15 kills).",
+          "13368": "Kill tier 3 soldiers in the Shayzien Combat Ring to earn tier 3 Shayzien armour (15 kills).",
+          "13374": "Kill tier 4 soldiers in the Shayzien Combat Ring to earn tier 4 Shayzien armour (20 kills).",
+          "13376": "Kill tier 4 soldiers in the Shayzien Combat Ring to earn tier 4 Shayzien armour (20 kills).",
+          "13375": "Kill tier 4 soldiers in the Shayzien Combat Ring to earn tier 4 Shayzien armour (20 kills).",
+          "13372": "Kill tier 4 soldiers in the Shayzien Combat Ring to earn tier 4 Shayzien armour (20 kills).",
+          "13373": "Kill tier 4 soldiers in the Shayzien Combat Ring to earn tier 4 Shayzien armour (20 kills).",
+          "13379": "Kill tier 5 soldiers in the Shayzien Combat Ring to earn tier 5 Shayzien armour (25 kills).",
+          "13381": "Kill tier 5 soldiers in the Shayzien Combat Ring to earn tier 5 Shayzien armour (25 kills).",
+          "13380": "Kill tier 5 soldiers in the Shayzien Combat Ring to earn tier 5 Shayzien armour (25 kills).",
+          "13377": "Kill tier 5 soldiers in the Shayzien Combat Ring to earn tier 5 Shayzien armour (25 kills).",
+          "13378": "Kill tier 5 soldiers in the Shayzien Combat Ring to earn tier 5 Shayzien armour (25 kills)."
         },
         "worldX": 1516,
         "worldY": 3617,
@@ -22626,7 +22626,15 @@
         "completionCondition": "MANUAL"
       }
     ],
-    "rewardType": "MILESTONE"
+    "rewardType": "MILESTONE",
+    "requirements": {
+      "skills": [
+        {
+          "skill": "DEFENCE",
+          "level": 20
+        }
+      ]
+    }
   },
   {
     "name": "Motherlode Mine",


### PR DESCRIPTION
## Summary
Two corrections to the Shayzien Combat Ring armour source:

1. **milestoneKills 8x too high.** Each tier drops one distinct armour piece per defeat, with no duplicates until that tier's 5-piece set is complete — so a full tier is guaranteed after exactly **5 defeats**. With sequential tier unlock, the cumulative guarantee is **5 / 10 / 15 / 20 / 25** total defeats, not the `40 / 80 / 120 / 160 / 200` previously encoded. Updated all 25 `milestoneKills` and the matching `perItemStepDescription` `(N kills)` text.
2. **Missing requirement.** Added `Defence 20` (the entry had no requirements block). Kourend favour was removed as a requirement in Jan 2024, so none is added.

## Citations
Wiki — [Combat Ring (Shayzien)](https://oldschool.runescape.wiki/w/Combat_Ring_(Shayzien)):
> To obtain a complete set of armour, the player must defeat each tier of soldier a total of five times.
> Soldiers will not drop duplicate armour pieces until after the player has obtained the complete set from that tier.
> Participation in the combat ring requires level 20 Defence.

## Verification
- `validate_drop_rates(Shayzien Armour)` → passed. JSON re-parsed OK.
- Diff confined to the Shayzien Armour block (25 milestone values + 25 matching step texts + one requirements block).