### PR TITLE
fix(data): Master Treasure Trails - clue upgrade is tier-scaled, not a flat 1/100

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -28358,7 +28358,7 @@
         "section": "Travel"
       },
       {
-        "description": "Obtain a master clue scroll by trading one clue of each tier (easy, medium, hard, elite) to Watson in Hosidius, or as a 1/100 rare drop from completing any easy/medium/hard/elite casket",
+        "description": "Obtain a master clue scroll by trading one clue of each tier (easy, medium, hard, elite) to Watson in Hosidius, or as a tier-scaled drop from opening a lower-tier reward casket (easy 1/50, medium 1/30, hard 1/15, elite 1/5)",
         "worldX": 1646,
         "worldY": 3577,
         "worldPlane": 0,


### PR DESCRIPTION
## Summary
The Loot step stated a master clue can drop "as a **1/100** rare drop from completing **any** easy/medium/hard/elite casket." The master-clue tertiary upgrade is **not** a flat rate and is **never 1/100** — it scales by tier: **easy 1/50, medium 1/30, hard 1/15, elite 1/5**. Reworded to the per-tier rates so a player isn't misled (elite is 20× more generous than the old figure). The Watson-trade half of the mechanic was already correct.

## Citations
Wiki reward-casket tertiary tables:
- [Reward casket (easy)](https://oldschool.runescape.wiki/w/Reward_casket_(easy)): Clue scroll (master) **1/50**
- [Reward casket (hard)](https://oldschool.runescape.wiki/w/Reward_casket_(hard)): Clue scroll (master) **1/15**
- Reward casket (elite): Clue scroll (master) **1/5** (medium 1/30 consistent)

## Verification
- `validate_drop_rates(Master Treasure Trails)` passed; JSON re-parsed OK. Single guidance-prose clause; no rate/coord/id fields touched.