### PR TITLE
fix(data): Underwater Crabs - Mogre Camp is entered via Murphy at Port Khazard

### DIFF
--- a/src/main/resources/com/collectionloghelper/drop_rates.json
+++ b/src/main/resources/com/collectionloghelper/drop_rates.json
@@ -30254,8 +30254,8 @@
         "wikiPage": "Fresh_crab_shell"
       }
     ],
-    "locationDescription": "Mogre Camp, underwater south of Mudskipper Point",
-    "travelTip": "Fairy ring AIQ -> Mudskipper Point; or Amulet of glory -> Draynor + run",
+    "locationDescription": "Mogre Camp, underwater - entered via Murphy at Port Khazard",
+    "travelTip": "Minigame Teleport (Fishing Trawler) -> Port Khazard, then speak to Murphy to dive",
     "guidanceSteps": [
       {
         "description": "Bank for Mogre Camp. Bring a weapon for level 23 underwater crabs, food, fishbowl helmet and diving apparatus to breathe underwater. Recipe for Disaster (Pirate Pete subquest) required to enter the underwater area.",
@@ -30271,17 +30271,17 @@
         "section": "Bank prep"
       },
       {
-        "description": "Travel to Mudskipper Point. Fairy ring AIQ teleports directly to Mudskipper Point. Alternatively amulet of glory to Draynor Village then run south-west along the coast.",
-        "worldX": 2987,
-        "worldY": 3033,
+        "description": "Travel to Port Khazard, where Murphy stands on the pier. The Fishing Trawler Minigame Teleport lands beside him; alternatively take a charter ship to Port Khazard or run south from Yanille.",
+        "worldX": 2668,
+        "worldY": 3162,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 15,
-        "travelTip": "Fairy ring AIQ -> Mudskipper Point (run NW); or Amulet of glory -> Draynor + run SW",
+        "travelTip": "Minigame Teleport -> Fishing Trawler (lands at Port Khazard, beside Murphy)",
         "section": "Travel"
       },
       {
-        "description": "Equip your fishbowl helmet and diving apparatus, then dive into the underwater entrance on the south side of Mudskipper Point to descend to the Mogre Camp underwater area.",
+        "description": "Equip your fishbowl helmet and diving apparatus (or a Medallion of the deep), then speak to Murphy at Port Khazard to dive down to the Mogre Camp underwater area.",
         "worldX": 2978,
         "worldY": 9181,
         "worldPlane": 0,
@@ -30307,9 +30307,9 @@
         "loopCount": 0
       },
       {
-        "description": "Surface via the underwater exit and bank fresh crab claws and shells at Port Sarim or Draynor Village once your inventory is full.",
-        "worldX": 2987,
-        "worldY": 3033,
+        "description": "Surface back to Port Khazard once your inventory is full, then bank your fresh crab claws and shells (teleport to the nearest bank).",
+        "worldX": 2668,
+        "worldY": 3162,
         "worldPlane": 0,
         "completionCondition": "ARRIVE_AT_TILE",
         "completionDistance": 15,


### PR DESCRIPTION
## Summary
Resolves the deferred routing defect. The guidance routed players to **Mudskipper Point** to dive to the Mogre Camp — but the Mogre Camp underwater area is entered by speaking to **Murphy at Port Khazard**; Mudskipper Point is a separate location. Rewrote the surface routing while leaving the underwater fight, drop rates, quest requirement, and gather-loop marker untouched.

## Changes
- `locationDescription` + source `travelTip`: Mudskipper Point → Port Khazard/Murphy.
- **step 1 (Travel):** now targets **Port Khazard (2668,3162)** via the Fishing Trawler Minigame Teleport (was Mudskipper Point 2987,3033).
- **step 2 (Dive):** "speak to Murphy at Port Khazard to dive" (was "dive south of Mudskipper Point"); underwater arrival coord (2978,9181) unchanged.
- **step 4 (Surface/Bank):** surface back to Port Khazard (2668,3162).
- **Unchanged:** underwater fight coord (2978,9181), crab drop rates (1/8), `RECIPE_FOR_DISASTER__PIRATE_PETE` requirement, and step-3 `loopBackToStep:4`/`loopCount:0` (asserted by `D4Batch3RegressionTest`).

## Sources
- Wiki — [Mogre Camp](https://oldschool.runescape.wiki/w/Mogre_Camp): "speak to Murphy at Port Khazard to go diving."
- `npc_spawns` — Murphy (NPC 5607) at **(2668, 3162, plane 0)** = Port Khazard.

## Verification
- `validate_drop_rates(Underwater Crabs)` — the one reported issue ("last step ARRIVE_AT_TILE") is **pre-existing** (the bank step's condition is unchanged; already on `master`). JSON re-parsed OK, ASCII-clean, 5 steps preserved.
- **Note:** the underwater fight coord (2978,9181) and the exact surface/bank return would benefit from in-game confirmation; the entry-location correction itself is wiki + cache sourced.