### PR TITLE
fix(data): Vampyre Kraken - correct Bottled storm rate in guidance prose

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -30859,7 +30859,7 @@
         "section": "Travel"
       },
       {
-        "description": "Board your boat and sail. Vampyre krakens are aggressive sea encounters at Sailing 78+. Use Protect from Magic while manning the cannon -- krakens deal magic-based tentacle attacks. Fire cannon until dead, then Harvest the carcass for a chance at Bottled storm (1/512) and Inky paint (1/1500).",
+        "description": "Board your boat and sail. Vampyre krakens are aggressive sea encounters at Sailing 78+. Use Protect from Magic while manning the cannon -- krakens deal magic-based tentacle attacks. Fire cannon until dead, then Harvest the carcass for a chance at Bottled storm (1/300) and Inky paint (1/1500).",
         "worldX": 1824,
         "worldY": 3691,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary
The Vampyre Kraken combat-step description stated **Bottled storm (1/512)**, which contradicts the source's own `Bottled storm` item `dropRate` of `0.003333` (= **1/300**). Aligned the prose to the authoritative item rate.

## Citation
Wiki — [Vampyre kraken](https://oldschool.runescape.wiki/w/Vampyre_kraken): Bottled storm drops at ~1/300 (~1/150 on a bounty task). The item's `dropRate` field (1/300) was already correct; only the descriptive text was stale.

## Verification
- `validate_drop_rates(Vampyre Kraken)` → passed. JSON re-parsed OK.
- Single-line prose change; no rate/coord/id fields touched.