### PR TITLE
fix(data): Deep Sea Fishing - Sailing requirement is 56, not 1

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -20636,7 +20636,7 @@
         },
         {
           "skill": "SAILING",
-          "level": 1
+          "level": 56
         }
       ]
     }


### PR DESCRIPTION
## Summary
Deep Sea Fishing's Sailing requirement was `1`; corrected to `56`.

Every clog fish here comes from deep sea trawling shoals, and every shoal requires a trawling net. The lowest-tier Rope trawling net needs **56 Sailing**, and the lowest shoal (Giant krill) requires **69 Fishing / 56 Sailing**. A Sailing-1 account can't trawl any shoal, so the honest gate is 56 (Fishing 69 was already correct).

## Citation
Wiki — [Deep sea trawling](https://oldschool.runescape.wiki/w/Deep_sea_trawling): shoals range from **69 Fishing / 56 Sailing** (Giant krill) up to 91 Fishing / 84 Sailing (Marlin); the rope trawling net requires 56 Sailing to use.

## Verification
- `validate_drop_rates(Deep Sea Fishing)` passed; JSON re-parsed OK. One-field change.