### PR TITLE
fix(data): Barracuda Trials - Soup is the Sailing skilling pet (isPet + wikiPage)

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -18351,8 +18351,8 @@
         "itemId": 31283,
         "name": "Soup",
         "dropRate": 0.000333,
-        "isPet": false,
-        "wikiPage": "Soup_(item)",
+        "isPet": true,
+        "wikiPage": "Soup",
         "independent": true
       }
     ],


### PR DESCRIPTION
## Summary
Cross-source follow-up recorded during OTHER batch 2/3. The item **Soup (`31283`)** — the Sailing skilling pet — was mis-flagged `isPet:false` with a 404 `wikiPage:"Soup_(item)"` in **Barracuda Trials**, the same defect already fixed for **Port Tasks** (merged #1156). Set `isPet:true` and `wikiPage` → `Soup` for consistency across both sources that carry this item.

## Citation
Wiki — [Soup](https://oldschool.runescape.wiki/w/Soup): "Soup is a skilling pet that can be obtained while training the Sailing skill."

## Verification
- JSON re-parsed OK. Item-field change only.