### PR TITLE
fix(data): Yama - Oathplate shards drop rate is 1/17.07, not 1/30

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -23418,7 +23418,7 @@
       {
         "itemId": 30765,
         "name": "Oathplate shards",
-        "dropRate": 0.03333,
+        "dropRate": 0.058582,
         "isPet": false,
         "wikiPage": "Oathplate_shards"
       },


### PR DESCRIPTION
## Summary
Resolves a deferred rate. The Oathplate shards rate was `0.03333` (1/30). The earlier deferral flagged a conflict between the boss main page ("1/15") and the verifier ("1/17.07"); the **item's own drop-table page** settles it — it lists the Yama source explicitly at **1/17.07**. Updated to `0.058582` (1/17.07).

## Citation
Wiki — [Oathplate shards](https://oldschool.runescape.wiki/w/Oathplate_shards) drop table: **"Yama 1238 12 1/17.07"** (12 shards per drop at 1/17.07). A Yama Contract separately guarantees 45 shards.

## Verification
- `validate_drop_rates(Yama)` — the one reported issue ("last step ARRIVE_AT_TILE") is **pre-existing** and unrelated to this change (guidance-shape, not this dropRate); it is already present on `master`. JSON re-parsed OK. Single-value change.