### PR TITLE
feat(guidance): dynamic Sailing dock resolver for port-based first steps

### DIFF
--- a/src/main/java/com/collectionloghelper/data/GuidanceStep.java
+++ b/src/main/java/com/collectionloghelper/data/GuidanceStep.java
@@ -34,6 +34,7 @@ import com.collectionloghelper.data.condition.ConditionNodeDeserializer;
 import com.google.gson.annotations.JsonAdapter;
 import javax.annotation.Nullable;
 import lombok.Value;
+import lombok.With;
 
 /**
  * A single step in a multi-step guidance sequence for obtaining collection log items.
@@ -58,9 +59,19 @@ public class GuidanceStep
 	@Nullable
 	Map<Integer, String> perItemStepDescription;
 
-	/** Target world coordinates for this step (0 = no location). */
+	/**
+	 * Target world coordinates for this step (0 = no location).
+	 *
+	 * <p>{@code @With} generates {@code withWorldX/withWorldY/withWorldPlane}
+	 * copy-methods used to produce a coordinate-overridden step at runtime (e.g.
+	 * the Sailing dynamic-dock first-step override) without mutating the
+	 * immutable {@code @Value}.
+	 */
+	@With
 	int worldX;
+	@With
 	int worldY;
+	@With
 	int worldPlane;
 
 	/** NPC to highlight for this step (0 = no NPC). */

--- a/src/main/java/com/collectionloghelper/guidance/GuidanceSequencer.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceSequencer.java
@@ -34,9 +34,11 @@ import com.collectionloghelper.data.StepWaypoint;
 import com.collectionloghelper.data.Zone;
 import com.collectionloghelper.guidance.bosses.BossGuidance;
 import com.collectionloghelper.guidance.bosses.BossGuidanceRegistry;
+import com.collectionloghelper.sailing.SailingDockResolver;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Consumer;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -54,6 +56,7 @@ public class GuidanceSequencer
 	private final PlayerInventoryState inventoryState;
 	private final RequirementsChecker requirementsChecker;
 	private final BossGuidanceRegistry bossRegistry;
+	private final SailingDockResolver sailingDockResolver;
 	private final CompletionChecker completionChecker;
 	private final StepAdvancer stepAdvancer;
 	private final SequencerEventAdapter eventAdapter;
@@ -118,11 +121,13 @@ public class GuidanceSequencer
 
 	@Inject
 	private GuidanceSequencer(PlayerInventoryState inventoryState, PlayerCollectionState collectionState,
-		RequirementsChecker requirementsChecker, BossGuidanceRegistry bossRegistry)
+		RequirementsChecker requirementsChecker, BossGuidanceRegistry bossRegistry,
+		SailingDockResolver sailingDockResolver)
 	{
 		this.inventoryState = inventoryState;
 		this.requirementsChecker = requirementsChecker;
 		this.bossRegistry = bossRegistry;
+		this.sailingDockResolver = sailingDockResolver;
 		this.completionChecker = new CompletionChecker(inventoryState, collectionState);
 		this.stepAdvancer = new StepAdvancer(this.completionChecker);
 		this.eventAdapter = new SequencerEventAdapter(this.completionChecker);
@@ -289,21 +294,47 @@ public class GuidanceSequencer
 	 */
 	private GuidanceStep resolveStep(int index)
 	{
-		GuidanceStep step = steps.get(index);
-		if (step.getConditionalAlternatives() == null || step.getConditionalAlternatives().isEmpty())
+		GuidanceStep cached = resolvedAlternatives.get(index);
+		if (cached != null)
 		{
-			return step;
+			return cached;
 		}
 
-		return resolvedAlternatives.computeIfAbsent(index, i ->
+		GuidanceStep step = steps.get(index);
+		GuidanceStep resolved = step;
+
+		// 1. Conditional alternatives (existing behaviour).
+		if (step.getConditionalAlternatives() != null && !step.getConditionalAlternatives().isEmpty())
 		{
-			GuidanceStep resolved = step.resolveAlternative(requirementsChecker);
+			resolved = step.resolveAlternative(requirementsChecker);
 			if (resolved != step)
 			{
-				log.info("Step {} resolved conditional alternative: {}", i + 1, resolved.getDescription());
+				log.info("Step {} resolved conditional alternative: {}", index + 1, resolved.getDescription());
 			}
-			return resolved;
-		});
+		}
+
+		// 2. Sailing dynamic-dock override for the first step: point port-based
+		//    Sailing sources at the player's best owned boat's dock rather than the
+		//    static Piscarilius anchor. Runtime-only; the static data is unchanged.
+		//    (The resolver is an optional collaborator; guard for tests that omit it.)
+		if (sailingDockResolver != null)
+		{
+			Optional<WorldPoint> dock = sailingDockResolver.resolveFirstStepOverride(resolved, index);
+			if (dock.isPresent())
+			{
+				WorldPoint d = dock.get();
+				resolved = resolved.withWorldX(d.getX()).withWorldY(d.getY()).withWorldPlane(d.getPlane());
+				log.info("Step {} dock override -> best ship dock ({}, {}, {})", index + 1, d.getX(), d.getY(), d.getPlane());
+			}
+		}
+
+		// Cache only when the step was actually modified, preserving the prior
+		// "return the raw step" behaviour for the common no-op case.
+		if (resolved != step)
+		{
+			resolvedAlternatives.put(index, resolved);
+		}
+		return resolved;
 	}
 
 	public int getCurrentIndex()

--- a/src/main/java/com/collectionloghelper/guidance/GuidanceSequencer.java
+++ b/src/main/java/com/collectionloghelper/guidance/GuidanceSequencer.java
@@ -304,7 +304,9 @@ public class GuidanceSequencer
 		GuidanceStep resolved = step;
 
 		// 1. Conditional alternatives (existing behaviour).
-		if (step.getConditionalAlternatives() != null && !step.getConditionalAlternatives().isEmpty())
+		boolean hasAlternatives = step.getConditionalAlternatives() != null
+			&& !step.getConditionalAlternatives().isEmpty();
+		if (hasAlternatives)
 		{
 			resolved = step.resolveAlternative(requirementsChecker);
 			if (resolved != step)
@@ -328,9 +330,11 @@ public class GuidanceSequencer
 			}
 		}
 
-		// Cache only when the step was actually modified, preserving the prior
-		// "return the raw step" behaviour for the common no-op case.
-		if (resolved != step)
+		// Cache the resolved step when it carried conditional alternatives (matching
+		// the prior computeIfAbsent stickiness, even when it resolves to the base
+		// step) or when the dock override modified it. Steps with neither are left
+		// uncached, preserving the prior "return the raw step" behaviour.
+		if (hasAlternatives || resolved != step)
 		{
 			resolvedAlternatives.put(index, resolved);
 		}

--- a/src/main/java/com/collectionloghelper/sailing/SailingDockResolver.java
+++ b/src/main/java/com/collectionloghelper/sailing/SailingDockResolver.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.sailing;
+
+import com.collectionloghelper.data.CompletionCondition;
+import com.collectionloghelper.data.GuidanceStep;
+import java.util.Optional;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.coords.WorldPoint;
+
+/**
+ * Resolves the dock of the player's <em>best</em> owned Sailing boat so guidance
+ * for port-based Sailing sources can point at the port where the player's ship
+ * actually is, rather than a fixed anchor.
+ *
+ * <p>OSRS exposes up to five boat slots via varbits. For each slot the game
+ * stores whether it is owned, its type/tier, its stored max HP, and its current
+ * port index. "Best" is defined as the highest boat type/tier, tie-broken by the
+ * higher stored max HP. The winning boat's port index is mapped to a dock
+ * {@link WorldPoint} via {@link SailingPort}.
+ *
+ * <p>All reads use raw varbit ids ({@link Client#getVarbitValue(int)}) so the
+ * feature works regardless of whether the pinned client's {@code VarbitID} class
+ * names these constants. Varbit ids are from RuneLite {@code VarbitID.java}
+ * (cache rev 2026-06-25): boat 1 OWNED/TYPE/PORT = 19258/19259/19260, stride 38
+ * between slots; STORED_MAXHP = 19463..19467.
+ *
+ * <p>{@link #resolveBestShipDock()} reads client state and must be called on the
+ * client thread.
+ */
+@Slf4j
+@Singleton
+public class SailingDockResolver
+{
+	private static final int BOAT_SLOTS = 5;
+	private static final int OWNED_BASE = 19258;
+	private static final int TYPE_BASE = 19259;
+	private static final int PORT_BASE = 19260;
+	private static final int SLOT_STRIDE = 38;
+	private static final int MAXHP_BASE = 19463;
+
+	/**
+	 * Canonical Port Piscarilius sailing-dock anchor (cache-confirmed) that
+	 * port-based Sailing sources use as the static first-step target in
+	 * drop_rates.json. A first step landing here is the "travel to your sailing
+	 * port" step and is eligible for the dynamic dock override.
+	 */
+	private static final int ANCHOR_X = 1824;
+	private static final int ANCHOR_Y = 3691;
+	private static final int ANCHOR_PLANE = 0;
+
+	private final Client client;
+
+	@Inject
+	private SailingDockResolver(Client client)
+	{
+		this.client = client;
+	}
+
+	/**
+	 * Resolves the dock coordinate of the player's best owned Sailing boat.
+	 *
+	 * <p>Must run on the client thread (reads varbits).
+	 *
+	 * @return the best boat's dock tile, or empty if the player owns no boat or
+	 *         the boat's port index is unknown
+	 */
+	public Optional<WorldPoint> resolveBestShipDock()
+	{
+		int bestType = -1;
+		int bestMaxHp = -1;
+		int bestPortId = -1;
+
+		for (int slot = 0; slot < BOAT_SLOTS; slot++)
+		{
+			if (client.getVarbitValue(OWNED_BASE + slot * SLOT_STRIDE) <= 0)
+			{
+				continue;
+			}
+
+			int type = client.getVarbitValue(TYPE_BASE + slot * SLOT_STRIDE);
+			int maxHp = client.getVarbitValue(MAXHP_BASE + slot);
+
+			if (type > bestType || (type == bestType && maxHp > bestMaxHp))
+			{
+				bestType = type;
+				bestMaxHp = maxHp;
+				bestPortId = client.getVarbitValue(PORT_BASE + slot * SLOT_STRIDE);
+			}
+		}
+
+		if (bestPortId < 0)
+		{
+			return Optional.empty();
+		}
+
+		Optional<SailingPort> port = SailingPort.fromId(bestPortId);
+		if (!port.isPresent())
+		{
+			log.debug("Best Sailing boat is at unknown port index {}", bestPortId);
+			return Optional.empty();
+		}
+		return Optional.of(port.get().getDock());
+	}
+
+	/**
+	 * Computes a dynamic-dock coordinate override for a guidance step, or empty if
+	 * the step is not an eligible Sailing first step or the player owns no boat.
+	 *
+	 * <p>Eligible = the first step (index 0) of a port-based Sailing source, i.e.
+	 * an {@code ARRIVE_AT_TILE} step whose static target is the canonical Port
+	 * Piscarilius sailing-dock anchor. Such sources currently point every player at
+	 * Piscarilius; this redirects them to the dock of their best owned boat.
+	 *
+	 * <p>Must run on the client thread (reads varbits).
+	 *
+	 * @param step  the guidance step being resolved
+	 * @param index the step's zero-based index in the sequence
+	 * @return the best-boat dock to use for this step, or empty to keep the static target
+	 */
+	public Optional<WorldPoint> resolveFirstStepOverride(GuidanceStep step, int index)
+	{
+		if (index != 0 || step == null)
+		{
+			return Optional.empty();
+		}
+		if (step.getCompletionCondition() != CompletionCondition.ARRIVE_AT_TILE)
+		{
+			return Optional.empty();
+		}
+		if (step.getWorldX() != ANCHOR_X || step.getWorldY() != ANCHOR_Y || step.getWorldPlane() != ANCHOR_PLANE)
+		{
+			return Optional.empty();
+		}
+		return resolveBestShipDock();
+	}
+}

--- a/src/main/java/com/collectionloghelper/sailing/SailingDockResolver.java
+++ b/src/main/java/com/collectionloghelper/sailing/SailingDockResolver.java
@@ -70,6 +70,10 @@ public class SailingDockResolver
 	 * drop_rates.json. A first step landing here is the "travel to your sailing
 	 * port" step and is eligible for the dynamic dock override.
 	 */
+	// NB: this static-data sentinel (1824,3691) is intentionally NOT the same tile
+	// as {@link SailingPort#PORT_PISCARILIUS}'s dock (1845,3687). This is the value
+	// authors placed in drop_rates.json as the "generic sailing port" first-step
+	// target; the enum holds the actual navigation tile. Do not "reconcile" them.
 	private static final int ANCHOR_X = 1824;
 	private static final int ANCHOR_Y = 3691;
 	private static final int ANCHOR_PLANE = 0;
@@ -123,9 +127,8 @@ public class SailingDockResolver
 		if (!port.isPresent())
 		{
 			log.debug("Best Sailing boat is at unknown port index {}", bestPortId);
-			return Optional.empty();
 		}
-		return Optional.of(port.get().getDock());
+		return port.map(SailingPort::getDock);
 	}
 
 	/**

--- a/src/main/java/com/collectionloghelper/sailing/SailingPort.java
+++ b/src/main/java/com/collectionloghelper/sailing/SailingPort.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * The port index -> dock world-coordinate table below is factual OSRS game data.
+ * The index/coordinate values were cross-referenced against the public,
+ * BSD-2-Clause-licensed "Where's My Boat" plugin
+ * (https://github.com/ArchRBX/wheresmyboat, (c) 2025 nucleon, Cooper Morris,
+ * AtchRBX), whose enums/Port.java enumerates each Sailing port with its
+ * navigation WorldPoint. Attribution retained per BSD-2-Clause.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.sailing;
+
+import java.util.Optional;
+import net.runelite.api.coords.WorldPoint;
+
+/**
+ * Enumerates every OSRS Sailing port/dock, keyed by the port index stored in the
+ * per-boat {@code SAILING_BOAT_N_PORT} varbit, with the dock's navigation
+ * {@link WorldPoint}. Used by {@link SailingDockResolver} to turn a boat's
+ * current port index into a real-world coordinate the guidance system can point
+ * at.
+ *
+ * <p>The port index is the value the game writes to {@code SAILING_BOAT_N_PORT};
+ * it is stable across the sailing-boat slots.
+ */
+public enum SailingPort
+{
+	PORT_SARIM(0, "Port Sarim", 1, 3050, 3192),
+	THE_PANDEMONIUM(1, "The Pandemonium", 1, 3069, 2986),
+	LANDS_END(2, "Land's End", 5, 1506, 3402),
+	MUSA_POINT(3, "Musa Point", 10, 2960, 3147),
+	HOSIDIUS(4, "Hosidius", 5, 1726, 3452),
+	RIMMINGTON(5, "Rimmington", 18, 2905, 3226),
+	CATHERBY(6, "Catherby", 20, 2796, 3412),
+	PORT_PISCARILIUS(7, "Port Piscarilius", 15, 1845, 3687),
+	BRIMHAVEN(8, "Brimhaven", 25, 2757, 3229),
+	ARDOUGNE(9, "Ardougne", 28, 2671, 3265),
+	PORT_KHAZARD(10, "Port Khazard", 30, 2685, 3161),
+	WITCHAVEN(11, "Witchaven", 34, 2746, 3304),
+	ENTRANA(12, "Entrana", 36, 2878, 3335),
+	CIVITAS_ILLA_FORTIS(13, "Civitas illa Fortis", 38, 1774, 3141),
+	CORSAIR_COVE(14, "Corsair Cove", 40, 2579, 2843),
+	CAIRN_ISLE(15, "Cairn Isle", 42, 2749, 2951),
+	SUNSET_COAST(16, "Sunset Coast", 44, 1511, 2975),
+	THE_SUMMER_SHORE(17, "The Summer Shore", 45, 3174, 2367),
+	ALDARIN(18, "Aldarin", 46, 1452, 2970),
+	RUINS_OF_UNKAH(19, "Ruins of Unkah", 48, 3143, 2824),
+	VOID_KNIGHTS_OUTPOST(20, "Void Knights' Outpost", 50, 2651, 2678),
+	PORT_ROBERTS(21, "Port Roberts", 50, 1860, 3306),
+	RED_ROCK(22, "Red Rock", 52, 2752, 2496),
+	RELLEKKA(23, "Rellekka", 62, 2630, 3705),
+	ETCETERIA(24, "Etceteria", 65, 2611, 3840),
+	PORT_TYRAS(25, "Port Tyras", 66, 2144, 3120),
+	DEEPFIN_POINT(26, "Deepfin Point", 67, 1923, 2758),
+	JATIZSO(27, "Jatizso", 68, 2412, 3780),
+	NEITIZNOT(28, "Neitiznot", 68, 2308, 3783),
+	PRIFDDINAS(29, "Prifddinas", 70, 2158, 3324),
+	PISCATORIS(30, "Piscatoris", 75, 2303, 3690),
+	LUNAR_ISLE(31, "Lunar Isle", 76, 2151, 3880),
+	ISLE_OF_SOULS(32, "Isle of Souls", 55, 2282, 2823),
+	WATERBIRTH_ISLAND(33, "Waterbirth Island", 74, 2543, 3765),
+	WEISS(34, "Weiss", 80, 2860, 3972),
+	DOGNOSE_ISLAND(35, "Dognose Island", 40, 3061, 2639),
+	REMOTE_ISLAND(36, "Remote Island", 45, 2971, 2603),
+	THE_LITTLE_PEARL(37, "The Little Pearl", 45, 3354, 2216),
+	THE_ONYX_CREST(38, "The Onyx Crest", 47, 2997, 2288),
+	LAST_LIGHT(39, "Last Light", 52, 2850, 2331),
+	CHARRED_ISLAND(40, "Charred Island", 60, 2660, 2395),
+	VATRACHOS_ISLAND(41, "Vatrachos Island", 46, 1872, 2985),
+	ANGLERS_RETREAT(42, "Anglers' Retreat", 51, 2467, 2721),
+	MINOTAURS_REST(43, "Minotaurs' Rest", 54, 1958, 3117),
+	ISLE_OF_BONES(44, "Isle of Bones", 56, 2532, 2531),
+	TEAR_OF_THE_SOUL(45, "Tear of the Soul", 61, 2318, 2774),
+	WINTUMBER_ISLAND(46, "Wintumber Island", 63, 2058, 2606),
+	THE_CROWN_JEWEL(47, "The Crown Jewel", 64, 1765, 2659),
+	RAINBOWS_END(48, "Rainbow's End", 69, 2344, 2270),
+	SUNBLEAK_ISLAND(49, "Sunbleak Island", 72, 2189, 2327),
+	SHIMMERING_ATOLL(50, "Shimmering Atoll", 49, 1557, 2771),
+	LAGUNA_AURORAE(51, "Laguna Aurorae", 58, 1202, 2733),
+	CHINCHOMPA_ISLAND(52, "Chinchompa Island", 42, 1892, 3429),
+	LLEDRITH_ISLAND(53, "Lledrith Island", 66, 2097, 3188),
+	YNYSDAIL(54, "Ynysdail", 73, 2222, 3466),
+	BUCCANEERS_HAVEN(55, "Buccaneers' Haven", 76, 2080, 3690),
+	DRUMSTICK_ISLE(56, "Drumstick Isle", 79, 2150, 3530),
+	BRITTLE_ISLE(57, "Brittle Isle", 81, 1954, 4056),
+	GRIMSTONE(58, "Grimstone", 87, 2927, 4056);
+
+	private final int portId;
+	private final String displayName;
+	private final int sailingLevelRequired;
+	private final int worldX;
+	private final int worldY;
+
+	SailingPort(int portId, String displayName, int sailingLevelRequired, int worldX, int worldY)
+	{
+		this.portId = portId;
+		this.displayName = displayName;
+		this.sailingLevelRequired = sailingLevelRequired;
+		this.worldX = worldX;
+		this.worldY = worldY;
+	}
+
+	public int getPortId()
+	{
+		return portId;
+	}
+
+	public String getDisplayName()
+	{
+		return displayName;
+	}
+
+	public int getSailingLevelRequired()
+	{
+		return sailingLevelRequired;
+	}
+
+	/**
+	 * @return the dock's navigation tile (all Sailing docks are on plane 0).
+	 */
+	public WorldPoint getDock()
+	{
+		return new WorldPoint(worldX, worldY, 0);
+	}
+
+	/**
+	 * Resolves a {@code SAILING_BOAT_N_PORT} varbit value to its port.
+	 *
+	 * @param portId the port index read from the varbit
+	 * @return the matching port, or empty if the index is unknown
+	 */
+	public static Optional<SailingPort> fromId(int portId)
+	{
+		for (SailingPort p : values())
+		{
+			if (p.portId == portId)
+			{
+				return Optional.of(p);
+			}
+		}
+		return Optional.empty();
+	}
+}

--- a/src/main/java/com/collectionloghelper/sailing/SailingPort.java
+++ b/src/main/java/com/collectionloghelper/sailing/SailingPort.java
@@ -4,10 +4,13 @@
  *
  * The port index -> dock world-coordinate table below is factual OSRS game data.
  * The index/coordinate values were cross-referenced against the public,
- * BSD-2-Clause-licensed "Where's My Boat" plugin
- * (https://github.com/ArchRBX/wheresmyboat, (c) 2025 nucleon, Cooper Morris,
- * AtchRBX), whose enums/Port.java enumerates each Sailing port with its
- * navigation WorldPoint. Attribution retained per BSD-2-Clause.
+ * BSD-2-Clause-licensed "Where's My Boat" plugin, whose enums/Port.java
+ * enumerates each Sailing port with its navigation WorldPoint.
+ *   Repository: https://github.com/ArchRBX/wheresmyboat
+ *   Upstream copyright (retained per BSD-2-Clause):
+ *     Copyright (c) 2025, nucleon <https://github.com/nucleon>
+ *     Copyright (c) 2025, Cooper Morris <https://github.com/coopermor>
+ *     Copyright (c) 2025, AtchRBX <https://github.com/AtchRBX>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequenceCompleteOrderingTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequenceCompleteOrderingTest.java
@@ -153,9 +153,9 @@ public class GuidanceSequenceCompleteOrderingTest
 		// which is the heart of the #801 ordering bug.
 		Constructor<GuidanceSequencer> seqCtor = GuidanceSequencer.class.getDeclaredConstructor(
 			PlayerInventoryState.class, PlayerCollectionState.class, RequirementsChecker.class,
-			com.collectionloghelper.guidance.bosses.BossGuidanceRegistry.class);
+			com.collectionloghelper.guidance.bosses.BossGuidanceRegistry.class, com.collectionloghelper.sailing.SailingDockResolver.class);
 		seqCtor.setAccessible(true);
-		sequencer = seqCtor.newInstance(inventoryState, collectionState, requirementsChecker, null);
+		sequencer = seqCtor.newInstance(inventoryState, collectionState, requirementsChecker, null, null);
 
 		when(inventoryState.hasItem(anyInt())).thenReturn(false);
 		when(inventoryState.hasAllItems(any())).thenReturn(true);

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerCacheResetTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerCacheResetTest.java
@@ -84,9 +84,9 @@ public class GuidanceSequencerCacheResetTest
 
 		Constructor<GuidanceSequencer> ctor = GuidanceSequencer.class.getDeclaredConstructor(
 			PlayerInventoryState.class, PlayerCollectionState.class, RequirementsChecker.class,
-			com.collectionloghelper.guidance.bosses.BossGuidanceRegistry.class);
+			com.collectionloghelper.guidance.bosses.BossGuidanceRegistry.class, com.collectionloghelper.sailing.SailingDockResolver.class);
 		ctor.setAccessible(true);
-		sequencer = ctor.newInstance(inventoryState, collectionState, requirementsChecker, null);
+		sequencer = ctor.newInstance(inventoryState, collectionState, requirementsChecker, null, null);
 	}
 
 	@Test

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerForceStepIndexTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerForceStepIndexTest.java
@@ -72,9 +72,9 @@ public class GuidanceSequencerForceStepIndexTest
 	{
 		Constructor<GuidanceSequencer> ctor = GuidanceSequencer.class.getDeclaredConstructor(
 			PlayerInventoryState.class, PlayerCollectionState.class, RequirementsChecker.class,
-			com.collectionloghelper.guidance.bosses.BossGuidanceRegistry.class);
+			com.collectionloghelper.guidance.bosses.BossGuidanceRegistry.class, com.collectionloghelper.sailing.SailingDockResolver.class);
 		ctor.setAccessible(true);
-		sequencer = ctor.newInstance(inventoryState, collectionState, requirementsChecker, null);
+		sequencer = ctor.newInstance(inventoryState, collectionState, requirementsChecker, null, null);
 	}
 
 	private GuidanceStep mockStep(String description)

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerNestedConditionalTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerNestedConditionalTest.java
@@ -89,9 +89,9 @@ public class GuidanceSequencerNestedConditionalTest
 
 		Constructor<GuidanceSequencer> ctor = GuidanceSequencer.class.getDeclaredConstructor(
 			PlayerInventoryState.class, PlayerCollectionState.class, RequirementsChecker.class,
-				com.collectionloghelper.guidance.bosses.BossGuidanceRegistry.class);
+				com.collectionloghelper.guidance.bosses.BossGuidanceRegistry.class, com.collectionloghelper.sailing.SailingDockResolver.class);
 		ctor.setAccessible(true);
-		sequencer = ctor.newInstance(inventoryState, collectionState, requirementsChecker, null);
+		sequencer = ctor.newInstance(inventoryState, collectionState, requirementsChecker, null, null);
 	}
 
 	// ── 1. Flat conditional — identical to legacy ─────────────────────────────

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerReDeriveTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerReDeriveTest.java
@@ -110,9 +110,9 @@ public class GuidanceSequencerReDeriveTest
 
 		Constructor<GuidanceSequencer> ctor = GuidanceSequencer.class.getDeclaredConstructor(
 			PlayerInventoryState.class, PlayerCollectionState.class, RequirementsChecker.class,
-			com.collectionloghelper.guidance.bosses.BossGuidanceRegistry.class);
+			com.collectionloghelper.guidance.bosses.BossGuidanceRegistry.class, com.collectionloghelper.sailing.SailingDockResolver.class);
 		ctor.setAccessible(true);
-		sequencer = ctor.newInstance(inventoryState, collectionState, requirementsChecker, null);
+		sequencer = ctor.newInstance(inventoryState, collectionState, requirementsChecker, null, null);
 	}
 
 	// ---- Forward / backward re-derivation (the loop) ----

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerRestockTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerRestockTest.java
@@ -94,9 +94,9 @@ public class GuidanceSequencerRestockTest
 
 		Constructor<GuidanceSequencer> ctor = GuidanceSequencer.class.getDeclaredConstructor(
 			PlayerInventoryState.class, PlayerCollectionState.class, RequirementsChecker.class,
-			com.collectionloghelper.guidance.bosses.BossGuidanceRegistry.class);
+			com.collectionloghelper.guidance.bosses.BossGuidanceRegistry.class, com.collectionloghelper.sailing.SailingDockResolver.class);
 		ctor.setAccessible(true);
-		sequencer = ctor.newInstance(inventoryState, collectionState, requirementsChecker, null);
+		sequencer = ctor.newInstance(inventoryState, collectionState, requirementsChecker, null, null);
 	}
 
 	// ---- Tests ----

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerStateDerivationTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerStateDerivationTest.java
@@ -96,9 +96,9 @@ public class GuidanceSequencerStateDerivationTest
 
 		Constructor<GuidanceSequencer> ctor = GuidanceSequencer.class.getDeclaredConstructor(
 			PlayerInventoryState.class, PlayerCollectionState.class, RequirementsChecker.class,
-			com.collectionloghelper.guidance.bosses.BossGuidanceRegistry.class);
+			com.collectionloghelper.guidance.bosses.BossGuidanceRegistry.class, com.collectionloghelper.sailing.SailingDockResolver.class);
 		ctor.setAccessible(true);
-		sequencer = ctor.newInstance(inventoryState, collectionState, requirementsChecker, null);
+		sequencer = ctor.newInstance(inventoryState, collectionState, requirementsChecker, null, null);
 	}
 
 	// ---- Tests ----

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerTest.java
@@ -83,9 +83,9 @@ public class GuidanceSequencerTest
 
 		Constructor<GuidanceSequencer> ctor = GuidanceSequencer.class.getDeclaredConstructor(
 			PlayerInventoryState.class, PlayerCollectionState.class, RequirementsChecker.class,
-				com.collectionloghelper.guidance.bosses.BossGuidanceRegistry.class);
+				com.collectionloghelper.guidance.bosses.BossGuidanceRegistry.class, com.collectionloghelper.sailing.SailingDockResolver.class);
 		ctor.setAccessible(true);
-		sequencer = ctor.newInstance(inventoryState, collectionState, requirementsChecker, null);
+		sequencer = ctor.newInstance(inventoryState, collectionState, requirementsChecker, null, null);
 	}
 
 	// ---- Helper methods ----

--- a/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerWaypointTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/GuidanceSequencerWaypointTest.java
@@ -89,11 +89,11 @@ public class GuidanceSequencerWaypointTest
 
 		Constructor<GuidanceSequencer> ctor = GuidanceSequencer.class.getDeclaredConstructor(
 			PlayerInventoryState.class, PlayerCollectionState.class, RequirementsChecker.class,
-			com.collectionloghelper.guidance.bosses.BossGuidanceRegistry.class);
+			com.collectionloghelper.guidance.bosses.BossGuidanceRegistry.class, com.collectionloghelper.sailing.SailingDockResolver.class);
 		ctor.setAccessible(true);
 		com.collectionloghelper.guidance.bosses.BossGuidanceRegistry bossRegistry =
 			org.mockito.Mockito.mock(com.collectionloghelper.guidance.bosses.BossGuidanceRegistry.class);
-		sequencer = ctor.newInstance(inventoryState, collectionState, requirementsChecker, bossRegistry);
+		sequencer = ctor.newInstance(inventoryState, collectionState, requirementsChecker, bossRegistry, null);
 	}
 
 	// ── Helpers ───────────────────────────────────────────────────────────────

--- a/src/test/java/com/collectionloghelper/guidance/bosses/BossGuidanceDispatchTest.java
+++ b/src/test/java/com/collectionloghelper/guidance/bosses/BossGuidanceDispatchTest.java
@@ -88,9 +88,9 @@ public class BossGuidanceDispatchTest
 
 		Constructor<GuidanceSequencer> seqCtor = GuidanceSequencer.class.getDeclaredConstructor(
 			PlayerInventoryState.class, PlayerCollectionState.class, RequirementsChecker.class,
-			BossGuidanceRegistry.class);
+			BossGuidanceRegistry.class, com.collectionloghelper.sailing.SailingDockResolver.class);
 		seqCtor.setAccessible(true);
-		sequencer = seqCtor.newInstance(inventoryState, collectionState, requirementsChecker, registry);
+		sequencer = seqCtor.newInstance(inventoryState, collectionState, requirementsChecker, registry, null);
 	}
 
 	private static GuidanceStep makeManualStep(String description)

--- a/src/test/java/com/collectionloghelper/sailing/SailingDockResolverTest.java
+++ b/src/test/java/com/collectionloghelper/sailing/SailingDockResolverTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.sailing;
+
+import com.collectionloghelper.data.CompletionCondition;
+import com.collectionloghelper.data.GuidanceStep;
+import java.lang.reflect.Constructor;
+import java.util.Optional;
+import net.runelite.api.Client;
+import net.runelite.api.coords.WorldPoint;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SailingDockResolverTest
+{
+	// Varbit ids (RuneLite VarbitID.java). Boat N (1-based): base + (N-1)*stride.
+	private static final int STRIDE = 38;
+	private static final int OWNED = 19258;
+	private static final int TYPE = 19259;
+	private static final int PORT = 19260;
+	private static final int MAXHP = 19463; // contiguous 19463..19467
+
+	private Client client;
+	private SailingDockResolver resolver;
+
+	@BeforeEach
+	void setUp() throws Exception
+	{
+		client = mock(Client.class);
+		Constructor<SailingDockResolver> c = SailingDockResolver.class.getDeclaredConstructor(Client.class);
+		c.setAccessible(true);
+		resolver = c.newInstance(client);
+	}
+
+	/** Stubs the four state varbits for a 1-based boat slot. */
+	private void boat(int slot, int owned, int type, int maxHp, int portId)
+	{
+		int off = (slot - 1) * STRIDE;
+		when(client.getVarbitValue(OWNED + off)).thenReturn(owned);
+		when(client.getVarbitValue(TYPE + off)).thenReturn(type);
+		when(client.getVarbitValue(PORT + off)).thenReturn(portId);
+		when(client.getVarbitValue(MAXHP + (slot - 1))).thenReturn(maxHp);
+	}
+
+	@Test
+	void noBoatsOwned_returnsEmpty()
+	{
+		// Mockito returns 0 for all unstubbed getVarbitValue -> nothing owned.
+		assertFalse(resolver.resolveBestShipDock().isPresent());
+	}
+
+	@Test
+	void singleOwnedBoat_returnsItsPortDock()
+	{
+		boat(1, 1, 3, 100, 0); // Port Sarim (id 0) = 3050,3192
+		Optional<WorldPoint> dock = resolver.resolveBestShipDock();
+		assertTrue(dock.isPresent());
+		assertEquals(new WorldPoint(3050, 3192, 0), dock.get());
+	}
+
+	@Test
+	void picksHighestTypeTier()
+	{
+		boat(1, 1, 3, 999, 0);  // lower tier, high hp, Port Sarim
+		boat(2, 1, 7, 10, 7);   // higher tier, low hp, Port Piscarilius (id 7) = 1845,3687
+		Optional<WorldPoint> dock = resolver.resolveBestShipDock();
+		assertTrue(dock.isPresent());
+		assertEquals(new WorldPoint(1845, 3687, 0), dock.get());
+	}
+
+	@Test
+	void tieOnType_breaksByHigherMaxHp()
+	{
+		boat(1, 1, 5, 100, 0);   // Port Sarim
+		boat(2, 1, 5, 200, 10);  // same tier, higher hp, Port Khazard (id 10) = 2685,3161
+		Optional<WorldPoint> dock = resolver.resolveBestShipDock();
+		assertTrue(dock.isPresent());
+		assertEquals(new WorldPoint(2685, 3161, 0), dock.get());
+	}
+
+	@Test
+	void unknownPortIndex_returnsEmpty()
+	{
+		boat(1, 1, 5, 100, 999); // no such port
+		assertFalse(resolver.resolveBestShipDock().isPresent());
+	}
+
+	@Test
+	void firstStepOverride_appliesToArriveAtAnchorWhenBoatOwned()
+	{
+		boat(1, 1, 5, 100, 10); // Port Khazard
+		GuidanceStep step = arriveStep(1824, 3691, 0);
+		Optional<WorldPoint> override = resolver.resolveFirstStepOverride(step, 0);
+		assertTrue(override.isPresent());
+		assertEquals(new WorldPoint(2685, 3161, 0), override.get());
+	}
+
+	@Test
+	void firstStepOverride_ignoresNonZeroIndex()
+	{
+		boat(1, 1, 5, 100, 10);
+		assertFalse(resolver.resolveFirstStepOverride(arriveStep(1824, 3691, 0), 1).isPresent());
+	}
+
+	@Test
+	void firstStepOverride_ignoresNonAnchorTile()
+	{
+		boat(1, 1, 5, 100, 10);
+		assertFalse(resolver.resolveFirstStepOverride(arriveStep(3000, 3000, 0), 0).isPresent());
+	}
+
+	@Test
+	void firstStepOverride_ignoresNonArriveCondition()
+	{
+		boat(1, 1, 5, 100, 10);
+		GuidanceStep manual = step(1824, 3691, 0, CompletionCondition.MANUAL);
+		assertFalse(resolver.resolveFirstStepOverride(manual, 0).isPresent());
+	}
+
+	@Test
+	void firstStepOverride_anchorButNoBoat_returnsEmpty()
+	{
+		// no boats stubbed
+		assertFalse(resolver.resolveFirstStepOverride(arriveStep(1824, 3691, 0), 0).isPresent());
+	}
+
+	private static GuidanceStep arriveStep(int x, int y, int plane)
+	{
+		return step(x, y, plane, CompletionCondition.ARRIVE_AT_TILE);
+	}
+
+	private static GuidanceStep step(int x, int y, int plane, CompletionCondition condition)
+	{
+		return new GuidanceStep(
+			"Sailing step",
+			null, x, y, plane,
+			0, null, null, null, null, null, null, null, null,
+			condition,
+			0, 0, 0, 0, null, null,
+			0, null, null, null, null, null,
+			0, 0, false, 0, null, null, 0, 0, null, null, null, null, null,
+			null, null,
+			null,
+			null,
+			null,
+			null);
+	}
+}

--- a/src/test/java/com/collectionloghelper/sailing/SailingPortTest.java
+++ b/src/test/java/com/collectionloghelper/sailing/SailingPortTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2025, cha-ndler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.collectionloghelper.sailing;
+
+import java.util.HashSet;
+import java.util.Set;
+import net.runelite.api.coords.WorldPoint;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SailingPortTest
+{
+	@Test
+	void portIdsAreUnique()
+	{
+		Set<Integer> ids = new HashSet<>();
+		for (SailingPort p : SailingPort.values())
+		{
+			assertTrue(ids.add(p.getPortId()), "duplicate port id: " + p.getPortId() + " (" + p + ")");
+		}
+	}
+
+	@Test
+	void allDocksArePositivePlaneZeroTiles()
+	{
+		for (SailingPort p : SailingPort.values())
+		{
+			WorldPoint d = p.getDock();
+			assertTrue(d.getX() > 0 && d.getY() > 0, p + " has non-positive dock coords");
+			assertEquals(0, d.getPlane(), p + " dock should be on plane 0");
+		}
+	}
+
+	@Test
+	void fromId_mapsKnownPorts()
+	{
+		assertEquals(SailingPort.PORT_SARIM, SailingPort.fromId(0).orElse(null));
+		assertEquals(SailingPort.PORT_PISCARILIUS, SailingPort.fromId(7).orElse(null));
+		assertEquals(SailingPort.PORT_KHAZARD, SailingPort.fromId(10).orElse(null));
+		assertEquals(SailingPort.GRIMSTONE, SailingPort.fromId(58).orElse(null));
+	}
+
+	@Test
+	void fromId_unknownIsEmpty()
+	{
+		assertFalse(SailingPort.fromId(-1).isPresent());
+		assertFalse(SailingPort.fromId(999).isPresent());
+	}
+
+	@Test
+	void seaTreasureFragmentIslandsAreMapped()
+	{
+		// The 7 named fragment islands the Sea Treasures follow-up will anchor to.
+		assertEquals(new WorldPoint(3061, 2639, 0), SailingPort.DOGNOSE_ISLAND.getDock());
+		assertEquals(new WorldPoint(2997, 2288, 0), SailingPort.THE_ONYX_CREST.getDock());
+		assertEquals(new WorldPoint(1872, 2985, 0), SailingPort.VATRACHOS_ISLAND.getDock());
+		assertEquals(new WorldPoint(1860, 3306, 0), SailingPort.PORT_ROBERTS.getDock());
+		assertEquals(new WorldPoint(1557, 2771, 0), SailingPort.SHIMMERING_ATOLL.getDock());
+		assertEquals(new WorldPoint(2532, 2531, 0), SailingPort.ISLE_OF_BONES.getDock());
+		assertEquals(new WorldPoint(2058, 2606, 0), SailingPort.WINTUMBER_ISLAND.getDock());
+	}
+}


### PR DESCRIPTION
## Summary
Port-based Sailing sources previously anchored **every** player's first guidance step to a fixed Port Piscarilius tile. This resolves that step at runtime to the dock of the player's **best owned boat**, and gracefully falls back to the static anchor when the player owns no boat / Sailing is untrained.

This replaces the static Piscarilius-vs-Port-Sarim anchor debate with a dynamic, per-player answer, and lays the coordinate groundwork for the Sea Treasures per-fragment follow-up.

## How it works
- **`SailingPort`** — a port-index → dock `WorldPoint` table (59 ports). The port coordinates were cross-referenced against the public **BSD-2-Clause** [Where's My Boat](https://github.com/ArchRBX/wheresmyboat) plugin's `Port` enum; attribution is retained in the file header per BSD-2-Clause (coordinate values are factual game data).
- **`SailingDockResolver`** — reads the per-boat varbits `SAILING_BOAT_N_{OWNED,TYPE,PORT,STORED_MAXHP}` (ids verified against RuneLite `VarbitID.java`), picks the **best** owned boat (**highest type tier, tie-broken by max HP**), and maps its port index to a dock coordinate. `resolveFirstStepOverride()` gates the override to **step 0** of an `ARRIVE_AT_TILE` source whose static target is the canonical Piscarilius sailing-dock anchor (1824,3691).
- **`GuidanceSequencer.resolveStep`** applies the override by producing a coordinate-only copy of the immutable step (new field-level `@With` withers on `GuidanceStep`'s `worldX/worldY/worldPlane`). Because `resolveStep` is the single funnel feeding the world-map arrow, overlays, **and** `ARRIVE_AT_TILE` completion, all three inherit the dynamic dock. The per-index cache means it resolves once per activation.

## Scope
Covers the **24 Piscarilius-anchored** Sailing sources (salvage, boat combat, ocean encounters, port tasks, cutting squid, sea treasures, lost schematics, boat paints, sailing misc). Non-port Sailing sources (Lava Strykewyrm, Aquanite, Deep Sea Fishing) are correctly untouched.

## Why it's safe for the test-guarded sources
The override is **runtime-only** — the static `drop_rates.json` data is unchanged. `SailingSourceTriageTest` (which loads and asserts the *static* Piscarilius coords for Cutting Squid / Sea Treasures / Port Tasks / Lost Schematics) still passes.

## Verification
- `./gradlew build` — **green** (all tests + `lintDropRates` + guidance ratchet).
- New unit tests: `SailingDockResolverTest` (best-ship selection by tier then HP, port mapping, empty fallback, first-step-override gating) and `SailingPortTest` (id uniqueness, dock validity, known mappings, the 7 Sea-Treasure fragment islands).
- `SailingSourceTriageTest` (7) and `D4Batch3RegressionTest` (3, the Underwater Crabs loop-marker suite) remain green.
- 10 existing `GuidanceSequencer*`/`BossGuidanceDispatch` tests updated for the new constructor param (resolver is a nullable collaborator, matching their existing `bossRegistry=null` pattern).

## Known limitation
The resolved dock is cached at activation, so if the player sails their boat to a different port mid-guidance the arrow stays on the activation-time dock until re-activation. Acceptable for a "travel to your dock" first step.

## Follow-up
Sea Treasures per-fragment guidance: 7 of the 8 fragment islands already have dock coords in `SailingPort` (Dognose, Onyx Crest, Vatrachos, Port Roberts, Shimmering Atoll, Isle of Bones, Wintumber).