### PR TITLE
fix(data): Runecrafting (Fire Runes) - fire altar is NW of Emir's Arena, not NE

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -30129,7 +30129,7 @@
       }
     ],
     "locationDescription": "Fire Altar, north-east of Al Kharid",
-    "travelTip": "Ring of dueling -> Emir's Arena (Al Kharid) -> run north-east to fire altar ruins; or Abyss (requires Enter the Abyss miniquest, omit glory/prayer for PvP danger)",
+    "travelTip": "Ring of dueling -> Emir's Arena (Al Kharid) -> run north/north-west to fire altar ruins; or Abyss (requires Enter the Abyss miniquest, omit glory/prayer for PvP danger)",
     "requirements": {
       "skills": [
         {
@@ -30146,7 +30146,7 @@
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 15,
-        "travelTip": "Ring of dueling -> Emir's Arena -> run north-east to fire altar ruins",
+        "travelTip": "Ring of dueling -> Emir's Arena -> run north/north-west to fire altar ruins",
         "requiredItemIds": [
           1442
         ],


### PR DESCRIPTION
## Summary
The Ring of dueling lands at Emir's Arena; the Fire Altar ruins lie **north and slightly west** of it, so directing the player `north-east` sends them the wrong way (the east component is inverted). The step-0 description already says "west of Emir's Arena", so the `north-east` travelTip was internally contradictory. Corrected both the top-level `travelTip` and the step-0 `travelTip` to `north/north-west`.

## Citation
Wiki — [Fire Altar](https://oldschool.runescape.wiki/w/Fire_Altar): "The entrance to the altar can be found **north of Al Kharid, west of the Emir's Arena**." (Coordinates confirm: ring-of-dueling landing → altar ruins is due north, slightly west.)

## Verification
- `validate_drop_rates` passed; JSON re-parsed OK. Prose-only change (no rate/coord/id fields).