### PR TITLE
fix(data): Farming (Fruit Trees) - Tree Gnome Village fairy ring is CIQ, not CLR

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -30193,7 +30193,7 @@
     },
     "guidanceSteps": [
       {
-        "description": "Start a fruit tree run. Plant saplings at all available patches: Gnome Stronghold (spirit tree), Lleyta (gnome glider), Brimhaven (Charter ship or Ardougne cloak 2+), Catherby (Catherby teleport or Camelot teleport), Tree Gnome Village (fairy ring CLR), and Farming Guild (85+ Farming, fairy ring CIR). Pay the nearby gardener to protect each tree from disease.",
+        "description": "Start a fruit tree run. Plant saplings at all available patches: Gnome Stronghold (spirit tree), Lleyta (gnome glider), Brimhaven (Charter ship or Ardougne cloak 2+), Catherby (Catherby teleport or Camelot teleport), Tree Gnome Village (fairy ring CIQ), and Farming Guild (85+ Farming, fairy ring CIR). Pay the nearby gardener to protect each tree from disease.",
         "worldX": 1249,
         "worldY": 3719,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary
The fruit-tree-run step directed players to Tree Gnome Village via fairy ring `CLR` — but **CLR lands on Ape Atoll**. The code nearest the Tree Gnome Village fruit tree patch is **CIQ**. Corrected `CLR` → `CIQ`.

## Citation
Wiki — [Fairy ring](https://oldschool.runescape.wiki/w/Fairy_ring): **CLR = Ape Atoll**; **CIQ = Tree Gnome Village** (to the north; north-west of Yanille).

## Verification
- `validate_drop_rates(Farming (Fruit Trees))` passed; JSON re-parsed OK. Single-token guidance fix.