### PR TITLE
fix(data): Rooftop Agility - min Agility is 1 (Draynor), fix Varrock travelTip

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -21971,7 +21971,7 @@
       "skills": [
         {
           "skill": "AGILITY",
-          "level": 10
+          "level": 1
         }
       ]
     },
@@ -21983,7 +21983,7 @@
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 25,
-        "travelTip": "Camelot teleport -> Seers' Village rooftop (60+ Agility); Varrock teleport for Varrock rooftop (10+)",
+        "travelTip": "Camelot teleport -> Seers' Village rooftop (60+ Agility); Varrock teleport for Varrock rooftop (30+)",
         "section": "Travel"
       },
       {


### PR DESCRIPTION
## Summary
Two corrections to the generic Rooftop Agility source:

1. **Agility gate 10 → 1.** The source models rooftop courses generically (Graceful + Marks of grace, earnable at any rooftop course). The lowest course, Draynor Village, became available at **level 1** after the May 2024 update removed its former level-10 requirement. The gate of 10 matches no current course and would hide the source from Agility 1–9 players who can already train at Draynor.
2. **travelTip fix.** The step travelTip labelled Varrock rooftop as `(10+)`; it requires **30 Agility**. The step's own description already said `Varrock (30+)`, so this was internally contradictory.

## Citations
- [Draynor Village Rooftop Course](https://oldschool.runescape.wiki/w/Draynor_Village_Rooftop_Course): "available to players with 1 Agility. … The Agility level requirement of 10 has been removed."
- [Varrock Rooftop Course](https://oldschool.runescape.wiki/w/Varrock_Rooftop_Course): "available to players with an Agility level of 30 or higher."

## Verification
- `validate_drop_rates(Rooftop Agility)` passed; JSON re-parsed OK.